### PR TITLE
[TS] ﻿LPS-165774 Unable to add Object with Rich or Long Text fields in DB2

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -810,7 +810,7 @@ public class ObjectEntryLocalServiceImpl
 			_getSelectExpressions(extensionDynamicObjectDefinitionTable));
 
 		List<Object[]> rows = _list(
-			DSLQueryFactoryUtil.selectDistinct(
+			DSLQueryFactoryUtil.select(
 				selectExpressions
 			).from(
 				dynamicObjectDefinitionTable
@@ -849,7 +849,7 @@ public class ObjectEntryLocalServiceImpl
 			_EXPRESSIONS);
 
 		List<Object[]> rows = _list(
-			DSLQueryFactoryUtil.selectDistinct(
+			DSLQueryFactoryUtil.select(
 				selectExpressions
 			).from(
 				dynamicObjectDefinitionTable


### PR DESCRIPTION
Hi @liferay-objects!

See https://issues.liferay.com/browse/LPS-165774

I think task [LPS-164047](https://issues.liferay.com/browse/LPS-164047) (Backed text fix) is related to the same issue one of our customers is facing (see aforementioned [LPS-165774](https://issues.liferay.com/browse/LPS-165774) for details).

Can we get rid of the `distinct` when getting the values/valuesList? If any of the columns are Rich or Long Text, i.e. `Clob` in DB2, we cannot use them in a `select distinct` (among other SQL operations, [see doc](https://www.ibm.com/docs/en/db2/11.5?topic=messages-sql0000-sql0249#sql0134n)).

Thanks!

