### PR TITLE
LPS-143347 buildService

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 9.0.1
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
@@ -21,6 +21,17 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class ObjectFieldRelationshipTypeException extends PortalException {
 
+	public static class MustNotDeleteObjectFieldRelationshipType
+		extends ObjectFieldRelationshipTypeException {
+
+		public MustNotDeleteObjectFieldRelationshipType() {
+			super(
+				"Object field cannot be deleted because it is of " +
+					"relationship type.");
+		}
+
+	}
+
 	public static class
 		MustNotEditDescriptionAndTitleUsingObjectFieldRelationshipType
 			extends ObjectFieldRelationshipTypeException {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
@@ -21,6 +21,17 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class ObjectFieldRelationshipTypeException extends PortalException {
 
+	public static class IsNotObjectFieldRelationshipType
+		extends ObjectFieldRelationshipTypeException {
+
+		public IsNotObjectFieldRelationshipType() {
+			super(
+				"Object field cannot be deleted because it is not of " +
+					"relationship type.");
+		}
+
+	}
+
 	public static class MustNotDeleteObjectFieldRelationshipType
 		extends ObjectFieldRelationshipTypeException {
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectFieldRelationshipTypeException.java
@@ -21,21 +21,30 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class ObjectFieldRelationshipTypeException extends PortalException {
 
-	public ObjectFieldRelationshipTypeException() {
+	public static class
+		MustNotEditDescriptionAndTitleUsingObjectFieldRelationshipType
+			extends ObjectFieldRelationshipTypeException {
+
+		public MustNotEditDescriptionAndTitleUsingObjectFieldRelationshipType() {
+			super(
+				"Description and title object fields cannot have a " +
+					"relationship type");
+		}
+
 	}
 
-	public ObjectFieldRelationshipTypeException(String msg) {
+	public static class MustNotEditNameOrDBTypeOfObjectFieldRelationshipType
+		extends ObjectFieldRelationshipTypeException {
+
+		public MustNotEditNameOrDBTypeOfObjectFieldRelationshipType() {
+			super(
+				"Object field relationship name and DB type cannot be changed");
+		}
+
+	}
+
+	private ObjectFieldRelationshipTypeException(String msg) {
 		super(msg);
-	}
-
-	public ObjectFieldRelationshipTypeException(
-		String msg, Throwable throwable) {
-
-		super(msg, throwable);
-	}
-
-	public ObjectFieldRelationshipTypeException(Throwable throwable) {
-		super(throwable);
 	}
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
@@ -142,6 +142,10 @@ public interface ObjectFieldLocalService
 	public ObjectField deleteObjectField(ObjectField objectField)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.DELETE)
+	public ObjectField deleteObjectFieldRelationshipType(long objectFieldId)
+		throws PortalException;
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
@@ -141,6 +141,13 @@ public class ObjectFieldLocalServiceUtil {
 		return getService().deleteObjectField(objectField);
 	}
 
+	public static ObjectField deleteObjectFieldRelationshipType(
+			long objectFieldId)
+		throws PortalException {
+
+		return getService().deleteObjectFieldRelationshipType(objectFieldId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
@@ -146,6 +146,15 @@ public class ObjectFieldLocalServiceWrapper
 		return _objectFieldLocalService.deleteObjectField(objectField);
 	}
 
+	@Override
+	public com.liferay.object.model.ObjectField
+			deleteObjectFieldRelationshipType(long objectFieldId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectFieldLocalService.deleteObjectFieldRelationshipType(
+			objectFieldId);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1091,9 +1091,8 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		if (Validator.isNotNull(objectField.getRelationshipType())) {
-			throw new ObjectFieldRelationshipTypeException(
-				"Description and title object fields cannot have a " +
-					"relationship type");
+			throw new ObjectFieldRelationshipTypeException.
+				MustNotEditDescriptionAndTitleUsingObjectFieldRelationshipType();
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -144,6 +144,22 @@ public class ObjectFieldLocalServiceImpl
 		return _deleteObjectField(objectField);
 	}
 
+	@Indexable(type = IndexableType.DELETE)
+	@Override
+	public ObjectField deleteObjectFieldRelationshipType(long objectFieldId)
+		throws PortalException {
+
+		ObjectField objectField = objectFieldPersistence.findByPrimaryKey(
+			objectFieldId);
+
+		if (Validator.isNull(objectField.getRelationshipType())) {
+			throw new ObjectFieldRelationshipTypeException.
+				IsNotObjectFieldRelationshipType();
+		}
+
+		return _deleteObjectField(objectField);
+	}
+
 	@Override
 	public ObjectField fetchObjectField(long objectDefinitionId, String name) {
 		return objectFieldPersistence.fetchByODI_N(objectDefinitionId, name);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -240,9 +240,8 @@ public class ObjectFieldLocalServiceImpl
 			if (!Objects.equals(objectField.getDBType(), dbType) ||
 				!Objects.equals(objectField.getName(), name)) {
 
-				throw new ObjectFieldRelationshipTypeException(
-					"Object field relationship name and DB type cannot be " +
-						"changed");
+				throw new ObjectFieldRelationshipTypeException.
+					MustNotEditNameOrDBTypeOfObjectFieldRelationshipType();
 			}
 		}
 		else {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -136,34 +136,12 @@ public class ObjectFieldLocalServiceImpl
 	public ObjectField deleteObjectField(ObjectField objectField)
 		throws PortalException {
 
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(
-				objectField.getObjectDefinitionId());
-
-		if ((objectDefinition.isApproved() || objectDefinition.isSystem()) &&
-			!Objects.equals(
-				objectDefinition.getExtensionDBTableName(),
-				objectField.getDBTableName())) {
-
-			throw new RequiredObjectFieldException();
+		if (Validator.isNotNull(objectField.getRelationshipType())) {
+			throw new ObjectFieldRelationshipTypeException.
+				MustNotDeleteObjectFieldRelationshipType();
 		}
 
-		objectField = objectFieldPersistence.remove(objectField);
-
-		_objectLayoutColumnPersistence.removeByObjectFieldId(
-			objectField.getObjectFieldId());
-
-		if (Objects.equals(
-				objectDefinition.getExtensionDBTableName(),
-				objectField.getDBTableName())) {
-
-			runSQL(
-				DynamicObjectDefinitionTable.getAlterTableDropColumnSQL(
-					objectField.getDBTableName(),
-					objectField.getDBColumnName()));
-		}
-
-		return objectField;
+		return _deleteObjectField(objectField);
 	}
 
 	@Override
@@ -311,6 +289,39 @@ public class ObjectFieldLocalServiceImpl
 		objectField.setRequired(required);
 
 		return objectFieldPersistence.update(objectField);
+	}
+
+	private ObjectField _deleteObjectField(ObjectField objectField)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(
+				objectField.getObjectDefinitionId());
+
+		if ((objectDefinition.isApproved() || objectDefinition.isSystem()) &&
+			!Objects.equals(
+				objectDefinition.getExtensionDBTableName(),
+				objectField.getDBTableName())) {
+
+			throw new RequiredObjectFieldException();
+		}
+
+		objectField = objectFieldPersistence.remove(objectField);
+
+		_objectLayoutColumnPersistence.removeByObjectFieldId(
+			objectField.getObjectFieldId());
+
+		if (Objects.equals(
+				objectDefinition.getExtensionDBTableName(),
+				objectField.getDBTableName())) {
+
+			runSQL(
+				DynamicObjectDefinitionTable.getAlterTableDropColumnSQL(
+					objectField.getDBTableName(),
+					objectField.getDBColumnName()));
+		}
+
+		return objectField;
 	}
 
 	private void _validateBusinessType(String businessType)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -165,7 +165,7 @@ public class ObjectRelationshipLocalServiceImpl
 				objectRelationship.getType(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-			_objectFieldLocalService.deleteObjectField(
+			_objectFieldLocalService.deleteObjectFieldRelationshipType(
 				objectRelationship.getObjectFieldId2());
 		}
 		else if (Objects.equals(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-143347

This is a follow-up from an observation made by Brian when he reviewed: brianchandotcom#111592.

The previous work prevents the user to delete an object field of relationship type when using the UI. This work prevents deleting using the Rest API.