### PR TITLE
LPS-147123 Fix exception retrieving dates in GraphQL

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2385,10 +2385,14 @@ public class GraphQLServletExtender {
 				public String serialize(Object value)
 					throws CoercingSerializeException {
 
-					SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
-						"yyyy-MM-dd'T'HH:mm:ss'Z'");
+					if (value instanceof Date) {
+						SimpleDateFormat simpleDateFormat =
+							new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-					return simpleDateFormat.format((Date)value);
+						return simpleDateFormat.format((Date)value);
+					}
+
+					return value.toString();
 				}
 
 				private Date _toDate(Object value) {


### PR DESCRIPTION
The root cause of the issue is related to the ObjectEntry persistence cache. At some moment, we are saving date fields as String instead of Date in the cache when a new object with a date object entry field is created. 

This string gets to the GraphQL Date parser and causes the crash.

It is important to continue investigating the root cause so it doesn't cause any other issues and then we can simplify this code that shouldn't be necessary.