### PR TITLE
LPS-143347 baseline

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 9.1.1
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalService.java
@@ -149,6 +149,10 @@ public interface ObjectFieldLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.DELETE)
+	public ObjectField deleteRelationshipTypeObjectField(long objectFieldId)
+		throws PortalException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceUtil.java
@@ -151,6 +151,13 @@ public class ObjectFieldLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static ObjectField deleteRelationshipTypeObjectField(
+			long objectFieldId)
+		throws PortalException {
+
+		return getService().deleteRelationshipTypeObjectField(objectFieldId);
+	}
+
 	public static <T> T dslQuery(DSLQuery dslQuery) {
 		return getService().dslQuery(dslQuery);
 	}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldLocalServiceWrapper.java
@@ -158,6 +158,15 @@ public class ObjectFieldLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectField
+			deleteRelationshipTypeObjectField(long objectFieldId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectFieldLocalService.deleteRelationshipTypeObjectField(
+			objectFieldId);
+	}
+
+	@Override
 	public <T> T dslQuery(com.liferay.petra.sql.dsl.query.DSLQuery dslQuery) {
 		return _objectFieldLocalService.dslQuery(dslQuery);
 	}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -147,6 +147,23 @@ public class ObjectFieldLocalServiceImpl
 		return _deleteObjectField(objectField);
 	}
 
+	@Indexable(type = IndexableType.DELETE)
+	@Override
+	public ObjectField deleteRelationshipTypeObjectField(long objectFieldId)
+		throws PortalException {
+
+		ObjectField objectField = objectFieldPersistence.findByPrimaryKey(
+			objectFieldId);
+
+		if (Validator.isNull(objectField.getRelationshipType())) {
+			throw new ObjectFieldRelationshipTypeException(
+				"Object field cannot be deleted because it is not of " +
+					"relationship type");
+		}
+
+		return _deleteObjectField(objectField);
+	}
+
 	@Override
 	public ObjectField fetchObjectField(long objectDefinitionId, String name) {
 		return objectFieldPersistence.fetchByODI_N(objectDefinitionId, name);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -169,7 +169,7 @@ public class ObjectRelationshipLocalServiceImpl
 				objectRelationship.getType(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-			_objectFieldLocalService.deleteObjectField(
+			_objectFieldLocalService.deleteRelationshipTypeObjectField(
 				objectRelationship.getObjectFieldId2());
 		}
 		else if (Objects.equals(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-143347

This is a follow-up from an observation made by Brian when he reviewed: [#111592](https://github.com/brianchandotcom/liferay-portal/pull/111592).

The previous work prevents the user to delete an object field of relationship type when using the UI. This work prevents deleting using the Rest API.