### PR TITLE
LPS-157167 Added onClose callback to properly close Modal backdrop/fade

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ExpressionBuilder.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ExpressionBuilder.tsx
@@ -83,7 +83,6 @@ export function ExpressionBuilder({
 }
 
 export function ExpressionBuilderModal({sidebarElements}: IModalProps) {
-	const {observer, onOpenChange} = useModal();
 	const editorRef = useRef<CodeMirror.Editor>(null);
 	const [
 		{error, onSave, required, source, validateExpressionURL},
@@ -95,6 +94,10 @@ export function ExpressionBuilderModal({sidebarElements}: IModalProps) {
 		source?: string;
 		validateExpressionURL?: string;
 	}>({});
+
+	const {observer, onOpenChange} = useModal({
+		onClose: () => setState({}),
+	});
 
 	useEffect(() => {
 		const openModal = (params: {
@@ -120,7 +123,6 @@ export function ExpressionBuilderModal({sidebarElements}: IModalProps) {
 	}
 
 	const closeModal = () => {
-		setState({});
 		onOpenChange(false);
 	};
 


### PR DESCRIPTION
FWD: https://github.com/fortunatomaldonado/liferay-portal/pull/36

Let me know if there are any questions or comments about this.
Thank you!

Ticket:[LPS-157167](https://issues.liferay.com/browse/LPS-157167)

Issue: The page freezes when closing the Expression Builder Modal in Object's Action Builder. This is due to modal's backdrop/fade not being closed when clicking on the 'X' or outside of the modal. The expression builder modal properly closes when using the 'Cancel' or 'Done' buttons, which use the method closeModal() to do so.

Solution: I added a setStatus({}) as an onClose callback to useModal(). This setStatus({}) was moved from closeModal() so it would be applied to the entire modal and not just the buttons that call closeModal(). This allows the modal to close properly regardless of which method was used to close it.