### PR TITLE
LPS-146073 | LPS-145899

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/configuration/FFSystemObjectRelationshipConfiguration.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/configuration/FFSystemObjectRelationshipConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Carolina Barbosa
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.object.web.internal.configuration.FFSystemObjectRelationshipConfiguration"
+)
+public interface FFSystemObjectRelationshipConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean enabled();
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/configuration/activator/FFSystemObjectRelationshipConfigurationActivator.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/configuration/activator/FFSystemObjectRelationshipConfigurationActivator.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.configuration.activator;
+
+import com.liferay.object.web.internal.configuration.FFSystemObjectRelationshipConfiguration;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Carolina Barbosa
+ */
+@Component(
+	configurationPid = "com.liferay.object.web.internal.configuration.FFSystemObjectRelationshipConfiguration",
+	immediate = true,
+	service = FFSystemObjectRelationshipConfigurationActivator.class
+)
+public class FFSystemObjectRelationshipConfigurationActivator {
+
+	public boolean enabled() {
+		return _ffSystemObjectRelationshipConfiguration.enabled();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_ffSystemObjectRelationshipConfiguration =
+			ConfigurableUtil.createConfigurable(
+				FFSystemObjectRelationshipConfiguration.class, properties);
+	}
+
+	private volatile FFSystemObjectRelationshipConfiguration
+		_ffSystemObjectRelationshipConfiguration;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/ObjectDefinitionsRelationshipsScreenNavigationCategory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/frontend/taglib/servlet/taglib/ObjectDefinitionsRelationshipsScreenNavigationCategory.java
@@ -18,6 +18,7 @@ import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.web.internal.configuration.activator.FFOneToOneRelationshipConfigurationActivator;
+import com.liferay.object.web.internal.configuration.activator.FFSystemObjectRelationshipConfigurationActivator;
 import com.liferay.object.web.internal.object.definitions.constants.ObjectDefinitionsScreenNavigationEntryConstants;
 import com.liferay.object.web.internal.object.definitions.display.context.ObjectDefinitionsRelationshipsDisplayContext;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -73,7 +74,11 @@ public class ObjectDefinitionsRelationshipsScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, ObjectDefinition objectDefinition) {
-		return !objectDefinition.isSystem();
+		if (objectDefinition.isSystem()) {
+			return _ffSystemObjectRelationshipConfiguration.enabled();
+		}
+
+		return true;
 	}
 
 	@Override
@@ -94,6 +99,10 @@ public class ObjectDefinitionsRelationshipsScreenNavigationCategory
 	@Reference
 	private FFOneToOneRelationshipConfigurationActivator
 		_ffOneToOneRelationshipConfigurationActivator;
+
+	@Reference
+	private FFSystemObjectRelationshipConfigurationActivator
+		_ffSystemObjectRelationshipConfiguration;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.object.model.ObjectDefinition)"


### PR DESCRIPTION
- LPS-144540 - Add responsive mode for New button
- LPS-144540 - Use utility classes for text button, show tooltip only in icon button
- LPS-144650 - Fix dropdown toggle not opening
- LPS-144540 - Use different font size for New button icon and text
- LPS-144540 - Hide changes behind FF in ManagementToolbarTag
- LPS-141685 Add UpdatedDataIsKeptWhenPublishing test
- LPS-141605 Add CannotUpdateObjectWithUpdatePermission test
- LPS-141608 Add CanViewObjectWithViewPermission test
- LPS-145539 Extract common code into a new method
- LPS-145539 Those methods should not be default since we have an implementation in FragmentEntryProcessorHelperImpl
- LPS-145539 Convert this method to public so we can reuse to calculate the href on LinkEditableElementMapper for display pages
- LPS-145539 Uses the new method to get the mapped field instead of rendering a template to get it
- LPS-145539 Removes deprecated methods, also delete:
- LPS-145539 baseline
- LPS-145539 SF
- LPS-145539 Rename to fieldName
- LPS-119552 Since Asset libraries are not possible to be loaded in the product menu as for the change requested in https://issues.liferay.com/browse/LPS-119461, we should delete the "Site" mark in the product menu, as it is not needed anymore
- LPS-145025 Allow to redirect the URL starts with path main
- LPS-145025 Include the ticket key on the post language update redirect
- LPS-145527 Adds an integration test to ensure the AssetCategoryLayoutDisplayPageInfoItemFieldValuesProvider is registered and works properly.
- LPS-145527 Adds integration tests to ensure the custom name logic works as expected.
- COMMERCE-7310 added print button on jsp
- COMMERCE-7310 modified commerce order template
- COMMERCE-7310 added parameter for pdf
- COMMERCE-7310 rename
- LPS-139938 Create skeleton module for Azure translator
- LPS-139938 Add Azure translator configuration
- LPS-139938 Add Azure translator implementation
- LPS-139938 Build lang
- LPS-139938 Rename Azure translator packages
- LPS-139938 Rename module directory
- LPS-145450 Rename Google Cloud translator packages
- LPS-145450 Rename module directory
- LPS-145450 Document breaking change
- LPS-145450 Upgrade no longer necessary
- LPS-139938 Update Poshi macro
- LPS-139938 Remove deprecated method
- LPS-139938 Use HttpUtil and remove HttpClient dep
- LPS-139938 Semver
- LPS-139938 Remove deprecated method
- LPS-139938 rename
- LPS-139938 Wordsmith
- LPS-131848 New article's version should preserve the original article owner.
- LPS-131848 Adds an integration test
- LPS-131848 SF
- LPS-137761 Adds support for ballooneditor on blogs-web
- LPS-137761 Source Formatting
- LPS-137761 Adds ballooneditor configuration conditionally
- LPS-137761 Make window available methods created from Editor component
- LPS-137761 Adds a feature flag for enabling balloonEditor
- LPS-137761 Apply review suggestions
- LPS-137761 Enable Balloon Editor in the sample module
- LPS-137761 Remove unused
- LPS-137761 When clicking outside editor's area, it will hide (liferay/insert)Toolbars
- LPS-137761 Fix the behaviour of closing properly liferayToolbars of CKEditor
- LPS-137761 Renames CKEditorSampleConfigContributor -> CKEditorSampleEditorConfigContributor
- LPS-137761 as used
- LPS-141688 Add CanViewAndEditObjectWithAddObjectPermission test
- LPS-141595 Add CannotLeavePicklistFieldEmpty test
- LPS-140559 Add CanViewPicklistEntryOnLayout test
- LPS-141821 Add CanMapPicklistTypeAndViewEntries test
- Revert "LPS-145541 Remove from versions"
- Revert "LPS-145541 Remove from IDE files"
- Revert "LPS-145541 Remove from gitignore"
- Revert "LPS-145541 Remove from lib dependency"
- LPS-145198 Fix tests
- LPS-145231 Replace ClayDropDown.Item with ClayDropDown.Divider for a separator
- LRQA-72707 Add macro for removing translation overrides via menu item
- LRQA-72707 Add macro for opening Language Override portlet via url
- LRQA-72707 Add test that will delete an overridden language key by removing all its translation overrides
- LRQA-72729 Make locator reusable
- LRQA-72729 Add macro for removing translation override for selected language
- LRQA-72729 Add macro for navigating to language key
- LRQA-72729 Add test for removing a translation override for selected language via menu item
- LRQA-72730 Add macro for clearing all overrides via Edit page
- LRQA-72730 Add test for clearing all overrides for overridden keys in edit page
- LRQA-72731 Add macro for updating the translation override values
- LRQA-72731 Add test for clearing all overrides for existing keys
- LRQA-72755 Don't run Blueprints functional tests on CE jobs
- LPS-145856 Modify locator to make it reusable
- LPS-145855 Run case on default instance
- LRQA-72744 Modify locator to make it reusable and update usages
- LRQA-72744 Use general locator
- LRQA-72744 Remove deprecated locators
- LRQA-72744 Modify macro to make it reusable and update usages
- LRQA-72748 Modify locator to make it reusable and update usages
- LRQA-72748 Modify macros to make them reusable
- LRAC-10420 Change the event to a hidden one by default
- LRAC-10420 Add hideAllEvents macro to hide all events before unhide all in the test
- LPS-145752 (portal-language-override-web) - validate edit form
- LPS-145752 portal-language-lang: lang: adds new lang key
- LPS-145704 portal-language-lang: lang: adds missing lang key
- LPS-145752 (portal-language-override-web) - auto SF
- LPS-145704 wordsmith
- LPS-145704 SF
- LPS-145704 regen
- LPS-145244 added css stylesheet
- LPS-145244 select menu and button group fixed
- LPS-145244 dropdown when window decrease the size
- LPS-145246 setting quicklinks expanded in context
- LPS-145244 fix navbar styles
- LPS-140163 SF
- LPS-140163 remove unused files
- LPS-145245 fix style classes on Card Subscription
- LPS-145244 create subscription drop down component
- LPS-145244 fix navbar max lenght
- LPS-140163 SF
- LPS-145244 upload
- LRCI-2605 Add methods to gather exclude properties for JUnit batch test class groups
- LRCI-2605 Add methods to gather include properties for JUnit batch test class groups
- LRCI-2605 Add methods to gather filter properties for JUnit batch test class groups
- LRCI-2605 Update finding the auto balance test files using job property objects
- LRCI-2605 Remove unnecessary classes due to updates
- LRCI-2605 Remove old logic that was replaced by job properties logic
- LRCI-2605 prep next
- LPS-145859 Refactor locator for page template card item
- LPS-145859 Update macro
- LPS-145859 Remove deprecated case
- LPS-145859 Refactor case to use Search template
- LPS-145859 Remove deprecated macro
- LPS-145859 Remove deprecated locators
- LPS-145859 Add locator for specific default title
- LPS-145859 Add macro to view default title
- LPS-145859 Update cases
- LPS-77699 Update Translations
- LPS-145874 search-experiences-service: Don't cache private addresses or if not enabled
- LPS-145874 search-experiences-service: Don't cache or return data if not enabled. Pass with HTTP code 2xx
- LPS-145800 Change assert function
- LRQA-72752 Direct login
- LRQA-72752 Use default browser binary
- LPS-144240 Poshi Automation for Bug LPS-141570
- LPS-144240 SF
- LPS-144240 Simplify case
- LPS-144732 Avoid null pointer exception  (if the user has been deleted for the DB the authorProfileImage is null).
- LPS-144732 The userId should be the same that the one for the portrait URL.
- LPS-144732 Add test.
- LPS-145615 - Dialect theme breaks for RTL due to theme compiler bug.
- LPS-145391 - Color Chart 1 is duplicated in Dialect Style Book.
- LPS-145443 - Release frontend-theme-dialect-style-guide-sample-web.
- LPS-145196 Add tests for blogs friendlyURL history assertions on staging site
- LPS-145196 Make filenames less verbose
- LPS-145196 Update usages
- LPS-145196 Add blogs property so ci:test:relevant query picks it up
- LPS-144823 Remove step about the closing message to stabilize test
- LPS-144939 Adapt Images after upgrade
- LRCI-2747 Update the shielded-container-lib portal dir when changing the tomcat version
- LPS-145461 Reactivate test
- LPS-105380 Project dependencies '.*-rest-client' can only be used for 'testIntegrationCompile'
- LPS-145803 Fix path to sidebar title
- LPS-145648 portal-kernel don't index empty keyword fields
- LPS-145648 portal-kernel: correct stream use
- LPS-144038 Tests related to the Content Performance panel in the Content Dashboard
- LPS-144038 Change ignore parameter to false
- LPS-144038 SF
- COMMERCE-7829 commerce-product-api autogenerated code (gw buildService)
- LPS-144038 Change function name from CloseContentPerformancePanel to CloseMetricsPanel
- LRQA-72094 Investigate CI failure of FormsSubmissions#CanBePartiallyFilledWithRequiredFields
- LPS-123845 Remove odata-v4-parser library
- LPS-123845 Remove translateQueryToCriteria use
- LPS-123845 Check conjunction name in lowercase
- LPS-123845 Localize true/false values
- LPS-123845 Fix tests
- LPS-123845 Fill initialQuery with the right structure, so we avoid calling the parser in the frontend side.
- LPS-123845 Add test.
- LPS-123845 Fix wrong reflexion method name in test call
- LPS-123845 Modify poshi test according to changes
- LPS-123845 #sfme
- Revert "LPS-137761 as used"
- Revert "LPS-137761 Renames CKEditorSampleConfigContributor -> CKEditorSampleEditorConfigContributor"
- Revert "LPS-137761 Fix the behaviour of closing properly liferayToolbars of CKEditor"
- Revert "LPS-137761 When clicking outside editor's area, it will hide (liferay/insert)Toolbars"
- Revert "LPS-137761 Remove unused"
- Revert "LPS-137761 Enable Balloon Editor in the sample module"
- Revert "LPS-137761 Apply review suggestions"
- Revert "LPS-137761 Adds a feature flag for enabling balloonEditor"
- Revert "LPS-137761 Make window available methods created from Editor component"
- Revert "LPS-137761 Adds ballooneditor configuration conditionally"
- Revert "LPS-137761 Source Formatting"
- Revert "LPS-137761 Adds support for ballooneditor on blogs-web"
- LRAC-10380 Fix tests adding login with test test user
- LRAC-10380 Fix SortTheResultsAnalysisAfterRearrangingBreakdowns changing the number of attributes
- LRAC-10380 Fix CheckTotalAndUniqueAndAverageChartDataIsShown adding closeAllSessions macro after send event
- LRAC-10154 [Enable] Ignored tests related to forms
- LRQA-72639 Investigate: Element not present in FormsFields#CanBeSubmittedWithAllFields
- LPS-143830 Override the UpgradeProcess.upgrade() method
- LPS-143830 Add back logging for PortalUpgradeProcess
- COMMERCE-8132 Add Configuration for checkout requested delivery date
- COMMERCE-8132 Add requested delivery date to checkout
- COMMERCE-8132 Add lang keys
- COMMERCE-8132 Regen
- COMMERCE-8132 BuildLang
- COMMERCE-8132 SF
- LPS-145863 Quarantine failing upgrade tests due to COMMERCE-8225
- LPS-145205 - Update alloy to 3.1.0-deprecated.90
- LPS-143628 Remove CurrentConnectionUtil usages in modules
- LPS-143628 Modify util-spring to expose CurrentConnection corresponding to OSGi service need
- LPS-143628 Modify SF to make sure CurrentConnectionUtil is no longer in modules
- LPS-143628 Remove EditorConfigurationFactoryUtil usages in modules
- LPS-143628 Modify SF to make sure EditorConfigurationFactoryUtil is no longer in modules
- LPS-143628 Remove GhostscriptUtil usages in modules
- LPS-143628 Modify util-spring to expose Ghostscript corresponding to OSGi service need
- LPS-143628 Modify SF to make sure GhostscriptUtil is no longer in modules
- LPS-118195 Uses new icon defined by Lexicon
- LRQA-71807 Test fix of SikuliClick
- LRQA-71807 SF
- LPS-139770 Add ViewTranslatedPicklistItemNameOnObjectLayout test
- LRAC-10060 [Enable] Ignored tests related to blogs
- LRAC-10060 Removing the passed tests from quarantine
- LPS-141822 Add EntriesAreNotDeletedWhenFormIsDeleted test
- LPS-145834 search-experiences-service: Remove BlogsEntry because of IndexerPostProcessorRegistryTest failing
- LPS-145834 search-experiences-service: Remove trailing slash
- LRQA-70863 Create test to assert LES can be disabled
- LPS-138464 Apply setResultsAndTotal pattern (additional places).
- LPS-138464 Apply SearchOrderByUtil pattern.
- LPS-138464 SF
- LPS-145441 Add tests for ContentDashboardGroupUtil.
- LPS-145441 When the descriptive name is null, the name should be returned.
- LPS-145441 SF
- LPS-144839 add test with the mimeType when returning folder content
- LPS-144839 add test to check DLFolderUtil new method
- LPS-144839 add test to check th return the folder in the results of the search
- LPS-144839 add test to check if the folder is no contained on the group do not return values
- LPS-144839 rename variables to meet the types
- LPS-144839 SF
- LRAC-10433 Add the option to change the year value in addFilter macro
- LRAC-10433 Add a new parameter in the test that use the addFilter macro
- LPS-137778 Bring keyboard events to openModal when an iframe is inserted there
- LPS-144271 Create project structure
- LPS-144271 Importmaps contributor API
- LPS-144271 Import maps implementation
- LPS-144271 Don't render importmaps if not needed
- LPS-144271 Namespace npm package
- LPS-144271 Rename for consistency
- LPS-144271 SF
- COMMERCE-8219 removed unused modules
- COMMERCE-8161 setup commerce term modules
- COMMERCE-8161 define service.xml
- COMMERCE-8161 set description as CLOB
- COMMERCE-8161 build services
- COMMERCE-8215 Removed unnecessary classes
- COMMERCE-8215 Added new entity
- COMMERCE-8215 Added new constants
- COMMERCE-8215 Added new configuration
- COMMERCE-8215 Added new method to commerce term entry implementation
- COMMERCE-8215 Added commerce term entry permission checker
- COMMERCE-8215 Added new commerce term web module skeleton
- COMMERCE-8215 Added commerce term portlet and portlet provider
- COMMERCE-8215 Added resource actions
- COMMERCE-8215 Added commerce term entry rel local and remote service implementation
- COMMERCE-8215 Added commerce term entry local and remote service implementation
- COMMERCE-8215 Remove empty package export
- COMMERCE-8215 Added required dependencies
- COMMERCE-8215 Added commerce term entry model and portlet resource permission
- COMMERCE-8215 Added commerce term entry workflow handler
- COMMERCE-8215 Added commerce term entry message listener
- COMMERCE-8215 Added model index contributors
- COMMERCE-8215 Added model query contributor
- COMMERCE-8215 Added model result contributors
- COMMERCE-8215 Added commerce term entry searcher and registrar
- COMMERCE-8215 Fixed test module dependencies
- COMMERCE-8215 Fixed service module bnd file
- COMMERCE-8215 Build lang
- COMMERCE-8215 Regen services
- COMMERCE-8215 Semantic versioning (gw baseline)
- COMMERCE-8215 Sort constants first, then free form text
- LPS-137761 Adds support for ballooneditor on blogs-web
- LPS-137761 Source Formatting
- LPS-137761 Adds ballooneditor configuration conditionally
- LPS-137761 Make window available methods created from Editor component
- LPS-137761 Adds a feature flag for enabling balloonEditor
- LPS-137761 Apply review suggestions
- LPS-137761 Enable Balloon Editor in the sample module
- LPS-137761 Remove unused
- LPS-137761 When clicking outside editor's area, it will hide (liferay/insert)Toolbars
- LPS-137761 Fix the behaviour of closing properly liferayToolbars of CKEditor
- LPS-137761 Renames CKEditorSampleConfigContributor -> CKEditorSampleEditorConfigContributor
- LPS-137761 as used
- LPS-137761 Bring back the forward reference of Editor/CKEditor base component
- LRCI-2605 Transition TCK test class groups over to Job Property objects
- LRCI-2605 Transition Plugins test class groups over to Job Property objects
- LRCI-2605 Transition Modules test class groups over to Job Property objects
- LRCI-2605 Clean up some of the code in the JUnit batch test class group
- LRCI-2605 Move segment test class groups over to Job Property objects
- LRCI-2605 Add a job property method that has the test suite name & test base dir
- LRCI-2605 Add globs to the JSONObject within a batch test class group
- LRCI-2605 Remove unused method in Testray Routines
- LRCI-2605 Add method to check if a specific batch is in the stable suite
- LRCI-2605 Add the pql_query in the JSONObject for functional test class groups
- LRCI-2605 Avoid reading files & finding files if the base files do not exist
- LRCI-2605 prep next
- LRQA-72650 Add click step for Roles Permissions Navigation
- LRQA-72650 Remove variable that was already declared
- LRQA-72650 Use correct locator
- LRAC-10440 Add CanHideDefaultAndCustomEvent testcase to run isolated
- LRAC-10440 Update hideCustomEvent macro
- LRAC-10437 Add searchBar macro in the test
- LRAC-10435 Change the max iterations
- LRAC-10434 - [Disable] tests
- LRAC-8176 - [Add] tests to quarantine
- LPS-145842 Fix the confirmation dialog when deleting an object entry
- LPS-145646 Inclusion of script field for condition node
- LRAC-8176 - [Remove] test from quarantine
- LRAC-8176 - [Add] test to quarantine
- LRAC-8176 These two tests will pass on Release branch routine since it is okay on 3.0.x (LRAC-10445), so let's keep them
- LRAC-8176 This tc is fixed by LRAC-10446, so let's keep it
- Bump to avoid conflict with 7.3.x
- LRCI-2751 Shift over to https for wildfly downloads
- LPS-144839 my bad
- LPS-141511 Add CanViewEntryWithOneColumn test
- LPS-140560 Add CanEditPicklistEntryOnLayout test
- LPS-141654 Add CannotSubmitEntryWithInvalidValueOnRelationshipField test
- LPS-141606 Add CanUpdateObjectWithUpdatePermission test
- LPS-142648 After migration to data engine the field type ddm-geolocation change to geolocation
- LPS-142648 After migration to data engine the name of coordinates is lat and lng instead of latitude and longitude
- LPS-142648 Removes unnecessary code since it is not used
- LPS-142648 Avoid rendering the template of journal to get the summary, since in some cases this value can cause js problems
- LPS-145917 Remove usage of GlobFilenameFilter
- LPS-145917 Inline
- LPS-145917 Hide type
- LPS-145917 Extract ccpp api and impl to modules.
- LPS-145917 Remove from lib dependencies
- LPS-145917 Remove from gitignore
- LPS-145917 Remove from IDE files
- LPS-145917 Remove from versions
- LPS-145917 ant build-lib-versions
- LPS-145658 Update commons-lang3 to latest version
- LPS-145658 Build lib versions
- LPS-141234 Add macro to verify all custom remote app fields are present after upgrade
- LPS-141234 Add test to verify custom remote app is present on content page on upgraded from 7.4.13
- LRCI-2671 Update com.liferay.jenkins.results.parser to 1.0.981 for gradle-plugins-testray
- LRCI-2671 prep next
- LPS-143628 prep next
- LPS-143628 LRCI-2671 prep next
- LPS-77699 Update Translations
- LPS-145836 Updating Dialect Style Book to fix colors
- LPS-145836 SF
- LRQA-72362 Move the macro to the suitable file
- LRQA-72362 Rename the macros name
- LRQA-72362 Move the localtors to right file
- LRQA-72362 Add more conditions for viewing conflicting change details
- LRQA-72362 Add a macro to view change details in Data
- LRQA-72673 Add a condition for viewing DDL record change details
- LRQA-72362 Update the locators name to more specific
- LRQA-72362 Add macro to view change details in Display
- LRQA-72362 Move the macros and locators to publications change details file
- LRQA-72362 Add macros to view publications change details in Parents and Children
- LRQA-72362 Add macro to goto change details Navbar
- LRQA-72362 Add a condition to make sure the display item
- LRQA-72362 Add a new test to view publications change details
- LPS-143802 (headless-admin-user-impl): Implements getObject on UserGroupResourceDTOConverter
- LPS-143802 (headless-admin-user-impl): Schema: Adds new GET endpoint for user group by external reference code
- LPS-143802 (headless-admin-user): Autogenerated: buildRest
- LPS-143802 (headless-admin-useer): Implements getUserGroupByExternalReferenceCode
- LPS-143986 (headless-admin-user-impl): Adds actions
- LPS-143802 (headless-admin-user-test): Implements tests
- LPS-143802 SF
- LPS-143802 (headless-admin-user-api): Baseline
- LPS-143802 (portal-impl): Adds new remote method fetchUserGroupByExternalReferenceCode
- LPS-143802 (liferay-portal): Autogenerated: buildService
- LPS-143802 (liferay-portal): packageinfo
- LPS-143802 (portal-impl): Implements fetchUserGroupByExternalReferenceCode
- LPS-143802 (headless-admin-user-impl): Adds exception mapper NoSuchUserGroupExceptionMapper
- LPS-143802 match modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/jaxrs/exception/mapper/NoSuchDataLayoutExceptionMapper.java
- LPS-138464 Apply setResultsAndTotal pattern (some more places).
- LPS-138464 Fix bug. Use orderByCol to calculate orderByAsc.
- LPS-138464 Apply SearchDisplayStyleUtil pattern.
- LPS-138464 SF
- LRQA-72375 Add the new test for default locale web content
- LPS-139040 Fix macro name viewEntriesTable
- LPS-139040 Add CanDefineFixedFilterForPicklistType test
- LPS-139040 Add negative assertion
- LPS-139769 Add CanSetDifferentPicklistItemNameLanguage test
- LPS-141662 Add CanRelateManyOtherEntriesBothObjects test
- LPS-141662 SF
- LPS-145977 search-experiences-rest-api: Fix context.language_id
- LRQA-72772 - Fix CanOrderByResource test
- LPS-145950 search-experiences-service: Don't cache invalid responses. Tie cache key to API key and URL
- LPS-145950 Simplify
- LPS-144028 Test Autom. Content page metrics
- LPS-145565 Improve teardown of tests related to content performance
- LPS-145565 Change test to use UI for DPT creation
- LPS-145951 Modify case
- LPS-145957 Modify case
- LRAC-10438 Send tracking for webContentViewed only the first time the web-content is in the viewport
- LPS-145940 Uses statusByUserName as modifier user instead of userName.
- LPS-145940 Don't need the first article version to know who is the author, since the LPS-131848 changes you can get it from the userName field of any article version.
- LPS-145204 Extended localizations saving text before user modifies input
- LPS-145204 Replaced comparison from defaultLocale to locale since defaultLocale might not be populated.
- LPS-145204 Removed defaultLocale since is no longer used.
- LPS-145357 If we have the UUID in the JSONObject, we should check the uuid from the JSONObject against the UUID from the Missing Reference to see if they match up. Otherwise, we'll just be arbitrarily picking the last Layout Missing Reference, which won't necessarily pick the right Layout if there are multiple Layout Missing References.
- LPS-125991 COMMERCE-8229 fix with the correct name
- LPS-145977 search-experiences-web: Fix "User's Language" option for field name input
- LRQA-72793 Investigate CI failure of ImageField#UploadImageFromDocumentsAndMedia
- LPS-145418,LPS-145417,LPS-144110,LPS-144853,LPS-145419,LPS-145065,LPS-145421,LPS-145420,LPS-145505,LPS-145504 Fix Objects quarantined tests
- LPS-139040 Fix Objects Poshi tests
- COMMERCE-7950 Add path to Display Page Item Remove
- COMMERCE-7950 Add macro to remove Product Display Page
- COMMERCE-7950 Add test to verify user selects, changes and removes a Default Product Display page by navigating to channels page
- LPS-145215 Update language keys
- LPS-145215 buildLang
- LPS-145215 Update poshi tests
- LPS-105380 Sort ThemeDisplay.set* calls
- LPS-105380 Auto SF
- LPS-139938 Auto SF
- LPS-144839 SF, add an empty line, as we finished referencing variable 'serviceContext'
- LPS-145984 Add loading indicator to the add site modal
- LPS-145784 Don't add friendly url entry when on staging
- LPS-145784 Update mapping for both new and existing friendly URLs
- LPS-145567 Pass disabled to react and allow render when is disabled
- LPS-145567 Add MutationObserver to suscribe on input disabled attribute changes
- LPS-145567 Baseline
- artifact:ignore commerce-tax-engine-fixed-service 4.0.14 prep next
- artifact:ignore frontend-data-set-web 1.0.11 prep next
- artifact:ignore search-experiences-rest-api 1.0.2 prep next
- artifact:ignore search-experiences-service 1.0.2 prep next
- LPS-141823 Add CanSubmitEntryWithDoubleFieldBlank test
- LPS-139768 Change macro name to addLanguageOnPicklistItem
- LPS-139768 Add CanSetDifferentPicklistNameLanguage test
- LPS-145832 Fix test for JournalArticles w/ multiple translations
- LPS-145832 Fix test JournalArticleMultiLanguageSearchGroupIdsTest.testSearchEverything
- LPS-144442 SF, rename variable names
- LPS-144442 SF, rename variable names
- LPS-144442 SF, rename variable names
- LPS-144442 Auto SF
- LPS-144442 SF, rename variable names
- LPS-144442 Auto SF
- LPS-144442 SF, rename variable names
- LPS-144442 SF, rename variable names
- LPS-144442 SF, rename variable names
- LPS-144442 Auto SF
- LPS-144915 Add CP 2.0 Properties for Poshi Tests
- LPS-144915 SF
- LPS-144915 Add setUp for CP 2.0
- LPS-144915 SF
- LPS-144915 Add path, macro and testcase stub
- LPS-144915 SF
- LPS-144915 Fix TearDown
- LPS-144915 SF
- LPS-144915 Fix CP macro
- LPS-144915 Fix setup and teardown in testcase
- LPS-144732 Fix order: we will sort the assert statement by the expected parameter
- LPS-144732 SF
- LPS-145716 Add CanCreateAction test
- LPS-145897 Calculate formattedDate correctly for all translations
- LPS-144473 Move pencil icon to USERS for consistency
- LPS-144473 Add method to mark entries are not relevant in order to not show the Control Menu if there is not at least one relevant entry
- LPS-144473 Baseline
- LPS-144473 Make use of the new method
- LPS-144473 Mark the Layout Header as not relevant
- LPS-144473 Mark as relevant when in edit mode
- LPS-144473 Add SF exception to be able to pass HttpServletRequest as parameter
- LPS-144473 Update case
- LPS-145931 Update the config file name
- LPS-145941 Add property to skip instance
- LPS-145938 Fix typo
- LPS-145935 Modify macro to make it reusable
- LPS-145935 Update usage
- LPS-145934 Update parameter name
- LPS-145942 Add missing step
- LPS-145656 Change object schema to improve integration for Setup DXP Cloud Environment
- LPS-145656 Open Setup DXP Cloud throught the modal in ActivationStatus Page
- LPS-145656 SF
- LPS-145165 Change behavior to save select input in DXP Cloud Form
- LPS-145165 Remove product title to DXP and DXP Cloud request
- LPS-145165  Fix role validations to redirect pages
- LPS-145165  Fix icon to commerce_icon.svg
- LPS-145165 SF
- LPS-145656 upload
- LPS-145621 Add course display pages to Masterclass main navigation
- LPS-145621 Adds missing assignment
- LPS-145930 Modify case to use Search template
- LPS-145932 Fix typo
- LPS-144234 Poshi Automation for Bug LPS-142166
- LPS-144234 Migrate case to ContentDisplay
- LPS-144234 Modify descriptions and task messages
- LPS-141756 Poshi Automation for Bug LPS-137055
- LPS-141756 Modify description
- LPS-141756 Rename case
- LPS-141756 Modify task messages
- LPS-141756 Use assertElementNotPresent
- LPS-141756 Auto SF
- LPS-142866 Add Role component references to SelectAssignment.js
- LPS-142866 Create Role assignment type component
- Revert "LPS-135604 Creating unit test to verify if numeric predefined value persists"
- Revert "LPS-135604 Synchronizing text field value"
- Revert "LPS-135604 Update field affected by calculate rule using predefined value"
- Revert "LPS-135604 Setting predefined value in the field update"
- Revert "LPS-135604 Updating correctly field affected by calculate rule"
- Revert "LPS-135604 Setting localizedValue from the current field"
- Revert "LPS-145842 Fix the confirmation dialog when deleting an object entry"
- LPS-145842 Fix confirmation dialog, while preserving forward of the entire `action` object to dropdown item click callback
- COMMERCE-8099 - Reordering a product with options causes mini-cart error
- COMMERCE-7905 add dependency with account-api
- COMMERCE-7905 fixed the find of the billing address
- COMMERCE-7905 fixed the find of the shipping address
- COMMERCE-8198 Fix order type rel condition
- LPS-145893 Migrate FDS displays in `remote-app-web`
- LPS-145893 Like this
- LPS-143303 Separate logic in two methods. The first one creates the empty layouts (just the entities), and the second populates them with data. This way we can reference the layouts in the data, such as link to pages and other logic
- LPS-143303 SF
- COMMERCE-8262 make requested delivery date optional
- LPS-145659 When displaying the summary of a process, make it possible to get the selected Layout IDs not just for a local staging process, but a remote one as well.
- LPS-145659 Use the languageId to query the parent page's name. Otherwise, we just get the whole XML containing the page name in every translation.
- LPS-145731 Remove ObjectForms#FormWithInactivatedObjectCannotBeUsed test
- LPS-139768 Change additional instance of previously changed macro
- LRAC-7890 Remove bug ticket message
- LRAC-8176 [Remove] ViewAllDocumentsAndMediaShownInAssetList from quarantine
- LRAC-10452 Add while loop in blockCustomEvent macro to search the event
- LRAC-10452 Add while loop in unblockCustomEvent macro to search the event
- LRAC-10452 Add while loop in unhideEvent macro to search the event
- LRAC-10450 Fix setUp adding lauchDXP macro that was missing
- LRAC-10450 Fix CanChangeRetentionPeriod with launchAC macro that was missing
- LRAC-10451 Change the attribute name to one that is not present in another test
- LRAC-10451 Change the edit option
- LRAC-8176 - [Add] tests to quarantine
- LRAC-10434 - [Disable] test
- LPS-140729 Change ObjectPortlet#StringDisplayedOnAutoGeneratedTable test to add the limit of characters
- LPS-145352 Improve CreateObject#RelationshipTabReappearsWhenReactivatedManyToMany test
- LRCI-2566 Change default browser Testray value to Chrome 86
- LPS-145945 Fix WebContentDisplayPortlet.viewContent failure after LPS-130552
- LPS-145969 Update Web Content description translation
- LPS-145965 Use suitable xpath
- LRQA-72775 Include Language Override tests in ci:test:usm
- LPS-145772 Create MobileContainer to wrap content
- LPS-145772 Move steps and selectedStep to context
- LPS-145772 Use steps from context
- LPS-145772 Rewrite logic for FormActions to handle mobile and large screen
- LPS-145772 Use MobileContainer for basics form
- LPS-145772 SF
- LPS-145772 Force Validation when the page loads with MobileContainer
- LPS-145772 Use Variables
- LPS-145772 upload
- LRQA-72567 Add permissions test for page tree
- LPS-144642 Update transitions references when changing a node id
- COMMERCE-8133 account-api added new action key for addresses
- COMMERCE-8133 account-service added support to new addresses actions
- COMMERCE-8133 commerce-account-service added support for new addresses actions
- COMMERCE-8133 commerce-checkout-web check permission on addresses
- COMMERCE-8133 manage guest account
- COMMERCE-8133 commerce-checkout-web added imports
- COMMERCE-8133 account-api semantic versioning (gw baseLine)
- COMMERCE-8133 SF
- LPS-144666 extract method to the display context
- LPS-144666 avoid NPE if external repository as sharepoint
- LPS-144666 In the case of the repository is not the same than the selected, change not only folder id, repository id too
- LPS-144666 avoid NPE if no modified date
- LPS-144666 show correct entries not the scoped group
- LPS-144666 On the case of there is no repository selected and if you try to access to a sharepoint folder, the folders are not listed because repository is the one of the site not of the repository
- LPS-144666 when selecting a external repository folder, the repository is not refreshed
- COMMERCE-8216 Fixed commerce term entry local service implementation
- COMMERCE-8216 Added new schema and endpoints
- COMMERCE-8216 Added required dependencies
- COMMERCE-8216 Added new dto converter
- COMMERCE-8216 Added term entity model
- COMMERCE-8216 Added term resource implementation
- COMMERCE-8216 Added integration tests
- COMMERCE-8216 Regen REST
- COMMERCE-8216 Inline
- COMMERCE-8216 #sfme, just for localization tables, follow order in modules/apps/commerce/commerce-term-api/src/main/java/com/liferay/commerce/term/model/CTermEntryLocalizationTable.java
- COMMERCE-8216 us used
- LPS-143303 New element that allows several field references, not only one. Will be used for composite keys
- LPS-143303 Include reference for mapping
- LPS-143303 Adds to schema validation
- LPS-143303 Pass context in methods since we have the layout and related information is needed
- LPS-143303 Change so that we export the friendlyURL of the layout instead of the plid
- LPS-143303 Take into account new properties when importing. Importing by friendlyURL will give more flexibility than by plid
- LPS-143303 Cast to interface
- LPS-143303 Move test resources to plid folder
- LPS-143303 Adapt expected output values for Page Definition with PLID
- LPS-143303 Test resources for Page Definition with Friendly URL
- LPS-143303 Adapt existing test importing Page with PLID
- LPS-143303 Add test importing Page with friendly URL
- LPS-143303 buildREST
- LPS-145795 The pkObjectFieldName of a native object does not have 'c_' at the beginning, so the relationshipIdName must be the last string after the last underline
- LPS-145802 Create new method to update only the TitleObjectFieldId property
- LPS-145802 buildService
- LPS-145802 Enable the user to edit only the TitleObjectFieldId property for native objects
- LPS-145802 Include dbColumnName when creating native object fields and change the object field name to match the UserDTO
- LPS-145802 Fix test
- LPS-145802 should be primitive
- LPS-145802 regen
- LPS-145802 don't trust as much
- LRQA-72579 View in context translated WC with FriendlyURL
- LRQA-72631 Assert URL contains delta by dropdown pagination
- LPS-142278 Should download into shielded container lib dir
- LPS-142278 Should copy portal jars from shielded container lib dir in BaseAutoDeployer
- LPS-142278 Remove old logic that sets LIFERAY_LIB_PORTAL_DIR by servlet context; shielded container dir is already set this way. Also, this was added by LPS-52665 to resolve JRuby issue when deploying portal using unexploded war - JRuby is no longer used and our customer facing documents never mention using unexploded war now.
- LPS-142278 Remove sysproperty for portal lib dir, this was added by LPS-65693 (a161a2a957de85c3eb6591d7921ca082a628a9a4) for integration tests in core, but these tests have been moved to modules.
- LPS-142278 Remove this, as long as no unit test fails we don't replace it with shielded container lib dir
- LPS-142278 Remove initialization logic these properties; this will also fix LPS-142277
- LPS-142278 SF, inline
- LPS-142278 Replace BACK_SLASH with SLASH for shielded container system property, so other properties can benefit from it; the paths obtained by _getLibDir() does not need this.
- LPS-142278 Remove LIFERAY_LIB_PORTAL_DIR
- LPS-142278 Remove WebDirDetector as no one is using it
- LPS-142278 Also remove LIFERAY_LIB_GLOBAL_DIR
- LPS-142278 Add integration test
- LPS-142278 Semantic versioning
- LPS-142278 Good enough
- LRQA-72676 Add the test for executing the script
- LPS-77699 Update Translations
- LPS-125991 COMMERCE-8229 CommerceAddress and CommerceAddressRestriction
- LPS-145971 Update liferay-ckeditor to 4.17.1-liferay.1
- LRAC-10446 Add clickAnyButton macro to discart analysis change
- LPS-146038 Modify case
- LPS-146043 Modify case
- LPS-137277 Remove not needed ignore annotations
- LRQA-72790 Use FormsAdmin.deleteForm macro to delete form
- LRQA-72790 Remove the unused macro
- LPS-144538 - Add text to bulk actions in lg screens
- LPS-143025 setting field name length to 255
- LPS-143025 build service
- LPS-143025 adding upgrade process to increase field name length
- LPS-144442 SF, rename variable names
- LPS-144029 Test Autom: Widget page metrics
- LPS-105380 Make it more flexible
- LPS-105380 Move logic to method, no logical changes
- LPS-105380 Use while statement
- LPS-105380 Show line number
- LPS-105380 Enable for master
- LPS-105380 prep next
- LPS-105380 prep next
- RELEASE-4694- Update release properties for U6 and GA10
- LPS-145994 Consider TermQuery filters to adapt the filter to the new DDM indexing way
- LPS-145994 Sort
- LPS-138634 Add post-upgrade tests to StagingUpgrade.testcase
- LRCI-2605 Add target to record the job summary
- LRCI-2605 Update com.liferay.jenkins.results.parser to 1.0.981
- LRCI-2605 Update references for com.liferay.jenkins.results.parser to 1.0.981
- LPS-135625 Remove unused SCREEN_NAME cookie
- LPS-135625 Remove unused USER_UUID cookie and related classes. These classes were deprecated in LPS-70680.
- LPS-135625 Versioning
- LPS-135625 add to VerifyProperties
- LRQA-72807 Quarantine from search suites
- LPS-142293 Update relevant from tango modules
- LPS-142293 SF
- LPS-145507 Fail when importing a translation for another group
- LPS-145507 Build lang
- LPS-145507 Baseline
- LPS-134692 Make sections collapsables in the info panel
- LPS-134692 Update tests snapshots
- LPS-134692 Refactor of SidebarPanelInfoView component adding new SidebarPanelCollapsibleSection component
- LPS-134692 Categories section expanded by default
- LPS-134692 Move SidebarPanelInfoView components to SidebarPanelInfoView folder
- LPS-134692 Remove unnecessary property
- COMMERCE-7988/8210 batch-engine-service java test deleted testReadRowsWithCommaInsideQuotes test now redundant
- COMMERCE-7988 batch-engine-service - TEST - fix compile time error
- COMMERCE-7988 batch-engine-service - TEST - update CSV reader test to try out all delimiters and enclosing characters
- COMMERCE-7988 wordsmith
- LPS-145705 Add CanUpdatePicklistName test
- LPS-145059 Only update the form settings if they exist
- LPS-145059 Allow mocks be manipulated by unit tests
- LPS-145059 Add unit test
- LPS-137072 COMMERCE-8229 fix RemoteAppEntry v1_0_1
- LPS-139707 COMMERCE-8229 fix RemoteAppEntry v2_0_0
- LPS-136999 COMMERCE-8229 fix RemoteAppEntry v2_2_0
- LPS-143120 COMMERCE-8229 fix RemoteAppEntry v2_4_0
- LPS-146133 Remove portal fabric
- LPS-146133 Remove portal resiliency and intraband
- LPS-146133 Semantic versioning
- LPS-146133 Remove old dependency to avoid bnd importing out of date package.
- LPS-145710 Add CanSearchAction test
- LPS-145764 Add CanEditItsOwnEntryWithOnlyAddPermission test
- LPS-145754 Add CannotAddPicklistWithoutAddPermission test
- LPS-145763 Add CanViewItsOwnEntryWithOnlyAddPermission test
- LPS-141637 Add CreateObject test
- LPS-141637 SF
- LRQA-72783 Add full stop for testcases
- LPS-145718 Add CanDeleteAction test
- LPS-141640 Add CreateObject test
- LPS-141640 SF
- LPS-141640 Fix test
- LPS-145708 Add CanUpdatePicklistItemName test
- LRQA-72817 Turn off the test for release bundles
- LRQA-72832 Add Blueprint test to acceptance and environment layer
- LPS-145990 Add testcase to assert users langauge option works in default blueprints element
- LPS-145990 Simplify steps
- LPS-145990 Rename test and add description
- LRCI-2605 Remove last references to job properties within test class groups
- LRCI-2605 Remove last references to job properties within job classes
- LRCI-2605 Enable the report jobs to run locally
- LRCI-2605 Record job properties within Job & BatchTestClassGroup objects
- LRCI-2605 Rename batch properties to job propertiess within job summary
- LRCI-2605 Fix finding base functional queries in relevant pulls
- LRCI-2605 SF
- LRCI-2756 Fix finding the QA Webistes functional batch query
- LRCI-2756 prep next
- LPS-145619 Set activeAutocomplete to false when an option is selected in the dropdown
- LPS-145619 Disable token colors in the dropdown when two tokens are mutually referenced
- LPS-145619 Update token values in the dropdown when a token is modified
- LPS-145619 Adapt tests
- LPS-145619 Remove not needed waitFor
- LPS-145619 Fix test warning
- LPS-145283 Copy type settings also for manual collections
- LPS-145283 Check if the type settings are copied from default segments entry when we are creating a new variation
- LPS-144073 (roles-admin-api): Adds new method getExcludedPanelAppKeys
- LPS-144073 (account-admin-web): Implements getExcludedPanelAppKeys
- LPS-144073 (roles-admin-api): Adds new key EXCLUDED_PANEL_APP_KEYS
- LPS-144073 (roles-admin-web): Adds excluded panel app keys on the request
- LPS-144073 (roles-admin-web): Checks for excluded panel app keys on navigation
- LPS-144073 (roles-admin-api): Baseline
- LPS-143986 (headless-admin-user-impl): Schema: Adds new DELETE endpoint for user group by external reference code
- LPS-143986 (headless-admin-user): Autogenerated: buildRest
- LPS-143986 (headless-admin-user-impl): UserGroupResourceDTOConverter: Implements getUserGroupId
- LPS-143986 (headless-admin-user-impl): Implements deleteUserGroupByExternalReferenceCode
- LPS-143986 (headless-admin-user): Adds actions
- LPS-143986 (headless-admin-user): Adds missing Override
- LPS-143986 (headless-admin-user-test): Implements tests
- LPS-145621 Test for names of the navigation menus for URL and NODE types
- LPS-144694 Should use the property set by the <condition> task
- LPS-145918 Remove from lib dependency
- LPS-145918 Remove from gitignore
- LPS-145918 Remove from IDE files
- LPS-145918 Remove from versions
- LPS-130552 Migrate macros in Content file to WidgetPages and update usages
- LPS-130552 Refactor viewEnabledFileTypesPGViaWCD macro and update usage
- LPS-130552 Refactor macros to use general locator and update usage
- LPS-130552 Migrate case from WebContentDisplay to AssetPublisherUseCase file
- LPS-130552 Migrate cases from WebContentDisplay to LocalizationWithWebContent
- LPS-130552 Migrate case from WebContentDisplay to WidgetPages file
- LPS-130552 Add steps and task message in setUp and tearDown
- LPS-130552 Refactor cases in WebContentDisplayWithStaging file
- LPS-130552 Refactor cases in WebContentDisplay file
- LPS-130552 Rename cases
- LPS-142927 Add xpath about bulk translation
- LPS-142927 Add macros about bulk translations
- LPS-142927 Update macro to make it work for bulk translations
- LPS-142927 Add tests about bulk translations
- LPS-142927 Update test to export via bulk translation
- LPS-142927 Duplicate with import tests
- LPS-142927 Add feature flags
- LPS-142927 Translate to Japanese
- LPS-142927 Assert three translation files status
- LPS-142927 Update icon names after LPS-145442
- LPS-142927 Remove annotations because they are not part of the SACRED refactoring project
- LPS-145948 Use the theme display if possible to get the port and server data from theme display and avoid getting it from _portalServerInetSocketAddress (since it depends on the first server call)
- LPS-145948 minor SF
- LRCI-2748 Do not download a fixpack dependency if using sp[0-9] format
- LRCI-2748 Disable the verify patch level process when using sp[0-9] patch dependencies
- LPS-145073 Unable to add data template script to the <head/> section of a portal page via HeaderResponse.addDepency(name,scope,version,xml)
- LPS-145073 Unable to add data template script to the <head/> section of a portal page via HeaderResponse.addDepency(name,scope,version,xml)
- LPS-145073 Use string contants
- LPS-145073 No need to catch exception to assert failure, just let it bubble up.
- LPS-145073 Don't pollute console output with the expected error message.
- LPS-145073 SF
- LPS-145885 Add target groupId info in portletURL
- LPS-146073 Create feature flag
- LPS-145899 Value should not be taken from ObjectEntry table if it is a native object. Get column value in native object table
