### PR TITLE
LPS-139900 Create warning "Only the first tab will be displayed when creating a new entry"

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/layout/layout-screen/LayoutScreen.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/layout/layout-screen/LayoutScreen.tsx
@@ -12,6 +12,7 @@
  * details.
  */
 
+import ClayAlert from '@clayui/alert';
 import React from 'react';
 
 import AddNewTabButton from './AddNewTabButton';
@@ -22,6 +23,15 @@ import './LayoutScreen.scss';
 const LayoutScreen: React.FC<React.HTMLAttributes<HTMLElement>> = () => {
 	return (
 		<div className="layout-tab">
+			<ClayAlert
+				displayType="info"
+				title={`${Liferay.Language.get('info')}:`}
+			>
+				{Liferay.Language.get(
+					'only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry'
+				)}
+			</ClayAlert>
+
 			<AddNewTabButton />
 
 			<ObjectLayoutTabs />

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one site pages variation can be the main one.
 only-one-sku-can-be-approved=Only one SKU can be approved.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry.
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change.
 only-this-instance=Only This Instance
 only-true-will-be-accepted=Only true will be accepted.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=لا يتم دعم إلا قا
 only-one-site-pages-variation-can-be-the-main-one=شبه صفحة واحدة فقط يمكن أن تكون الرئيسية.
 only-one-sku-can-be-approved=لا يمكن الموافق إلا على وحدة حفظ مخزون واحدة فقط.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=يعرض نتائج محتوى الويب المدرج في عنصر واجهة المستخدم لعرض محتوى الويب فقط.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=سيتم تعديل هذا الحدث فقط. ولن تتغير بقية السلسلة.
 only-this-instance=هذا المثيل فقط
 only-true-will-be-accepted=سيتم قبول الصواب فقط.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Може да бъде одобрен само един МСА. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Показвайте само резултатите за уеб съдържание, изброено в притурка за показване на уеб съдържание. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Само това събитие ще бъде променено. Останалата част от серията няма да се промени. (Automatic Translation)
 only-this-instance=Само този екземпляр (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Només s'admet una regla amb l
 only-one-site-pages-variation-can-be-the-main-one=Només una variant de les pàgines del lloc pot ser la principal.
 only-one-sku-can-be-approved=Només es pot aprovar una SKU.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Mostra només els resultats del contingut web llistats en el giny de Visualització del contingut web.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Només es modificarà aquest esdeveniment. La resta de la sèrie no canviarà.
 only-this-instance=Només aquesta instància
 only-true-will-be-accepted=Només s'acceptarà "true".

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Je podporováno pouze jedno pr
 only-one-site-pages-variation-can-be-the-main-one=Pouze jedna varianta stránek webu může být hlavní.
 only-one-sku-can-be-approved=Schválení lze pouze jedné SKU. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Zobrazují výsledky pouze pro webový obsah uvedený ve widgetu zobrazení webového obsahu. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Pouze tato událost bude změněna. Zbytek série se nezmění. (Automatic Translation)
 only-this-instance=Pouze tato instance
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Der kan kun godkendes én lagervare. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Vis kun resultater for webindhold, der er angivet i en widget til visning af webindhold. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Kun denne hændelse vil blive ændret. Resten af serien ændres ikke. (Automatic Translation)
 only-this-instance=Kun denne forekomst (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Es wird nur eine Regel mit der
 only-one-site-pages-variation-can-be-the-main-one=Nur eine sitespezifische Seitenvariation kann als Hauptseitenvariation festgelegt werden.
 only-one-sku-can-be-approved=Nur eine SKU kann genehmigt werden.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Nur Resultate für Webcontent anzeigen, welcher auch in einem Webcontentanzeige-Widget angezeigt wird.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Es wird nur dieser Termin geändert. Die übrige Serie ist nicht betroffen.
 only-this-instance=Nur dieser Termin
 only-true-will-be-accepted=Nur "true" wird akzeptiert.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Μόνο μια παραλλαγή σελίδων του site μπορεί να είναι η κύρια.
 only-one-sku-can-be-approved=Μόνο ένα SKU μπορεί να εγκριθεί. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Εμφάνιση αποτελεσμάτων μόνο για περιεχόμενο web που παρατίθεται σε ένα widget εμφάνισης περιεχομένου Web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Μόνο αυτό το συμβάν θα τροποποιηθεί. Η υπόλοιπη σειρά δεν θα αλλάξει. (Automatic Translation)
 only-this-instance=Μόνο αυτή η παρουσία (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one site pages variation can be the main one.
 only-one-sku-can-be-approved=Only one SKU can be approved.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry.
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change.
 only-this-instance=Only This Instance
 only-true-will-be-accepted=Only true will be accepted.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one site pages variation can be the main one. (Automatic Copy)
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one site pages variation can be the main one. (Automatic Copy)
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Solo se admite una regla con l
 only-one-site-pages-variation-can-be-the-main-one=Sólo una variante de las páginas del sitio puede ser la principal.
 only-one-sku-can-be-approved=Solo se puede aprobar una SKU.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Solo se mostrarán los resultados del contenido web que aparece en el widget de visualización de contenido web.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Solo se modificará este evento. El resto de la serie no cambiará.
 only-this-instance=Solo esta ocurrencia
 only-true-will-be-accepted=Solo se admite el valor «true».

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Kinnitada saab ainult ühe SKU. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Saate kuvada ainult veebisisu kuvavidinas loetletud veebisisu tulemid. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Ainult seda sündmust muudetakse. Ülejäänud seeria ei muutu. (Automatic Translation)
 only-this-instance=Ainult see eksemplar (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Soilik Guneko Orrien Aldakuntza bat izan daiteke nagusia.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=فقط یک قانون با ت
 only-one-site-pages-variation-can-be-the-main-one=فقط یکی از صفحات سایت می‌تواند صفحه اصلی باشد.
 only-one-sku-can-be-approved=فقط یک SKU می تواند تایید شود.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=فقط نتایج را برای محتوای وب ذکر شده در یک ویجت نمایش محتوای وب نشان می دهد. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=فقط این رویداد تغییر خواهد کرد. بقیه سری ها تغییر نخواهند کرد.
 only-this-instance=فقط این مورد
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Vain yksi sääntö per yhdist
 only-one-site-pages-variation-can-be-the-main-one=Vain yksi Sivuston sivujen muunnelma voi olla päämuunnelma.
 only-one-sku-can-be-approved=Vain yksi SKU voidaan hyväskyä.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Näytä tulokset vain web-sisällöille, jotka on lueteltu web-sisällön esityswidgetissä.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Vain tätä tapahtumaa muutetaan. Muut sarjassa eivät muutu.
 only-this-instance=Vain tässä ilmentymässä
 only-true-will-be-accepted=Vain tosi hyväksytään.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Une seule règle avec la combi
 only-one-site-pages-variation-can-be-the-main-one=Seule une variante de pages peut être la principale.
 only-one-sku-can-be-approved=Une seule UGS peut être approuvée.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Afficher uniquement les résultats pour le contenu web présent dans le widget Affichage de contenu web.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Seul cet événement sera modifié. Le reste des séries resteront inchangées.
 only-this-instance=Seule cette instance
 only-true-will-be-accepted=Seul vrai sera accepté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Une seule règle avec la combi
 only-one-site-pages-variation-can-be-the-main-one=Seule une variante de pages peut être la principale.
 only-one-sku-can-be-approved=Une seule UGS peut être approuvée.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Afficher uniquement les résultats pour le contenu web présent dans le widget Affichage de contenu web.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Seul cet événement sera modifié. Le reste des séries resteront inchangées.
 only-this-instance=Seule cette instance
 only-true-will-be-accepted=Seul vrai sera accepté.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=संयोजन {0} के 
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=केवल एक स्कू को मंजूरी दी जा सकती है। (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=केवल वेब सामग्री डिस्प्ले विजेट में सूचीबद्ध वेब सामग्री के परिणाम दिखाते हैं। (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=केवल इस घटना को संशोधित किया जाएगा। बाकी श्रृंखला नहीं बदलेगी।
 only-this-instance=केवल यह उदाहरण
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Samo jedna varijacija stranica sitea može biti glavna.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Csak egy szabály támogatott 
 only-one-site-pages-variation-can-be-the-main-one=Csak egy webhely oldalváltozat lehet az elsődleges.
 only-one-sku-can-be-approved=Csak egy SKU hagyható jóvá.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Csak a Webes tartalom megjelenítése widgetben felsorolt tartalmat mutassa.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Csak ez az esemény lesz módosítva. A sorozat többi tagja nem változik.
 only-this-instance=Csak ebben az esetben
 only-true-will-be-accepted=Csak az igaz érték fogadható el.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Hanya satu Situs Halaman Variasi dapat menjadi yang utama.
 only-one-sku-can-be-approved=Hanya satu SKU yang dapat disetujui. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Hanya tampilkan hasil untuk konten web yang tercantum dalam widget tampilan konten web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Hanya kejadian ini yang akan diubah. Sisa seri tidak akan berubah. (Automatic Translation)
 only-this-instance=Hanya Instans Ini (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=E' consentita solo una regola 
 only-one-site-pages-variation-can-be-the-main-one=Solo una Variazione di Pagine Sito può essere quella principale.
 only-one-sku-can-be-approved=È possibile approvare una sola USK. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Mostra solo i risultati per il contenuto Web elencato in un widget di visualizzazione del contenuto Web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Verrà modificato solo questo evento. Il resto della serie non cambierà.
 only-this-instance=Solo quest'Istanza
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=רק כלל אחד עם הצי
 only-one-site-pages-variation-can-be-the-main-one=רק וריאציית דפי אתר אחת יכולה להיות הוריאציה הראשית.
 only-one-sku-can-be-approved=ניתן לאשר רק SKU אחד.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=הצג רק תוצאות עבור תוכן אינטרנט שמפורט ביישומון תצוגת תוכן אינטרנט.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=רק האירוע הזה ישונה. שאר הסדרה לא תשתנה.
 only-this-instance=המופע הזה בלבד
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported={0}のコンビネーション
 only-one-site-pages-variation-can-be-the-main-one=ひとつのサイトページバリーションしかメインにできません。
 only-one-sku-can-be-approved=1つのSKUのみ承認されます
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Webコンテンツ表示ウィジェットにリストされたWebコンテンツの結果だけ表示します。
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=このイベントのみを変更します。今後の繰り返しイベントは変更されません。
 only-this-instance=このインスタンスのみ
 only-true-will-be-accepted=true のみが受け付けられます。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=SKU를 하나만 승인할 수 있습니다. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=웹 컨텐츠 표시 위젯에 나열된 웹 컨텐츠에 대한 결과만 표시하십시오.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=이 이벤트만 수정됩니다. 시리즈의 나머지 는 변경되지 않습니다. (Automatic Translation)
 only-this-instance=이 인스턴스만 (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=ຮູບແບບໜ້າຕ່າງໆຂອງໄຊທ໌ເທົ່ານັ້ນທີ່ສາມາດເປັນຫຼັກ
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Galima patvirtinti tik vieną SKU. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Rodyti tik žiniatinklio turinio, pateikto žiniatinklio turinio rodymo valdiklyje, rezultatus. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Bus modifikuotas tik šis įvykis. Likusi serijos dalis nepasikeis. (Automatic Translation)
 only-this-instance=Tik šis egzempliorius (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Hanya satu halaman laman web variasi boleh menjadi yang utama. (Automatic Translation)
 only-one-sku-can-be-approved=Hanya satu SKU sahaja yang boleh diluluskan. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Hanya tunjuk hasil untuk kandungan web yang disenaraikan dalam widget paparan kandungan web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Hanya peristiwa ini akan diubahsuai. Selebihnya siri ini tidak akan berubah. (Automatic Translation)
 only-this-instance=Hanya Contoh Ini (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Bare en regel med kombinasjone
 only-one-site-pages-variation-can-be-the-main-one=Bare en nettstedssidevariant kan være hovednettstedssidevariant.
 only-one-sku-can-be-approved=Bare én SKU kan godkjennes. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Bare vis resultater for webinnhold listet i en webinnholdvisningswidget.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Bare denne hendelsen vil endres. Resten av serien endres ikke.
 only-this-instance=Bare denne instansen
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Er wordt slechts één regel m
 only-one-site-pages-variation-can-be-the-main-one=Er kan maar één sitepaginavariant als standaard worden geselecteerd.
 only-one-sku-can-be-approved=Er kan slechts één SKU goedgekeurd worden.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Alleen resultaten tonen voor webcontent in een widget voor weergave van webcontent.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Alleen deze gebeurtenis wordt gewijzigd. De rest van de reeks zal niet veranderen.
 only-this-instance=Alleen deze instance
 only-true-will-be-accepted=Alleen waar wordt geaccepteerd.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Er kan maar één sitepaginavariant als standaard worden geselecteerd.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=W połączeniu z {0} tylko jed
 only-one-site-pages-variation-can-be-the-main-one=Może być tylko jeden główny wariant stron witryny.
 only-one-sku-can-be-approved=Można zatwierdzić tylko jedną jednostkę SKU. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Wyniki wyświetlania są wyświetlane tylko dla zawartości sieci Web wymienionej w widżetu wyświetlania zawartości sieci Web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Tylko to zdarzenie zostanie zmodyfikowane. Reszta serii się nie zmieni. (Automatic Translation)
 only-this-instance=Tylko w tej instancji
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Apenas uma regra é suportada 
 only-one-site-pages-variation-can-be-the-main-one=Apenas uma variação de páginas do site pode ser a principal.
 only-one-sku-can-be-approved=Apenas uma SKU será aprovada.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Exibir somente os resultados para o conteúdo web listado no widget de Exibição de Conteúdo Web.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Apenas este evento será modificado. O resto da série não será alterada.
 only-this-instance=Apenas esta instância
 only-true-will-be-accepted=Apenas verdadeiro será aceito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Apenas uma regra com a combina
 only-one-site-pages-variation-can-be-the-main-one=Apenas uma variante de páginas do site pode ser a principal.
 only-one-sku-can-be-approved=Apenas um SKU pode ser aprovado. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Apenas mostre resultados para conteúdo da Web listado em um widget de exibição de conteúdo da Web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Apenas este evento será modificado. O resto da série não vai mudar. (Automatic Translation)
 only-this-instance=Apenas esta instância
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Un singur SKU poate fi aprobat. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Se afișează numai rezultatele pentru conținutul web listat într-un widget de afișare a conținutului web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Numai acest eveniment va fi modificat. Restul seriei nu se va schimba. (Automatic Translation)
 only-this-instance=Numai această instanță (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=С комбинацией {0} 
 only-one-site-pages-variation-can-be-the-main-one=Только один Вариант страниц сайта может быть основным.
 only-one-sku-can-be-approved=Только один SKU может быть утвержден. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Отображаются только результаты для веб-контента, перечисленного в виджете отображения веб-контента. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Только это событие будет изменено. Остальная часть серии не изменится. (Automatic Translation)
 only-this-instance=Только этот экземпляр
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Podporované je len jedno prav
 only-one-site-pages-variation-can-be-the-main-one=Iba jeden variant stránok môže byť hlavný.
 only-one-sku-can-be-approved=Môže byť schválená iba jedna skladová kumuláda. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Zobrazia sa iba výsledky webového obsahu uvedeného v miniaplikácii na zobrazenie webového obsahu. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Upraví sa iba táto udalosť. Zvyšok série sa nezmení. (Automatic Translation)
 only-this-instance=Iba táto inštancia
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Odobriti je mogoče samo eno SKU. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Prikaz rezultatov za spletno vsebino, ki je navedena v gradniku za prikaz spletne vsebine. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Samo ta dogodek bo spremenjen. Preostanek serije se ne bo spremenil. (Automatic Translation)
 only-this-instance=Samo ta primerek (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Само једна Варијација Страница Сајта може бити главна.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Samo jedna Varijacija Stranica Sajta može biti glavna.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget. (Automatic Copy)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Endast en regel med kombinatio
 only-one-site-pages-variation-can-be-the-main-one=Endast en sidsamlingsvariant kan vara den primära.
 only-one-sku-can-be-approved=Endast en SKU kan godkännas.
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Visa bara resultat för webbinnehåll som är synligt i artikel-portlets.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Endast den här händelsen kommer att ändras. Resten av serien kommer inte att ändras.
 only-this-instance=Endast denna instans
 only-true-will-be-accepted=Endast true accepteras.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=இதனுடன் {0} ஒ�
 only-one-site-pages-variation-can-be-the-main-one=ஒரே ஒரு Site Pages Variation மட்டுமே முக்கியமாக இருக்க முடியும்.
 only-one-sku-can-be-approved=Only one SKU can be approved. (Automatic Copy)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Web Content Display விட்ஜெட்டில் பட்டியலிடப்பட்ட, Web Content-கான முடிவுகளை மட்டும் காண்பி.
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=இந்த நிகழ்வை மாற்றியமைக்கப்படும். தொடரின் மற்ற நிகழ்வுகள் மாறாது.
 only-this-instance=இந்த நிகழ்வு மட்டுமே
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=สนับสนุนหน
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=สามารถอนุมัติ SKU ได้เพียงหนึ่งรายการเท่านั้น (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=แสดงเฉพาะผลลัพธ์สําหรับเนื้อหาเว็บที่แสดงในวิดเจ็ตการแสดงผลเนื้อหาเว็บเท่านั้น (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=เฉพาะเหตุการณ์นี้เท่านั้นที่จะถูกแก้ไข ส่วนที่เหลือของซีรีส์จะไม่เปลี่ยนแปลง
 only-this-instance=เฉพาะอินสแตนซ์นี้
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Yalnızca bir SKU onaylanabilir. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Yalnızca bir web içeriği görüntüleme widget'ında listelenen web içeriğinin sonuçlarını göster. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Yalnızca bu olay değiştirilecek. Serinin geri kalanı değişmeyecek. (Automatic Translation)
 only-this-instance=Yalnızca Bu Örnek (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Only one rule with the combina
 only-one-site-pages-variation-can-be-the-main-one=Only one Site Pages Variation can be the main one.
 only-one-sku-can-be-approved=Можна затвердити лише один артикул. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Відображати результати для веб-вмісту, переліченого у віджеті відображення веб-вмісту. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Буде змінено лише цю подію. Решта серій не зміниться. (Automatic Translation)
 only-this-instance=Лише цей екземпляр (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=Chỉ duy nhất luật với 
 only-one-site-pages-variation-can-be-the-main-one=Chỉ một trang biến thể duy nhất trở thành trang chính.
 only-one-sku-can-be-approved=Chỉ có một SKU có thể được phê duyệt. (Automatic Translation)
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Chỉ hiển thị kết quả cho nội dung web được liệt kê trong tiện ích hiển thị nội dung web. (Automatic Translation)
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Chỉ sự kiện này mới được sửa đổi. Phần còn lại của bộ truyện sẽ không thay đổi. (Automatic Translation)
 only-this-instance=Chỉ phiên bản này (Automatic Translation)
 only-true-will-be-accepted=Only true will be accepted. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=对于组合 {0}，仅支持�
 only-one-site-pages-variation-can-be-the-main-one=主要的网页变动只能有一种。
 only-one-sku-can-be-approved=仅可以批准一个 SKU。
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=只显示在 Web 内容显示微件中列出的 web 内容结果。
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=只有此活动将被更改。整个系列的其他部分将不会改变。
 only-this-instance=只有此实例
 only-true-will-be-accepted=仅接受 true。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -6189,6 +6189,7 @@ only-one-rule-with-the-combination-x-is-supported=對於組合 {0}，僅支持�
 only-one-site-pages-variation-can-be-the-main-one=只有一個站台頁面變更能是主要一個。
 only-one-sku-can-be-approved=僅可以批准一個 SKU。
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=只顯示在「網站內容顯示 Widget」中列出的網站內容結果。
+only-the-first-tab-will-be-used-when-creating-a-new-entry-the-remaining-Tabs-can-be-accessed-while-updating-the-entry=Only the first Tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry. (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=只有此活動將被更改，整個系列的其他部分將不會改變。
 only-this-instance=只有這實體
 only-true-will-be-accepted=僅接受 true。


### PR DESCRIPTION
Hi reviewer

This PR adds an Alert in Layout tab to explicit a business rule. I talked with Victor Santos (PD) for a little change in relation with mock up.

In mockup the alert should be added like that: 

![Screenshot from 2021-09-28 16-45-19](https://user-images.githubusercontent.com/38770741/135155432-619c3288-1217-450f-8d61-04c2499b53d5.png)

But, the [Clay Alert](https://clayui.com/docs/components/alert.html) have a horizonal margin in message that given a little difference in a relation to mock up. 

![Screenshot from 2021-09-28 16-53-13](https://user-images.githubusercontent.com/38770741/135156458-be9415e7-f489-45e7-b7c7-9939f135072d.png)

Therefor, talking with Victor, was decided would stay like that:

![Screenshot from 2021-09-28 16-49-09](https://user-images.githubusercontent.com/38770741/135155900-bc082e23-dac2-4d15-86fd-fcb728f43187.png)

This explanation is for not cause confusion in validation with the mock up.

The related task: https://issues.liferay.com/browse/LPS-139900

Thanks for your review time.