### PR TITLE
LPS-163599 - add disableFlag property in InputLocalized

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
@@ -95,6 +95,7 @@ export default function EditRelationship({
 				)}
 
 				<InputLocalized
+					disableFlag={readOnly}
 					disabled={readOnly}
 					error={errors.label}
 					label={Liferay.Language.get('label')}


### PR DESCRIPTION
[LPS-163599](https://issues.liferay.com/browse/LPS-163599)

In this issue, the user is allowed to edit the flag field, but that wasn't supposed to happen. To solve I added the disableFlag property in InputLocalized

Before: 

![image](https://user-images.githubusercontent.com/86370873/196240173-01860f62-5a98-4220-81b5-a72d484e67d4.png)

After:

![image](https://user-images.githubusercontent.com/86370873/196240231-48c9d2fd-7d64-4f21-849a-9efbb2c0d3a9.png)


