### PR TITLE
[TS] LPS-147944 Picklist only shows a single page (20 items) of results

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
@@ -44,7 +44,7 @@ const headers = new Headers({
 
 async function fetchPickList() {
 	const result = await fetch(
-		'/o/headless-admin-list-type/v1.0/list-type-definitions',
+		'/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=-1',
 		{
 			headers,
 			method: 'GET',


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147944

The headless API is paginated.

https://learn.liferay.com/dxp/latest/en/headless-delivery/using-liferay-as-a-headless-platform.html#keep-data-size-manageable

Setting pageSize to -1 is able to work around the issue, because it tells the headless API to return all the results. However, if you suspect this might cause scalability issues for extremely large picklists, please let us know how we can better resolve this issue.