### PR TITLE
[TS] LPS-157935 - Upload/Attachment field in Objects

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -2337,8 +2338,11 @@ public class ObjectEntryLocalServiceImpl
 					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
+			JSONObject entryJsonObject = JSONFactoryUtil.createJSONObject(entry.getValue().toString());
+			Long fileEntryId = GetterUtil.getLong(entryJsonObject.get("fileEntryId"));
+
 			DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
-				GetterUtil.getLong(entry.getValue()));
+					fileEntryId);
 
 			if (dlFileEntry != null) {
 				_validateFileExtension(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1070,10 +1070,6 @@ public class ObjectEntryLocalServiceImpl
 				}
 			}
 
-			if (Objects.equals("documentsAndMedia", fileSource)) {
-				return;
-			}
-
 			DLFolder dlFileEntryFolder = dlFileEntry.getFolder();
 
 			DLFolder dlFolder = _getDLFolder(


### PR DESCRIPTION
Issue related: https://issues.liferay.com/browse/LPS-157935

Hi team, the current customer reported that after the solution shared from https://issues.liferay.com/browse/LPS-155103, the form submission is unavailable. In the first commit I'm proposing to change the ID from the upload field. As it comes in a JSON format, I had to get the specific ID value through the string of the object.  

In the second commit I had to revert this verification to allow the portal to get the correct entryId of a attachment from the Item Selector perspective. The document submitted on Forms wasn't being listed in the Object entries table.

Please lemme now If I have to change something or in case of any doubts.

Thanks,
Richard.