### PR TITLE
LPS-151953 [Site Initializer] _objectEntryLocalService.addOrUpdateObjectEntry using ERC

### DIFF
--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -330,23 +330,14 @@ public class Main {
 	private void _addTestrayTask(long testrayBuildId, String testrayTaskName)
 		throws Exception {
 
-		StringBundler filterSB = new StringBundler(5);
-
-		filterSB.append("buildId eq ");
-		filterSB.append(testrayBuildId);
-		filterSB.append(" and name eq '");
-		filterSB.append(testrayTaskName);
-		filterSB.append("'");
-
-		StringBundler objectEntryMapKeySB = new StringBundler(4);
-
-		objectEntryMapKeySB.append("Task#");
-		objectEntryMapKeySB.append(testrayTaskName);
-		objectEntryMapKeySB.append("#testrayBuildId#");
-		objectEntryMapKeySB.append(testrayBuildId);
+		String objectEntryMapKey = StringBundler.concat(
+			"Task#", testrayTaskName, "#testrayBuildId#", testrayBuildId);
 
 		long testrayTaskId = _getObjectEntryId(
-			filterSB.toString(), "tasks", objectEntryMapKeySB.toString());
+			StringBundler.concat(
+				"buildId eq ", testrayBuildId, " and name eq '",
+				testrayTaskName, "'"),
+			"tasks", objectEntryMapKey);
 
 		if (testrayTaskId != 0) {
 			return;
@@ -364,7 +355,7 @@ public class Main {
 			).build(),
 			testrayTaskName, "tasks");
 
-		_objectEntryIds.put(objectEntryMapKeySB.toString(), testrayTaskId);
+		_objectEntryIds.put(objectEntryMapKey, testrayTaskId);
 	}
 
 	private void _addTestrayWarnings(

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -323,8 +323,10 @@ public class Main {
 			).put(
 				"r_issueToCaseResultsIssues_c_issueId",
 				() -> {
+					String filterString = "name eq '" + testrayIssueName + "'";
+
 					long testrayIssueId = _getObjectEntryId(
-						testrayIssueName, "issues");
+						null, filterString, "issues");
 
 					if (testrayIssueId > 0) {
 						return testrayIssueId;
@@ -339,7 +341,27 @@ public class Main {
 	private void _addTestrayTask(long testrayBuildId, String testrayTaskName)
 		throws Exception {
 
-		long testrayTaskId = _getObjectEntryId(testrayTaskName, "tasks");
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Task#");
+		sb.append(testrayTaskName);
+		sb.append("#testrayBuildId#");
+		sb.append(testrayBuildId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("buildId eq ");
+		sb.append(testrayBuildId);
+		sb.append(" and name eq '");
+		sb.append(testrayTaskName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
+		long testrayTaskId = _getObjectEntryId(
+			objectEntryMapKey, filterString, "tasks");
 
 		if (testrayTaskId != 0) {
 			return;
@@ -347,7 +369,7 @@ public class Main {
 
 		LocalDateTime localDateTime = LocalDateTime.now(ZoneOffset.UTC);
 
-		_postObjectEntry(
+		testrayTaskId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"dueStatus", _TESTRAY_CASE_RESULT_STATUS_IN_PROGRESS
 			).put(
@@ -356,6 +378,8 @@ public class Main {
 				"statusUpdateDate", localDateTime::toString
 			).build(),
 			testrayTaskName, "tasks");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayTaskId);
 	}
 
 	private void _addTestrayWarnings(
@@ -401,11 +425,11 @@ public class Main {
 	}
 
 	private long _getObjectEntryId(
-			String name, String objectDefinitionShortName)
+			String objectEntryMapKey, String filterString,
+			String objectDefinitionShortName)
 		throws Exception {
 
-		Long objectEntryId = _objectEntryIds.get(
-			objectDefinitionShortName + "#" + name);
+		Long objectEntryId = _objectEntryIds.get(objectEntryMapKey);
 
 		if (objectEntryId != null) {
 			return objectEntryId;
@@ -416,7 +440,7 @@ public class Main {
 			HashMapBuilder.put(
 				"fields", "id"
 			).put(
-				"filter", "name eq '" + name + "'"
+				"filter", filterString
 			).build());
 
 		JSONObject responseJSONObject = new JSONObject(
@@ -428,17 +452,9 @@ public class Main {
 			return 0;
 		}
 
-		_objectEntryIds.put(
-			objectDefinitionShortName + "#" + name, objectEntryId);
-
 		JSONObject jsonObject = jsonArray.getJSONObject(0);
 
-		objectEntryId = jsonObject.getLong("id");
-
-		_objectEntryIds.put(
-			objectDefinitionShortName + "#" + name, objectEntryId);
-
-		return objectEntryId;
+		return jsonObject.getLong("id");
 	}
 
 	private Map<String, String> _getPropertiesMap(Element element) {
@@ -509,7 +525,27 @@ public class Main {
 			long testrayProjectId)
 		throws Exception {
 
-		long testrayBuildId = _getObjectEntryId(testrayBuildName, "builds");
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Build#");
+		sb.append(testrayBuildName);
+		sb.append("#testrayProjectId#");
+		sb.append(testrayProjectId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("projectId eq ");
+		sb.append(testrayProjectId);
+		sb.append(" and name eq '");
+		sb.append(testrayBuildName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
+		long testrayBuildId = _getObjectEntryId(
+			objectEntryMapKey, filterString, "builds");
 
 		if (testrayBuildId != 0) {
 			return testrayBuildId;
@@ -520,7 +556,7 @@ public class Main {
 		long testrayRoutineId = _getTestrayRoutineId(
 			testrayProjectId, propertiesMap.get("testray.build.type"));
 
-		return _postObjectEntry(
+		testrayBuildId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"description", _getTestrayBuildDescription(propertiesMap)
 			).put(
@@ -538,6 +574,10 @@ public class Main {
 				"r_routineToBuilds_c_routineId", testrayRoutineId
 			).build(),
 			testrayBuildName, "builds");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayBuildId);
+
+		return testrayBuildId;
 	}
 
 	private Map<String, Object> _getTestrayCaseProperties(Element element) {
@@ -658,14 +698,22 @@ public class Main {
 	private long _getTestrayCaseTypeId(String testrayCaseTypeName)
 		throws Exception {
 
+		String objectEntryMapKey = "CaseType#" + testrayCaseTypeName;
+		String filterString = "name eq '" + testrayCaseTypeName + "'";
+
 		long testrayCaseTypeId = _getObjectEntryId(
-			testrayCaseTypeName, "casetypes");
+			objectEntryMapKey, filterString, "casetypes");
 
 		if (testrayCaseTypeId != 0) {
 			return testrayCaseTypeId;
 		}
 
-		return _postObjectEntry(null, testrayCaseTypeName, "casetypes");
+		testrayCaseTypeId = _postObjectEntry(
+			null, testrayCaseTypeName, "casetypes");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayCaseTypeId);
+
+		return testrayCaseTypeId;
 	}
 
 	private long _getTestrayComponentId(
@@ -673,102 +721,195 @@ public class Main {
 			long testrayTeamId)
 		throws Exception {
 
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Component#");
+		sb.append(testrayComponentName);
+		sb.append("#testrayProjectId#");
+		sb.append(testrayProjectId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("projectId eq ");
+		sb.append(testrayProjectId);
+		sb.append(" and name eq '");
+		sb.append(testrayComponentName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
 		long testrayComponentId = _getObjectEntryId(
-			testrayComponentName, "components");
+			objectEntryMapKey, filterString, "components");
 
 		if (testrayComponentId != 0) {
 			return testrayComponentId;
 		}
 
-		return _postObjectEntry(
+		testrayComponentId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"r_projectToComponents_c_projectId", testrayProjectId
 			).put(
 				"r_teamToComponents_c_teamId", testrayTeamId
 			).build(),
 			testrayComponentName, "components");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayComponentId);
+
+		return testrayComponentId;
 	}
 
 	private long _getTestrayFactorCategoryId(String testrayFactorCategoryName)
 		throws Exception {
 
+		String objectEntryMapKey =
+			"FactorCategory#" + testrayFactorCategoryName;
+		String filterString = "name eq '" + testrayFactorCategoryName + "'";
+
 		long testrayFactorCategoryId = _getObjectEntryId(
-			testrayFactorCategoryName, "factorcategories");
+			objectEntryMapKey, filterString, "factorcategories");
 
 		if (testrayFactorCategoryId != 0) {
 			return testrayFactorCategoryId;
 		}
 
-		return _postObjectEntry(
+		testrayFactorCategoryId = _postObjectEntry(
 			null, testrayFactorCategoryName, "factorcategories");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayFactorCategoryId);
+
+		return testrayFactorCategoryId;
 	}
 
 	private long _getTestrayFactorOptionId(
 			long testrayFactorCategoryId, String testrayFactorOptionName)
 		throws Exception {
 
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("FactorOption#");
+		sb.append(testrayFactorOptionName);
+		sb.append("#testrayFactorCategoryId#");
+		sb.append(testrayFactorCategoryId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("factorCategoryId eq ");
+		sb.append(testrayFactorCategoryId);
+		sb.append(" and name eq '");
+		sb.append(testrayFactorOptionName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
 		long testrayFactorOptionId = _getObjectEntryId(
-			testrayFactorOptionName, "factoroptions");
+			objectEntryMapKey, filterString, "factoroptions");
 
 		if (testrayFactorOptionId != 0) {
 			return testrayFactorOptionId;
 		}
 
-		return _postObjectEntry(
+		testrayFactorOptionId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"r_factorCategoryToOptions_c_factorCategoryId",
 				testrayFactorCategoryId
 			).build(),
 			testrayFactorOptionName, "factoroptions");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayFactorOptionId);
+
+		return testrayFactorOptionId;
 	}
 
 	private long _getTestrayProductVersionId(
 			long testrayProjectId, String testrayProductVersionName)
 		throws Exception {
 
+		String objectEntryMapKey =
+			"ProductVersion#" + testrayProductVersionName;
+		String filterString = "name eq '" + testrayProductVersionName + "'";
+
 		long testrayProductVersionId = _getObjectEntryId(
-			testrayProductVersionName, "productversions");
+			objectEntryMapKey, filterString, "productversions");
 
 		if (testrayProductVersionId != 0) {
 			return testrayProductVersionId;
 		}
 
-		return _postObjectEntry(
+		testrayProductVersionId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"r_projectToProductVersions_c_projectId", testrayProjectId
 			).build(),
 			testrayProductVersionName, "productversions");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayProductVersionId);
+
+		return testrayProductVersionId;
 	}
 
 	private long _getTestrayProjectId(String testrayProjectName)
 		throws Exception {
 
+		String objectEntryMapKey = "Project#" + testrayProjectName;
+		String filterString = "name eq '" + testrayProjectName + "'";
+
 		long testrayProjectId = _getObjectEntryId(
-			testrayProjectName, "projects");
+			objectEntryMapKey, filterString, "projects");
 
 		if (testrayProjectId != 0) {
 			return testrayProjectId;
 		}
 
-		return _postObjectEntry(null, testrayProjectName, "projects");
+		testrayProjectId = _postObjectEntry(
+			null, testrayProjectName, "projects");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayProjectId);
+
+		return testrayProjectId;
 	}
 
 	private long _getTestrayRoutineId(
 			long testrayProjectId, String testrayRoutineName)
 		throws Exception {
 
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Routine#");
+		sb.append(testrayRoutineName);
+		sb.append("#testrayProjectId#");
+		sb.append(testrayProjectId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("projectId eq ");
+		sb.append(testrayProjectId);
+		sb.append(" and name eq '");
+		sb.append(testrayRoutineName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
 		long testrayRoutineId = _getObjectEntryId(
-			testrayRoutineName, "routines");
+			objectEntryMapKey, filterString, "routines");
 
 		if (testrayRoutineId != 0) {
 			return testrayRoutineId;
 		}
 
-		return _postObjectEntry(
+		testrayRoutineId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"r_routineToProjects_c_projectId", testrayProjectId
 			).build(),
 			testrayRoutineName, "routines");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayRoutineId);
+
+		return testrayRoutineId;
 	}
 
 	private String _getTestrayRunEnvironmentHash(
@@ -815,7 +956,27 @@ public class Main {
 			long testrayBuildId, String testrayRunName)
 		throws Exception {
 
-		long testrayRunId = _getObjectEntryId(testrayRunName, "runs");
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Run#");
+		sb.append(testrayRunName);
+		sb.append("#testrayBuildId#");
+		sb.append(testrayBuildId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("buildId eq ");
+		sb.append(testrayBuildId);
+		sb.append(" and name eq '");
+		sb.append(testrayRunName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
+		long testrayRunId = _getObjectEntryId(
+			objectEntryMapKey, filterString, "runs");
 
 		if (testrayRunId != 0) {
 			return testrayRunId;
@@ -838,6 +999,8 @@ public class Main {
 			).build(),
 			testrayRunName, "runs");
 
+		_objectEntryIds.put(objectEntryMapKey, testrayRunId);
+
 		JSONObject jsonObject = new JSONObject();
 
 		jsonObject.put(
@@ -855,17 +1018,41 @@ public class Main {
 			long testrayProjectId, String testrayTeamName)
 		throws Exception {
 
-		long testrayTeamId = _getObjectEntryId(testrayTeamName, "teams");
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Team#");
+		sb.append(testrayTeamName);
+		sb.append("#testrayProjectId#");
+		sb.append(testrayProjectId);
+
+		String objectEntryMapKey = sb.toString();
+
+		sb = new StringBundler(5);
+
+		sb.append("projectId eq ");
+		sb.append(testrayProjectId);
+		sb.append(" and name eq '");
+		sb.append(testrayTeamName);
+		sb.append("'");
+
+		String filterString = sb.toString();
+
+		long testrayTeamId = _getObjectEntryId(
+			objectEntryMapKey, filterString, "teams");
 
 		if (testrayTeamId != 0) {
 			return testrayTeamId;
 		}
 
-		return _postObjectEntry(
+		testrayTeamId = _postObjectEntry(
 			HashMapBuilder.<String, Object>put(
 				"r_projectToTeams_c_projectId", testrayProjectId
 			).build(),
 			testrayTeamName, "teams");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayTeamId);
+
+		return testrayTeamId;
 	}
 
 	private long _increment(
@@ -972,13 +1159,7 @@ public class Main {
 		JSONObject responseJSONObject = new JSONObject(
 			httpResponse.getContent());
 
-		long id = responseJSONObject.getLong("id");
-
-		if (id > 0) {
-			_objectEntryIds.put(objectDefinitionShortName + "#" + name, id);
-		}
-
-		return id;
+		return responseJSONObject.getLong("id");
 	}
 
 	private void _processArchive(byte[] bytes) throws Exception {

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -326,7 +326,7 @@ public class Main {
 					String filterString = "name eq '" + testrayIssueName + "'";
 
 					long testrayIssueId = _getObjectEntryId(
-						null, filterString, "issues");
+						filterString, "issues", null);
 
 					if (testrayIssueId > 0) {
 						return testrayIssueId;
@@ -361,7 +361,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayTaskId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "tasks");
+			filterString, "tasks", objectEntryMapKey);
 
 		if (testrayTaskId != 0) {
 			return;
@@ -425,8 +425,8 @@ public class Main {
 	}
 
 	private long _getObjectEntryId(
-			String objectEntryMapKey, String filterString,
-			String objectDefinitionShortName)
+			String filterString, String objectDefinitionShortName,
+			String objectEntryMapKey)
 		throws Exception {
 
 		Long objectEntryId = _objectEntryIds.get(objectEntryMapKey);
@@ -545,7 +545,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayBuildId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "builds");
+			filterString, "builds", objectEntryMapKey);
 
 		if (testrayBuildId != 0) {
 			return testrayBuildId;
@@ -702,7 +702,7 @@ public class Main {
 		String filterString = "name eq '" + testrayCaseTypeName + "'";
 
 		long testrayCaseTypeId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "casetypes");
+			filterString, "casetypes", objectEntryMapKey);
 
 		if (testrayCaseTypeId != 0) {
 			return testrayCaseTypeId;
@@ -741,7 +741,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayComponentId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "components");
+			filterString, "components", objectEntryMapKey);
 
 		if (testrayComponentId != 0) {
 			return testrayComponentId;
@@ -768,7 +768,7 @@ public class Main {
 		String filterString = "name eq '" + testrayFactorCategoryName + "'";
 
 		long testrayFactorCategoryId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "factorcategories");
+			filterString, "factorcategories", objectEntryMapKey);
 
 		if (testrayFactorCategoryId != 0) {
 			return testrayFactorCategoryId;
@@ -806,7 +806,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayFactorOptionId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "factoroptions");
+			filterString, "factoroptions", objectEntryMapKey);
 
 		if (testrayFactorOptionId != 0) {
 			return testrayFactorOptionId;
@@ -833,7 +833,7 @@ public class Main {
 		String filterString = "name eq '" + testrayProductVersionName + "'";
 
 		long testrayProductVersionId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "productversions");
+			filterString, "productversions", objectEntryMapKey);
 
 		if (testrayProductVersionId != 0) {
 			return testrayProductVersionId;
@@ -857,7 +857,7 @@ public class Main {
 		String filterString = "name eq '" + testrayProjectName + "'";
 
 		long testrayProjectId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "projects");
+			filterString, "projects", objectEntryMapKey);
 
 		if (testrayProjectId != 0) {
 			return testrayProjectId;
@@ -895,7 +895,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayRoutineId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "routines");
+			filterString, "routines", objectEntryMapKey);
 
 		if (testrayRoutineId != 0) {
 			return testrayRoutineId;
@@ -976,7 +976,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayRunId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "runs");
+			filterString, "runs", objectEntryMapKey);
 
 		if (testrayRunId != 0) {
 			return testrayRunId;
@@ -1038,7 +1038,7 @@ public class Main {
 		String filterString = sb.toString();
 
 		long testrayTeamId = _getObjectEntryId(
-			objectEntryMapKey, filterString, "teams");
+			filterString, "teams", objectEntryMapKey);
 
 		if (testrayTeamId != 0) {
 			return testrayTeamId;

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -330,27 +330,23 @@ public class Main {
 	private void _addTestrayTask(long testrayBuildId, String testrayTaskName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
+		StringBundler filterSB = new StringBundler(5);
 
-		sb.append("Task#");
-		sb.append(testrayTaskName);
-		sb.append("#testrayBuildId#");
-		sb.append(testrayBuildId);
+		filterSB.append("buildId eq ");
+		filterSB.append(testrayBuildId);
+		filterSB.append(" and name eq '");
+		filterSB.append(testrayTaskName);
+		filterSB.append("'");
 
-		String objectEntryMapKey = sb.toString();
+		StringBundler objectEntryMapKeySB = new StringBundler(4);
 
-		sb = new StringBundler(5);
-
-		sb.append("buildId eq ");
-		sb.append(testrayBuildId);
-		sb.append(" and name eq '");
-		sb.append(testrayTaskName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		objectEntryMapKeySB.append("Task#");
+		objectEntryMapKeySB.append(testrayTaskName);
+		objectEntryMapKeySB.append("#testrayBuildId#");
+		objectEntryMapKeySB.append(testrayBuildId);
 
 		long testrayTaskId = _getObjectEntryId(
-			filterString, "tasks", objectEntryMapKey);
+			filterSB.toString(), "tasks", objectEntryMapKeySB.toString());
 
 		if (testrayTaskId != 0) {
 			return;
@@ -368,7 +364,7 @@ public class Main {
 			).build(),
 			testrayTaskName, "tasks");
 
-		_objectEntryIds.put(objectEntryMapKey, testrayTaskId);
+		_objectEntryIds.put(objectEntryMapKeySB.toString(), testrayTaskId);
 	}
 
 	private void _addTestrayWarnings(

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -255,13 +255,32 @@ public class Main {
 
 		_addTestrayAttachments(testcaseNode, testrayCaseResultId);
 
-		_addTestrayIssue(
+		_addTestrayCaseResultIssue(
 			testrayCaseResultId,
 			(String)testrayCasePropertiesMap.get("testray.case.issue"));
-		_addTestrayIssue(
+		_addTestrayCaseResultIssue(
 			testrayCaseResultId,
 			(String)testrayCasePropertiesMap.get("testray.case.defect"));
 		_addTestrayWarnings(testrayCasePropertiesMap, testrayCaseResultId);
+	}
+
+	private void _addTestrayCaseResultIssue(
+			long testrayCaseResultId, String testrayIssueName)
+		throws Exception {
+
+		if (_isEmpty(testrayIssueName)) {
+			return;
+		}
+
+		_postObjectEntry(
+			HashMapBuilder.<String, Object>put(
+				"r_caseResultToCaseResultsIssues_c_caseResultId",
+				testrayCaseResultId
+			).put(
+				"r_issueToCaseResultsIssues_c_issueId",
+				_getTestrayIssueId(testrayIssueName)
+			).build(),
+			null, "caseresultsissueses");
 	}
 
 	private void _addTestrayCases(
@@ -306,36 +325,6 @@ public class Main {
 				"testrayFactorOptionName", testrayFactorOptionName
 			).build(),
 			null, "factors");
-	}
-
-	private void _addTestrayIssue(
-			long testrayCaseResultId, String testrayIssueName)
-		throws Exception {
-
-		if (_isEmpty(testrayIssueName)) {
-			return;
-		}
-
-		_postObjectEntry(
-			HashMapBuilder.<String, Object>put(
-				"r_caseResultToCaseResultsIssues_c_caseResultId",
-				testrayCaseResultId
-			).put(
-				"r_issueToCaseResultsIssues_c_issueId",
-				() -> {
-					String filterString = "name eq '" + testrayIssueName + "'";
-
-					long testrayIssueId = _getObjectEntryId(
-						filterString, "issues", null);
-
-					if (testrayIssueId > 0) {
-						return testrayIssueId;
-					}
-
-					return _postObjectEntry(null, testrayIssueName, "issues");
-				}
-			).build(),
-			null, "caseresultsissueses");
 	}
 
 	private void _addTestrayTask(long testrayBuildId, String testrayTaskName)
@@ -822,6 +811,24 @@ public class Main {
 		_objectEntryIds.put(objectEntryMapKey, testrayFactorOptionId);
 
 		return testrayFactorOptionId;
+	}
+
+	private long _getTestrayIssueId(String testrayIssueName) throws Exception {
+		String filterString = "name eq '" + testrayIssueName + "'";
+		String objectEntryMapKey = "Issue#" + testrayIssueName;
+
+		long testrayIssueId = _getObjectEntryId(
+			filterString, "issues", objectEntryMapKey);
+
+		if (testrayIssueId > 0) {
+			return testrayIssueId;
+		}
+
+		testrayIssueId = _postObjectEntry(null, testrayIssueName, "issues");
+
+		_objectEntryIds.put(objectEntryMapKey, testrayIssueId);
+
+		return testrayIssueId;
 	}
 
 	private long _getTestrayProductVersionId(

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -501,27 +501,14 @@ public class Main {
 			long testrayProjectId)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("Build#");
-		sb.append(testrayBuildName);
-		sb.append("#testrayProjectId#");
-		sb.append(testrayProjectId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("projectId eq ");
-		sb.append(testrayProjectId);
-		sb.append(" and name eq '");
-		sb.append(testrayBuildName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"Build#", testrayBuildName, "#testrayProjectId#", testrayProjectId);
 
 		long testrayBuildId = _getObjectEntryId(
-			filterString, "builds", objectEntryMapKey);
+			StringBundler.concat(
+				"projectId eq ", testrayProjectId, " and name eq '",
+				testrayBuildName, "'"),
+			"builds", objectEntryMapKey);
 
 		if (testrayBuildId != 0) {
 			return testrayBuildId;
@@ -675,10 +662,10 @@ public class Main {
 		throws Exception {
 
 		String objectEntryMapKey = "CaseType#" + testrayCaseTypeName;
-		String filterString = "name eq '" + testrayCaseTypeName + "'";
 
 		long testrayCaseTypeId = _getObjectEntryId(
-			filterString, "casetypes", objectEntryMapKey);
+			"name eq '" + testrayCaseTypeName + "'", "casetypes",
+			objectEntryMapKey);
 
 		if (testrayCaseTypeId != 0) {
 			return testrayCaseTypeId;
@@ -697,27 +684,15 @@ public class Main {
 			long testrayTeamId)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("Component#");
-		sb.append(testrayComponentName);
-		sb.append("#testrayProjectId#");
-		sb.append(testrayProjectId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("projectId eq ");
-		sb.append(testrayProjectId);
-		sb.append(" and name eq '");
-		sb.append(testrayComponentName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"Component#", testrayComponentName, "#testrayProjectId#",
+			testrayProjectId);
 
 		long testrayComponentId = _getObjectEntryId(
-			filterString, "components", objectEntryMapKey);
+			StringBundler.concat(
+				"projectId eq ", testrayProjectId, " and name eq '",
+				testrayComponentName, "'"),
+			"components", objectEntryMapKey);
 
 		if (testrayComponentId != 0) {
 			return testrayComponentId;
@@ -741,10 +716,10 @@ public class Main {
 
 		String objectEntryMapKey =
 			"FactorCategory#" + testrayFactorCategoryName;
-		String filterString = "name eq '" + testrayFactorCategoryName + "'";
 
 		long testrayFactorCategoryId = _getObjectEntryId(
-			filterString, "factorcategories", objectEntryMapKey);
+			"name eq '" + testrayFactorCategoryName + "'", "factorcategories",
+			objectEntryMapKey);
 
 		if (testrayFactorCategoryId != 0) {
 			return testrayFactorCategoryId;
@@ -762,27 +737,15 @@ public class Main {
 			long testrayFactorCategoryId, String testrayFactorOptionName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("FactorOption#");
-		sb.append(testrayFactorOptionName);
-		sb.append("#testrayFactorCategoryId#");
-		sb.append(testrayFactorCategoryId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("factorCategoryId eq ");
-		sb.append(testrayFactorCategoryId);
-		sb.append(" and name eq '");
-		sb.append(testrayFactorOptionName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"FactorOption#", testrayFactorOptionName,
+			"#testrayFactorCategoryId#", testrayFactorCategoryId);
 
 		long testrayFactorOptionId = _getObjectEntryId(
-			filterString, "factoroptions", objectEntryMapKey);
+			StringBundler.concat(
+				"factorCategoryId eq ", testrayFactorCategoryId,
+				" and name eq '", testrayFactorOptionName, "'"),
+			"factoroptions", objectEntryMapKey);
 
 		if (testrayFactorOptionId != 0) {
 			return testrayFactorOptionId;
@@ -801,11 +764,10 @@ public class Main {
 	}
 
 	private long _getTestrayIssueId(String testrayIssueName) throws Exception {
-		String filterString = "name eq '" + testrayIssueName + "'";
 		String objectEntryMapKey = "Issue#" + testrayIssueName;
 
 		long testrayIssueId = _getObjectEntryId(
-			filterString, "issues", objectEntryMapKey);
+			"name eq '" + testrayIssueName + "'", "issues", objectEntryMapKey);
 
 		if (testrayIssueId > 0) {
 			return testrayIssueId;
@@ -824,10 +786,10 @@ public class Main {
 
 		String objectEntryMapKey =
 			"ProductVersion#" + testrayProductVersionName;
-		String filterString = "name eq '" + testrayProductVersionName + "'";
 
 		long testrayProductVersionId = _getObjectEntryId(
-			filterString, "productversions", objectEntryMapKey);
+			"name eq '" + testrayProductVersionName + "'", "productversions",
+			objectEntryMapKey);
 
 		if (testrayProductVersionId != 0) {
 			return testrayProductVersionId;
@@ -848,10 +810,10 @@ public class Main {
 		throws Exception {
 
 		String objectEntryMapKey = "Project#" + testrayProjectName;
-		String filterString = "name eq '" + testrayProjectName + "'";
 
 		long testrayProjectId = _getObjectEntryId(
-			filterString, "projects", objectEntryMapKey);
+			"name eq '" + testrayProjectName + "'", "projects",
+			objectEntryMapKey);
 
 		if (testrayProjectId != 0) {
 			return testrayProjectId;
@@ -869,27 +831,15 @@ public class Main {
 			long testrayProjectId, String testrayRoutineName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("Routine#");
-		sb.append(testrayRoutineName);
-		sb.append("#testrayProjectId#");
-		sb.append(testrayProjectId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("projectId eq ");
-		sb.append(testrayProjectId);
-		sb.append(" and name eq '");
-		sb.append(testrayRoutineName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"Routine#", testrayRoutineName, "#testrayProjectId#",
+			testrayProjectId);
 
 		long testrayRoutineId = _getObjectEntryId(
-			filterString, "routines", objectEntryMapKey);
+			StringBundler.concat(
+				"projectId eq ", testrayProjectId, " and name eq '",
+				testrayRoutineName, "'"),
+			"routines", objectEntryMapKey);
 
 		if (testrayRoutineId != 0) {
 			return testrayRoutineId;
@@ -950,27 +900,14 @@ public class Main {
 			long testrayBuildId, String testrayRunName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("Run#");
-		sb.append(testrayRunName);
-		sb.append("#testrayBuildId#");
-		sb.append(testrayBuildId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("buildId eq ");
-		sb.append(testrayBuildId);
-		sb.append(" and name eq '");
-		sb.append(testrayRunName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"Run#", testrayRunName, "#testrayBuildId#", testrayBuildId);
 
 		long testrayRunId = _getObjectEntryId(
-			filterString, "runs", objectEntryMapKey);
+			StringBundler.concat(
+				"buildId eq ", testrayBuildId, " and name eq '", testrayRunName,
+				"'"),
+			"runs", objectEntryMapKey);
 
 		if (testrayRunId != 0) {
 			return testrayRunId;
@@ -1012,27 +949,14 @@ public class Main {
 			long testrayProjectId, String testrayTeamName)
 		throws Exception {
 
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("Team#");
-		sb.append(testrayTeamName);
-		sb.append("#testrayProjectId#");
-		sb.append(testrayProjectId);
-
-		String objectEntryMapKey = sb.toString();
-
-		sb = new StringBundler(5);
-
-		sb.append("projectId eq ");
-		sb.append(testrayProjectId);
-		sb.append(" and name eq '");
-		sb.append(testrayTeamName);
-		sb.append("'");
-
-		String filterString = sb.toString();
+		String objectEntryMapKey = StringBundler.concat(
+			"Team#", testrayTeamName, "#testrayProjectId#", testrayProjectId);
 
 		long testrayTeamId = _getObjectEntryId(
-			filterString, "teams", objectEntryMapKey);
+			StringBundler.concat(
+				"projectId eq ", testrayProjectId, " and name eq '",
+				testrayTeamName, "'"),
+			"teams", objectEntryMapKey);
 
 		if (testrayTeamId != 0) {
 			return testrayTeamId;

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -84,6 +84,7 @@ public class Main {
 			properties.getProperty("s3.inbox.folder.name"),
 			properties.getProperty("s3.processed.folder.name"));
 
+		main.prepareCache();
 		main.uploadToTestray();
 	}
 
@@ -119,6 +120,15 @@ public class Main {
 		catch (Exception exception) {
 			_logger.log(Level.SEVERE, exception.getMessage(), exception);
 		}
+	}
+
+	public void prepareCache() throws Exception {
+		_loadTestrayCaseTypes();
+		_loadTestrayComponents();
+		_loadTestrayFactorCategories();
+		_loadTestrayFactorOptions();
+		_loadTestrayProjects();
+		_loadTestrayTeams();
 	}
 
 	public void uploadToTestray() throws Exception {
@@ -1049,6 +1059,168 @@ public class Main {
 		String trimmedValue = value.trim();
 
 		return trimmedValue.isEmpty();
+	}
+
+	private void _loadTestrayCaseTypes() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "casetypes",
+			HashMapBuilder.put(
+				"fields", "id,name"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					"CaseType#" + jsonObject.getString("name"),
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	private void _loadTestrayComponents() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "components",
+			HashMapBuilder.put(
+				"fields",
+				"id,name,r_projectToComponents_c_projectId," +
+					"r_teamToComponents_c_teamId"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					StringBundler.concat(
+						"Component#", jsonObject.getString("name"),
+						"#testrayTeamId#",
+						jsonObject.getLong("r_teamToComponents_c_teamId")),
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	private void _loadTestrayFactorCategories() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "factorcategories",
+			HashMapBuilder.put(
+				"fields", "id,name"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					"FactorCategory#" + jsonObject.getString("name"),
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	private void _loadTestrayFactorOptions() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "factoroptions",
+			HashMapBuilder.put(
+				"fields", "id,name,r_factorCategoryToOptions_c_factorCategoryId"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					StringBundler.concat(
+						"FactorOption#", jsonObject.getString("name"),
+						"#testrayFactorCategoryId#",
+						jsonObject.getLong(
+							"r_factorCategoryToOptions_c_factorCategoryId")),
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	private void _loadTestrayProjects() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "projects",
+			HashMapBuilder.put(
+				"fields", "id,name"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					"Project#" + jsonObject.getString("name"),
+					jsonObject.getLong("id"));
+			}
+		}
+	}
+
+	private void _loadTestrayTeams() throws Exception {
+		HttpInvoker.HttpResponse httpResponse = _invoke(
+			null, null, HttpInvoker.HttpMethod.GET, "teams",
+			HashMapBuilder.put(
+				"fields", "id,name,r_projectToTeams_c_projectId"
+			).put(
+				"page", "0"
+			).build());
+
+		JSONObject responseJSONObject = new JSONObject(
+			httpResponse.getContent());
+
+		JSONArray jsonArray = responseJSONObject.getJSONArray("items");
+
+		if (!jsonArray.isEmpty()) {
+			for (int i = 0; i < jsonArray.length(); i++) {
+				JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+				_objectEntryIds.put(
+					StringBundler.concat(
+						"Team#", jsonObject.getString("name"),
+						"#testrayProjectId#",
+						jsonObject.getLong("r_projectToTeams_c_projectId")),
+					jsonObject.getLong("id"));
+			}
+		}
 	}
 
 	private void _postObjectEntries(

--- a/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
+++ b/modules/apps/site-initializer/site-initializer-testray/extra/gcp-function/src/main/java/com/liferay/site/initializer/testray/extra/gcp/function/Main.java
@@ -143,17 +143,65 @@ public class Main {
 			_s3BucketName,
 			Storage.BlobListOption.prefix(_s3InboxFolderName + "/"));
 
+		int totalFiles = 0;
+
+		for (Blob blob : page.iterateAll()) {
+			totalFiles++;
+		}
+
+		int processedFiles = 0;
+
 		for (Blob blob : page.iterateAll()) {
 			String name = blob.getName();
+			long blobSize = blob.getSize();
+			String blobSizeString = blob.getSize() + " B";
+
+			if (blobSize > 1024) {
+				blobSize = blobSize / 1000;
+				blobSizeString = blobSize + " KB";
+			}
+
+			if (blobSize > 1024) {
+				blobSize = blobSize / 1024;
+				blobSizeString = blobSize + " MB";
+			}
 
 			if (name.equals(_s3InboxFolderName + "/")) {
 				continue;
 			}
 
 			try {
-				_logger.info("Processing archive " + name);
+				long initialTime = System.currentTimeMillis();
+
+				_logger.info(
+					"Processing archive " + name + " - " + blobSizeString +
+						" (" + ++processedFiles + "/" + totalFiles + ")");
 
 				_processArchive(blob.getContent());
+
+				long spentTime = System.currentTimeMillis() - initialTime;
+
+				String spentTimeString = spentTime + " ms";
+
+				if (spentTime > 1000) {
+					spentTime = spentTime / 1000;
+					spentTimeString = spentTime + " s";
+				}
+
+				if (spentTime > 60) {
+					spentTime = spentTime / 60;
+					spentTimeString = spentTime + " m";
+				}
+
+				if (spentTime > 60) {
+					spentTime = spentTime / 60;
+					spentTimeString = spentTime + " h";
+				}
+
+				_logger.info(
+					"File processed in " + spentTimeString + " - " +
+						blobSizeString + " (" + processedFiles + "/" +
+							totalFiles + ")");
 
 				blob.copyTo(
 					_s3BucketName,
@@ -1275,13 +1323,59 @@ public class Main {
 			DocumentBuilder documentBuilder =
 				documentBuilderFactory.newDocumentBuilder();
 
+			int totalDocuments = tempDirectoryFile.listFiles().length;
+
+			int processedDocuments = 0;
+
 			for (File file : tempDirectoryFile.listFiles()) {
 				try {
-					_logger.info("Parsing document " + file.getName());
+					long fileSize = file.length();
+					String fileSizeString = fileSize + " B";
+
+					if (fileSize > 1024) {
+						fileSize = fileSize / 1000;
+						fileSizeString = fileSize + " KB";
+					}
+
+					if (fileSize > 1024) {
+						fileSize = fileSize / 1024;
+						fileSizeString = fileSize + " MB";
+					}
+
+					long initialTime = System.currentTimeMillis();
+
+					_logger.info(
+						"Parsing document " + file.getName() + " - " +
+							fileSizeString + " (" + ++processedDocuments + "/" +
+								totalDocuments + ")");
 
 					Document document = documentBuilder.parse(file);
 
 					_processDocument(document);
+
+					long spentTime = System.currentTimeMillis() - initialTime;
+
+					String spentTimeString = spentTime + " ms";
+
+					if (spentTime > 1000) {
+						spentTime = spentTime / 1000;
+						spentTimeString = spentTime + " s";
+					}
+
+					if (spentTime > 60) {
+						spentTime = spentTime / 60;
+						spentTimeString = spentTime + " m";
+					}
+
+					if (spentTime > 60) {
+						spentTime = spentTime / 60;
+						spentTimeString = spentTime + " h";
+					}
+
+					_logger.info(
+						"Document processed in " + spentTimeString + " - " +
+							fileSizeString + " (" + processedDocuments + "/" +
+								totalDocuments + ")");
 				}
 				catch (Exception exception) {
 					_logger.log(

--- a/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-definitions/testray-issue.json
+++ b/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-definitions/testray-issue.json
@@ -6,7 +6,7 @@
 	"objectFields": [
 		{
 			"DBType": "String",
-			"indexed": false,
+			"indexed": true,
 			"indexedAsKeyword": false,
 			"label": {
 				"en_US": "Name"

--- a/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/1_testray-case-type.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/1_testray-case-type.object-entries.json
@@ -1,0 +1,65 @@
+{
+	"object-entries": [
+		{
+			"name": "Automated Functional Test"
+		},
+		{
+			"name": "Batch"
+		},
+		{
+			"name": "Central Requirements"
+		},
+		{
+			"name": "Compile"
+		},
+		{
+			"name": "Cucumber"
+		},
+		{
+			"name": "Exploratory Test"
+		},
+		{
+			"name": "Fix Pack Test"
+		},
+		{
+			"name": "Integration Test"
+		},
+		{
+			"name": "JS Unit Test"
+		},
+		{
+			"name": "Manual Test"
+		},
+		{
+			"name": "Manual Test WIP"
+		},
+		{
+			"name": "Modules Integration AWS Test"
+		},
+		{
+			"name": "Modules Integration Project Templates Test"
+		},
+		{
+			"name": "Modules Integration Test"
+		},
+		{
+			"name": "Modules Unit Project Templates Test"
+		},
+		{
+			"name": "Modules Unit Test"
+		},
+		{
+			"name": "REST"
+		},
+		{
+			"name": "Selenium"
+		},
+		{
+			"name": "Semantic Versioning"
+		},
+		{
+			"name": "Unit Test"
+		}
+	],
+	"objectDefinitionName": "CaseType"
+}

--- a/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/2_testray-project.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/2_testray-project.object-entries.json
@@ -1,0 +1,145 @@
+{
+	"object-entries": [
+		{
+			"name": "Application Server"
+		},
+		{
+			"name": "Analytics Cloud"
+		},
+		{
+			"name": "App Builder"
+		},
+		{
+			"name": "Customer Support"
+		},
+		{
+			"name": "DXP Cloud Client"
+		},
+		{
+			"name": "Forms"
+		},
+		{
+			"name": "Help Center"
+		},
+		{
+			"name": "HR"
+		},
+		{
+			"name": "HR Review"
+		},
+		{
+			"name": "LESA"
+		},
+		{
+			"name": "Liferay Analytics Cloud"
+		},
+		{
+			"name": "Liferay Cloud Platform"
+		},
+		{
+			"name": "Liferay Dev"
+		},
+		{
+			"name": "Liferay Portal 6.1"
+		},
+		{
+			"name": "Liferay Portal 6.2"
+		},
+		{
+			"name": "Liferay Portal 7.0"
+		},
+		{
+			"name": "Liferay Portal 7.1"
+		},
+		{
+			"name": "Liferay Portal 7.2"
+		},
+		{
+			"name": "Liferay Portal 7.3"
+		},
+		{
+			"name": "Liferay Portal 7.4"
+		},
+		{
+			"name": "Liferay Sync"
+		},
+		{
+			"name": "Loop"
+		},
+		{
+			"name": "LRDCOM"
+		},
+		{
+			"name": "LXC: Liferay Dev"
+		},
+		{
+			"description": "Test results for liferay.com/marketplace tests",
+			"name": "Marketplace"
+		},
+		{
+			"name": "Objects"
+		},
+		{
+			"name": "Partner"
+		},
+		{
+			"name": "Patcher"
+		},
+		{
+			"name": "Salesforce"
+		},
+		{
+			"name": "Search Infrastructure"
+		},
+		{
+			"description": "All functional features related to the Segmentation & Personalization team",
+			"name": "Segmentation & Personalization"
+		},
+		{
+			"name": "Solutions"
+		},
+		{
+			"name": "Staging"
+		},
+		{
+			"name": "Testray"
+		},
+		{
+			"name": "Upgrades"
+		},
+		{
+			"name": "Workflow"
+		},
+		{
+			"name": "WWW"
+		},
+		{
+			"name": "[old] Audience Targeting"
+		},
+		{
+			"name": "[old] Environments"
+		},
+		{
+			"description": "Global Services LatAm, Project Gr1d - Innovation Cloud. Testray - GS Workflow Process: http://goo.gl/an21mo",
+			"name": "[old] GS-LatAm: Gr1d - Innovation Cloud"
+		},
+		{
+			"description": "Global Services LatAm, Project Petrobrás. Testray - GS Workflow Process: http://goo.gl/an21mo",
+			"name": "[old] GS-LatAm: Project Petrobrás"
+		},
+		{
+			"description": "Global Services USA, Project FHLB-NY - Federal Home Loan Bank - New York. Testray - GS Workflow Process: http://goo.gl/an21mo",
+			"name": "[old] GS-USA: Project FHLB-NY"
+		},
+		{
+			"name": "[old] JDK11"
+		},
+		{
+			"name": "[old] LCS"
+		},
+		{
+			"name": "[old] Liferay Marketplace 1.0"
+		}
+	],
+	"objectDefinitionName": "Project"
+}

--- a/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/3_testray-factor-category.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/3_testray-factor-category.object-entries.json
@@ -1,0 +1,49 @@
+{
+	"object-entries": [
+		{
+			"name": "Application Server",
+			"externalReferenceCode": "TRFCAT-001"
+		},
+		{
+			"name": "Browser",
+			"externalReferenceCode": "TRFCAT-002"
+		},
+		{
+			"name": "Database",
+			"externalReferenceCode": "TRFCAT-003"
+		},
+		{
+			"name": "Java JDK",
+			"externalReferenceCode": "TRFCAT-004"
+		},
+		{
+			"name": "Liferay Version",
+			"externalReferenceCode": "TRFCAT-005"
+		},
+		{
+			"name": "Mobile Browser",
+			"externalReferenceCode": "TRFCAT-006"
+		},
+		{
+			"name": "Mobile Device",
+			"externalReferenceCode": "TRFCAT-007"
+		},
+		{
+			"name": "Mobile Operating System",
+			"externalReferenceCode": "TRFCAT-008"
+		},
+		{
+			"name": "Operating System",
+			"externalReferenceCode": "TRFCAT-009"
+		},
+		{
+			"name": "Portal Edition",
+			"externalReferenceCode": "TRFCAT-010"
+		},
+		{
+			"name": "Product Edition",
+			"externalReferenceCode": "TRFCAT-011"
+		}
+	],
+	"objectDefinitionName": "FactorCategory"
+}

--- a/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/4_testray-factor-option.object-entries.json
+++ b/modules/apps/site-initializer/site-initializer-testray/src/main/resources/site-initializer/object-entries/4_testray-factor-option.object-entries.json
@@ -1,0 +1,1041 @@
+{
+    "object-entries": [
+        {
+            "name": "Any App Server",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Geronimo 2.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Geronimo 3.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Glassfish 3.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "IBM Websphere (Liberty) 8.5.x",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 6.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 6.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 7.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 7.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 7.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss 7.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss AS 6.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss AS 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss AS 7.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 5.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 5.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 6.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 6.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 6.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 6.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 6.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 7.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 7.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JBoss EAP 7.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "JOnAS 5.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Jetty 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Jetty 8.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Jetty 8.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Jetty 9.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Oracle Weblogic Server 12cR2 (12.2.x)",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Resin 4.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "TCat 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tc Server 3.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "TcServer 2.8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "TcServer 2.9",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "TcServer 3.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "TomEE 1.5.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat 6.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat 8.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat 8.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Tomcat 9.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WebSphere",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WebSphere 8.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Weblogic",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Weblogic 10.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Weblogic 11g",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Weblogic 12c",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 7.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 8.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 8.5.5.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 8.5.5.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 8.5.5.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 8.5.5.x",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Websphere 9.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 11.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 14.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 16.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 17.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 18.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 22.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "WildFly 23.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Wildfly",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Wildfly 10.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Wildfly 10.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "tc Server",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "tc Server 2.6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "tc Server 3.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "tc Server 4.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-001$]"
+        },
+        {
+            "name": "Any Browser",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome 34.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome 44.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome 57",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome 65.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome 86.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Chrome x",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Edge 20.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Edge 40.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Edge latest",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox 22.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox 29.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox 38.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox 45.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox 52.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox latest",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Firefox x",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "IE x",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 10",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Internet Explorer 9",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Microsoft Edge",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari 10",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari 12",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari 13",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari 8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "Safari Latest",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-002$]"
+        },
+        {
+            "name": "AWS Aurora 5.6.10a",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "AWS Aurora 5.7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Any ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Aurora MySQL 5.6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Aurora MySQL 5.7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Hypersonic",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "IBM DB2 10.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "IBM DB2 10.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "IBM DB2 11.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "IBM DB2 11.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "IBM DB2 9.7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Maria DB 10.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.0.18",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.1.14",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.1.8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MariaDB 10.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2005",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2008",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2008 R2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2008r2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2012",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2014",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2016",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2017",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Microsoft SQL Server 2019",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MySQL 5.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MySQL 5.6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MySQL 5.7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "MySQL 8.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle 12c Release 2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Oracle ",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 10",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 10.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 12",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 12.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 13.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 8.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 9.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 9.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 9.3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 9.4",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "PostgreSQL 9.6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Sybase 15.5",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Sybase 15.7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Sybase 16.0",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-003$]"
+        },
+        {
+            "name": "Adopt OpenJDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Adopt OpenJDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "AdoptOpenJDK8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Any JDK",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Azul Open JDK 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Azul Zulu JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Azul Zulu JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "IBM J9 - OpenJDK8-OPENJ9",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "IBM J9 2.6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "IBM J9 JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "JRockit 1.6.0_24 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Adopt Open JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Adopt Open JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java IBM J9 JDK 8 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java IBM J9 JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java JDK 7 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java JDK 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java JDK 8 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Open JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Open JDK 8 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Open JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Oracle JDK 7 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Oracle JDK 8 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Oracle JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Redhat Open JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Zulu Open JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Java Zulu Open JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Open JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Open JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Open JDK8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 6 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 6 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 7 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 8 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle JDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Oracle Open JDK 11",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Red Hat OpenJDK 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Red Hat OpenJDK 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-004$]"
+        },
+        {
+            "name": "Liferay DXP 7.3 EP2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-005$]"
+        },
+        {
+            "name": "Liferay DXP 7.3 EP3",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-005$]"
+        },
+        {
+            "name": "Liferay DXP Fix Pack 13",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-005$]"
+        },
+        {
+            "name": "Google Chrome 18",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-006$]"
+        },
+        {
+            "name": "ASUS Nexus 7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-007$]"
+        },
+        {
+            "name": "Samsung Galaxy Nexus 7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-007$]"
+        },
+        {
+            "name": "iPad (3rd Generation)",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-007$]"
+        },
+        {
+            "name": "iPod Touch (4th Generation)",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-007$]"
+        },
+        {
+            "name": "Android 4.2.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-008$]"
+        },
+        {
+            "name": "Alpine Linux 3.10 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Alpine Linux 3.8",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Alpine Linux 3.8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Amazon Linux 2 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Any OS",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "CentOS 5 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "CentOS 6 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "CentOS 6.7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "CentOS 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Debian 10",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Debian 6",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Debian 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Debian 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Debian 9 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "IBM AIX 6.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "IBM AIX 7.1",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "IBM AIX 7.2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "OSX 10.10 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "OSX 10.12 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "OSX 10.13 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "OSX 12.2 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Oracle Linux 6 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Oracle Linux 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Oracle Linux 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Red Hat 8 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Red Hat Enterprise Linux 7",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "SUSE 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "SUSE 12 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "SUSE 15",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "SUSE 15 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "SUSE Enterprise Linux 12 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Solaris 10 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Solaris 11 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 14 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 16 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 16.4 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 18 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 18.04",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Ubuntu 20 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows 10 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows 7 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2008",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2012",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2012 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2012 R2",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2012r2 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2016",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2016 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2019",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows Server 2019 64-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "Windows XP 32-Bit",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-009$]"
+        },
+        {
+            "name": "DXP",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-011$]"
+        },
+        {
+            "name": "Portal",
+            "r_factorCategoryToOptions_c_factorCategoryId": "[$FactorCategory#TRFCAT-011$]"
+        }
+    ],
+    "objectDefinitionName": "FactorOption"
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-147486

- LRQA-74442 Improve openPanelBeforeConfiguration macro conditional
- LRQA-74442 Fix LanguageCacheData test
- LRQA-74364 Add macro to publish content page
- LRQA-74368 Add path for page audit sidebar
- LRQA-74368 Fix path being used at tests
- LRQA-74173 Add property to allow blogs at content dashboard
- LPS-151826 Modify tests to handle new RaylifeAP Site created.
- LRQA-74454 Baseline
- LPS-150079 Add assert for tooltip
- LPS-151821 Update annotations
- LPS-150068 Add test for the DM staging
- COMMERCE-8928 specification_option_facets removed unused aui:script and class
- LPS-151110 Set indexed attribute of row layout structure items based on the nonindexable value
- LPS-151110 Set indexed attribute of fragment layout structure items based on the values of nonIndexableFragmentEntryLinkIds array
- LPS-151110 sort
- LPS-150916 Assert preview as well
- LPS-150916 Assert partial text
- LPS-150536 Test Autom. for Bug: Traffic sources behavior
- LPS-150536 Refactor NoNavigationWithoutIncomingTraffic test
- LPS-150860 Add new locator for view special entry
- LPS-150860 Add new macro for view special entry
- LPS-150860 Add test for message threads appear from newest to oldest by default
- LPS-150860 Update macro to assert partial text
- LPS-150860 Define the existing position macro in MB
- LPS-150860 Remove unnecessary xpath and macro
- LPS-150860 Move case to appropriate file
- LPS-148504 Add test for view blog entry via display page template
- LPS-151289 Adds new test to check if we are adding the correct number of columns when we are adding a collection to a content page, it should be 1 for mobile
- LPS-151349 add design-pack sample to workspaces
- LPS-151626 Auto SF
- LPS-151626 SF
- LPS-151626 SF, rename
- LPS-151626 These files are actually autogenerated
- LPS-151464 Check if the page exists with the urlWithoutLocale in more cases (not only if the URL only has 1 slash)
- LPS-151464 Also for private pages
- LPS-151464 Only try to fetch private page when public was null
- LPS-151464 Apply the same logic to replaceExportLayoutReferences
- LPS-151464 Add integration test cases for "/" in the friendly URL of a layout
- LPS-77699 Update Translations
- LPS-147486 fix _getObjectEntryId to filter by relationship id
- LPS-147486 Indexed issue name
- LPS-147486 sort
- LPS-147486 _getTestrayIssueId and _addTestrayCaseResultIssue
- LPS-147486 simplify and as used
- LPS-147486 use StringBundler.concat
- LPS-147486 make it consistent
- LPS-151412 prepare cache
- Debug
- LPS-147486 add object entries
