### PR TITLE
LPS-149098 Added field name to error message and changed type to danger.

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
@@ -118,9 +118,12 @@ portletDisplay.setURLBack(backURL);
 								shouldSubmitForm = false;
 
 								Liferay.Util.openToast({
-									message:
-										'<liferay-ui:message key="the-maximum-length-is-280-characters-for-text-fields" />',
-									type: 'warning',
+									message: Liferay.Util.sub(
+										'<liferay-ui:message key="the-entry-value-exceeds-the-maximum-length-of-x-characters-for-object-field-x" />',
+										'280',
+										'"' + field.fieldName + '"'
+									),
+									type: 'danger',
 								});
 
 								return false;


### PR DESCRIPTION
Original notes from @SelenaAungst:

> Type was changed to danger to match the error message for Long Text fields and stay to consistent with max length error messages.

https://issues.liferay.com/browse/LPS-149098