### PR TITLE
LPS-145795 | LPS-145796 | LPS-145802 

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 8.0.1
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -372,4 +372,9 @@ public interface ObjectDefinitionLocalService
 	public ObjectDefinition updateObjectDefinition(
 		ObjectDefinition objectDefinition);
 
+	@Indexable(type = IndexableType.REINDEX)
+	public ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException;
+
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -458,6 +458,14 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().updateObjectDefinition(objectDefinition);
 	}
 
+	public static ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException {
+
+		return getService().updateTitleObjectFieldId(
+			objectDefinitionId, titleObjectFieldId);
+	}
+
 	public static ObjectDefinitionLocalService getService() {
 		return _service;
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -523,6 +523,15 @@ public class ObjectDefinitionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectDefinitionLocalService.updateTitleObjectFieldId(
+			objectDefinitionId, titleObjectFieldId);
+	}
+
+	@Override
 	public ObjectDefinitionLocalService getWrappedService() {
 		return _objectDefinitionLocalService;
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionService.java
@@ -99,4 +99,8 @@ public interface ObjectDefinitionService extends BaseService {
 			Map<Locale, String> pluralLabelMap, String scope)
 		throws PortalException;
 
+	public ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException;
+
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionServiceUtil.java
@@ -116,6 +116,14 @@ public class ObjectDefinitionServiceUtil {
 			pluralLabelMap, scope);
 	}
 
+	public static ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException {
+
+		return getService().updateTitleObjectFieldId(
+			objectDefinitionId, titleObjectFieldId);
+	}
+
 	public static ObjectDefinitionService getService() {
 		return _service;
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionServiceWrapper.java
@@ -134,6 +134,15 @@ public class ObjectDefinitionServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectDefinitionService.updateTitleObjectFieldId(
+			objectDefinitionId, titleObjectFieldId);
+	}
+
+	@Override
 	public ObjectDefinitionService getWrappedService() {
 		return _objectDefinitionService;
 	}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -209,10 +209,8 @@ public class ObjectEntryDTOConverter
 			else if (Objects.equals(
 						objectField.getRelationshipType(), "oneToMany")) {
 
-				String[] objectFieldNameParts = objectFieldName.split(
-					StringPool.UNDERLINE);
-
-				String relationshipIdName = objectFieldNameParts[3];
+				String relationshipIdName = objectFieldName.substring(
+					objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);
 
 				long objectEntryId = 0;
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -78,10 +78,8 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 				String objectFieldName = objectField.getName();
 
-				String[] objectFieldNameParts = objectFieldName.split(
-					StringPool.UNDERLINE);
-
-				String relationshipIdName = objectFieldNameParts[3];
+				String relationshipIdName = objectFieldName.substring(
+					objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);
 
 				graphQLDTOProperties.add(
 					GraphQLDTOProperty.of(relationshipIdName, Long.class));

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -79,13 +79,13 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 				String objectFieldName = objectField.getName();
 
-				String[] objectFieldNameParts = objectFieldName.split(
-					StringPool.UNDERLINE);
+				String relationshipIdName = objectFieldName.substring(
+					objectFieldName.lastIndexOf(StringPool.UNDERLINE) + 1);
 
 				_entityFieldsMap.put(
-					objectFieldNameParts[3],
+					relationshipIdName,
 					new IntegerEntityField(
-						objectFieldNameParts[3],
+						relationshipIdName,
 						locale ->
 							"nestedFieldArray.value_long#" + objectFieldName));
 			}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionMetadata.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/UserSystemObjectDefinitionMetadata.java
@@ -54,9 +54,10 @@ public class UserSystemObjectDefinitionMetadata
 			createObjectField(
 				"Text", "String", "email-address", "emailAddress", true),
 			createObjectField(
-				"Text", "String", "first-name", "firstName", true),
+				"Text", "firstName", "String", "first-name", "givenName", true),
 			createObjectField(
-				"Text", "String", "middle-name", "middleName", false),
+				"Text", "middleName", "String", "middle-name", "additionalName",
+				false),
 			createObjectField(
 				"Text", "uuid_", "String", "uuid", "uuid", false));
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectDefinitionServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectDefinitionServiceHttp.java
@@ -417,6 +417,48 @@ public class ObjectDefinitionServiceHttp {
 		}
 	}
 
+	public static com.liferay.object.model.ObjectDefinition
+			updateTitleObjectFieldId(
+				HttpPrincipal httpPrincipal, Long objectDefinitionId,
+				long titleObjectFieldId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectDefinitionServiceUtil.class, "updateTitleObjectFieldId",
+				_updateTitleObjectFieldIdParameterTypes9);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectDefinitionId, titleObjectFieldId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.object.model.ObjectDefinition)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		ObjectDefinitionServiceHttp.class);
 
@@ -447,5 +489,7 @@ public class ObjectDefinitionServiceHttp {
 			java.util.Map.class, String.class, String.class, String.class,
 			boolean.class, java.util.Map.class, String.class
 		};
+	private static final Class<?>[] _updateTitleObjectFieldIdParameterTypes9 =
+		new Class[] {Long.class, long.class};
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectDefinitionServiceSoap.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectDefinitionServiceSoap.java
@@ -259,6 +259,26 @@ public class ObjectDefinitionServiceSoap {
 		}
 	}
 
+	public static com.liferay.object.model.ObjectDefinitionSoap
+			updateTitleObjectFieldId(
+				Long objectDefinitionId, long titleObjectFieldId)
+		throws RemoteException {
+
+		try {
+			com.liferay.object.model.ObjectDefinition returnValue =
+				ObjectDefinitionServiceUtil.updateTitleObjectFieldId(
+					objectDefinitionId, titleObjectFieldId);
+
+			return com.liferay.object.model.ObjectDefinitionSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		ObjectDefinitionServiceSoap.class);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -572,6 +572,20 @@ public class ObjectDefinitionLocalServiceImpl
 			portlet, null, null, pluralLabelMap, scope);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionPersistence.fetchByPrimaryKey(objectDefinitionId);
+
+		objectDefinition.setTitleObjectFieldId(titleObjectFieldId);
+
+		return objectDefinitionPersistence.update(objectDefinition);
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionServiceImpl.java
@@ -142,6 +142,18 @@ public class ObjectDefinitionServiceImpl
 			pluralLabelMap, scope);
 	}
 
+	@Override
+	public ObjectDefinition updateTitleObjectFieldId(
+			Long objectDefinitionId, long titleObjectFieldId)
+		throws PortalException {
+
+		_objectDefinitionModelResourcePermission.check(
+			getPermissionChecker(), objectDefinitionId, ActionKeys.UPDATE);
+
+		return _objectDefinitionLocalService.updateTitleObjectFieldId(
+			objectDefinitionId, titleObjectFieldId);
+	}
+
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/EditObjectDefinitionMVCActionCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/EditObjectDefinitionMVCActionCommand.java
@@ -76,8 +76,16 @@ public class EditObjectDefinitionMVCActionCommand extends BaseMVCActionCommand {
 		Map<Locale, String> pluralLabelMap =
 			LocalizationUtil.getLocalizationMap(actionRequest, "pluralLabel");
 		String scope = ParamUtil.getString(actionRequest, "scope");
+		boolean system = ParamUtil.getBoolean(actionRequest, "system");
 
 		try {
+			if (system) {
+				_objectDefinitionService.updateTitleObjectFieldId(
+					objectDefinitionId, titleObjectFieldId);
+
+				return;
+			}
+
 			_objectDefinitionService.updateCustomObjectDefinition(
 				objectDefinitionId, descriptionObjectFieldId,
 				titleObjectFieldId, active, labelMap, name, panelCategoryOrder,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
@@ -55,6 +55,8 @@ renderResponse.setTitle(LanguageUtil.format(request, "edit-x", objectDefinition.
 
 		<aui:model-context bean="<%= objectDefinition %>" model="<%= ObjectDefinition.class %>" />
 
+		<aui:input name="system" type="hidden" value="<%= objectDefinition.isSystem() %>" />
+
 		<h2 class="sheet-title">
 			<%= LanguageUtil.get(request, "information") %>
 		</h2>
@@ -95,7 +97,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "edit-x", objectDefinition.
 					<clay:col
 						md="11"
 					>
-						<aui:select disabled="<%= objectDefinition.isSystem() || !objectDefinitionsDetailsDisplayContext.hasUpdateObjectDefinitionPermission() %>" name="titleObjectFieldId" showEmptyOption="<%= false %>">
+						<aui:select disabled="<%= !objectDefinitionsDetailsDisplayContext.hasUpdateObjectDefinitionPermission() %>" name="titleObjectFieldId" showEmptyOption="<%= false %>">
 							<aui:option label='<%= LanguageUtil.get(request, "id") %>' selected="<%= true %>" value="" />
 
 							<%


### PR DESCRIPTION
- LPS-145795 The pkObjectFieldName of a native object does not have 'c_' at the beginning, so the objectFieldName must be the last string after the last underline
- LPS-145802 Create new method to update only the TitleObjectFieldId property
- LPS-145802 buildService
- LPS-145802 Enable editing of Title Field for native objects
- LPS-145802 Include dbColumnName when creating native object fields and change the object field name to match the UserDTO
