### PR TITLE
LPS-148242 Not needed

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -884,7 +884,7 @@ public class ObjectEntryLocalServiceImpl
 					}
 
 					return _inlineSQLHelper.getPermissionWherePredicate(
-						dynamicObjectDefinitionTable.getName(),
+						objectDefinition2.getClassName(),
 						dynamicObjectDefinitionTable.getPrimaryKeyColumn());
 				}
 			)
@@ -959,8 +959,12 @@ public class ObjectEntryLocalServiceImpl
 						return null;
 					}
 
+					ObjectDefinition objectDefinition2 =
+						_objectDefinitionPersistence.findByPrimaryKey(
+							objectRelationship.getObjectDefinitionId2());
+
 					return _inlineSQLHelper.getPermissionWherePredicate(
-						dynamicObjectDefinitionTable.getName(),
+						objectDefinition2.getClassName(),
 						dynamicObjectDefinitionTable.getPrimaryKeyColumn());
 				}
 			)

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -152,8 +152,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectEntry objectEntry1 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition1.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition1.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectField objectField = _objectFieldLocalService.getObjectField(
@@ -161,8 +160,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectEntry objectEntryA = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition2.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition2.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		List<ObjectEntry> objectEntries =
@@ -277,8 +275,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectEntry objectEntry1 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition1.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition1.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectField objectField = _objectFieldLocalService.getObjectField(
@@ -286,8 +283,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectEntry objectEntryA = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition2.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition2.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		List<ObjectEntry> objectEntries =
@@ -383,13 +379,11 @@ public class ObjectRelatedModelsProviderTest {
 
 		ObjectEntry objectEntry1 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition1.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition1.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 		ObjectEntry objectEntry2 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition2.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition2.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		List<ObjectEntry> objectEntries =
@@ -415,8 +409,7 @@ public class ObjectRelatedModelsProviderTest {
 
 		objectEntry2 = _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), 0,
-			_objectDefinition2.getObjectDefinitionId(),
-			Collections.<String, Serializable>emptyMap(),
+			_objectDefinition2.getObjectDefinitionId(), Collections.emptyMap(),
 			ServiceContextTestUtil.getServiceContext());
 
 		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
@@ -438,8 +431,6 @@ public class ObjectRelatedModelsProviderTest {
 		_testIndividualScopeViewPermission(
 			objectEntry2, objectRelationship, objectRelatedModelsProvider,
 			objectEntry1);
-
-		// TODO deleteObjectRelationshipMappingTableValues
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -353,10 +353,10 @@ public class ObjectRelatedModelsProviderTest {
 		Assert.assertEquals(objectEntries.toString(), 2, objectEntries.size());
 
 		_testCompanyScopeViewPermission(
-			objectRelationship, objectRelatedModelsProvider, objectEntry1);
+			objectRelatedModelsProvider, objectRelationship, objectEntry1);
 
 		_testIndividualScopeViewPermission(
-			objectEntryA, objectRelationship, objectRelatedModelsProvider,
+			objectEntryA, objectRelatedModelsProvider, objectRelationship,
 			objectEntry1);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
@@ -426,10 +426,10 @@ public class ObjectRelatedModelsProviderTest {
 		Assert.assertEquals(objectEntries.toString(), 2, objectEntries.size());
 
 		_testCompanyScopeViewPermission(
-			objectRelationship, objectRelatedModelsProvider, objectEntry1);
+			objectRelatedModelsProvider, objectRelationship, objectEntry1);
 
 		_testIndividualScopeViewPermission(
-			objectEntry2, objectRelationship, objectRelatedModelsProvider,
+			objectEntry2, objectRelatedModelsProvider, objectRelationship,
 			objectEntry1);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
@@ -456,9 +456,9 @@ public class ObjectRelatedModelsProviderTest {
 	}
 
 	private void _testCompanyScopeViewPermission(
-			ObjectRelationship objectRelationship,
 			ObjectRelatedModelsProvider<ObjectEntry>
 				objectRelatedModelsProvider,
+			ObjectRelationship objectRelationship,
 			ObjectEntry parentObjectEntry)
 		throws Exception {
 
@@ -490,9 +490,10 @@ public class ObjectRelatedModelsProviderTest {
 	}
 
 	private void _testIndividualScopeViewPermission(
-			ObjectEntry childObjectEntry, ObjectRelationship objectRelationship,
+			ObjectEntry childObjectEntry,
 			ObjectRelatedModelsProvider<ObjectEntry>
 				objectRelatedModelsProvider,
+			ObjectRelationship objectRelationship,
 			ObjectEntry parentObjectEntry)
 		throws Exception {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -140,15 +140,8 @@ public class ObjectRelatedModelsProviderTest {
 	public void testObjectEntry1to1ObjectRelatedModelsProviderImpl()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(),
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_ONE);
+		ObjectRelationship objectRelationship = _createRelationship(
+			ObjectRelationshipConstants.TYPE_ONE_TO_ONE);
 
 		ObjectRelatedModelsProvider<ObjectEntry> objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
@@ -272,15 +265,8 @@ public class ObjectRelatedModelsProviderTest {
 	public void testObjectEntry1toMObjectRelatedModelsProviderImpl()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(),
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectRelationship objectRelationship = _createRelationship(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectRelatedModelsProvider<ObjectEntry> objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
@@ -385,15 +371,8 @@ public class ObjectRelatedModelsProviderTest {
 	public void testObjectEntryMtoMObjectRelatedModelsProviderImpl()
 		throws Exception {
 
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(),
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+		ObjectRelationship objectRelationship = _createRelationship(
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		ObjectRelatedModelsProvider<ObjectEntry> objectRelatedModelsProvider =
 			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
@@ -464,6 +443,18 @@ public class ObjectRelatedModelsProviderTest {
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
+	}
+
+	private ObjectRelationship _createRelationship(String relationshipType)
+		throws Exception {
+
+		return _objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			_objectDefinition1.getObjectDefinitionId(),
+			_objectDefinition2.getObjectDefinitionId(),
+			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), relationshipType);
 	}
 
 	private void _setUser(User user) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -31,11 +31,23 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.util.LocalizedMapUtil;
 import com.liferay.object.util.ObjectFieldUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -47,8 +59,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -65,6 +79,17 @@ public class ObjectRelatedModelsProviderTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		_user = UserTestUtil.addUser();
+
+		_userRole = RoleLocalServiceUtil.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+	}
 
 	@Before
 	public void setUp() throws Exception {
@@ -101,6 +126,13 @@ public class ObjectRelatedModelsProviderTest {
 			_objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
 				_objectDefinition2.getObjectDefinitionId());
+
+		_setUser(TestPropsValues.getUser());
+	}
+
+	@After
+	public void tearDown() {
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 	}
 
 	@Ignore
@@ -338,6 +370,13 @@ public class ObjectRelatedModelsProviderTest {
 
 		Assert.assertEquals(objectEntries.toString(), 2, objectEntries.size());
 
+		_testCompanyScopeViewPermission(
+			objectRelationship, objectRelatedModelsProvider, objectEntry1);
+
+		_testIndividualScopeViewPermission(
+			objectEntryA, objectRelationship, objectRelatedModelsProvider,
+			objectEntry1);
+
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 	}
@@ -414,11 +453,95 @@ public class ObjectRelatedModelsProviderTest {
 
 		Assert.assertEquals(objectEntries.toString(), 2, objectEntries.size());
 
+		_testCompanyScopeViewPermission(
+			objectRelationship, objectRelatedModelsProvider, objectEntry1);
+
+		_testIndividualScopeViewPermission(
+			objectEntry2, objectRelationship, objectRelatedModelsProvider,
+			objectEntry1);
+
 		// TODO deleteObjectRelationshipMappingTableValues
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 	}
+
+	private void _setUser(User user) {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		PrincipalThreadLocal.setName(user.getUserId());
+	}
+
+	private void _testCompanyScopeViewPermission(
+			ObjectRelationship objectRelationship,
+			ObjectRelatedModelsProvider<ObjectEntry>
+				objectRelatedModelsProvider,
+			ObjectEntry parentObjectEntry)
+		throws Exception {
+
+		_setUser(_user);
+
+		Assert.assertEquals(
+			0,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				0, objectRelationship.getObjectRelationshipId(),
+				parentObjectEntry.getObjectEntryId()));
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), _objectDefinition2.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			_userRole.getRoleId(), ActionKeys.VIEW);
+
+		Assert.assertEquals(
+			2,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				0, objectRelationship.getObjectRelationshipId(),
+				parentObjectEntry.getObjectEntryId()));
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			TestPropsValues.getCompanyId(), _objectDefinition2.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			_userRole.getRoleId(), ActionKeys.VIEW);
+	}
+
+	private void _testIndividualScopeViewPermission(
+			ObjectEntry childObjectEntry, ObjectRelationship objectRelationship,
+			ObjectRelatedModelsProvider<ObjectEntry>
+				objectRelatedModelsProvider,
+			ObjectEntry parentObjectEntry)
+		throws Exception {
+
+		Assert.assertEquals(
+			0,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				0, objectRelationship.getObjectRelationshipId(),
+				parentObjectEntry.getObjectEntryId()));
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), _objectDefinition2.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(childObjectEntry.getObjectEntryId()),
+			_userRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		Assert.assertEquals(
+			1,
+			objectRelatedModelsProvider.getRelatedModelsCount(
+				0, objectRelationship.getObjectRelationshipId(),
+				parentObjectEntry.getObjectEntryId()));
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			TestPropsValues.getCompanyId(), _objectDefinition2.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(childObjectEntry.getObjectEntryId()),
+			_userRole.getRoleId(), ActionKeys.VIEW);
+	}
+
+	private static PermissionChecker _originalPermissionChecker;
+	private static User _user;
+	private static Role _userRole;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _objectDefinition1;
@@ -441,5 +564,8 @@ public class ObjectRelatedModelsProviderTest {
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/RelatedModelFDSActionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/RelatedModelFDSActionProvider.java
@@ -21,11 +21,13 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.web.internal.object.entries.constants.ObjectEntriesFDSNames;
 import com.liferay.object.web.internal.object.entries.frontend.data.set.data.model.RelatedModel;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -59,6 +61,13 @@ public class RelatedModelFDSActionProvider implements FDSActionProvider {
 		}
 
 		RelatedModel relatedModel = (RelatedModel)model;
+
+		if (!_objectEntryService.hasModelResourcePermission(
+				_objectEntryLocalService.getObjectEntry(relatedModel.getId()),
+				ActionKeys.UPDATE)) {
+
+			return null;
+		}
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
@@ -111,6 +120,9 @@ public class RelatedModelFDSActionProvider implements FDSActionProvider {
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
Hi @liferay-objects,

to solve this problem I just needed to match child object definition class name instead of child dynamic object definition table name.

the query below is executed to list the related object entries in relationship tab,

```
select distinct ObjectEntry.*
  from O_20100_Author
  inner join ObjectEntry on ObjectEntry.objectEntryId = O_20100_Author.c_authorId_
  inner join O_20100_Author_x on O_20100_Author_x.c_authorId_ = O_20100_Author.c_authorId_
  inner join R_20100Author_Book_authorBook on R_20100Author_Book_authorBook.c_authorId_ = O_20100_Author.c_authorId_
  where ObjectEntry.groupId = ?
  and ObjectEntry.companyId = ?
  and ObjectEntry.objectDefinitionId = ?
  and R_20100Author_Book_authorBook.c_bookId_ = ?
```

if an user isn't omniadmin and its roles don't have company scope view permission, below condition will be set,
```
and O_20100_Author.c_authorId_ in (select distinct ResourcePermission.primKeyId
							      from ResourcePermission
						           where ResourcePermission.companyId = ?
							      and ResourcePermission.name = ?
						              and ResourcePermission.scope = ?
							      and ResourcePermission.viewActionId = ?
							      and (ResourcePermission.roleId in (?, ?) or ResourcePermission.ownerId = ?));

```
previously the ResourcePermission.name matched the name of the child dynamic object definition table (e.g. O_20100_Author), but there are no object resource permissions with this structure,

now the ResourcePermission.name is matched with the child object definition class name(e.g com.liferay.object.model.ObjectDefinition#42951).

I also opted to solve a disassociation issue in this scenario,

I just validated that if an user doesn't have permission to update a related entry this user won't be able to disassociate it.


https://user-images.githubusercontent.com/42913501/156360999-ea0f1e12-3af2-4c65-8885-3d3101f2cc5d.mp4


