### PR TITLE
LPS-146605 Cover updateAsset with integration test

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -672,13 +672,23 @@ public class ObjectEntryLocalServiceImpl
 			visible = true;
 		}
 
+		String title = StringPool.BLANK;
+
+		try {
+			title = objectEntry.getTitleValue();
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException, portalException);
+			}
+		}
+
 		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
 			userId, objectEntry.getNonzeroGroupId(),
 			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
 			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
 			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-			visible, null, null, null, null, ContentTypes.TEXT_PLAIN,
-			String.valueOf(objectEntry.getObjectEntryId()),
+			visible, null, null, null, null, ContentTypes.TEXT_PLAIN, title,
 			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
 			0, priority);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -666,12 +666,6 @@ public class ObjectEntryLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectEntry.getObjectDefinitionId());
 
-		boolean visible = false;
-
-		if (objectEntry.isApproved()) {
-			visible = true;
-		}
-
 		String title = StringPool.BLANK;
 
 		try {
@@ -688,7 +682,8 @@ public class ObjectEntryLocalServiceImpl
 			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
 			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
 			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-			visible, null, null, null, null, ContentTypes.TEXT_PLAIN, title,
+			objectEntry.isApproved(), null, null, null, null,
+			ContentTypes.TEXT_PLAIN, title,
 			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
 			0, priority);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.depot.model.DepotEntry;
@@ -28,6 +29,7 @@ import com.liferay.object.exception.ObjectDefinitionScopeException;
 import com.liferay.object.exception.ObjectEntryValuesException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -1048,6 +1050,28 @@ public class ObjectEntryLocalServiceTest {
 			20);
 
 		Assert.assertEquals(0, baseModelSearchResult.getLength());
+	}
+
+	@Test
+	public void testUpdateAsset() throws Exception {
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			_objectDefinition.getObjectDefinitionId(), "emailAddress");
+
+		_objectDefinitionLocalService.updateTitleObjectFieldId(
+			_objectDefinition.getObjectDefinitionId(),
+			objectField.getObjectFieldId());
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddress", "john@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			_objectDefinition.getClassName(), objectEntry.getObjectEntryId());
+
+		Assert.assertEquals("john@liferay.com", assetEntry.getTitle());
 	}
 
 	@Test


### PR DESCRIPTION
Hi @liferay-objects, the problem was the AssetEntry's title always receive the objectEntryId instead of the object entry's titleValue, then in [workflow-metrics layer](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-metrics-integration/src/main/java/com/liferay/portal/workflow/kaleo/metrics/integration/internal/helper/IndexerHelper.java#L226-L260) when it indexes the title for object entry, it get the title from the AssetEntry because now the ObjectEntryAssetRenderer exists, previously, it took from the workflowHandler because the ObjectEntryAssetRenderer didn't exist.

I used a try-catch block to avoid an exception when I get the titleValue because I believe that if an exception is thrown the asset entry should be created without the proper title, let me know if this approach is correct.

![Objects - Liferay DXP](https://user-images.githubusercontent.com/42913501/152371960-72290a5e-b641-45ca-b6aa-efd223d6fb71.gif)
