### PR TITLE
LPS-147193 Place transitions labels into labels property

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -2499,6 +2499,16 @@ plugins.includes=</echo>
 					/>
 				</chmod>
 
+				<chmod
+					perm="777"
+					type="both"
+				>
+					<fileset
+						dir="dist/${tstamp.value}/liferay-portal-${lp.version}/elasticsearch-sidecar"
+						includes="**/*"
+					/>
+				</chmod>
+
 				<if>
 					<equals arg1="${zip.executable.file}" arg2="liferay-portal-tomcat" />
 					<then>

--- a/modules/.releng/sdk/gradle-plugins-defaults/artifact.properties
+++ b/modules/.releng/sdk/gradle-plugins-defaults/artifact.properties
@@ -1,5 +1,5 @@
-artifact.git.id=d84212f8bf26856637f009e4d6cb75cb98e3ec24
-artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.280/com.liferay.gradle.plugins.defaults-7.0.280-javadoc.jar
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.280/com.liferay.gradle.plugins.defaults-7.0.280-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.280/com.liferay.gradle.plugins.defaults-7.0.280-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.280/com.liferay.gradle.plugins.defaults-7.0.280.jar
+artifact.git.id=ab7239813875190b02f30e192e674f04059b12c5
+artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.281/com.liferay.gradle.plugins.defaults-7.0.281-javadoc.jar
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.281/com.liferay.gradle.plugins.defaults-7.0.281-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.281/com.liferay.gradle.plugins.defaults-7.0.281-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.defaults/7.0.281/com.liferay.gradle.plugins.defaults-7.0.281.jar

--- a/modules/.releng/sdk/gradle-plugins-source-formatter/artifact.properties
+++ b/modules/.releng/sdk/gradle-plugins-source-formatter/artifact.properties
@@ -1,4 +1,4 @@
-artifact.git.id=2380d33e8d0f27997852a0394eb9a027c37d49ef
-artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.98/com.liferay.gradle.plugins.source.formatter-5.1.98-javadoc.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.98/com.liferay.gradle.plugins.source.formatter-5.1.98-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.98/com.liferay.gradle.plugins.source.formatter-5.1.98.jar
+artifact.git.id=7101a1616d722ae2c92ae41be0b1fbfe8b0a192c
+artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.99/com.liferay.gradle.plugins.source.formatter-5.1.99-javadoc.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.99/com.liferay.gradle.plugins.source.formatter-5.1.99-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins.source.formatter/5.1.99/com.liferay.gradle.plugins.source.formatter-5.1.99.jar

--- a/modules/.releng/sdk/gradle-plugins/artifact.properties
+++ b/modules/.releng/sdk/gradle-plugins/artifact.properties
@@ -1,5 +1,5 @@
-artifact.git.id=33bd425c557e39ca69bea104981d95700c6b75ae
-artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.135/com.liferay.gradle.plugins-13.2.135-javadoc.jar
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.135/com.liferay.gradle.plugins-13.2.135-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.135/com.liferay.gradle.plugins-13.2.135-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.135/com.liferay.gradle.plugins-13.2.135.jar
+artifact.git.id=ab7239813875190b02f30e192e674f04059b12c5
+artifact.javadoc.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.136/com.liferay.gradle.plugins-13.2.136-javadoc.jar
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.136/com.liferay.gradle.plugins-13.2.136-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.136/com.liferay.gradle.plugins-13.2.136-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.gradle.plugins/13.2.136/com.liferay.gradle.plugins-13.2.136.jar

--- a/modules/.releng/util/source-formatter/artifact.properties
+++ b/modules/.releng/util/source-formatter/artifact.properties
@@ -1,6 +1,6 @@
-artifact.git.id=2380d33e8d0f27997852a0394eb9a027c37d49ef
-artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1201/com.liferay.source.formatter-1.0.1201-sources-commercial.jar
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1201/com.liferay.source.formatter-1.0.1201-sources.jar
-artifact.tar.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1201/com.liferay.source.formatter-1.0.1201.tar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1201/com.liferay.source.formatter-1.0.1201.jar
-artifact.zip.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1201/com.liferay.source.formatter-1.0.1201.zip
+artifact.git.id=7101a1616d722ae2c92ae41be0b1fbfe8b0a192c
+artifact.sources-commercial.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1202/com.liferay.source.formatter-1.0.1202-sources-commercial.jar
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1202/com.liferay.source.formatter-1.0.1202-sources.jar
+artifact.tar.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1202/com.liferay.source.formatter-1.0.1202.tar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1202/com.liferay.source.formatter-1.0.1202.jar
+artifact.zip.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.source.formatter/1.0.1202/com.liferay.source.formatter-1.0.1202.zip

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/taglib/clay/data/set/view/table/PendingCommerceOrderClayTableDataSetDisplayView.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/taglib/clay/data/set/view/table/PendingCommerceOrderClayTableDataSetDisplayView.java
@@ -45,6 +45,9 @@ public class PendingCommerceOrderClayTableDataSetDisplayView
 		clayTableSchemaBuilder.addClayTableSchemaField("orderId", "order-id");
 
 		clayTableSchemaBuilder.addClayTableSchemaField(
+			"externalReferenceCode", "ERC");
+
+		clayTableSchemaBuilder.addClayTableSchemaField(
 			"accountName", "account");
 
 		clayTableSchemaBuilder.addClayTableSchemaField("author", "created-by");

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/taglib/clay/data/set/view/table/PlacedCommerceOrderClayTableDataSetDisplayView.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/taglib/clay/data/set/view/table/PlacedCommerceOrderClayTableDataSetDisplayView.java
@@ -46,6 +46,12 @@ public class PlacedCommerceOrderClayTableDataSetDisplayView
 
 		clayTableSchemaField.setContentRenderer("actionLink");
 
+		clayTableSchemaBuilder.addClayTableSchemaField(
+			"externalReferenceCode", "ERC");
+
+		clayTableSchemaBuilder.addClayTableSchemaField(
+			"purchaseOrderNumber", "purchase-order-number");
+
 		clayTableSchemaBuilder.addClayTableSchemaField("date", "order-date");
 
 		clayTableSchemaBuilder.addClayTableSchemaField(

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/util/CommerceOrderClayTableUtil.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/util/CommerceOrderClayTableUtil.java
@@ -193,10 +193,13 @@ public class CommerceOrderClayTableUtil {
 
 			orders.add(
 				new Order(
+					commerceOrder.getExternalReferenceCode(),
 					commerceOrder.getCommerceOrderId(),
 					commerceOrder.getCommerceAccountName(),
 					dateFormat.format(orderDate), commerceOrder.getUserName(),
-					commerceOrderStatusLabel, workflowStatusLabel, amount));
+					commerceOrderStatusLabel,
+					commerceOrder.getPurchaseOrderNumber(), workflowStatusLabel,
+					amount));
 		}
 
 		return orders;

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/model/Order.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/model/Order.java
@@ -20,14 +20,17 @@ package com.liferay.commerce.order.content.web.internal.model;
 public class Order {
 
 	public Order(
-		long orderId, String accountName, String date, String author,
-		String orderStatus, String status, String amount) {
+		String externalReferenceCode, long orderId, String accountName,
+		String date, String author, String orderStatus,
+		String purchaseOrderNumber, String status, String amount) {
 
+		_externalReferenceCode = externalReferenceCode;
 		_orderId = orderId;
 		_accountName = accountName;
 		_date = date;
 		_author = author;
 		_orderStatus = orderStatus;
+		_purchaseOrderNumber = purchaseOrderNumber;
 		_status = status;
 		_amount = amount;
 
@@ -50,12 +53,20 @@ public class Order {
 		return _date;
 	}
 
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
 	public long getOrderId() {
 		return _orderId;
 	}
 
 	public String getOrderStatus() {
 		return _orderStatus;
+	}
+
+	public String getPurchaseOrderNumber() {
+		return _purchaseOrderNumber;
 	}
 
 	public String getStatus() {
@@ -70,8 +81,10 @@ public class Order {
 	private final String _amount;
 	private final String _author;
 	private final String _date;
+	private final String _externalReferenceCode;
 	private final long _orderId;
 	private final String _orderStatus;
+	private final String _purchaseOrderNumber;
 	private final String _status;
 	private final String _title;
 

--- a/modules/apps/commerce/commerce-price-list-api/bnd.bnd
+++ b/modules/apps/commerce/commerce-price-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Commerce Price List API
 Bundle-SymbolicName: com.liferay.commerce.price.list.api
-Bundle-Version: 13.0.1
+Bundle-Version: 14.0.0
 Export-Package:\
 	com.liferay.commerce.price.list.configuration,\
 	com.liferay.commerce.price.list.constants,\

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/persistence/CommercePriceEntryPersistence.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/persistence/CommercePriceEntryPersistence.java
@@ -773,49 +773,151 @@ public interface CommercePriceEntryPersistence
 	public int countByCPInstanceUuid(String CPInstanceUuid);
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
-	public CommercePriceEntry findByC_C(
-			long commercePriceListId, String CPInstanceUuid)
-		throws NoSuchPriceEntryException;
-
-	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param commercePriceListId the commerce price list ID
-	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
-	 */
-	public CommercePriceEntry fetchByC_C(
+	public java.util.List<CommercePriceEntry> findByC_C(
 		long commercePriceListId, String CPInstanceUuid);
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
-	public CommercePriceEntry fetchByC_C(
-		long commercePriceListId, String CPInstanceUuid,
+	public java.util.List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public java.util.List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public java.util.List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator,
 		boolean useFinderCache);
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the commerce price entry that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
 	 */
-	public CommercePriceEntry removeByC_C(
-			long commercePriceListId, String CPInstanceUuid)
+	public CommercePriceEntry findByC_C_First(
+			long commercePriceListId, String CPInstanceUuid,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
 		throws NoSuchPriceEntryException;
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry fetchByC_C_First(
+		long commercePriceListId, String CPInstanceUuid,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry findByC_C_Last(
+			long commercePriceListId, String CPInstanceUuid,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
+		throws NoSuchPriceEntryException;
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry fetchByC_C_Last(
+		long commercePriceListId, String CPInstanceUuid,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	public CommercePriceEntry[] findByC_C_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
+		throws NoSuchPriceEntryException;
+
+	/**
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 */
+	public void removeByC_C(long commercePriceListId, String CPInstanceUuid);
 
 	/**
 	 * Returns the number of commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
@@ -1137,53 +1239,165 @@ public interface CommercePriceEntryPersistence
 	public int countByLtE_S(Date expirationDate, int status);
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
-	public CommercePriceEntry findByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
-		throws NoSuchPriceEntryException;
-
-	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param commercePriceListId the commerce price list ID
-	 * @param CPInstanceUuid the cp instance uuid
-	 * @param status the status
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
-	 */
-	public CommercePriceEntry fetchByC_C_S(
+	public java.util.List<CommercePriceEntry> findByC_C_S(
 		long commercePriceListId, String CPInstanceUuid, int status);
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
-	public CommercePriceEntry fetchByC_C_S(
-		long commercePriceListId, String CPInstanceUuid, int status,
+	public java.util.List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public java.util.List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public java.util.List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator,
 		boolean useFinderCache);
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the commerce price entry that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
 	 */
-	public CommercePriceEntry removeByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
+	public CommercePriceEntry findByC_C_S_First(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
 		throws NoSuchPriceEntryException;
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry fetchByC_C_S_First(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry findByC_C_S_Last(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
+		throws NoSuchPriceEntryException;
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public CommercePriceEntry fetchByC_C_S_Last(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	public CommercePriceEntry[] findByC_C_S_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid, int status,
+			com.liferay.portal.kernel.util.OrderByComparator<CommercePriceEntry>
+				orderByComparator)
+		throws NoSuchPriceEntryException;
+
+	/**
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 */
+	public void removeByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status);
 
 	/**
 	 * Returns the number of commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.

--- a/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/persistence/CommercePriceEntryUtil.java
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/java/com/liferay/commerce/price/list/service/persistence/CommercePriceEntryUtil.java
@@ -1015,64 +1015,187 @@ public class CommercePriceEntryUtil {
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
-	public static CommercePriceEntry findByC_C(
-			long commercePriceListId, String CPInstanceUuid)
-		throws com.liferay.commerce.price.list.exception.
-			NoSuchPriceEntryException {
+	public static List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid) {
 
 		return getPersistence().findByC_C(commercePriceListId, CPInstanceUuid);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
-	public static CommercePriceEntry fetchByC_C(
-		long commercePriceListId, String CPInstanceUuid) {
+	public static List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end) {
 
-		return getPersistence().fetchByC_C(commercePriceListId, CPInstanceUuid);
+		return getPersistence().findByC_C(
+			commercePriceListId, CPInstanceUuid, start, end);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
 	 */
-	public static CommercePriceEntry fetchByC_C(
-		long commercePriceListId, String CPInstanceUuid,
+	public static List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().findByC_C(
+			commercePriceListId, CPInstanceUuid, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public static List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		OrderByComparator<CommercePriceEntry> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().fetchByC_C(
-			commercePriceListId, CPInstanceUuid, useFinderCache);
+		return getPersistence().findByC_C(
+			commercePriceListId, CPInstanceUuid, start, end, orderByComparator,
+			useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the commerce price entry that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
 	 */
-	public static CommercePriceEntry removeByC_C(
-			long commercePriceListId, String CPInstanceUuid)
+	public static CommercePriceEntry findByC_C_First(
+			long commercePriceListId, String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
 		throws com.liferay.commerce.price.list.exception.
 			NoSuchPriceEntryException {
 
-		return getPersistence().removeByC_C(
-			commercePriceListId, CPInstanceUuid);
+		return getPersistence().findByC_C_First(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+	}
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry fetchByC_C_First(
+		long commercePriceListId, String CPInstanceUuid,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_C_First(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry findByC_C_Last(
+			long commercePriceListId, String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws com.liferay.commerce.price.list.exception.
+			NoSuchPriceEntryException {
+
+		return getPersistence().findByC_C_Last(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry fetchByC_C_Last(
+		long commercePriceListId, String CPInstanceUuid,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_C_Last(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	public static CommercePriceEntry[] findByC_C_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws com.liferay.commerce.price.list.exception.
+			NoSuchPriceEntryException {
+
+		return getPersistence().findByC_C_PrevAndNext(
+			commercePriceEntryId, commercePriceListId, CPInstanceUuid,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 */
+	public static void removeByC_C(
+		long commercePriceListId, String CPInstanceUuid) {
+
+		getPersistence().removeByC_C(commercePriceListId, CPInstanceUuid);
 	}
 
 	/**
@@ -1468,69 +1591,200 @@ public class CommercePriceEntryUtil {
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
-	public static CommercePriceEntry findByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
-		throws com.liferay.commerce.price.list.exception.
-			NoSuchPriceEntryException {
+	public static List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status) {
 
 		return getPersistence().findByC_C_S(
 			commercePriceListId, CPInstanceUuid, status);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
-	public static CommercePriceEntry fetchByC_C_S(
-		long commercePriceListId, String CPInstanceUuid, int status) {
+	public static List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end) {
 
-		return getPersistence().fetchByC_C_S(
-			commercePriceListId, CPInstanceUuid, status);
+		return getPersistence().findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, start, end);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
 	 */
-	public static CommercePriceEntry fetchByC_C_S(
-		long commercePriceListId, String CPInstanceUuid, int status,
+	public static List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end, OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, start, end,
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	public static List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end, OrderByComparator<CommercePriceEntry> orderByComparator,
 		boolean useFinderCache) {
 
-		return getPersistence().fetchByC_C_S(
-			commercePriceListId, CPInstanceUuid, status, useFinderCache);
+		return getPersistence().findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, start, end,
+			orderByComparator, useFinderCache);
 	}
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the commerce price entry that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
 	 */
-	public static CommercePriceEntry removeByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
+	public static CommercePriceEntry findByC_C_S_First(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
 		throws com.liferay.commerce.price.list.exception.
 			NoSuchPriceEntryException {
 
-		return getPersistence().removeByC_C_S(
+		return getPersistence().findByC_C_S_First(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry fetchByC_C_S_First(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_C_S_First(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry findByC_C_S_Last(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws com.liferay.commerce.price.list.exception.
+			NoSuchPriceEntryException {
+
+		return getPersistence().findByC_C_S_Last(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	public static CommercePriceEntry fetchByC_C_S_Last(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_C_S_Last(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
+	}
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	public static CommercePriceEntry[] findByC_C_S_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws com.liferay.commerce.price.list.exception.
+			NoSuchPriceEntryException {
+
+		return getPersistence().findByC_C_S_PrevAndNext(
+			commercePriceEntryId, commercePriceListId, CPInstanceUuid, status,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 */
+	public static void removeByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status) {
+
+		getPersistence().removeByC_C_S(
 			commercePriceListId, CPInstanceUuid, status);
 	}
 

--- a/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/persistence/packageinfo
+++ b/modules/apps/commerce/commerce-price-list-api/src/main/resources/com/liferay/commerce/price/list/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/commerce/commerce-price-list-service/bnd.bnd
+++ b/modules/apps/commerce/commerce-price-list-service/bnd.bnd
@@ -2,5 +2,5 @@ Bundle-Name: Liferay Commerce Price List Service
 Bundle-SymbolicName: com.liferay.commerce.price.list.service
 Bundle-Version: 4.0.21
 Liferay-Enterprise-App: product.id=9a473157-06a6-44b6-b017-a360ffaf5f38
-Liferay-Require-SchemaVersion: 2.3.0
+Liferay-Require-SchemaVersion: 2.4.0
 Liferay-Service: true

--- a/modules/apps/commerce/commerce-price-list-service/service.xml
+++ b/modules/apps/commerce/commerce-price-list-service/service.xml
@@ -57,7 +57,7 @@
 		<finder name="CPInstanceUuid" return-type="Collection">
 			<finder-column name="CPInstanceUuid" />
 		</finder>
-		<finder name="C_C" return-type="CommercePriceEntry" unique="true">
+		<finder name="C_C" return-type="Collection">
 			<finder-column name="commercePriceListId" />
 			<finder-column name="CPInstanceUuid" />
 		</finder>
@@ -69,7 +69,7 @@
 			<finder-column comparator="&lt;" name="expirationDate" />
 			<finder-column name="status" />
 		</finder>
-		<finder name="C_C_S" return-type="CommercePriceEntry" unique="true">
+		<finder name="C_C_S" return-type="Collection">
 			<finder-column name="commercePriceListId" />
 			<finder-column name="CPInstanceUuid" />
 			<finder-column name="status" />

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/CommercePriceListUpgradeStepRegistrator.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/CommercePriceListUpgradeStepRegistrator.java
@@ -113,6 +113,11 @@ public class CommercePriceListUpgradeStepRegistrator
 
 			});
 
+		registry.register(
+			"2.3.0", "2.4.0",
+			new com.liferay.commerce.price.list.internal.upgrade.v2_4_0.
+				CommercePriceEntryUpgradeProcess());
+
 		if (_log.isInfoEnabled()) {
 			_log.info("Commerce price list upgrade step registrator finished");
 		}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v2_4_0/CommercePriceEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/upgrade/v2_4_0/CommercePriceEntryUpgradeProcess.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.commerce.price.list.internal.upgrade.v2_4_0;
+
+import com.liferay.commerce.price.list.internal.upgrade.base.BaseCommercePriceListUpgradeProcess;
+import com.liferay.commerce.price.list.model.CommercePriceEntryTable;
+
+/**
+ * @author Riccardo Alberti
+ */
+public class CommercePriceEntryUpgradeProcess
+	extends BaseCommercePriceListUpgradeProcess {
+
+	@Override
+	public void doUpgrade() throws Exception {
+		dropIndexes(
+			CommercePriceEntryTable.INSTANCE.getTableName(), "IX_2D76B43E");
+	}
+
+}

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/persistence/impl/CommercePriceEntryPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/service/persistence/impl/CommercePriceEntryPersistenceImpl.java
@@ -2788,103 +2788,143 @@ public class CommercePriceEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_CPINSTANCEUUID_CPINSTANCEUUID_3 =
 		"(commercePriceEntry.CPInstanceUuid IS NULL OR commercePriceEntry.CPInstanceUuid = '')";
 
-	private FinderPath _finderPathFetchByC_C;
+	private FinderPath _finderPathWithPaginationFindByC_C;
+	private FinderPath _finderPathWithoutPaginationFindByC_C;
 	private FinderPath _finderPathCountByC_C;
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
 	@Override
-	public CommercePriceEntry findByC_C(
-			long commercePriceListId, String CPInstanceUuid)
-		throws NoSuchPriceEntryException {
-
-		CommercePriceEntry commercePriceEntry = fetchByC_C(
-			commercePriceListId, CPInstanceUuid);
-
-		if (commercePriceEntry == null) {
-			StringBundler sb = new StringBundler(6);
-
-			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-			sb.append("commercePriceListId=");
-			sb.append(commercePriceListId);
-
-			sb.append(", CPInstanceUuid=");
-			sb.append(CPInstanceUuid);
-
-			sb.append("}");
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(sb.toString());
-			}
-
-			throw new NoSuchPriceEntryException(sb.toString());
-		}
-
-		return commercePriceEntry;
-	}
-
-	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param commercePriceListId the commerce price list ID
-	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
-	 */
-	@Override
-	public CommercePriceEntry fetchByC_C(
+	public List<CommercePriceEntry> findByC_C(
 		long commercePriceListId, String CPInstanceUuid) {
 
-		return fetchByC_C(commercePriceListId, CPInstanceUuid, true);
+		return findByC_C(
+			commercePriceListId, CPInstanceUuid, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
 	@Override
-	public CommercePriceEntry fetchByC_C(
-		long commercePriceListId, String CPInstanceUuid,
+	public List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end) {
+
+		return findByC_C(commercePriceListId, CPInstanceUuid, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
+	 */
+	@Override
+	public List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return findByC_C(
+			commercePriceListId, CPInstanceUuid, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	@Override
+	public List<CommercePriceEntry> findByC_C(
+		long commercePriceListId, String CPInstanceUuid, int start, int end,
+		OrderByComparator<CommercePriceEntry> orderByComparator,
 		boolean useFinderCache) {
 
 		CPInstanceUuid = Objects.toString(CPInstanceUuid, "");
 
+		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
-			finderArgs = new Object[] {commercePriceListId, CPInstanceUuid};
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByC_C;
+				finderArgs = new Object[] {commercePriceListId, CPInstanceUuid};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByC_C;
+			finderArgs = new Object[] {
+				commercePriceListId, CPInstanceUuid, start, end,
+				orderByComparator
+			};
 		}
 
-		Object result = null;
+		List<CommercePriceEntry> list = null;
 
 		if (useFinderCache) {
-			result = finderCache.getResult(_finderPathFetchByC_C, finderArgs);
-		}
+			list = (List<CommercePriceEntry>)finderCache.getResult(
+				finderPath, finderArgs);
 
-		if (result instanceof CommercePriceEntry) {
-			CommercePriceEntry commercePriceEntry = (CommercePriceEntry)result;
+			if ((list != null) && !list.isEmpty()) {
+				for (CommercePriceEntry commercePriceEntry : list) {
+					if ((commercePriceListId !=
+							commercePriceEntry.getCommercePriceListId()) ||
+						!CPInstanceUuid.equals(
+							commercePriceEntry.getCPInstanceUuid())) {
 
-			if ((commercePriceListId !=
-					commercePriceEntry.getCommercePriceListId()) ||
-				!Objects.equals(
-					CPInstanceUuid, commercePriceEntry.getCPInstanceUuid())) {
+						list = null;
 
-				result = null;
+						break;
+					}
+				}
 			}
 		}
 
-		if (result == null) {
-			StringBundler sb = new StringBundler(4);
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
 
 			sb.append(_SQL_SELECT_COMMERCEPRICEENTRY_WHERE);
 
@@ -2899,6 +2939,14 @@ public class CommercePriceEntryPersistenceImpl
 				bindCPInstanceUuid = true;
 
 				sb.append(_FINDER_COLUMN_C_C_CPINSTANCEUUID_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(CommercePriceEntryModelImpl.ORDER_BY_JPQL);
 			}
 
 			String sql = sb.toString();
@@ -2918,20 +2966,13 @@ public class CommercePriceEntryPersistenceImpl
 					queryPos.add(CPInstanceUuid);
 				}
 
-				List<CommercePriceEntry> list = query.list();
+				list = (List<CommercePriceEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
 
-				if (list.isEmpty()) {
-					if (useFinderCache) {
-						finderCache.putResult(
-							_finderPathFetchByC_C, finderArgs, list);
-					}
-				}
-				else {
-					CommercePriceEntry commercePriceEntry = list.get(0);
+				cacheResult(list);
 
-					result = commercePriceEntry;
-
-					cacheResult(commercePriceEntry);
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
 			catch (Exception exception) {
@@ -2942,30 +2983,326 @@ public class CommercePriceEntryPersistenceImpl
 			}
 		}
 
-		if (result instanceof List<?>) {
+		return list;
+	}
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry findByC_C_First(
+			long commercePriceListId, String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws NoSuchPriceEntryException {
+
+		CommercePriceEntry commercePriceEntry = fetchByC_C_First(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+
+		if (commercePriceEntry != null) {
+			return commercePriceEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("commercePriceListId=");
+		sb.append(commercePriceListId);
+
+		sb.append(", CPInstanceUuid=");
+		sb.append(CPInstanceUuid);
+
+		sb.append("}");
+
+		throw new NoSuchPriceEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry fetchByC_C_First(
+		long commercePriceListId, String CPInstanceUuid,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		List<CommercePriceEntry> list = findByC_C(
+			commercePriceListId, CPInstanceUuid, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry findByC_C_Last(
+			long commercePriceListId, String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws NoSuchPriceEntryException {
+
+		CommercePriceEntry commercePriceEntry = fetchByC_C_Last(
+			commercePriceListId, CPInstanceUuid, orderByComparator);
+
+		if (commercePriceEntry != null) {
+			return commercePriceEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("commercePriceListId=");
+		sb.append(commercePriceListId);
+
+		sb.append(", CPInstanceUuid=");
+		sb.append(CPInstanceUuid);
+
+		sb.append("}");
+
+		throw new NoSuchPriceEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry fetchByC_C_Last(
+		long commercePriceListId, String CPInstanceUuid,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		int count = countByC_C(commercePriceListId, CPInstanceUuid);
+
+		if (count == 0) {
 			return null;
 		}
+
+		List<CommercePriceEntry> list = findByC_C(
+			commercePriceListId, CPInstanceUuid, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	@Override
+	public CommercePriceEntry[] findByC_C_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws NoSuchPriceEntryException {
+
+		CPInstanceUuid = Objects.toString(CPInstanceUuid, "");
+
+		CommercePriceEntry commercePriceEntry = findByPrimaryKey(
+			commercePriceEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommercePriceEntry[] array = new CommercePriceEntryImpl[3];
+
+			array[0] = getByC_C_PrevAndNext(
+				session, commercePriceEntry, commercePriceListId,
+				CPInstanceUuid, orderByComparator, true);
+
+			array[1] = commercePriceEntry;
+
+			array[2] = getByC_C_PrevAndNext(
+				session, commercePriceEntry, commercePriceListId,
+				CPInstanceUuid, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommercePriceEntry getByC_C_PrevAndNext(
+		Session session, CommercePriceEntry commercePriceEntry,
+		long commercePriceListId, String CPInstanceUuid,
+		OrderByComparator<CommercePriceEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
 		else {
-			return (CommercePriceEntry)result;
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_COMMERCEPRICEENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_C_COMMERCEPRICELISTID_2);
+
+		boolean bindCPInstanceUuid = false;
+
+		if (CPInstanceUuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_C_C_CPINSTANCEUUID_3);
+		}
+		else {
+			bindCPInstanceUuid = true;
+
+			sb.append(_FINDER_COLUMN_C_C_CPINSTANCEUUID_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(CommercePriceEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(commercePriceListId);
+
+		if (bindCPInstanceUuid) {
+			queryPos.add(CPInstanceUuid);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commercePriceEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommercePriceEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
 		}
 	}
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; from the database.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
-	 * @return the commerce price entry that was removed
 	 */
 	@Override
-	public CommercePriceEntry removeByC_C(
-			long commercePriceListId, String CPInstanceUuid)
-		throws NoSuchPriceEntryException {
+	public void removeByC_C(long commercePriceListId, String CPInstanceUuid) {
+		for (CommercePriceEntry commercePriceEntry :
+				findByC_C(
+					commercePriceListId, CPInstanceUuid, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
 
-		CommercePriceEntry commercePriceEntry = findByC_C(
-			commercePriceListId, CPInstanceUuid);
-
-		return remove(commercePriceEntry);
+			remove(commercePriceEntry);
+		}
 	}
 
 	/**
@@ -4186,112 +4523,152 @@ public class CommercePriceEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_LTE_S_STATUS_2 =
 		"commercePriceEntry.status = ?";
 
-	private FinderPath _finderPathFetchByC_C_S;
+	private FinderPath _finderPathWithPaginationFindByC_C_S;
+	private FinderPath _finderPathWithoutPaginationFindByC_C_S;
 	private FinderPath _finderPathCountByC_C_S;
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or throws a <code>NoSuchPriceEntryException</code> if it could not be found.
+	 * Returns all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the matching commerce price entry
-	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 * @return the matching commerce price entries
 	 */
 	@Override
-	public CommercePriceEntry findByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
-		throws NoSuchPriceEntryException {
-
-		CommercePriceEntry commercePriceEntry = fetchByC_C_S(
-			commercePriceListId, CPInstanceUuid, status);
-
-		if (commercePriceEntry == null) {
-			StringBundler sb = new StringBundler(8);
-
-			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-			sb.append("commercePriceListId=");
-			sb.append(commercePriceListId);
-
-			sb.append(", CPInstanceUuid=");
-			sb.append(CPInstanceUuid);
-
-			sb.append(", status=");
-			sb.append(status);
-
-			sb.append("}");
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(sb.toString());
-			}
-
-			throw new NoSuchPriceEntryException(sb.toString());
-		}
-
-		return commercePriceEntry;
-	}
-
-	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param commercePriceListId the commerce price list ID
-	 * @param CPInstanceUuid the cp instance uuid
-	 * @param status the status
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
-	 */
-	@Override
-	public CommercePriceEntry fetchByC_C_S(
+	public List<CommercePriceEntry> findByC_C_S(
 		long commercePriceListId, String CPInstanceUuid, int status) {
 
-		return fetchByC_C_S(commercePriceListId, CPInstanceUuid, status, true);
+		return findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
 	}
 
 	/**
-	 * Returns the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 * Returns a range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @return the range of matching commerce price entries
 	 */
 	@Override
-	public CommercePriceEntry fetchByC_C_S(
-		long commercePriceListId, String CPInstanceUuid, int status,
+	public List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end) {
+
+		return findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching commerce price entries
+	 */
+	@Override
+	public List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end, OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		return findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, start, end,
+			orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>CommercePriceEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param start the lower bound of the range of commerce price entries
+	 * @param end the upper bound of the range of commerce price entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching commerce price entries
+	 */
+	@Override
+	public List<CommercePriceEntry> findByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status, int start,
+		int end, OrderByComparator<CommercePriceEntry> orderByComparator,
 		boolean useFinderCache) {
 
 		CPInstanceUuid = Objects.toString(CPInstanceUuid, "");
 
+		FinderPath finderPath = null;
 		Object[] finderArgs = null;
 
-		if (useFinderCache) {
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache) {
+				finderPath = _finderPathWithoutPaginationFindByC_C_S;
+				finderArgs = new Object[] {
+					commercePriceListId, CPInstanceUuid, status
+				};
+			}
+		}
+		else if (useFinderCache) {
+			finderPath = _finderPathWithPaginationFindByC_C_S;
 			finderArgs = new Object[] {
-				commercePriceListId, CPInstanceUuid, status
+				commercePriceListId, CPInstanceUuid, status, start, end,
+				orderByComparator
 			};
 		}
 
-		Object result = null;
+		List<CommercePriceEntry> list = null;
 
 		if (useFinderCache) {
-			result = finderCache.getResult(_finderPathFetchByC_C_S, finderArgs);
-		}
+			list = (List<CommercePriceEntry>)finderCache.getResult(
+				finderPath, finderArgs);
 
-		if (result instanceof CommercePriceEntry) {
-			CommercePriceEntry commercePriceEntry = (CommercePriceEntry)result;
+			if ((list != null) && !list.isEmpty()) {
+				for (CommercePriceEntry commercePriceEntry : list) {
+					if ((commercePriceListId !=
+							commercePriceEntry.getCommercePriceListId()) ||
+						!CPInstanceUuid.equals(
+							commercePriceEntry.getCPInstanceUuid()) ||
+						(status != commercePriceEntry.getStatus())) {
 
-			if ((commercePriceListId !=
-					commercePriceEntry.getCommercePriceListId()) ||
-				!Objects.equals(
-					CPInstanceUuid, commercePriceEntry.getCPInstanceUuid()) ||
-				(status != commercePriceEntry.getStatus())) {
+						list = null;
 
-				result = null;
+						break;
+					}
+				}
 			}
 		}
 
-		if (result == null) {
-			StringBundler sb = new StringBundler(5);
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
 
 			sb.append(_SQL_SELECT_COMMERCEPRICEENTRY_WHERE);
 
@@ -4309,6 +4686,14 @@ public class CommercePriceEntryPersistenceImpl
 			}
 
 			sb.append(_FINDER_COLUMN_C_C_S_STATUS_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(CommercePriceEntryModelImpl.ORDER_BY_JPQL);
+			}
 
 			String sql = sb.toString();
 
@@ -4329,20 +4714,13 @@ public class CommercePriceEntryPersistenceImpl
 
 				queryPos.add(status);
 
-				List<CommercePriceEntry> list = query.list();
+				list = (List<CommercePriceEntry>)QueryUtil.list(
+					query, getDialect(), start, end);
 
-				if (list.isEmpty()) {
-					if (useFinderCache) {
-						finderCache.putResult(
-							_finderPathFetchByC_C_S, finderArgs, list);
-					}
-				}
-				else {
-					CommercePriceEntry commercePriceEntry = list.get(0);
+				cacheResult(list);
 
-					result = commercePriceEntry;
-
-					cacheResult(commercePriceEntry);
+				if (useFinderCache) {
+					finderCache.putResult(finderPath, finderArgs, list);
 				}
 			}
 			catch (Exception exception) {
@@ -4353,31 +4731,345 @@ public class CommercePriceEntryPersistenceImpl
 			}
 		}
 
-		if (result instanceof List<?>) {
-			return null;
-		}
-		else {
-			return (CommercePriceEntry)result;
-		}
+		return list;
 	}
 
 	/**
-	 * Removes the commerce price entry where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
 	 *
 	 * @param commercePriceListId the commerce price list ID
 	 * @param CPInstanceUuid the cp instance uuid
 	 * @param status the status
-	 * @return the commerce price entry that was removed
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
 	 */
 	@Override
-	public CommercePriceEntry removeByC_C_S(
-			long commercePriceListId, String CPInstanceUuid, int status)
+	public CommercePriceEntry findByC_C_S_First(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
 		throws NoSuchPriceEntryException {
 
-		CommercePriceEntry commercePriceEntry = findByC_C_S(
-			commercePriceListId, CPInstanceUuid, status);
+		CommercePriceEntry commercePriceEntry = fetchByC_C_S_First(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
 
-		return remove(commercePriceEntry);
+		if (commercePriceEntry != null) {
+			return commercePriceEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("commercePriceListId=");
+		sb.append(commercePriceListId);
+
+		sb.append(", CPInstanceUuid=");
+		sb.append(CPInstanceUuid);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchPriceEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry fetchByC_C_S_First(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		List<CommercePriceEntry> list = findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, 0, 1,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry
+	 * @throws NoSuchPriceEntryException if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry findByC_C_S_Last(
+			long commercePriceListId, String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws NoSuchPriceEntryException {
+
+		CommercePriceEntry commercePriceEntry = fetchByC_C_S_Last(
+			commercePriceListId, CPInstanceUuid, status, orderByComparator);
+
+		if (commercePriceEntry != null) {
+			return commercePriceEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("commercePriceListId=");
+		sb.append(commercePriceListId);
+
+		sb.append(", CPInstanceUuid=");
+		sb.append(CPInstanceUuid);
+
+		sb.append(", status=");
+		sb.append(status);
+
+		sb.append("}");
+
+		throw new NoSuchPriceEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching commerce price entry, or <code>null</code> if a matching commerce price entry could not be found
+	 */
+	@Override
+	public CommercePriceEntry fetchByC_C_S_Last(
+		long commercePriceListId, String CPInstanceUuid, int status,
+		OrderByComparator<CommercePriceEntry> orderByComparator) {
+
+		int count = countByC_C_S(commercePriceListId, CPInstanceUuid, status);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<CommercePriceEntry> list = findByC_C_S(
+			commercePriceListId, CPInstanceUuid, status, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the commerce price entries before and after the current commerce price entry in the ordered set where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63;.
+	 *
+	 * @param commercePriceEntryId the primary key of the current commerce price entry
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next commerce price entry
+	 * @throws NoSuchPriceEntryException if a commerce price entry with the primary key could not be found
+	 */
+	@Override
+	public CommercePriceEntry[] findByC_C_S_PrevAndNext(
+			long commercePriceEntryId, long commercePriceListId,
+			String CPInstanceUuid, int status,
+			OrderByComparator<CommercePriceEntry> orderByComparator)
+		throws NoSuchPriceEntryException {
+
+		CPInstanceUuid = Objects.toString(CPInstanceUuid, "");
+
+		CommercePriceEntry commercePriceEntry = findByPrimaryKey(
+			commercePriceEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			CommercePriceEntry[] array = new CommercePriceEntryImpl[3];
+
+			array[0] = getByC_C_S_PrevAndNext(
+				session, commercePriceEntry, commercePriceListId,
+				CPInstanceUuid, status, orderByComparator, true);
+
+			array[1] = commercePriceEntry;
+
+			array[2] = getByC_C_S_PrevAndNext(
+				session, commercePriceEntry, commercePriceListId,
+				CPInstanceUuid, status, orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected CommercePriceEntry getByC_C_S_PrevAndNext(
+		Session session, CommercePriceEntry commercePriceEntry,
+		long commercePriceListId, String CPInstanceUuid, int status,
+		OrderByComparator<CommercePriceEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_COMMERCEPRICEENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_C_C_S_COMMERCEPRICELISTID_2);
+
+		boolean bindCPInstanceUuid = false;
+
+		if (CPInstanceUuid.isEmpty()) {
+			sb.append(_FINDER_COLUMN_C_C_S_CPINSTANCEUUID_3);
+		}
+		else {
+			bindCPInstanceUuid = true;
+
+			sb.append(_FINDER_COLUMN_C_C_S_CPINSTANCEUUID_2);
+		}
+
+		sb.append(_FINDER_COLUMN_C_C_S_STATUS_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(CommercePriceEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(commercePriceListId);
+
+		if (bindCPInstanceUuid) {
+			queryPos.add(CPInstanceUuid);
+		}
+
+		queryPos.add(status);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						commercePriceEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<CommercePriceEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the commerce price entries where commercePriceListId = &#63; and CPInstanceUuid = &#63; and status = &#63; from the database.
+	 *
+	 * @param commercePriceListId the commerce price list ID
+	 * @param CPInstanceUuid the cp instance uuid
+	 * @param status the status
+	 */
+	@Override
+	public void removeByC_C_S(
+		long commercePriceListId, String CPInstanceUuid, int status) {
+
+		for (CommercePriceEntry commercePriceEntry :
+				findByC_C_S(
+					commercePriceListId, CPInstanceUuid, status,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			remove(commercePriceEntry);
+		}
 	}
 
 	/**
@@ -4767,23 +5459,6 @@ public class CommercePriceEntryPersistenceImpl
 			commercePriceEntry);
 
 		finderCache.putResult(
-			_finderPathFetchByC_C,
-			new Object[] {
-				commercePriceEntry.getCommercePriceListId(),
-				commercePriceEntry.getCPInstanceUuid()
-			},
-			commercePriceEntry);
-
-		finderCache.putResult(
-			_finderPathFetchByC_C_S,
-			new Object[] {
-				commercePriceEntry.getCommercePriceListId(),
-				commercePriceEntry.getCPInstanceUuid(),
-				commercePriceEntry.getStatus()
-			},
-			commercePriceEntry);
-
-		finderCache.putResult(
 			_finderPathFetchByC_ERC,
 			new Object[] {
 				commercePriceEntry.getCompanyId(),
@@ -4867,25 +5542,6 @@ public class CommercePriceEntryPersistenceImpl
 		CommercePriceEntryModelImpl commercePriceEntryModelImpl) {
 
 		Object[] args = new Object[] {
-			commercePriceEntryModelImpl.getCommercePriceListId(),
-			commercePriceEntryModelImpl.getCPInstanceUuid()
-		};
-
-		finderCache.putResult(_finderPathCountByC_C, args, Long.valueOf(1));
-		finderCache.putResult(
-			_finderPathFetchByC_C, args, commercePriceEntryModelImpl);
-
-		args = new Object[] {
-			commercePriceEntryModelImpl.getCommercePriceListId(),
-			commercePriceEntryModelImpl.getCPInstanceUuid(),
-			commercePriceEntryModelImpl.getStatus()
-		};
-
-		finderCache.putResult(_finderPathCountByC_C_S, args, Long.valueOf(1));
-		finderCache.putResult(
-			_finderPathFetchByC_C_S, args, commercePriceEntryModelImpl);
-
-		args = new Object[] {
 			commercePriceEntryModelImpl.getCompanyId(),
 			commercePriceEntryModelImpl.getExternalReferenceCode()
 		};
@@ -5465,8 +6121,17 @@ public class CommercePriceEntryPersistenceImpl
 			new String[] {String.class.getName()},
 			new String[] {"CPInstanceUuid"}, false);
 
-		_finderPathFetchByC_C = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_C",
+		_finderPathWithPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"commercePriceListId", "CPInstanceUuid"}, true);
+
+		_finderPathWithoutPaginationFindByC_C = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"commercePriceListId", "CPInstanceUuid"}, true);
 
@@ -5503,8 +6168,18 @@ public class CommercePriceEntryPersistenceImpl
 			new String[] {Date.class.getName(), Integer.class.getName()},
 			new String[] {"expirationDate", "status"}, false);
 
-		_finderPathFetchByC_C_S = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_S",
+		_finderPathWithPaginationFindByC_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_C_S",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"commercePriceListId", "CPInstanceUuid", "status"},
+			true);
+
+		_finderPathWithoutPaginationFindByC_C_S = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_C_S",
 			new String[] {
 				Long.class.getName(), String.class.getName(),
 				Integer.class.getName()

--- a/modules/apps/commerce/commerce-price-list-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/resources/META-INF/sql/indexes.sql
@@ -2,7 +2,7 @@ create unique index IX_DEFDE07C on CPLCommerceGroupAccountRel (commercePriceList
 create index IX_E475B7EB on CPLCommerceGroupAccountRel (uuid_[$COLUMN_LENGTH:75$], companyId);
 
 create index IX_2FCFB9FB on CommercePriceEntry (CPInstanceUuid[$COLUMN_LENGTH:75$]);
-create unique index IX_2D76B43E on CommercePriceEntry (commercePriceListId, CPInstanceUuid[$COLUMN_LENGTH:75$]);
+create index IX_E653D524 on CommercePriceEntry (commercePriceListId, CPInstanceUuid[$COLUMN_LENGTH:75$], status);
 create index IX_B058565F on CommercePriceEntry (companyId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create index IX_790F9C1C on CommercePriceEntry (displayDate, status);
 create index IX_770DC1E1 on CommercePriceEntry (expirationDate, status);

--- a/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
+++ b/modules/apps/commerce/commerce-price-list-test/src/testIntegration/java/com/liferay/commerce/price/list/service/persistence/test/CommercePriceEntryPersistenceTest.java
@@ -688,33 +688,6 @@ public class CommercePriceEntryPersistenceTest {
 
 	private void _assertOriginalValues(CommercePriceEntry commercePriceEntry) {
 		Assert.assertEquals(
-			Long.valueOf(commercePriceEntry.getCommercePriceListId()),
-			ReflectionTestUtil.<Long>invoke(
-				commercePriceEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "commercePriceListId"));
-		Assert.assertEquals(
-			commercePriceEntry.getCPInstanceUuid(),
-			ReflectionTestUtil.invoke(
-				commercePriceEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "CPInstanceUuid"));
-
-		Assert.assertEquals(
-			Long.valueOf(commercePriceEntry.getCommercePriceListId()),
-			ReflectionTestUtil.<Long>invoke(
-				commercePriceEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "commercePriceListId"));
-		Assert.assertEquals(
-			commercePriceEntry.getCPInstanceUuid(),
-			ReflectionTestUtil.invoke(
-				commercePriceEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "CPInstanceUuid"));
-		Assert.assertEquals(
-			Integer.valueOf(commercePriceEntry.getStatus()),
-			ReflectionTestUtil.<Integer>invoke(
-				commercePriceEntry, "getColumnOriginalValue",
-				new Class<?>[] {String.class}, "status"));
-
-		Assert.assertEquals(
 			Long.valueOf(commercePriceEntry.getCompanyId()),
 			ReflectionTestUtil.<Long>invoke(
 				commercePriceEntry, "getColumnOriginalValue",

--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -445,7 +445,7 @@ definition {
 	@description = "LPS-135400 - Verify it is possible to add a relation with an entry through the Relationship field"
 	@priority = "5"
 	test CanAddRelationOnRelationshipField {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 141652",
@@ -1353,7 +1353,7 @@ definition {
 	@description = "LPS-135401 - Verify that it is possible to delete a relation with an entry on the Relationship tab"
 	@priority = "5"
 	test CanDeleteRelationOnRelationshipTab {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 141661",
@@ -2675,7 +2675,7 @@ definition {
 	@description = "LPS-135401 - Verify that it is possible to relate to many other entries on both objects"
 	@priority = "5"
 	test CanRelateManyOtherEntriesBothObjects {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		for (var nameObject : list "A,B") {
 			ObjectAdmin.addObjectViaAPI(
@@ -4600,6 +4600,8 @@ definition {
 	@description = "LPS-139803 - Verify it the Object Entry Title is displayed on the Relationship tab"
 	@priority = "4"
 	test CanViewObjectEntryTitleOnRelationshipTab {
+		property portal.upstream = "quarantine";
+
 		ObjectAdmin.addObjectViaAPI(
 			labelName = "Custom Object 141620",
 			objectName = "CustomObject141620",
@@ -5321,6 +5323,8 @@ definition {
 	@description = "LPS-135401 - Verify that when adding an entry that was already related to another it will keep related to both entries"
 	@priority = "4"
 	test ChoosingAlreadyRelatedEntryWillKeepOnBothEntries {
+		property portal.upstream = "quarantine";
+
 		for (var letter : list "A,B") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object ${letter}",
@@ -7398,6 +7402,8 @@ definition {
 	@description = "LPS-135401 - Verify if Prevent deletion type of Relationship Many to Many won't allow the user to delete an entry with relation"
 	@priority = "4"
 	test PreventDeletionManyToManyWontAllowDelete {
+		property portal.upstream = "quarantine";
+
 		for (var nameObject : list "A,B") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object ${nameObject}",
@@ -7606,7 +7612,7 @@ definition {
 	@description = "LPS-135401 - Verify if Prevent deletion type of Relationship One to Many won't allow the user to delete an entry with relation from the parent Object"
 	@priority = "5"
 	test PreventDeletionOneToManyWontAllowDelete {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		for (var nameObject : list "A,B") {
 			ObjectAdmin.addObjectViaAPI(
@@ -8202,6 +8208,8 @@ definition {
 	@description = "LPS-139005 - Verify that the Relationship tab is no longer displayed when the child object is inactivated (One to Many)"
 	@priority = "4"
 	test RelationshipTabDisappearsWhenInactivatedOneToMany {
+		property portal.upstream = "quarantine";
+
 		for (var letter : list "A,B") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Custom Object ${letter}",

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.exportimport.kernel.exception.RemoteExportException;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -33,16 +34,21 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys;
 import com.liferay.product.navigation.product.menu.display.context.ProductMenuDisplayContext;
 import com.liferay.product.navigation.site.administration.internal.application.list.SiteAdministrationPanelCategory;
 import com.liferay.product.navigation.site.administration.internal.constants.SiteAdministrationWebKeys;
@@ -57,6 +63,7 @@ import java.util.ResourceBundle;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
+import javax.portlet.RenderRequest;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -298,6 +305,34 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 			_themeDisplay.getUser());
 
 		return _notificationsCount;
+	}
+
+	public String getPageTreeURL() {
+		return PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				_portletRequest,
+				ProductNavigationProductMenuPortletKeys.
+					PRODUCT_NAVIGATION_PRODUCT_MENU,
+				RenderRequest.RENDER_PHASE)
+		).setMVCPath(
+			"/portlet/pages_tree.jsp"
+		).setRedirect(
+			ParamUtil.getString(
+				_portletRequest, "redirect", _themeDisplay.getURLCurrent())
+		).setBackURL(
+			ParamUtil.getString(
+				_portletRequest, "p_l_back_url", _themeDisplay.getURLCurrent())
+		).setParameter(
+			"selPpid",
+			() -> {
+				PortletDisplay portletDisplay =
+					_themeDisplay.getPortletDisplay();
+
+				return portletDisplay.getId();
+			}
+		).setWindowState(
+			LiferayWindowState.EXCLUSIVE
+		).buildString();
 	}
 
 	public PanelCategory getPanelCategory() {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -32,7 +32,6 @@ page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%
 page import="com.liferay.exportimport.kernel.exception.RemoteExportException" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.criteria.URLItemSelectorReturnType" %><%@
-page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.exception.SystemException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
@@ -40,16 +39,12 @@ page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
-page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
-page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
-page import="com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys" %><%@
 page import="com.liferay.product.navigation.site.administration.internal.constants.SiteAdministrationWebKeys" %><%@
 page import="com.liferay.product.navigation.site.administration.internal.display.context.ContentPanelCategoryDisplayContext" %><%@
 page import="com.liferay.product.navigation.site.administration.internal.display.context.SiteAdministrationPanelCategoryDisplayContext" %><%@
@@ -59,8 +54,7 @@ page import="com.liferay.taglib.aui.AUIUtil" %>
 <%@ page import="java.util.List" %><%@
 page import="java.util.Map" %>
 
-<%@ page import="javax.portlet.PortletURL" %><%@
-page import="javax.portlet.RenderRequest" %>
+<%@ page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -47,6 +47,7 @@ page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys" %><%@
 page import="com.liferay.product.navigation.site.administration.internal.constants.SiteAdministrationWebKeys" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -115,23 +115,6 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 </c:if>
 
 <c:if test="<%= !group.isDepot() && !group.isCompany() %>">
-
-	<%
-	PortletURL portletURL = PortletURLBuilder.create(
-		PortletURLFactoryUtil.create(request, ProductNavigationProductMenuPortletKeys.PRODUCT_NAVIGATION_PRODUCT_MENU, RenderRequest.RENDER_PHASE)
-	).setMVCPath(
-		"/portlet/pages_tree.jsp"
-	).setRedirect(
-		ParamUtil.getString(request, "redirect", themeDisplay.getURLCurrent())
-	).setBackURL(
-		ParamUtil.getString(request, "p_l_back_url", themeDisplay.getURLCurrent())
-	).setParameter(
-		"selPpid", portletDisplay.getId()
-	).setWindowState(
-		LiferayWindowState.EXCLUSIVE
-	).buildPortletURL();
-	%>
-
 	<aui:script sandbox="<%= true %>">
 		var pagesTreeToggle = document.getElementById(
 			'<portlet:namespace />pagesTreeSidenavToggleId'
@@ -144,7 +127,9 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 				'com.liferay.product.navigation.product.menu.web_pagesTreeState',
 				'open'
 			).then(() => {
-				Liferay.Util.fetch('<%= portletURL.toString() %>')
+				Liferay.Util.fetch(
+					'<%= siteAdministrationPanelCategoryDisplayContext.getPageTreeURL() %>'
+				)
 					.then((response) => {
 						if (!response.ok) {
 							throw new Error(

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -122,7 +122,9 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 	).setMVCPath(
 		"/portlet/pages_tree.jsp"
 	).setRedirect(
-		themeDisplay.getURLCurrent()
+		ParamUtil.getString(request, "redirect", themeDisplay.getURLCurrent())
+	).setBackURL(
+		ParamUtil.getString(request, "p_l_back_url", themeDisplay.getURLCurrent())
 	).setParameter(
 		"selPpid", portletDisplay.getId()
 	).setWindowState(

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "7.0.280"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "7.0.281"
 	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "1.2.8"
 	classpath group: "de.undercouch", name: "gradle-download-task", version: "3.3.0"
 	classpath group: "gradle.plugin.org.ysb33r.gradle", name: "gradletest", version: "2.0"

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	compileInclude group: "com.google.errorprone", name: "error_prone_annotations", version: "2.4.0"
 	compileInclude group: "com.google.guava", name: "failureaccess", version: "1.0.1"
 	compileInclude group: "com.google.guava", name: "guava", version: "30.1.1-jre"
-	compileInclude group: "com.upokecenter", name: "cbor", version: "4.5.2"
+	compileInclude group: "com.upokecenter", name: "cbor", version: "4.2.0"
 	compileInclude group: "com.yubico", name: "webauthn-server-core", version: "1.6.4"
 	compileInclude group: "com.yubico", name: "yubico-util", version: "1.6.4"
 	compileInclude group: "net.i2p.crypto", name: "eddsa", version: "0.3.0"

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-fido2-web/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "com.augustcellars.cose", name: "cose-java", version: "1.1.0"
-	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.13.1"
+	compileInclude group: "com.fasterxml.jackson.dataformat", name: "jackson-dataformat-cbor", version: "2.11.2"
 	compileInclude group: "com.fasterxml.jackson.datatype", name: "jackson-datatype-jdk8", version: "2.11.2"
 	compileInclude group: "com.github.peteroupc", name: "numbers", version: "1.7.4"
 	compileInclude group: "com.google.errorprone", name: "error_prone_annotations", version: "2.4.0"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/xmlSchemaUtil.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/source-builder/xmlSchemaUtil.js
@@ -95,10 +95,30 @@ function getLocationValue(field, context) {
 										itemChild.childNodes
 									);
 
+									const itemChildNodesAttributes = getChildAttributes(
+										item.childNodes
+									);
+
 									let itemContent;
 
 									if (childNodesAttributes.length) {
 										itemContent = childNodesAttributes;
+									}
+									else if (
+										itemChildNodesAttributes.length
+									) {
+										itemContent = itemChildNodesAttributes;
+
+										if (itemChildNodesAttributes.length) {
+											if (!childContent[item.tagName]) {
+												childContent[item.tagName] = [];
+											}
+
+											childContent[
+												item.tagName
+											] = itemContent;
+										}
+										break;
 									}
 									else {
 										itemContent = itemChild.textContent;

--- a/modules/etl/talend/pom.xml
+++ b/modules/etl/talend/pom.xml
@@ -111,7 +111,7 @@
 				<plugin>
 					<groupId>com.liferay</groupId>
 					<artifactId>com.liferay.source.formatter</artifactId>
-					<version>1.0.1201</version>
+					<version>1.0.1202</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/modules/sdk/gradle-plugins-defaults/bnd.bnd
+++ b/modules/sdk/gradle-plugins-defaults/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins Defaults
 Bundle-SymbolicName: com.liferay.gradle.plugins.defaults
-Bundle-Version: 7.0.281
+Bundle-Version: 7.0.282
 Export-Package:\
 	com.liferay.gradle.plugins.defaults,\
 	com.liferay.gradle.plugins.defaults.extensions,\

--- a/modules/sdk/gradle-plugins-defaults/build.gradle
+++ b/modules/sdk/gradle-plugins-defaults/build.gradle
@@ -18,7 +18,7 @@ copyGradleTestDependencies {
 dependencies {
 	compile group: "com.github.jk1", name: "gradle-license-report", version: "1.8"
 	compile group: "com.gradle.publish", name: "plugin-publish-plugin", version: "0.11.0"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.app.javadoc.builder", version: "1.2.4"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.baseline", version: "6.0.6"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.cache", version: "1.0.18"

--- a/modules/sdk/gradle-plugins-defaults/src/main/resources/com/liferay/gradle/plugins/defaults/dependencies/config-maven.gradle
+++ b/modules/sdk/gradle-plugins-defaults/src/main/resources/com/liferay/gradle/plugins/defaults/dependencies/config-maven.gradle
@@ -68,7 +68,7 @@ tasks.withType(Upload) {
 					repositoryURL = "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases"
 				}
 
-				if (project.path.startsWith(":dxp:") && !project.path.endsWith("-api") && !project.path.endsWith("-spi") && !project.path.contains("-demo-") && !project.path.contains("-demo-data-") && repositoryURL.equals("https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases")) {
+				if (project.path.startsWith(":dxp:") && !project.path.endsWith("-api") && !project.path.endsWith("-spi") && !project.path.contains("-demo-") && !project.path.contains("-demo-data-") && (repositoryURL.equals("https://repository.liferay.com/nexus/content/repositories/liferay-public-releases") || repositoryURL.equals("https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases"))) {
 					repositoryURL = "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-private-releases"
 				}
 
@@ -82,7 +82,7 @@ tasks.withType(Upload) {
 					snapshotRepositoryURL = "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots"
 				}
 
-				if (project.path.startsWith(":dxp:") && !project.path.endsWith("-api") && !project.path.endsWith("-spi") && !project.path.contains("-demo-") && !project.path.contains("-demo-data-") && snapshotRepositoryURL.equals("https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots")) {
+				if (project.path.startsWith(":dxp:") && !project.path.endsWith("-api") && !project.path.endsWith("-spi") && !project.path.contains("-demo-") && !project.path.contains("-demo-data-") && (snapshotRepositoryURL.equals("https://repository.liferay.com/nexus/content/repositories/liferay-public-snapshots") || snapshotRepositoryURL.equals("https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-snapshots"))) {
 					snapshotRepositoryURL = "https://repository-cdn.liferay.com/nexus/content/repositories/liferay-private-snapshots"
 				}
 

--- a/modules/sdk/gradle-plugins-source-formatter/README.markdown
+++ b/modules/sdk/gradle-plugins-source-formatter/README.markdown
@@ -13,7 +13,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "5.1.98"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "5.1.99"
 	}
 
 	repositories {
@@ -123,7 +123,7 @@ manually adding a dependency to the `sourceFormatter` configuration:
 
 ```gradle
 dependencies {
-	sourceFormatter group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.1201"
+	sourceFormatter group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.1202"
 }
 ```
 

--- a/modules/sdk/gradle-plugins-source-formatter/bnd.bnd
+++ b/modules/sdk/gradle-plugins-source-formatter/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Description: The Source Formatter Gradle plugin lets you format project files using the Liferay Source Formatter tool.
 Bundle-Name: Liferay Gradle Plugins Source Formatter
 Bundle-SymbolicName: com.liferay.gradle.plugins.source.formatter
-Bundle-Version: 5.1.99
+Bundle-Version: 5.1.100
 Export-Package: com.liferay.gradle.plugins.source.formatter
 -includeresource: @com.liferay.source.formatter-*.jar!/com/liferay/source/formatter/SourceFormatterArgs.class

--- a/modules/sdk/gradle-plugins-source-formatter/build.gradle
+++ b/modules/sdk/gradle-plugins-source-formatter/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.util", version: "1.0.46"
 
 	compileOnly fileTree(builtBy: [rootProject.tasks.getByName("extractGradleApi" + gradleVersion.replace(".", ""))], dir: new File(rootProject.buildDir, "gradle-${gradleVersion}"))
-	compileOnly group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.1201"
+	compileOnly group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.1202"
 }
 
 gradleTest {

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMissing/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMissing/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 			exclude group: "com.liferay", module: "com.liferay.gradle.util"
 		}

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMulti/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMulti/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 			exclude group: "com.liferay", module: "com.liferay.gradle.util"
 		}
 	}

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMultiExclude/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMultiExclude/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136"
 	}
 
 	repositories {

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveSingle/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveSingle/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bndlib"
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.gradle"

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/targetPlatformDefaultDependencies/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/targetPlatformDefaultDependencies/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 			exclude group: "com.liferay", module: "com.liferay.gradle.util"
 		}

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/targetPlatformTheme/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/targetPlatformTheme/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+		classpath(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 			exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 		}
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.theme.builder", version: "2.0.17"

--- a/modules/sdk/gradle-plugins-workspace/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 	compile group: "com.bmuschko", name: "gradle-docker-plugin", version: "6.6.1"
 	compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
 	compile group: "com.liferay", name: "com.liferay.ant.bnd", version: "3.2.8"
-	compile(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.135") {
+	compile(group: "com.liferay", name: "com.liferay.gradle.plugins", version: "13.2.136") {
 		exclude group: "biz.aQute.bnd", module: "biz.aQute.bnd"
 	}
 	compile(group: "com.liferay", name: "com.liferay.gradle.plugins.css.builder", version: "5.0.2") {

--- a/modules/sdk/gradle-plugins/bnd.bnd
+++ b/modules/sdk/gradle-plugins/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins
 Bundle-SymbolicName: com.liferay.gradle.plugins
-Bundle-Version: 13.2.136
+Bundle-Version: 13.2.137
 Export-Package:\
 	com.liferay.gradle.plugins,\
 	com.liferay.gradle.plugins.extensions,\

--- a/modules/sdk/gradle-plugins/build.gradle
+++ b/modules/sdk/gradle-plugins/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.python", version: "1.0.1"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.rest.builder", version: "1.1.103"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.service.builder", version: "4.0.84"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "5.1.98"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "5.1.99"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.test.integration", version: "3.0.5"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.tld.formatter", version: "1.0.11"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.tlddoc.builder", version: "1.3.8"

--- a/modules/sdk/gradle-plugins/src/main/resources/com/liferay/gradle/plugins/dependencies/portal-tools.properties
+++ b/modules/sdk/gradle-plugins/src/main/resources/com/liferay/gradle/plugins/dependencies/portal-tools.properties
@@ -10,6 +10,6 @@ com.liferay.portal.tools.rest.builder=1.0.226
 com.liferay.portal.tools.service.builder=1.0.412
 com.liferay.portal.tools.upgrade.table.builder=1.0.10
 com.liferay.portal.tools.wsdd.builder=1.0.11
-com.liferay.source.formatter=1.0.1201
+com.liferay.source.formatter=1.0.1202
 com.liferay.tld.formatter=1.0.5
 com.liferay.whip=1.0.3

--- a/modules/util/source-formatter/bnd.bnd
+++ b/modules/util/source-formatter/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Source Formatter
 Bundle-SymbolicName: com.liferay.source.formatter
-Bundle-Version: 1.0.1202
+Bundle-Version: 1.0.1203
 Import-Package:\
 	!javax.portlet,\
 	\

--- a/modules/util/source-formatter/samples/pom.xml
+++ b/modules/util/source-formatter/samples/pom.xml
@@ -16,7 +16,7 @@
 			<plugin>
 				<groupId>com.liferay</groupId>
 				<artifactId>com.liferay.source.formatter</artifactId>
-				<version>1.0.1201</version>
+				<version>1.0.1202</version>
 				<configuration>
 					<baseDir>src/main</baseDir>
 				</configuration>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBundleInformationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBundleInformationCheck.java
@@ -47,6 +47,9 @@ public class BNDBundleInformationCheck extends BaseFileCheck {
 		if (bundleVersion == null) {
 			addMessage(fileName, "Missing Bundle-Version");
 		}
+		else if (!bundleVersion.matches("^\\d+\\.\\d+\\.\\d+$")) {
+			addMessage(fileName, "Invalid Bundle-Version: " + bundleVersion);
+		}
 		else if (absolutePath.endsWith("-test/bnd.bnd") &&
 				 !bundleVersion.equals("1.0.0")) {
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBundleInformationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBundleInformationCheck.java
@@ -40,24 +40,7 @@ public class BNDBundleInformationCheck extends BaseFileCheck {
 		}
 
 		_checkBundleName(fileName, absolutePath, content);
-
-		String bundleVersion = BNDSourceUtil.getDefinitionValue(
-			content, "Bundle-Version");
-
-		if (bundleVersion == null) {
-			addMessage(fileName, "Missing Bundle-Version");
-		}
-		else if (!bundleVersion.matches("^\\d+\\.\\d+\\.\\d+$")) {
-			addMessage(fileName, "Invalid Bundle-Version: " + bundleVersion);
-		}
-		else if (absolutePath.endsWith("-test/bnd.bnd") &&
-				 !bundleVersion.equals("1.0.0")) {
-
-			addMessage(
-				fileName,
-				"'Bundle-Version' for *-test modules should always be " +
-					"'1.0.0', since we do not publish these");
-		}
+		_checkBundleVersion(fileName, absolutePath, content);
 
 		return content;
 	}
@@ -119,6 +102,28 @@ public class BNDBundleInformationCheck extends BaseFileCheck {
 		}
 		else {
 			addMessage(fileName, "Missing Bundle-SymbolicName");
+		}
+	}
+
+	private void _checkBundleVersion(
+		String fileName, String absolutePath, String content) {
+
+		String bundleVersion = BNDSourceUtil.getDefinitionValue(
+			content, "Bundle-Version");
+
+		if (bundleVersion == null) {
+			addMessage(fileName, "Missing Bundle-Version");
+		}
+		else if (!bundleVersion.matches("^\\d+\\.\\d+\\.\\d+$")) {
+			addMessage(fileName, "Invalid Bundle-Version: " + bundleVersion);
+		}
+		else if (absolutePath.endsWith("-test/bnd.bnd") &&
+				 !bundleVersion.equals("1.0.0")) {
+
+			addMessage(
+				fileName,
+				"'Bundle-Version' for *-test modules should always be " +
+					"'1.0.0', since we do not publish these");
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/resources/META-INF/maven/com.liferay/com.liferay.source.formatter/plugin-help.xml
+++ b/modules/util/source-formatter/src/main/resources/META-INF/maven/com.liferay/com.liferay.source.formatter/plugin-help.xml
@@ -7,7 +7,7 @@
 	<description/>
 	<groupId>com.liferay</groupId>
 	<artifactId>com.liferay.source.formatter</artifactId>
-	<version>1.0.1201</version>
+	<version>1.0.1202</version>
 	<goalPrefix>source-formatter</goalPrefix>
 	<mojos>
 		<mojo>

--- a/modules/util/source-formatter/src/main/resources/META-INF/maven/plugin.xml
+++ b/modules/util/source-formatter/src/main/resources/META-INF/maven/plugin.xml
@@ -7,7 +7,7 @@
 	<description/>
 	<groupId>com.liferay</groupId>
 	<artifactId>com.liferay.source.formatter</artifactId>
-	<version>1.0.1201</version>
+	<version>1.0.1202</version>
 	<goalPrefix>source-formatter</goalPrefix>
 	<isolatedRealm>false</isolatedRealm>
 	<inheritedByDefault>true</inheritedByDefault>

--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -6,7 +6,7 @@ import org.gradle.util.GUtil
 
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "7.0.280"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "7.0.281"
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "1.2.3"
 		classpath group: "de.undercouch", name: "gradle-download-task", version: "3.3.0"
 		classpath group: "gradle.plugin.org.ysb33r.gradle", name: "gradletest", version: "1.1"

--- a/tools/sdk/dependencies/com.liferay.source.formatter/ivy.xml
+++ b/tools/sdk/dependencies/com.liferay.source.formatter/ivy.xml
@@ -11,6 +11,6 @@
 	</info>
 
 	<dependencies defaultconf="default">
-		<dependency name="com.liferay.source.formatter" org="com.liferay" rev="1.0.1201" />
+		<dependency name="com.liferay.source.formatter" org="com.liferay" rev="1.0.1202" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
- COMMERCE-8465 add key to shipping fixed option
- COMMERCE-8465 upgrade process
- COMMERCE-8465 generate upgrade process table
- COMMERCE-8465 checkout step to use new shipping option key
- COMMERCE-8465 shipping fixed option service impl
- COMMERCE-8465 align to new methods signatures
- COMMERCE-8465 buildService
- COMMERCE-8465 baseline
- COMMERCE-8465 Do I need to check the existence of the column? Shouldn't that logic be in the alterTableAddColumn method?
- COMMERCE-8024 Registry to manage offline payments
- COMMERCE-8024 Add configuration and implementation
- COMMERCE-8024 dependencies
- COMMERCE-8024 new label
- COMMERCE-8024 buildLang
- LPS-147418 Revert "LPS-147417 Add feature flag"
- Revert "LPS-144896 Create feature flag for Object Views"
- LPS-147172 Remove ObjectView FF calls
- Revert "LPS-146804 Create feature flag for object entry permissions action"
- LPS-147171 Remove ObjectEntryPermissions FF calls
- LPS-147874 Create test stubs
- LPS-147877 Petra HTTP Invoker
- LPS-92618 SF
- LPS-92618 prep next
- LPS-147267 prep next
- LPS-147267 LPS-92618 prep next
- LPS-92618 regen
- LPS-147106 - Fix CanApplyPermissionOnlyToSpecificSiteWhenScopedBySite test
- LPS-147106 SF
- LPS-147879 Remove invalid tests
- LPS-147476 Update Congrats Information Fragment to Mobile and Tablet View
- LPS-147877 prep next
- LPS-147891 CotnentUtil dependency on kernel
- LPS-147891 not used
- LPS-140660 Raylife D2C Mobile Design for Property Info Page
- LPS-140660 SF
- LPS-140660 upload
- LPS-147875 - Fix rendering of commerce open carts widget in Dialect theme.
- LPS-147235 Not showing anyone segment assets when combining assets from all segments in manual collections
- LPS-147233 Avoid retrieve items segment by segment when user belongs to more than one and combined segments check is active
- LPS-147233 Refactor to simplify the assetEntryQuery creation method
- LPS-147233 Add new test that checks no duplicate assets are returned
- LPS-146640 Fix task timers key in delete function
- LPS-146640 Add timer information panel content
- LPS-146640 Add method to create taskTimers object when creating new timer from summary area
- LPS-146640 Add functions to create, delete and update timers
- LPS-146640 Add styles related to timers information panel
- LPS-147573 Create duration field and scale components
- LPS-147573 Add fields to duration component and create methods to handle recurrence
- LPS-147573 Add styles related to duration components
- LPS-147573 Add language properties
- LPS-147573 Build languages
- LPS-147457 Replace "content: normal" by "content: ''" to avoid accessibility issues
- LPS-147457 Prevent accessibility errors caused by the use of 'content: normal' from style sheets. Remove styles that should be controlled by Clay. Bootstrap used a pseudo element to generate the 'dropdown-toggle' caret styles. Clay disabled this a while ago
- LRQA-73377 - Add skip property on Worflow tests
- LRAC-10560 Add viewNameListIsNotPresent macro
- LRAC-10582 Add CanUpdateNumberOfMembersForDynamicSegment testcase
- LRAC-10582 SF
- LRAC-10582 Add CanUpdateNumberOfMembersForDynamicSegment to quarantine
- not needed
- LPS-145675 Add CanAddObjectPortletWidget Test
- LPS-145675 SF
- LPS-146115 Add RaylifeLandingMobile tests
- LPS-146115 SF
- LRQA-73381 Investigate CI failure of CPDynamicdatalists#EditBooleanFieldShowLabel
- LRQA-73369 Refactor of PGDynamicdatalists#ViewIntegerFieldPredefinedValue
- LPS-127272 Fix AddWebContentTemplateWithSmallImage test
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.78 prep next
- artifact:ignore object-web 1.0.45 prep next
- LPS-147507 Add permission checker to Guest User on Calendar
- LRQA-65584 remove  ignore of CPDynamicdatalists#CopyDataDefinition
- LPS-147461 Update Congrats Fragment to Mobile and Tablet View
- POSHI-251 Fix for windows
- POSHI-251 Inline
- POSHI-251 Use com.liferay.gradle.plugins.poshi.runner:3.0.27
- POSHI-251 prep next
- LPS-81905 Fix AddRecordWithBlankLinkToPageField test
- LPS-145723 Add CanInactivateAction test
- LPS-145747 Add CanReactivateAction test
- LPS-145726 Add CanRetrieveDataProvidersOnSelectFromListField test
- LPS-147921 Add more Objects tests to relevant
- LPS-147913 Don't need to be protected fields
- LPS-147913 Catch and log parse exceptions.
- LPS-147913 Extract into a new method and catch and log the exception
- LPS-147913 Removes no necessary exceptions
- LPS-147913 Rename
- LPS-147576 Add shippingConfiguration in raylife product
- LPS-147576 Add checkout request on payment flow
- LPS-147576 upload
- POSHI-254 Update Poshi Runner version to 1.0.336
- POSHI-254 Generate CHANGELOG
- POSHI-254 prep next
- POSHI-254 prep next
- LPS-145293 Wrong command, my bad
- LPS-147169 Regen portal-osgi-configuration.properties
- LPS-133798 Revert
- LPS-147924 Remove portal-remote-axis-extender
- LPS-147924 compileInclude axis inside commerce-shipping-engine-fedex, there is no axis extender providing it anymore.
- LPS-147924 Remove AxisServlet
- LPS-147924 Remove unused dependencies
- LPS-147924 Remove unused ant target
- LPS-147924 Remove axis from lib dependencies
- LPS-147924 Remove from gitignore
- LPS-147924 Remove from IDE files
- LPS-147924 Remove from lib versions
- LPS-147924 ant build-lib-versions
- LPS-147924 Semantic versioning
- LRAC-8176 [Remove] tests that are showing stable runs on CI
- Revert "LPS-144872 Create feature flag for ObjectFieldBusinessType"
- LPS-147100 Remove usages of ObjectFieldBusinessType feature flag
- LPS-147100 Fix functional tests
- LRQA-73235 Format css in main.css
- COMMERCE-8470 batch-engine-api - define default value
- COMMERCE-8470 batch-planner-web - update
- COMMERCE-8470 batch-planner - propagate delimiter query parameter to batch-engine
- COMMERCE-8470 batch-planner - depending on file type different policies are available, we need fetch method
- COMMERCE-8470 batch-planner - handle optional policy, only csv file can have csv delimiter defined
- COMMERCE-8470 batch-planner - buildService
- COMMERCE-8470 batch-engine-api - baseline
- LPS-77699 Update Translations
- LPS-147608 SF, remove unused variables
- LPS-147258 Remove custom font-size and use Clay utility instead
- LPS-147258 Remove unused code from SCSS
- LPS-147258 Modify test snapshots
- LPS-147525 Change the modal to have a width of 600px.
- COMMERCE-6609 dispatch-talend-web - JSP - variables naming changes
- LPS-144631 Adds ClayTreeView implementation to SelectLayout
- LPS-144631 Reflect the selection in the tree
- LPS-144631 Do not allow selecting disabled items
- LPS-130975 Remove unused ThemeAdapter css file
- LPS-130975 Variables import is not necessary
- LRQA-73382 Existing hypersonic database will not allow release tests to skip admin new password creation so this creates a specific testcase to cover the embedded database. Then delete db files for the rest of the test cases
- LPS-147936 Add condition to avoid unneeded operation
- LPS-147936 Use UI steps to add pages
- LPS-147938 Remove unused XLSTextStripper
- LPS-147938 Create Tika service module
- LPS-147938 Move TikaRawMetadataProcessor to module.
- LPS-147938 Move MimeTypesImpl to module
- LPS-147938 Create TextExtractor and move FileImpl's text extraction logic to module.
- LPS-147938 Disable TesseractOCRParser
- LPS-147938 Setup Tika classloader
- LPS-147938 Turn on parent buddy policy to load tika dependencies from portal classloader.
- LPS-147938 Don't check bundle with parent buddy policy, as that would lead to see portal resources which will for sure to fail.
- LPS-147938 Rewire subjvm's classpath to adapt module jars.
- LPS-147938 Singleton TikaConfig
- LPS-147938 Move Tike settings to module
- LPS-147938 Remove tika config from system properties
- LPS-147938 Remove from system bundle export
- LPS-147938 Clean up portal properties
- LPS-147938 Remove tika to lib dependencies
- LPS-147938 Remove from git ignore
- LPS-147938 Remove from IDE files
- LPS-147938 Remove from lib versions
- LPS-147938 Semantic versioning
- LRQA-63664 Update the test to discard the changes
- LPS-147234 Update the ContentImagesUpgradeProcess could identify the fileEntry in the dynamic element data
- LPS-147234 We do have the fileEntryId in the data, take it and reuse the method _getFileEntryByFileEntryId
- LPS-147143 Adds RenderRequest to display context
- LPS-147143 Use as redirect and backURL the dragged the parameter.
- LPS-147143 Adds redirect and backURL to ProductMenuPortletURL.
- LPS-147935 Support to format Poshi Scripts outside liferay-portal repo
- LPS-147935 SF
- LRCI-2786 Remove unused methods Build#getStatusReport()
- LRCI-2786 Remove unused methods from BuildTest.java
- LRCI-2786 Add methods to determine if a string is a valid json object or array
- LRCI-2786 Add method to get data from archive file if available
- LRCI-2786 Use 'getConsoleText()' to take advantage of the JenkinsConsoleTextLoader
- LRCI-2786 Remove unchanged parameters from 'downloadSampleURL()'
- LRCI-2786 Archive the build artifacts when in CI & not originally from an archive
- LRCI-2786 prep next
- LPS-147918 Create a SummaryContributor for JournalArticle
- LPS-147918 Copy from JournalArticleIndexer.doGetSummary, no logic changes.
- LPS-147918 Copy from JournalArticleIndexerPostProcessor.postProcessSummary, no logic changes
- LPS-147918 Deletes the old component
- LPS-147918 Uses ModelSummaryContributor
- LPS-146691 Provides a new method in order to get the formVariationKey for a specific info item.
- LPS-146691 Baseline
- LPS-146691 Implements getInfoItemFormVariationKey.
- LPS-146691 Adds an InfoItemTemplatedRenderer to be used to register a component for each TemplateInfoItemCapability implementation.
- LPS-146691 Adds a TemplateInfoItemTemplatedRenderer provider.
- LPS-146691 Deletes old InfoItemRenderer implementation
- LPS-146691 Adds required dependencies.
- LPS-146691 removes locale parameter since it is not used
- LPS-146691 SF - inline
- LPS-146691 It is not needed
- LPS-146691 SF - Rename
- LPS-146691 Adds new provider class for info item object variation
- LPS-146691 Moves method
- LPS-146691 Register new interface
- LPS-146691 Creates new implementations for InfoItemObjectVariationProvider for Journal and DL
- LPS-146691 Uses new interface to get the form variation key
- LPS-147487 setup testray import files
- LPS-147487 Add project and case
- LPS-147487 sf
- LPS-147487 Update Testray Cases
- LPS-147487 Add generic context
- LPS-147487 SF
- LPS-147487 Get projectId from get request
- LPS-147487 remove entries data
- LPS-147487 addTestBuild
- LPS-147487 Update listBuckets
- LPS-147487 add unzipFile method
- LPS-147487 SF
- LPS-147487 Update getResults
- LPS-147487 readFiles
- LPS-147487 refactor unzipFiles to _unTarGzip
- LPS-147487 use _documentBuilderFactory and _documentBuilder as private attributes
- LPS-147487 use Document directly instead File
- LPS-147487 use _groupId as private attribute
- LPS-147487 no longer used
- LPS-147487 remove System.out.println
- LPS-147487 SF
- LPS-147487 set TestrayProject name to mandatory and searchble
- LPS-147487 parameterize groupId
- LPS-147487 create PropsUtil and PropsValues
- LPS-147487 add TODO comment
- LPS-147487 move HttpClient to com.liferay.site.initializer.testray.extra.java.function.http
- LPS-147487 grab HttpInvoker from Portal
- LPS-147487 create HttpUtil
- LPS-147487 rename
- LPS-147487 SF
- LPS-147487 add com.liferay.petra.http.invoker dependency
- LPS-147487 change scope from site to company in ObjectDefinitions
- LPS-147487 groupId is no longer used because scope was changed to company
- LPS-147487 change RemoteApp to work with company scope instead site
- LPS-147487 add commons-logging dependency
- LPS-147487 add testray.password and testray.user properties
- LPS-147487 implement post method in HttpUtil
- LPS-147487 use HttpUtil.post
- LPS-147487 refactoring HttpUtil.post to HttpUtil.invoke to make it generic
- LPS-147487 delete because is no longer used. We are using HttpUtil instead
- LPS-147487 use long instead int
- LPS-147487 auto SF
- LPS-147487 SF
- LPS-147930 Add remote staging properties for the test
- LPS-147941 Update the error message for test
- LPS-147475 Create new role name when auto create is enabled
- LRQA-73398 Investigate CI failure of LocalizedSimpleFieldsetsStructure#VerifyNestedFieldsetEditionOnStructure
- LPS-147487 gcp-function
- LPS-147724 Add CannotSaveAnotherLayoutAsDefault test
- LPS-147756 Add CanCreateView Test
- LPS-147757 CanUpdateView Test
- LPS-147756 SF
- COMMERCE-8486 remove service reference, use sql query
- COMMERCE-8486 inline
- COMMERCE-8486 rename
- LPS-147906 Avoid infinite loop by only going one level of nested objects
- LPS-147969 Fix checkbox behavior & dropdown table when no data present
- LPS-147969 upload
- LPS-147726 fix Team Extranet testcases
- COMMERCE-8486 Missing '
- COMMERCE-8486 set proper key
- Revert "LPS-147071 Bump upokecenter cbor"
- Revert "LPS-143867 Bump jackson dataformat cbor"
- LPS-147980 Quarantine tests that are flaky only in CI and need a deeper investigation
- LPS-103170 Configure Upload task
- LPS-147935 prep next
- LPS-103170 LPS-147935 prep next
- LPS-105380 Ensure that bundle version is a valid value
- LPS-105380 SF extract check for bundle version into method
- LPS-147152 Use dragged parameters if available.
- LPS-147152 SF move to display context
- LRQA-73299 Add permissions to elasticsearch-sidecar dir for 7.4 release bundles & docker images
- COMMERCE-8476 Add columns in data set display view
- COMMERCE-8476 Add fields to clay model object
- COMMERCE-8338 Autogenerated code (gw buildService)
- COMMERCE-8338 Remove unique index on priceentry
- COMMERCE-8338 Fix service methods
- COMMERCE-8338 Add upgrade process
- COMMERCE-8338 Update schema version
- LPS-147193 Place transitions labels into labels property
