### PR TITLE
LPS-138698 Keyword and Text options are not updated on the fly after updating the field type

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
@@ -116,7 +116,14 @@ ObjectField objectField = (ObjectField)request.getAttribute(ObjectWebKeys.OBJECT
 		const searchableContainer = document.querySelector(
 			'#<portlet:namespace />searchableContainer'
 		);
+		const indexedGroup = document.querySelector(
+			'#<portlet:namespace />indexedGroup'
+		);
+		const indexed = document.querySelector('#<portlet:namespace />indexed')
+			.value;
 
+		indexedGroup.style.display =
+			indexed && event.target.value === 'String' ? 'block' : 'none';
 		searchableContainer.style.display =
 			event.target.value !== 'Blob' ? 'block' : 'none';
 	}
@@ -125,7 +132,7 @@ ObjectField objectField = (ObjectField)request.getAttribute(ObjectWebKeys.OBJECT
 		const indexedGroup = document.querySelector(
 			'#<portlet:namespace />indexedGroup'
 		);
-		const type = '<%= objectField.getType() %>';
+		const type = document.querySelector('#<portlet:namespace />type').value;
 
 		indexedGroup.style.display =
 			event.target.checked && type === 'String' ? 'block' : 'none';


### PR DESCRIPTION
Hi reviewers!

I changed the way of get the field values from object persisted to get values in the HTML document, because in the object persisted the values can to be outdated in relation to the form, furthermore, I added a validation in `onChangeFieldType` to show or not the searchable options.

Thanks for your review time.