### PR TITLE
LPS-164070 Use Control Panel group for Object PanelApps

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/application/list/ObjectDefinitionsPanelApp.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/application/list/ObjectDefinitionsPanelApp.java
@@ -18,7 +18,12 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -49,6 +54,15 @@ public class ObjectDefinitionsPanelApp extends BasePanelApp {
 	)
 	public void setPortlet(Portlet portlet) {
 		super.setPortlet(portlet);
+	}
+
+	@Override
+	protected Group getGroup(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return themeDisplay.getControlPanelGroup();
 	}
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
@@ -21,6 +21,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
 
@@ -76,6 +78,15 @@ public class ObjectEntriesPanelApp extends BasePanelApp {
 		}
 
 		return super.isShow(permissionChecker, group);
+	}
+
+	@Override
+	protected Group getGroup(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return themeDisplay.getControlPanelGroup();
 	}
 
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
@@ -15,6 +15,7 @@
 package com.liferay.object.web.internal.object.entries.application.list;
 
 import com.liferay.application.list.BasePanelApp;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.petra.string.StringPool;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
@@ -82,11 +84,18 @@ public class ObjectEntriesPanelApp extends BasePanelApp {
 
 	@Override
 	protected Group getGroup(HttpServletRequest httpServletRequest) {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
+		if (StringUtil.equals(
+				_objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_COMPANY)) {
 
-		return themeDisplay.getControlPanelGroup();
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			return themeDisplay.getControlPanelGroup();
+		}
+
+		return super.getGroup(httpServletRequest);
 	}
 
 	private final ObjectDefinition _objectDefinition;


### PR DESCRIPTION
Motivation
=======
[LPS-164070](https://issues.liferay.com/browse/LPS-164070)
Currently the Object PanelApp URLs reference the site the link was generated on instead of the Control Panel. this can result in Localisation issue

Proposed Solution
========
If I understand correctly, Objects are Globally scoped entities, so it would be best to use the Control Panel group to avoid any group specific conflicts. I've followed the pattern set by DepotAdminPanelApp to achieve this.

Steps to Verify
========

1. Go to Control Panel > Instance Settings > Localization > Language
2. Add Italian (Italy) (move from Available to Current)
3. Save Localization
4. Go to GUEST site (Liferay DXP)
5. Go to Menu > Configuration > Site Settings > Localization
6. Set Define a custom default language and additional available languages for this site
7. Change Default Language to Italian
8. Save
9. Go to Control Panel > Objects
10. Create new Object (fill out the fields with "test")
11. Click Save

**Expected behaviour:** Object is created
**Actual behaviour:** "An error occurred." Alert is displayed. (Logs indicate missing en_US localisation)

References to existing code
========
The same logic was applied in [DepotAdminPanelApp](https://github.com/liferay/liferay-portal/blob/master/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotAdminPanelApp.java#L70)


Alternative Solutions that were discarded (if applies)
========
Could have changed [PortalImpl](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L7451) to add a new category to this check, but given Objects is a module, I did not want to introduce a magic String here.