### PR TITLE
LPS-146404 Do not allow removing object entries of one type from the API of another

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
+++ b/modules/apps/object/object-dynamic-data-mapping/src/main/java/com/liferay/object/dynamic/data/mapping/internal/storage/ObjectDDMStorageAdapter.java
@@ -103,7 +103,8 @@ public class ObjectDDMStorageAdapter implements DDMStorageAdapter {
 				objectDefinition, objectEntryId);
 
 			if (objectEntry != null) {
-				_objectEntryManager.deleteObjectEntry(objectEntry.getId());
+				_objectEntryManager.deleteObjectEntry(
+					objectDefinition, objectEntry.getId());
 			}
 
 			return DDMStorageAdapterDeleteResponse.Builder.newBuilder(

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 2.1.1
+Bundle-Version: 3.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.manager.v1_0,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -40,7 +40,9 @@ public interface ObjectEntryManager {
 			ObjectEntry objectEntry, String scopeKey)
 		throws Exception;
 
-	public void deleteObjectEntry(long objectEntryId) throws Exception;
+	public void deleteObjectEntry(
+			ObjectDefinition objectDefinition, long objectEntryId)
+		throws Exception;
 
 	public void deleteObjectEntry(
 			String externalReferenceCode, long companyId,

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -122,7 +122,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 
 	@Override
 	public boolean deleteDTO(long id) throws Exception {
-		_objectEntryManager.deleteObjectEntry(id);
+		_objectEntryManager.deleteObjectEntry(_objectDefinition, id);
 
 		return true;
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -103,7 +103,7 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 	@Override
 	public void deleteObjectEntry(Long objectEntryId) throws Exception {
-		_objectEntryManager.deleteObjectEntry(objectEntryId);
+		_objectEntryManager.deleteObjectEntry(_objectDefinition, objectEntryId);
 	}
 
 	@Override


### PR DESCRIPTION
As the ObjectEntryService does not check the type of object (object definition) and the objectEntryIds are unique, and neither do the APIs, now it is possible to delete or update an objectEntryId from the API of another Object.

I've added checks to be sure that the objectDefinitionId is the same as the API's one to avoid this issue.

Although is an API issue, I have preferred to send it to you first because I modify the deleteObjectEntry method and cause a breaking change in ObjectManager API, to be sure that this doesn't affect you.

**Steps to reproduce:**

1. Create an Object type Employee with some fields
2. Create an Object type Manager with some fields
3. Create some managers and some employees
4. Using the Manager API try to delete an employee. I've added the curl command where you should replace the {employeeId}
```
curl -X 'DELETE' -u 'test@liferay.com:test' 'http://localhost:8080/o/c/managers/{employeeId}'
```

**Expected result:** 404 Not Found response as this API should not know about other object type entries.
**Result:** The employee is deleted and with a 200 ok response