### PR TITLE
LPS-146898 buildService

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalService.java
@@ -15,6 +15,7 @@
 package com.liferay.object.service;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectView;
 import com.liferay.object.model.ObjectViewColumn;
 import com.liferay.object.model.ObjectViewSortColumn;
@@ -104,6 +105,8 @@ public interface ObjectViewLocalService
 	 */
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
+
+	public void deleteObjectFieldFromObjectView(ObjectField objectField);
 
 	/**
 	 * Deletes the object view with the primary key from the database. Also notifies the appropriate model listeners.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalServiceUtil.java
@@ -92,6 +92,12 @@ public class ObjectViewLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
+	public static void deleteObjectFieldFromObjectView(
+		com.liferay.object.model.ObjectField objectField) {
+
+		getService().deleteObjectFieldFromObjectView(objectField);
+	}
+
 	/**
 	 * Deletes the object view with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectViewLocalServiceWrapper.java
@@ -92,6 +92,13 @@ public class ObjectViewLocalServiceWrapper
 		return _objectViewLocalService.createPersistedModel(primaryKeyObj);
 	}
 
+	@Override
+	public void deleteObjectFieldFromObjectView(
+		com.liferay.object.model.ObjectField objectField) {
+
+		_objectViewLocalService.deleteObjectFieldFromObjectView(objectField);
+	}
+
 	/**
 	 * Deletes the object view with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
-import com.liferay.object.model.ObjectView;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
 import com.liferay.object.service.base.ObjectFieldLocalServiceBaseImpl;
@@ -443,13 +442,7 @@ public class ObjectFieldLocalServiceImpl
 		_objectLayoutColumnPersistence.removeByObjectFieldId(
 			objectField.getObjectFieldId());
 
-		List<ObjectView> objectViews =
-			_objectViewPersistence.findByObjectDefinitionId(
-				objectField.getObjectDefinitionId());
-
-		for (ObjectView objectView : objectViews) {
-			_objectViewLocalService.deleteObjectView(objectView);
-		}
+		_objectViewLocalService.deleteObjectFieldFromObjectView(objectField);
 
 		if (Objects.equals(
 				objectDefinition.getExtensionDBTableName(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectViewLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectViewLocalServiceImpl.java
@@ -16,6 +16,7 @@ package com.liferay.object.service.impl;
 
 import com.liferay.object.exception.DefaultObjectViewException;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectView;
 import com.liferay.object.model.ObjectViewColumn;
 import com.liferay.object.model.ObjectViewSortColumn;
@@ -89,6 +90,21 @@ public class ObjectViewLocalServiceImpl extends ObjectViewLocalServiceBaseImpl {
 				user, objectView.getObjectViewId(), objectViewSortColumns));
 
 		return objectView;
+	}
+
+	@Override
+	public void deleteObjectFieldFromObjectView(ObjectField objectField) {
+		List<ObjectView> objectViews =
+			objectViewPersistence.findByObjectDefinitionId(
+				objectField.getObjectDefinitionId());
+
+		for (ObjectView objectView : objectViews) {
+			_objectViewColumnPersistence.removeByOVI_OFN(
+				objectView.getObjectViewId(), objectField.getName());
+
+			_objectViewSortColumnPersistence.removeByOVI_OFN(
+				objectView.getObjectViewId(), objectField.getName());
+		}
 	}
 
 	@Indexable(type = IndexableType.DELETE)


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-146898

Follow-up: https://github.com/brianchandotcom/liferay-portal/pull/114196

Hi Brian!
The goal of this task  is to delete an object field from the object view when the user is deletes a field. This way, we can keep the object view updated with the object fields available.

Your changes mean that it will delete the entire object view when deleting an object field. (https://github.com/brianchandotcom/liferay-portal/pull/114196)

ObjectViewColumn does not have a LocalService because this entity represent a piece of the ObjectView. So the ObjectViewLocalService is responsible for the actions of ObjectViewColumn. ObjectView does not have ObjectViewColumn as a column in the database. ObjectViewColumn has the ObjectView ID. In resume, ObjectView creates the ObjectViewColumn and sets it to itself dynamically so we don't have to worry about if ObjectViewColumn is indexable.

The same happens with ObjectLayoutColumn. ObjectLayoutColumn is a piece of ObjectLayout entity and does not have a LocalService. 

We cannot create a method from the ObjectFieldLocalService calling the ObjectLayoutLocalService because it would cause a cyclic dependency. 