### PR TITLE
[TS] LPS-157935 - Upload/Attachment field in Objects

### DIFF
--- a/modules/apps/object/object-service/build.gradle
+++ b/modules/apps/object/object-service/build.gradle
@@ -4,6 +4,7 @@ buildService {
 }
 
 dependencies {
+	compileInclude group: "org.apache.commons", name: "commons-lang3", version: "3.11"
 	compileInclude group: "org.codehaus.groovy", name: "groovy", version: "2.4.21"
 
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -156,6 +157,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -1288,6 +1290,19 @@ public class ObjectEntryLocalServiceImpl
 			objectDefinition.getExtensionDBTableName());
 	}
 
+	private Long _getFileEntryValue(Serializable entry) throws JSONException {
+		String entryValueString = entry.toString();
+
+		if (!NumberUtils.isParsable(entryValueString)) {
+			JSONObject entryJSONObject = JSONFactoryUtil.createJSONObject(
+				entryValueString);
+
+			return entryJSONObject.getLong("fileEntryId");
+		}
+
+		return GetterUtil.getLong(entryValueString);
+	}
+
 	private GroupByStep _getManyToManyRelatedObjectEntriesGroupByStep(
 			long groupId, long objectRelationshipId, long primaryKey,
 			boolean reverse, FromStep fromStep)
@@ -2337,8 +2352,10 @@ public class ObjectEntryLocalServiceImpl
 					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
+			Long fileEntryId = _getFileEntryValue(entry.getValue());
+
 			DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
-				GetterUtil.getLong(entry.getValue()));
+				fileEntryId);
 
 			if (dlFileEntry != null) {
 				_validateFileExtension(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1046,19 +1046,13 @@ public class ObjectEntryLocalServiceImpl
 		throws PortalException {
 
 		try {
-			String fileSource = null;
 			boolean showFilesInDocumentsAndMedia = false;
 			String storageDLFolderPath = null;
 
 			for (ObjectFieldSetting objectFieldSetting : objectFieldSettings) {
 				if (Objects.equals(
-						objectFieldSetting.getName(), "fileSource")) {
-
-					fileSource = objectFieldSetting.getValue();
-				}
-				else if (Objects.equals(
-							objectFieldSetting.getName(),
-							"showFilesInDocumentsAndMedia")) {
+						objectFieldSetting.getName(),
+						"showFilesInDocumentsAndMedia")) {
 
 					showFilesInDocumentsAndMedia = GetterUtil.getBoolean(
 						objectFieldSetting.getValue());
@@ -1069,10 +1063,6 @@ public class ObjectEntryLocalServiceImpl
 
 					storageDLFolderPath = objectFieldSetting.getValue();
 				}
-			}
-
-			if (Objects.equals("documentsAndMedia", fileSource)) {
-				return;
 			}
 
 			DLFolder dlFileEntryFolder = dlFileEntry.getFolder();


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-157935

Hi team, the current customer reported that after the solution shared from https://issues.liferay.com/browse/LPS-155103, the form submission is unavailable. In the first commit I'm proposing to change the ID from the upload field. As it comes in a JSON format, I had to get the specific ID value through the string of the object.

In the second commit I had to revert this verification to allow the portal to get the correct entryId of a attachment from the Item Selector perspective. The document submitted on Forms wasn't being listed in the Object entries table. I'm not entirely sure if the second commit can affect something defined by the objects team, but I wanted to allow the user to view the entries of objects created using ItemSelector or not. What wasn't happening.

Please let me know If I have to change something or in case of any doubts.

Thanks,
Richard.
