### PR TITLE
LPS-145898 Fix error getting a new relationship in GraphQL after creation without restarting the server

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionTable;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.base.ObjectRelationshipLocalServiceBaseImpl;
@@ -349,6 +350,9 @@ public class ObjectRelationshipLocalServiceImpl
 			runSQL(
 				DynamicObjectDefinitionTable.getAlterTableAddColumnSQL(
 					dbTableName, objectField.getDBColumnName(), "Long"));
+
+			_objectDefinitionLocalService.deployObjectDefinition(
+				objectDefinition2);
 		}
 
 		return objectField;
@@ -495,6 +499,9 @@ public class ObjectRelationshipLocalServiceImpl
 			}
 		}
 	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectDefinitionPersistence _objectDefinitionPersistence;


### PR DESCRIPTION
We found a bug or strange behavior as we were testing object relationships in GraphQL.

When a new relation is created, the GraphQL field is not recognized and causes the query to be invalid until the server is restarted. That is because the GraphQLDTOContributor, that is the object that maps the GraphQL type to the Object Definition type, is created when the ObjectDefinition is deployed, that is, when it is published.

If new fields are added after the publication, these fields are not available in GraphQL, and as the relationship creates the new field, we need to deploy again the ObjectDefinition to be available in runtime without restarting the server.

Please, take a look at the PR to see if I didn't miss any other consequence redeploying the ObjectDefinition, and also to check if this is necessary for some other part of the code. From my understanding, once the ObjectDefinition is published it is not possible to add any new field so we don't have this problem in any other use case.

More information could be found in the Jira ticket: [LPS-145898](https://issues.liferay.com/browse/LPS-145898)

Thank you very much! 🙂 

