### PR TITLE
LPS-145198 Fix tests

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -2212,7 +2212,7 @@ definition {
 
 		AssertElementPresent(locator1 = "PopulateObjectFormsConfiguration#ALERT_ICON_MESSAGE");
 
-		LexiconEntry.gotoEllipsisMenuItem(menuItem = "Edit");
+		LexiconEntry.gotoVerticalEllipsisMenuItemNoError(menuItem = "Edit");
 
 		FormsAdminNavigator.openPublishURL();
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/PopulateObjectFormsConfiguration.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/PopulateObjectFormsConfiguration.testcase
@@ -400,13 +400,9 @@ definition {
 
 		Navigator.gotoBack();
 
-		Click(
-			key_rowIndexNumber = "1",
-			locator1 = "Icon#ROW_VERTICAL_ELLIPSIS_N");
+		LexiconEntry.openEntryMenu(rowEntry = "Form 1");
 
-		AssertElementNotPresent(
-			key_itemName = "Entries",
-			locator1 = "FormsAdmin#FORMS_DROPDOWN_MENU_ITEM");
+		MenuItem.viewNotPresent(menuItem = "View Entries");
 	}
 
 	@description = "LPS-133365 - Verify if it's possible to select Object as a Storage Type"


### PR DESCRIPTION
Hi, 

After fixing [LPS-145198](https://issues.liferay.com/browse/LPS-145198) two tests using the Forms actions dropdown started to fail:

1. CreateObject#CannotSubmitEntriesInFormAfterObjectInactivated
2. PopulateObjectFormsConfiguration#CannotViewFormsEntries

I'm sending the fix here.