### PR TITLE
[TS] LPP-45803 > LPS-157577 Get object definitions of companies instead of just default company with DB Partition

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -85,6 +85,7 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -682,15 +683,19 @@ public class ObjectDefinitionLocalServiceImpl
 		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
-		List<ObjectDefinition> objectDefinitions =
-			objectDefinitionLocalService.getCustomObjectDefinitions(
-				WorkflowConstants.STATUS_APPROVED);
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				List<ObjectDefinition> objectDefinitions =
+					objectDefinitionLocalService.getObjectDefinitions(
+						companyId, true, false,
+						WorkflowConstants.STATUS_APPROVED);
 
-		for (ObjectDefinition objectDefinition : objectDefinitions) {
-			serviceRegistrationsMap.put(
-				objectDefinition.getObjectDefinitionId(),
-				objectDefinitionDeployer.deploy(objectDefinition));
-		}
+				for (ObjectDefinition objectDefinition : objectDefinitions) {
+					serviceRegistrationsMap.put(
+						objectDefinition.getObjectDefinitionId(),
+						objectDefinitionDeployer.deploy(objectDefinition));
+				}
+			});
 
 		_serviceRegistrationsMaps.put(
 			objectDefinitionDeployer, serviceRegistrationsMap);
@@ -1326,6 +1331,9 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private DynamicQueryBatchIndexingActionableFactory


### PR DESCRIPTION
Motivation
=======
This work solves the problem reported in [LPP-45803](https://issues.liferay.com/browse/LPP-45803) and fixes by LPS [LPS-157577](https://issues.liferay.com/browse/LPS-157577) ticket 
cc : @tototrinh 

Proposed Solution
========
What we did to solve this problem.

 Get object definitions of companies instead of just default company with DB Partition

Steps to Verify
========
Steps to reproduce
1. In a clean 7.4 U30 bundle, enable database partitioning by adding the following property to your portal-ext.properties file:
include-and-override=portal-liferay-online.properties
2. Start up Liferay
3. Log in to Liferay
4. Create a new virtual instance
5. Access the new virtual instance and log in
6. Go to Control Panel -> Objects
7. Add an object > press Save
8. Open the object again for editing
Click the 'Fields' tab > add a new field with *Type: text > press Save
9. Go back to editing the object (Details tab)
10. Under 'Panel Category Key' select 'Applications -> Custom Apps'
11. Display > Show Widget > Click on Publish
12. Under 'Applications -> Custom Apps' you will see the customization
13. Restart Liferay
14. Go to the new virtual instance and log in > check for Object