### PR TITLE
LPS-154221 Persist externalReferenceCode with objectEntryId when null

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.62
-Liferay-Require-SchemaVersion: 3.7.0
+Liferay-Require-SchemaVersion: 3.8.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/ObjectServiceUpgrade.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/ObjectServiceUpgrade.java
@@ -27,6 +27,7 @@ import com.liferay.object.internal.upgrade.v3_0_0.ObjectFieldSettingUpgradeProce
 import com.liferay.object.internal.upgrade.v3_2_0.ObjectValidationRuleUpgradeProcess;
 import com.liferay.object.internal.upgrade.v3_3_0.util.ObjectViewFilterColumnTable;
 import com.liferay.object.internal.upgrade.v3_4_0.ObjectActionUpgradeProcess;
+import com.liferay.object.internal.upgrade.v3_8_0.ObjectEntryExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -90,6 +91,10 @@ public class ObjectServiceUpgrade implements UpgradeStepRegistrator {
 			"3.6.0", "3.7.0",
 			new com.liferay.object.internal.upgrade.v3_7_0.
 				ObjectActionUpgradeProcess());
+
+		registry.register(
+			"3.7.0", "3.8.0",
+			new ObjectEntryExternalReferenceCodeUpgradeProcess());
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v3_8_0/ObjectEntryExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v3_8_0/ObjectEntryExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.upgrade.v3_8_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class ObjectEntryExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		processConcurrently(
+			"select objectEntryId from ObjectEntry where " +
+				"externalReferenceCode is null or externalReferenceCode = ''",
+			resultSet -> new Object[] {resultSet.getLong("objectEntryId")},
+			columns -> {
+				long objectEntryId = (long)columns[0];
+
+				String sql =
+					"update ObjectEntry set externalReferenceCode = ? where " +
+						"objectEntryId = ?";
+
+				try (PreparedStatement updatePreparedStatement =
+						connection.prepareStatement(sql)) {
+
+					updatePreparedStatement.setString(
+						1, String.valueOf(objectEntryId));
+					updatePreparedStatement.setLong(2, objectEntryId);
+
+					updatePreparedStatement.executeUpdate();
+				}
+			},
+			"Unable to update external reference code for object entries");
+	}
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -207,6 +207,8 @@ public class ObjectEntryLocalServiceImpl
 		objectEntry.setUserId(user.getUserId());
 		objectEntry.setUserName(user.getFullName());
 
+		objectEntry.setExternalReferenceCode(
+			String.valueOf(objectEntry.getObjectEntryId()));
 		objectEntry.setObjectDefinitionId(objectDefinitionId);
 		objectEntry.setStatus(WorkflowConstants.STATUS_DRAFT);
 		objectEntry.setStatusByUserId(user.getUserId());


### PR DESCRIPTION
It's a preparation step to make object entry auto-generated screen to work with externalReferenceCode instead of objectEntryId. This way it will work with any ObjectEntryManager implementation.