### PR TITLE
LPS-157453 Replace "id" with "externalReferenceCode" as it replaced

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -60,9 +60,9 @@ public class ObjectEntryEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE)
 		).put(
-			"id",
+			"externalReferenceCode",
 			new IdEntityField(
-				"id",
+				"externalReferenceCode",
 				locale -> Field.getSortableFieldName(Field.ENTRY_CLASS_PK),
 				String::valueOf)
 		).put(


### PR DESCRIPTION
Notes from @javalosjr96:

> Ticket: [LPS-157453](https://issues.liferay.com/browse/LPS-157453)
> 
> Issue: When creating an Object and adding entries to it, the ID column is unsortable and a 400:BAD_REQUEST error appears in a notification in the portal.
> 
> Cause: This https://github.com/brianchandotcom/liferay-portal/pull/119400 changed "id" to "externalReferenceCode", but they didn't update the MAP that used "id" as a key.
> 
> Solution:
> Replace "id" with "externalReferenceCode" in _entityFieldsMap