### PR TITLE
LPS-141861 Add full width to dropdowns

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/form/CustomSelect/CustomSelect.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/form/CustomSelect/CustomSelect.scss
@@ -1,21 +1,6 @@
-.custom-select-trigger {
-	background-color: #f1f2f5;
-	color: #272833;
-	cursor: pointer;
-
-	&:focus {
-		background-color: #f0f5ff;
-		border-color: #80acff;
-		box-shadow: 0 0 0 0.125rem #fff, 0 0 0 0.25rem #80acff;
-		color: #272833;
-		outline: 0;
-	}
-
-	&::placeholder {
-		color: #272833;
-	}
-
-	&::-ms-input-placeholder {
-		color: #272833;
+.object__custom-select {
+	&-input {
+		caret-color: transparent;
+		cursor: pointer;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/form/CustomSelect/CustomSelect.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/form/CustomSelect/CustomSelect.tsx
@@ -53,7 +53,7 @@ const CustomSelect: React.FC<ICustomSelectProps> = ({
 
 	return (
 		<ClayForm.Group
-			className={classNames(className, {
+			className={classNames('object__custom-select', className, {
 				'has-error': error,
 			})}
 		>
@@ -65,10 +65,9 @@ const CustomSelect: React.FC<ICustomSelectProps> = ({
 
 			<ClayAutocomplete>
 				<ClayAutocomplete.Input
-					className="custom-select-trigger"
+					className="object__custom-select-input"
 					onClick={() => setActive(!active)}
 					placeholder={Liferay.Language.get('choose-an-option')}
-					readOnly
 					ref={inputRef}
 					value={value}
 				/>


### PR DESCRIPTION
Hey @miltonmc,

This changes was originated from your suggests in #232! I did some changes because I noticed that I don't need of the input as `readOnly`. I was using it because I wanted to hide the input cursor, but I did this with `caret-color: transparent;` CSS prop. This alteration removed a lot of unnecessary code. 

I'm not sure if this is a good practice.