### PR TITLE
LPS-140096 The Relationship tab name in the layout should be the label defined in the layout creation

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContext.java
@@ -169,21 +169,8 @@ public class ObjectEntryDisplayContext {
 						objectLayoutTab.getObjectLayoutTabId()
 					).buildString()
 				).setLabel(
-					() -> {
-						if (objectLayoutTab.getObjectRelationshipId() > 0) {
-							ObjectRelationship objectRelationship =
-								_objectRelationshipLocalService.
-									fetchObjectRelationship(
-										objectLayoutTab.
-											getObjectRelationshipId());
-
-							return objectRelationship.getLabel(
-								_objectRequestHelper.getLocale());
-						}
-
-						return objectLayoutTab.getName(
-							_objectRequestHelper.getLocale());
-					}
+					() -> objectLayoutTab.getName(
+						_objectRequestHelper.getLocale())
 				).build());
 		}
 


### PR DESCRIPTION
Hi reviewer!

This changes remove a code snippet that changed a tab name from default layout to the relationship name, when render a relationship tab.

I'm not a Java boy, therefor, I recommends a discerning look for this. 😄 

Thanks for your review time. 