### PR TITLE
LPS-145842 There is no confirmation dialog when deleting an object entry

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -123,7 +123,6 @@ export function handleAction(
 function ActionItem({
 	action,
 	closeMenu,
-	data,
 	handleAction,
 	itemData,
 	itemId,
@@ -136,7 +135,7 @@ function ActionItem({
 }) {
 	const context = useContext(DataSetContext);
 
-	const {icon, label, target} = action;
+	const {data, icon, label, target} = action;
 
 	function handleClickOnLink(event) {
 		event.preventDefault();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -121,22 +121,22 @@ export function handleAction(
 }
 
 function ActionItem({
+	action,
 	closeMenu,
 	data,
 	handleAction,
-	icon,
 	itemData,
 	itemId,
-	label,
 	method,
 	onClick,
 	setLoading,
 	size,
-	target,
 	title,
 	url,
 }) {
 	const context = useContext(DataSetContext);
+
+	const {icon, label, target} = action;
 
 	function handleClickOnLink(event) {
 		event.preventDefault();
@@ -171,13 +171,7 @@ function ActionItem({
 			onClick={(event) => {
 				if (onActionDropdownItemClick) {
 					onActionDropdownItemClick({
-						action: {
-							data,
-							icon,
-							label,
-							target,
-							url,
-						},
+						action,
 						event,
 						itemData,
 					});
@@ -390,7 +384,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 
 			return (
 				<ActionItem
-					{...item}
+					action={item}
 					closeMenu={() => setMenuActive(false)}
 					handleAction={handleAction}
 					itemData={itemData}


### PR DESCRIPTION
### References

- [LPS-145842](https://issues.liferay.com/browse/LPS-145842)
- https://github.com/liferay-objects/liferay-portal/pull/352

### What is the goal?

@danvb112 This PR is an improvement to the bugfix solution in https://github.com/liferay-objects/liferay-portal/pull/352. That solution does the job and fixes the issue. The improvement in this PR is that we are are preserving forwarding of the entire `action` object to the `onActionDropdownItemClick`. It is consistent with the forwarding of the entire `itemData` object. This is to future-proof the code and make it more robust. If a function gets an argument, mutates it and passes it with the same name, it makes the code harder to read and follow. A dev can make assumptions that object has a property or some value, and then suddenly it doesn't. We are doing this bad pattern already too much in `ActionsDropdownRenderer`, the best example is handling of href / url / formatted url. But, that's a refactor for a separate task.

### What does it look like?

There are no changes in UI with this PR. Delete confirmation should continue to work. 

### How to replicate

See steps to reproduce in the Jira ticket.