### PR TITLE
LPS-157565 &  LPS-156398 Configure relationship api headless URL and take into account user to set the file size

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Card.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Card.scss
@@ -31,6 +31,11 @@
 			flex-direction: row;
 			gap: 1rem;
 			padding: 0;
+
+			.has-error {
+				position: relative;
+				top: 12px;
+			}
 		}
 
 		&--no-padding {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -47,6 +47,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
 import com.liferay.object.web.internal.asset.model.ObjectEntryAssetRendererFactory;
@@ -114,10 +115,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		InfoItemFormProvider<ObjectEntry> infoItemFormProvider =
 			new ObjectEntryInfoItemFormProvider(
 				objectDefinition, _infoItemFieldReaderFieldSetProvider,
-				_objectDefinitionLocalService, _objectFieldLocalService,
+				_listTypeEntryLocalService, _objectDefinitionLocalService,
+				_objectFieldLocalService, _objectFieldSettingLocalService,
 				_objectRelationshipLocalService, _objectScopeProviderRegistry,
 				_restContextPathResolverRegistry,
-				_templateInfoItemFieldSetProvider);
+				_templateInfoItemFieldSetProvider, _userLocalService);
 
 		List<ServiceRegistration<?>> serviceRegistrations = ListUtil.fromArray(
 			_bundleContext.registerService(
@@ -420,6 +422,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
 
 	@Reference
 	private ObjectRelatedModelsProviderRegistry

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -40,6 +40,7 @@ import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
+import com.liferay.object.rest.context.path.RESTContextPathResolverRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerServicesTracker;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -114,7 +115,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			new ObjectEntryInfoItemFormProvider(
 				objectDefinition, _infoItemFieldReaderFieldSetProvider,
 				_objectDefinitionLocalService, _objectFieldLocalService,
-				_objectRelationshipLocalService,
+				_objectRelationshipLocalService, _objectScopeProviderRegistry,
+				_restContextPathResolverRegistry,
 				_templateInfoItemFieldSetProvider);
 
 		List<ServiceRegistration<?>> serviceRegistrations = ListUtil.fromArray(
@@ -434,6 +436,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RESTContextPathResolverRegistry _restContextPathResolverRegistry;
 
 	private ServiceTrackerMap<String, PortletResourcePermission>
 		_serviceTrackerMap;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -26,7 +26,7 @@ import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
 import com.liferay.list.type.model.ListTypeEntry;
-import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
+import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
@@ -41,7 +41,7 @@ import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
-import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.info.item.ObjectEntryInfoItemFields;
 import com.liferay.object.web.internal.util.ObjectConfigurationUtil;
@@ -54,7 +54,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -78,22 +78,28 @@ public class ObjectEntryInfoItemFormProvider
 	public ObjectEntryInfoItemFormProvider(
 		ObjectDefinition objectDefinition,
 		InfoItemFieldReaderFieldSetProvider infoItemFieldReaderFieldSetProvider,
+		ListTypeEntryLocalService listTypeEntryLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectFieldLocalService objectFieldLocalService,
+		ObjectFieldSettingLocalService objectFieldSettingLocalService,
 		ObjectRelationshipLocalService objectRelationshipLocalService,
 		ObjectScopeProviderRegistry objectScopeProviderRegistry,
 		RESTContextPathResolverRegistry restContextPathResolverRegistry,
-		TemplateInfoItemFieldSetProvider templateInfoItemFieldSetProvider) {
+		TemplateInfoItemFieldSetProvider templateInfoItemFieldSetProvider,
+		UserLocalService userLocalService) {
 
 		_objectDefinition = objectDefinition;
 		_infoItemFieldReaderFieldSetProvider =
 			infoItemFieldReaderFieldSetProvider;
+		_listTypeEntryLocalService = listTypeEntryLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectFieldLocalService = objectFieldLocalService;
+		_objectFieldSettingLocalService = objectFieldSettingLocalService;
 		_objectRelationshipLocalService = objectRelationshipLocalService;
 		_objectScopeProviderRegistry = objectScopeProviderRegistry;
 		_restContextPathResolverRegistry = restContextPathResolverRegistry;
 		_templateInfoItemFieldSetProvider = templateInfoItemFieldSetProvider;
+		_userLocalService = userLocalService;
 	}
 
 	@Override
@@ -235,7 +241,7 @@ public class ObjectEntryInfoItemFormProvider
 
 	private String _getAcceptedFileExtensions(ObjectField objectField) {
 		ObjectFieldSetting acceptedFileExtensionsObjectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+			_objectFieldSettingLocalService.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(), "acceptedFileExtensions");
 
 		if (acceptedFileExtensionsObjectFieldSetting == null) {
@@ -279,7 +285,7 @@ public class ObjectEntryInfoItemFormProvider
 		ObjectField objectField) {
 
 		ObjectFieldSetting objectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+			_objectFieldSettingLocalService.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(), "fileSource");
 
 		if (objectFieldSetting == null) {
@@ -354,7 +360,7 @@ public class ObjectEntryInfoItemFormProvider
 
 	private long _getMaximumFileSize(ObjectField objectField) {
 		ObjectFieldSetting objectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+			_objectFieldSettingLocalService.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(), "maximumFileSize");
 
 		long maximumFileSizeForGuestUsers =
@@ -459,7 +465,7 @@ public class ObjectEntryInfoItemFormProvider
 		List<SelectInfoFieldType.Option> options = new ArrayList<>();
 
 		List<ListTypeEntry> listTypeEntries =
-			ListTypeEntryLocalServiceUtil.getListTypeEntries(
+			_listTypeEntryLocalService.getListTypeEntries(
 				objectField.getListTypeDefinitionId());
 
 		for (ListTypeEntry listTypeEntry : listTypeEntries) {
@@ -512,7 +518,7 @@ public class ObjectEntryInfoItemFormProvider
 			return true;
 		}
 
-		User user = UserLocalServiceUtil.fetchUser(serviceContext.getUserId());
+		User user = _userLocalService.fetchUser(serviceContext.getUserId());
 
 		if ((user == null) || user.isDefaultUser()) {
 			return true;
@@ -526,9 +532,12 @@ public class ObjectEntryInfoItemFormProvider
 
 	private final InfoItemFieldReaderFieldSetProvider
 		_infoItemFieldReaderFieldSetProvider;
+	private final ListTypeEntryLocalService _listTypeEntryLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectFieldLocalService _objectFieldLocalService;
+	private final ObjectFieldSettingLocalService
+		_objectFieldSettingLocalService;
 	private final ObjectRelationshipLocalService
 		_objectRelationshipLocalService;
 	private final ObjectScopeProviderRegistry _objectScopeProviderRegistry;
@@ -536,5 +545,6 @@ public class ObjectEntryInfoItemFormProvider
 		_restContextPathResolverRegistry;
 	private final TemplateInfoItemFieldSetProvider
 		_templateInfoItemFieldSetProvider;
+	private final UserLocalService _userLocalService;
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -17,25 +17,42 @@ package com.liferay.object.web.internal.info.item.provider;
 import com.liferay.info.exception.NoSuchFormVariationException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
+import com.liferay.info.field.type.FileInfoFieldType;
+import com.liferay.info.field.type.NumberInfoFieldType;
+import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.field.reader.InfoItemFieldReaderFieldSetProvider;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
+import com.liferay.list.type.model.ListTypeEntry;
+import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.info.item.ObjectEntryInfoItemFields;
 import com.liferay.object.web.internal.util.ObjectFieldDBTypeUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
+
+import java.math.BigDecimal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Jorge Ferrer
@@ -107,6 +124,102 @@ public class ObjectEntryInfoItemFormProvider
 		return getInfoForm(formVariationKey);
 	}
 
+	private InfoField<?> _addAttributes(
+		InfoField.FinalStep finalStep, ObjectField objectField) {
+
+		if (Objects.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			finalStep.attribute(
+				FileInfoFieldType.ALLOWED_FILE_EXTENSIONS,
+				_getAcceptedFileExtensions(objectField)
+			).attribute(
+				FileInfoFieldType.FILE_SOURCE, _getFileSourceType(objectField)
+			).attribute(
+				FileInfoFieldType.MAX_FILE_SIZE,
+				_getMaximumFileSize(objectField)
+			);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_DECIMAL)) {
+
+			finalStep.attribute(NumberInfoFieldType.DECIMAL, true);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_INTEGER)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.MAX_VALUE,
+				BigDecimal.valueOf(
+					ObjectFieldValidationConstants.
+						BUSINESS_TYPE_INTEGER_VALUE_MAX)
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE,
+				BigDecimal.valueOf(
+					ObjectFieldValidationConstants.
+						BUSINESS_TYPE_INTEGER_VALUE_MIN)
+			);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.MAX_VALUE,
+				BigDecimal.valueOf(
+					ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX)
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE,
+				BigDecimal.valueOf(
+					ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN)
+			);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
+
+			finalStep.attribute(
+				SelectInfoFieldType.OPTIONS, _getOptions(objectField));
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
+
+			finalStep.attribute(
+				NumberInfoFieldType.DECIMAL, true
+			).attribute(
+				NumberInfoFieldType.DECIMAL_PART_MAX_LENGTH, 16
+			).attribute(
+				NumberInfoFieldType.MAX_VALUE,
+				new BigDecimal(
+					ObjectFieldValidationConstants.
+						BUSINESS_TYPE_PRECISION_DECIMAL_VALUE_MAX)
+			).attribute(
+				NumberInfoFieldType.MIN_VALUE,
+				new BigDecimal(
+					ObjectFieldValidationConstants.
+						BUSINESS_TYPE_PRECISION_DECIMAL_VALUE_MIN)
+			);
+		}
+
+		return finalStep.build();
+	}
+
+	private String _getAcceptedFileExtensions(ObjectField objectField) {
+		ObjectFieldSetting acceptedFileExtensionsObjectFieldSetting =
+			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+				objectField.getObjectFieldId(), "acceptedFileExtensions");
+
+		if (acceptedFileExtensionsObjectFieldSetting == null) {
+			return StringPool.BLANK;
+		}
+
+		return acceptedFileExtensionsObjectFieldSetting.getValue();
+	}
+
 	private InfoFieldSet _getBasicInformationInfoFieldSet() {
 		return InfoFieldSet.builder(
 		).infoFieldSetEntry(
@@ -135,6 +248,31 @@ public class ObjectEntryInfoItemFormProvider
 		).name(
 			"configuration"
 		).build();
+	}
+
+	private FileInfoFieldType.FileSourceType _getFileSourceType(
+		ObjectField objectField) {
+
+		ObjectFieldSetting objectFieldSetting =
+			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+				objectField.getObjectFieldId(), "fileSource");
+
+		if (objectFieldSetting == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectFieldSetting.getValue(), "documentsAndMedia")) {
+
+			return FileInfoFieldType.FileSourceType.DOCUMENTS_AND_MEDIA;
+		}
+		else if (Objects.equals(
+					objectFieldSetting.getValue(), "userComputer")) {
+
+			return FileInfoFieldType.FileSourceType.USER_COMPUTER;
+		}
+
+		return null;
 	}
 
 	private InfoForm _getInfoForm(long objectDefinitionId)
@@ -167,6 +305,18 @@ public class ObjectEntryInfoItemFormProvider
 		).name(
 			_objectDefinition.getClassName()
 		).build();
+	}
+
+	private long _getMaximumFileSize(ObjectField objectField) {
+		ObjectFieldSetting objectFieldSetting =
+			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
+				objectField.getObjectFieldId(), "maximumFileSize");
+
+		if (objectFieldSetting == null) {
+			return 0;
+		}
+
+		return GetterUtil.getLong(objectFieldSetting.getValue());
 	}
 
 	private InfoFieldSet _getObjectDefinitionInfoFieldSet(
@@ -214,7 +364,7 @@ public class ObjectEntryInfoItemFormProvider
 					}
 
 					unsafeConsumer.accept(
-						ObjectFieldDBTypeUtil.addAttributes(
+						_addAttributes(
 							InfoField.builder(
 							).infoFieldType(
 								ObjectFieldDBTypeUtil.getInfoFieldType(
@@ -244,6 +394,25 @@ public class ObjectEntryInfoItemFormProvider
 		).name(
 			objectDefinition.getName()
 		).build();
+	}
+
+	private List<SelectInfoFieldType.Option> _getOptions(
+		ObjectField objectField) {
+
+		List<SelectInfoFieldType.Option> options = new ArrayList<>();
+
+		List<ListTypeEntry> listTypeEntries =
+			ListTypeEntryLocalServiceUtil.getListTypeEntries(
+				objectField.getListTypeDefinitionId());
+
+		for (ListTypeEntry listTypeEntry : listTypeEntries) {
+			options.add(
+				new SelectInfoFieldType.Option(
+					new FunctionInfoLocalizedValue<>(listTypeEntry::getName),
+					listTypeEntry.getKey()));
+		}
+
+		return options;
 	}
 
 	private final InfoItemFieldReaderFieldSetProvider

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -50,8 +50,10 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -487,6 +489,23 @@ public class ObjectEntryInfoItemFormProvider
 
 		return PortalUtil.getPortalURL(serviceContext.getRequest()) +
 			restContextPath;
+	}
+
+	private boolean _isDefaultUser() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return true;
+		}
+
+		User user = UserLocalServiceUtil.fetchUser(serviceContext.getUserId());
+
+		if ((user == null) || user.isDefaultUser()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -44,6 +44,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.info.item.ObjectEntryInfoItemFields;
+import com.liferay.object.web.internal.util.ObjectConfigurationUtil;
 import com.liferay.object.web.internal.util.ObjectFieldDBTypeUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -356,11 +357,23 @@ public class ObjectEntryInfoItemFormProvider
 			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
 				objectField.getObjectFieldId(), "maximumFileSize");
 
+		long maximumFileSizeForGuestUsers =
+			ObjectConfigurationUtil.maximumFileSizeForGuestUsers();
+
 		if (objectFieldSetting == null) {
-			return 0;
+			return maximumFileSizeForGuestUsers;
 		}
 
-		return GetterUtil.getLong(objectFieldSetting.getValue());
+		long maximumFileSize = GetterUtil.getLong(
+			objectFieldSetting.getValue());
+
+		if ((maximumFileSizeForGuestUsers < maximumFileSize) &&
+			_isDefaultUser()) {
+
+			maximumFileSize = maximumFileSizeForGuestUsers;
+		}
+
+		return maximumFileSize;
 	}
 
 	private InfoFieldSet _getObjectDefinitionInfoFieldSet(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectConfigurationUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectConfigurationUtil.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.util;
+
+import com.liferay.object.configuration.ObjectConfiguration;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	configurationPid = "com.liferay.object.configuration.ObjectConfiguration",
+	immediate = true, service = {}
+)
+public class ObjectConfigurationUtil {
+
+	public static int maximumFileSizeForGuestUsers() {
+		return _objectConfiguration.maximumFileSizeForGuestUsers();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_objectConfiguration = ConfigurableUtil.createConfigurable(
+			ObjectConfiguration.class, properties);
+	}
+
+	private static volatile ObjectConfiguration _objectConfiguration;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectFieldDBTypeUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectFieldDBTypeUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.object.web.internal.util;
 
-import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
@@ -22,111 +21,15 @@ import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.field.type.NumberInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
-import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
-import com.liferay.list.type.model.ListTypeEntry;
-import com.liferay.list.type.service.ListTypeEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectFieldConstants;
-import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.model.ObjectField;
-import com.liferay.object.model.ObjectFieldSetting;
-import com.liferay.object.service.ObjectFieldSettingLocalServiceUtil;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.GetterUtil;
 
-import java.math.BigDecimal;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
  * @author Eudaldo Alonso
  */
 public class ObjectFieldDBTypeUtil {
-
-	public static InfoField<?> addAttributes(
-		InfoField.FinalStep finalStep, ObjectField objectField) {
-
-		if (Objects.equals(
-				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
-
-			finalStep.attribute(
-				FileInfoFieldType.ALLOWED_FILE_EXTENSIONS,
-				_getAcceptedFileExtensions(objectField)
-			).attribute(
-				FileInfoFieldType.FILE_SOURCE, _getFileSourceType(objectField)
-			).attribute(
-				FileInfoFieldType.MAX_FILE_SIZE,
-				_getMaximumFileSize(objectField)
-			);
-		}
-		else if (Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_DECIMAL)) {
-
-			finalStep.attribute(NumberInfoFieldType.DECIMAL, true);
-		}
-		else if (Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_INTEGER)) {
-
-			finalStep.attribute(
-				NumberInfoFieldType.MAX_VALUE,
-				BigDecimal.valueOf(
-					ObjectFieldValidationConstants.
-						BUSINESS_TYPE_INTEGER_VALUE_MAX)
-			).attribute(
-				NumberInfoFieldType.MIN_VALUE,
-				BigDecimal.valueOf(
-					ObjectFieldValidationConstants.
-						BUSINESS_TYPE_INTEGER_VALUE_MIN)
-			);
-		}
-		else if (Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_LONG_INTEGER)) {
-
-			finalStep.attribute(
-				NumberInfoFieldType.MAX_VALUE,
-				BigDecimal.valueOf(
-					ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MAX)
-			).attribute(
-				NumberInfoFieldType.MIN_VALUE,
-				BigDecimal.valueOf(
-					ObjectFieldValidationConstants.BUSINESS_TYPE_LONG_VALUE_MIN)
-			);
-		}
-		else if (Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
-
-			finalStep.attribute(
-				SelectInfoFieldType.OPTIONS, _getOptions(objectField));
-		}
-		else if (Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
-
-			finalStep.attribute(
-				NumberInfoFieldType.DECIMAL, true
-			).attribute(
-				NumberInfoFieldType.DECIMAL_PART_MAX_LENGTH, 16
-			).attribute(
-				NumberInfoFieldType.MAX_VALUE,
-				new BigDecimal(
-					ObjectFieldValidationConstants.
-						BUSINESS_TYPE_PRECISION_DECIMAL_VALUE_MAX)
-			).attribute(
-				NumberInfoFieldType.MIN_VALUE,
-				new BigDecimal(
-					ObjectFieldValidationConstants.
-						BUSINESS_TYPE_PRECISION_DECIMAL_VALUE_MIN)
-			);
-		}
-
-		return finalStep.build();
-	}
 
 	public static InfoFieldType getInfoFieldType(ObjectField objectField) {
 		if (Objects.equals(
@@ -173,74 +76,6 @@ public class ObjectFieldDBTypeUtil {
 		}
 
 		return TextInfoFieldType.INSTANCE;
-	}
-
-	private static String _getAcceptedFileExtensions(ObjectField objectField) {
-		ObjectFieldSetting acceptedFileExtensionsObjectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
-				objectField.getObjectFieldId(), "acceptedFileExtensions");
-
-		if (acceptedFileExtensionsObjectFieldSetting == null) {
-			return StringPool.BLANK;
-		}
-
-		return acceptedFileExtensionsObjectFieldSetting.getValue();
-	}
-
-	private static FileInfoFieldType.FileSourceType _getFileSourceType(
-		ObjectField objectField) {
-
-		ObjectFieldSetting objectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
-				objectField.getObjectFieldId(), "fileSource");
-
-		if (objectFieldSetting == null) {
-			return null;
-		}
-
-		if (Objects.equals(
-				objectFieldSetting.getValue(), "documentsAndMedia")) {
-
-			return FileInfoFieldType.FileSourceType.DOCUMENTS_AND_MEDIA;
-		}
-		else if (Objects.equals(
-					objectFieldSetting.getValue(), "userComputer")) {
-
-			return FileInfoFieldType.FileSourceType.USER_COMPUTER;
-		}
-
-		return null;
-	}
-
-	private static long _getMaximumFileSize(ObjectField objectField) {
-		ObjectFieldSetting objectFieldSetting =
-			ObjectFieldSettingLocalServiceUtil.fetchObjectFieldSetting(
-				objectField.getObjectFieldId(), "maximumFileSize");
-
-		if (objectFieldSetting == null) {
-			return 0;
-		}
-
-		return GetterUtil.getLong(objectFieldSetting.getValue());
-	}
-
-	private static List<SelectInfoFieldType.Option> _getOptions(
-		ObjectField objectField) {
-
-		List<SelectInfoFieldType.Option> options = new ArrayList<>();
-
-		List<ListTypeEntry> listTypeEntries =
-			ListTypeEntryLocalServiceUtil.getListTypeEntries(
-				objectField.getListTypeDefinitionId());
-
-		for (ListTypeEntry listTypeEntry : listTypeEntries) {
-			options.add(
-				new SelectInfoFieldType.Option(
-					new FunctionInfoLocalizedValue<>(listTypeEntry::getName),
-					listTypeEntry.getKey()));
-		}
-
-		return options;
 	}
 
 }


### PR DESCRIPTION
Motivation
---
In order to support relationship on app pages integration, we should set the api headless url to info framework select field and also we should take into account if the user is a default user or not to set the max file size.

[Link to the issue](https://issues.liferay.com/browse/LPS-156398) -> Configure relationship api headless URL
[Link to the issue](https://issues.liferay.com/browse/LPS-157565) -> Take into account user to set the file size

Proposed Solution
---
**Configure relationship api headless URL**
Copy and adapt logic from _ObjectRelationshipDDMFormFieldTemplateContextContributor_#__getAPIURL_ to get the optionsURL.

**Take into account user to set the file size**
Gets the _maximumFileSizeForGuestUsers_ from _ObjectConfiguration_ and set it if the user is the default user. 