### PR TITLE
LPS-157056 Specify maxValue and minValue for Integer and Long Integer and maxValue, minValue and decimalPartMaxLength for Precision Decimal field types of Objects

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 29.1.1
+Bundle-Version: 29.2.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldValidationConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldValidationConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.constants;
+
+/**
+ * @author Rubén Pulido
+ */
+public class ObjectFieldValidationConstants {
+
+	public static final long MAX_SAFE_LONG = 9007199254740991L;
+
+	public static final long MIN_SAFE_LONG = -9007199254740991L;
+
+}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.11.0
+version 2.12.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.configuration.ObjectConfiguration;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionScopeException;
@@ -2404,13 +2405,15 @@ public class ObjectEntryLocalServiceImpl
 					throw new ObjectEntryValuesException.ExceedsLongSize(
 						16, objectField.getName());
 				}
-				else if (value > _MAX_SAFE_LONG) {
+				else if (value > ObjectFieldValidationConstants.MAX_SAFE_LONG) {
 					throw new ObjectEntryValuesException.ExceedsLongMaxSize(
-						_MAX_SAFE_LONG, objectField.getName());
+						ObjectFieldValidationConstants.MAX_SAFE_LONG,
+						objectField.getName());
 				}
-				else if (value < _MIN_SAFE_LONG) {
+				else if (value < ObjectFieldValidationConstants.MIN_SAFE_LONG) {
 					throw new ObjectEntryValuesException.ExceedsLongMinSize(
-						_MIN_SAFE_LONG, objectField.getName());
+						ObjectFieldValidationConstants.MIN_SAFE_LONG,
+						objectField.getName());
 				}
 			}
 		}
@@ -2443,10 +2446,6 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 	}
-
-	private static final long _MAX_SAFE_LONG = 9007199254740991L;
-
-	private static final long _MIN_SAFE_LONG = -9007199254740991L;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryLocalServiceImpl.class);

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectFieldDBTypeUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectFieldDBTypeUtil.java
@@ -26,8 +26,11 @@ import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.model.ObjectField;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,12 +53,49 @@ public class ObjectFieldDBTypeUtil {
 
 			finalStep.attribute(NumberInfoFieldType.DECIMAL, true);
 		}
+
+		if (Objects.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_INTEGER)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.MAX_VALUE, BigDecimal.valueOf(2147483647)
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE, BigDecimal.valueOf(-2147483648)
+			);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.MAX_VALUE,
+				BigDecimal.valueOf(ObjectFieldValidationConstants.MAX_SAFE_LONG)
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE,
+				BigDecimal.valueOf(ObjectFieldValidationConstants.MIN_SAFE_LONG)
+			);
+		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
 
 			finalStep.attribute(
 				SelectInfoFieldType.OPTIONS, _getOptions(objectField));
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.DECIMAL_PART_MAX_LENGTH, 16
+			).attribute(
+				NumberInfoFieldType.MAX_VALUE,
+				new BigDecimal("99999999999999.9999999999999999")
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE,
+				new BigDecimal("-99999999999999.9999999999999999")
+			);
 		}
 
 		return finalStep.build();


### PR DESCRIPTION
Hi team!

This PR sets the maximum and minimum values for Integer, Long Integer and Precision Decimal field types, as well as the decimalPartMaxLength for Precision Decimal, so validation can be performed when mapping Numeric Input Fields in the Page Editor to Objects fields of these types.

For Decimal, we would need to specify these values as well, for which this [task](https://issues.liferay.com/browse/LPS-157056) has been created.

Thank you!