### PR TITLE
LPS-156314 baseline

### DIFF
--- a/modules/apps/object/object-admin-rest-api/bnd.bnd
+++ b/modules/apps/object/object-admin-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Admin REST API
 Bundle-SymbolicName: com.liferay.object.admin.rest.api
-Bundle-Version: 6.0.1
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.object.admin.rest.dto.v1_0,\
 	com.liferay.object.admin.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.11.0
+version 3.12.0

--- a/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/util/packageinfo
+++ b/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
- LPS-156431 Change the Raylife Application structure
- LPS-156431 prep next
- LPS-155974 Update packages `@clayui/*` to v3.62.0
- LPS-155974 Update package `@clayui/css` to v3.62.1
- POSHI-365 Disable webdriver for poshi unit test
- POSHI-350 Error out if selenium method is called when webdriver is disabled
- POSHI-341 Change wait time to 500ms
- POSHI-348 Update jsoup to 1.15.1
- POSHI-350 Simplify
- POSHI-341 POSHI-348 POSHI-350 SF
- POSHI-341 POSHI-348 POSHI-350 prep next
- LCD-14295 Update project template tokens
- LCD-14295 prep next
- LPS-155543 Move jsonwebservice package from portal-impl
- LPS-155543 Move tests
- LPS-155543 Make JSONWebServiceActionsManagerImpl an osgi component
- LPS-155543 Export required packages
- LPS-155543 Add required dependencies
- LPS-155543 Move MethodParametersResolver api
- LPS-155543 Merge MethodParametersResolver/MethodParametersResolverImpl into MethodParametersResolverUtil
- LPS-155543 Not needed anymore
- LPS-155543 Use compileInclude
- LPS-155543 Avoid export the com.liferay.portal.spring.context package
- LPS-155543 Semver
- LPS-143632 Remove LanguageUtil usages in modules, part 1a
- LPS-155163 Add macro for the friendly URL redirection configuration
- LPS-155163 Add macro for checking the redirection type
- LPS-155163 Add tests for the friendly URL service
- LPS-155163 Add precondition to cover requirement
- LPS-154855 remove properties: module.framework.resolver.revision.batch.size; This property was added in this task https://issues.liferay.com/browse/LPS-82179 , we wanted to resolve bundles in batches. But in method ModuleResolver of class org.eclipse.osgi.container.ModuleResolver, if this property is empty, the default batch size is Integer.MAX_VALUE, and It's still batch processing, so, we can remove it.
- LPS-149694 Add test for setting multiple mime type size limit at site and instance levels
- LRQA-51488 Match the key
- LRQA-51488 Regen
- LPS-77699 Update Translations
- LPS-156314 baseline
