### PR TITLE
[TS] LPS-165245 It's possible to update Custom Validation outside of Expression Builder

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -284,7 +284,9 @@ public class ObjectDefinitionResourceImpl
 
 		// TODO Move logic to service
 
-		if (!Validator.isBlank(objectDefinition.getStorageType())) {
+		if (!Validator.isBlank(objectDefinition.getStorageType()) &&
+			!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-135430"))) {
+
 			throw new ObjectDefinitionStorageTypeException();
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -126,6 +126,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -2688,6 +2689,8 @@ public class ObjectEntryLocalServiceImpl
 
 			FinderCacheUtil.clearDSLQueryCache(
 				dynamicObjectDefinitionTable.getTableName());
+
+			objectEntryPersistence.clearCache(SetUtil.fromArray(objectEntryId));
 		}
 		catch (Exception exception) {
 			throw new SystemException(exception);

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/macros/PRMUtils.macro
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/macros/PRMUtils.macro
@@ -28,6 +28,10 @@ definition {
 	macro gotoPRM {
 		Navigator.openSiteURL(siteName = "Partner Portal");
 
+		if (IsElementPresent(locator1 = "PRMUtils#SIGN_IN")) {
+			Click(locator1 = "PRMUtils#SIGN_IN");
+		}
+
 		Refresh();
 	}
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/paths/PRMUtils.path
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/paths/PRMUtils.path
@@ -16,6 +16,11 @@
 	<td>//head//title[contains(.,'${key_tabTitle}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>SIGN_IN</td>
+	<td>//div//a[contains(@class,'btn-solid') and contains(.,'Sign In')]</td>
+	<td></td>
+</tr>
 
 </tbody>
 </table>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/tests/PRMHeaderAndFooter.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/tests/PRMHeaderAndFooter.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	var baseURL = PropsUtil.get("portal.url");
+
 	property custom.properties = "feature.flag.LPS-135430=true";
 	property osgi.modules.includes = "osb-site-initializer-partner-portal";
 	property portal.release = "false";

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/tests/PRMHeaderAndFooter.testcase
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/osb-site-initializer-partner-portal-test/src/testFunctional/tests/PRMHeaderAndFooter.testcase
@@ -1,6 +1,7 @@
 @component-name = "OSB Site Initializer Partner Portal"
 definition {
 
+	var baseURL = PropsUtil.get("portal.url");
 	property custom.properties = "feature.flag.LPS-135430=true";
 	property osgi.modules.includes = "osb-site-initializer-partner-portal";
 	property portal.release = "false";
@@ -47,7 +48,7 @@ definition {
 		}
 
 		task ("Verify if current URL contains 'partner-portal-name/enablement") {
-			AssertLocation.assertPartialLocation(value1 = "${testSiteURL}/enablement");
+			AssertLocation.assertPartialLocation(value1 = "enablement");
 		}
 	}
 
@@ -63,7 +64,7 @@ definition {
 		}
 
 		task ("Verify if current URL contains 'partner-portal-name/home") {
-			AssertLocation.assertPartialLocation(value1 = "${testSiteURL}/home");
+			AssertLocation.assertPartialLocation(value1 = "home");
 		}
 	}
 
@@ -79,7 +80,7 @@ definition {
 		}
 
 		task ("Verify if current URL contains 'partner-portal-name/marketing") {
-			AssertLocation.assertPartialLocation(value1 = "${testSiteURL}/marketing");
+			AssertLocation.assertPartialLocation(value1 = "marketing");
 		}
 	}
 
@@ -95,7 +96,7 @@ definition {
 		}
 
 		task ("Verify if current URL contains 'partner-portal-name/sales") {
-			AssertLocation.assertPartialLocation(value1 = "${testSiteURL}/sales");
+			AssertLocation.assertPartialLocation(value1 = "sales");
 		}
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
@@ -42,11 +42,6 @@ expect {
 }
 
 expect {
-	"showReports - Show all available outputs\r\r\n   scope: verify" {}
-	timeout {send_user "No available command verify:showReports";exit 2}
-}
-
-expect {
 	"executeAll - Execute all pending upgrades\r\r\n   scope: upgrade" {}
 	timeout {send_user "No available command upgrade:executeAll";exit 2}
 }
@@ -97,11 +92,6 @@ expect {
 }
 
 expect {
-	"show - Show all verify processes for a specific verify process name" {send "help verify:showReports\r"}
+	"show - Show all verify processes for a specific verify process name" {send_user "PASS"}
 	timeout {send_user "No help output for command verify:show";exit 2}
-}
-
-expect {
-	"showReports - Show all available outputs" {send_user "PASS"}
-	timeout {send_user "No help output for command verify:showReports";exit 2}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchResultPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchResultPortlet.macro
@@ -20,6 +20,12 @@ definition {
 				locator1 = "Checkbox#ANY_CHECKBOX");
 		}
 
+		if ("${disableDisplaySelectedResultInContext}" == "true") {
+			Uncheck(
+				checkboxName = "Display Selected Result in Context",
+				locator1 = "Checkbox#ANY_CHECKBOX");
+		}
+
 		if ("${displayDocumentForm}" == "true") {
 			Check(
 				checkboxName = "Display Results in Document Form",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -1771,14 +1771,16 @@ definition {
 		}
 	}
 
-	macro getDatabaseVersion {
+	macro getBuildNumber {
 		var mysqlStatement = "SELECT buildNumber FROM Release_ WHERE servletContextName='portal';";
 
-		var databaseVersion = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
+		var sqlResults = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
 
-		echo("## * Database Version is: ${databaseVersion}");
+		var portalBuildNumber = StringUtil.regexReplaceAll("${sqlResults}", "[buildNumber\n]", "");
 
-		return "${databaseVersion}";
+		echo("## * Build Number is: ${portalBuildNumber}");
+
+		return "${portalBuildNumber}";
 	}
 
 	macro ignore404URLs {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -1783,6 +1783,18 @@ definition {
 		return "${portalBuildNumber}";
 	}
 
+	macro getSchemaVersion {
+		var mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName='portal';";
+
+		var sqlResults = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
+
+		var portalSchemaVersion = StringUtil.regexReplaceAll("${sqlResults}", "[schemaVersion\n]", "");
+
+		echo("## * Schema Version is: ${portalSchemaVersion}");
+
+		return "${portalSchemaVersion}";
+	}
+
 	macro ignore404URLs {
 		var portalURL = PropsUtil.get("portal.url");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -550,6 +550,33 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPS-165397."
+	@priority = "3"
+	test CanDisableDisplaySelectedResultWithContentPages {
+		task ("Add a New Page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Example Page",
+				type = "content");
+
+			JSONLayout.publishLayout(
+				groupName = "Guest",
+				layoutName = "Example Page");
+		}
+
+		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
+
+		SearchResultPortlet.configureSearchResults(disableDisplaySelectedResultInContext = "true");
+
+		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
+
+		Search.gotoResultAssetViaTitle(searchAssetTitle = "Example Page");
+
+		AssertElementNotPresent(locator1 = "Portlet#ERROR");
+
+		AssertElementPresent(locator1 = "Search#EMBEDDED_SEARCH_BAR");
+	}
+
 	@description = "This is a use case for LPS-151026."
 	@priority = "3"
 	test CanHighlightResultsAndDisableHighlighting {
@@ -678,33 +705,6 @@ definition {
 
 			SearchFacetPortlet.viewFacetItemsSpecificOrder(facetList = "Product,Engineering,2022,2021");
 		}
-	}
-
-	@description = "This is a use case for LPS-165397."
-	@priority = "3"
-	test CanUncheckDisplaySelectedResultWithContentPages {
-		task ("Add a New Page") {
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Example Page",
-				type = "content");
-
-			JSONLayout.publishLayout(
-				groupName = "Guest",
-				layoutName = "Example Page");
-		}
-
-		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
-
-		SearchResultPortlet.configureSearchResults(disableDisplaySelectedResultInContext = "true");
-
-		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
-
-		Search.gotoResultAssetViaTitle(searchAssetTitle = "Example Page");
-
-		AssertElementNotPresent(locator1 = "Portlet#ERROR");
-
-		AssertElementPresent(locator1 = "Search#EMBEDDED_SEARCH_BAR");
 	}
 
 	@priority = "4"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -680,6 +680,41 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPS-165397."
+	@priority = "3"
+	test CanUncheckDisplaySelectedResultWithContentPages {
+		task ("Add a New Page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Example Page",
+				type = "content");
+
+			JSONLayout.publishLayout(
+				groupName = "Guest",
+				layoutName = "Example Page");
+		}
+
+		task ("Search for 'Example Page'") {
+			SearchPortlets.searchEmbedded(searchTerm = "Example Page");
+		}
+
+		task ("Uncheck the 'Display Selected Result in Context' box into 'Configuration'") {
+			SearchResultPortlet.configureSearchResults(disableDisplaySelectedResultInContext = "true");
+		}
+
+		task ("Search for 'Example Page' again") {
+			SearchPortlets.searchEmbedded(searchTerm = "Example Page");
+		}
+
+		task ("Click on the Search Result") {
+			Search.gotoResultAssetViaTitle(searchAssetTitle = "Example Page");
+		}
+
+		task ("Assert Search bar is avaible") {
+			AssertElementPresent(locator1 = "Search#EMBEDDED_SEARCH_BAR");
+		}
+	}
+
 	@priority = "4"
 	test CanViewTermsOfUseWhenEnterpriseSearchIsEnabled {
 		property custom.properties = "enterprise.product.notification.enabled=true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -694,25 +694,17 @@ definition {
 				layoutName = "Example Page");
 		}
 
-		task ("Search for 'Example Page'") {
-			SearchPortlets.searchEmbedded(searchTerm = "Example Page");
-		}
+		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
 
-		task ("Uncheck the 'Display Selected Result in Context' box into 'Configuration'") {
-			SearchResultPortlet.configureSearchResults(disableDisplaySelectedResultInContext = "true");
-		}
+		SearchResultPortlet.configureSearchResults(disableDisplaySelectedResultInContext = "true");
 
-		task ("Search for 'Example Page' again") {
-			SearchPortlets.searchEmbedded(searchTerm = "Example Page");
-		}
+		SearchPortlets.searchEmbedded(searchTerm = "Example Page");
 
-		task ("Click on the Search Result") {
-			Search.gotoResultAssetViaTitle(searchAssetTitle = "Example Page");
-		}
+		Search.gotoResultAssetViaTitle(searchAssetTitle = "Example Page");
 
-		task ("Assert Search bar is avaible") {
-			AssertElementPresent(locator1 = "Search#EMBEDDED_SEARCH_BAR");
-		}
+		AssertElementNotPresent(locator1 = "Portlet#ERROR");
+
+		AssertElementPresent(locator1 = "Search#EMBEDDED_SEARCH_BAR");
 	}
 
 	@priority = "4"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -10,11 +10,11 @@ definition {
 	property testray.main.component.name = "Database Upgrade Framework";
 	property upgrade.reports.enabled = "true";
 
-	@description = "LPS-154683: Upgrade Report provides the version of the database"
+	@description = "LPS-154683: Upgrade Report provides the type and version of the database"
 	@priority = "3"
-	test DatabaseVersionLogged {
+	test DatabaseLogged {
 		property skip.start.app.server = "true";
-		property test.name.skip.portal.instance = "UpgradeReport#DatabaseVersionLogged";
+		property test.name.skip.portal.instance = "UpgradeReport#DatabaseLogged";
 		property testcase.url = "http://www.example.com";
 
 		task ("Look for the upgrade report") {
@@ -25,11 +25,11 @@ definition {
 			echo("${fileContent}");
 		}
 
-		task ("Read the version is correct in the report") {
-			var databaseVersion = Upgrade.getDatabaseVersion();
+		task ("Read the type and version is correct in the report") {
+			var databaseType = PropsUtil.get("database.type");
 
-			if (contains("${fileContent}", "Final portal build number: ${databaseVersion}")) {
-				fail("Database version is not present in upgrade report.");
+			if (!(contains("${fileContent}", "Using ${databaseType} version 5.7"))) {
+				fail("Database type and version is not present in upgrade report.");
 			}
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -172,6 +172,16 @@ definition {
 				fail("Upgrade report does not contain expected warnings.");
 			}
 		}
+
+		task ("Read the content. Check for class name and message") {
+			if (!(contains("${fileContent}", "Class name:"))) {
+				fail("Upgrade report does not contain the warning class name.");
+			}
+
+			if (!(contains("${fileContent}", "occurrences of the following warnings: "))) {
+				fail("Upgrade report does not contain the warning message.");
+			}
+		}
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -77,6 +77,44 @@ definition {
 
 	}
 
+	@description = "LPS-158741: Upgrade Report provides the initial, final, and expected portal build number"
+	@priority = "3"
+	test BuildNumberLogged {
+		property skip.start.app.server = "true";
+		property test.name.skip.portal.instance = "UpgradeReport#BuildNumberLogged";
+		property testcase.url = "http://www.example.com";
+
+		task ("Look for the upgrade report") {
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
+
+			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
+
+			echo("${fileContent}");
+		}
+
+		task ("Read the intial portal build number") {
+			if (!(contains("${fileContent}", "Initial portal build number: 7413"))) {
+				fail("Inital portal build number is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the final portal build number") {
+			var finalBuildVersion = Upgrade.getBuildNumber();
+
+			if (!(contains("${fileContent}", "Final portal build number: ${finalBuildVersion}"))) {
+				fail("Final portal build number is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the expected portal build number") {
+			var expectedBuildVersion = Upgrade.getBuildNumber();
+
+			if (!(contains("${fileContent}", "Expected portal build number: ${expectedBuildVersion}"))) {
+				fail("Expected portal build number is not present in upgrade report.");
+			}
+		}
+	}
+
 	@description = "LPS-154683: Upgrade Report is created when property is set to true"
 	@priority = "4"
 	test ReportGeneratedWhenEnabled {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -14,7 +14,7 @@ definition {
 	@priority = "3"
 	test DatabaseVersionLogged {
 		property skip.start.app.server = "true";
-		property test.name.skip.portal.instance = "UpgradeReport#DatabaseVersionProvided";
+		property test.name.skip.portal.instance = "UpgradeReport#DatabaseVersionLogged";
 		property testcase.url = "http://www.example.com";
 
 		task ("Look for the upgrade report") {
@@ -50,7 +50,7 @@ definition {
 	test ErrorsLogged {
 		property portal.version = "6.0.12";
 		property skip.start.app.server = "true";
-		property test.name.skip.portal.instance = "UpgradeReport#ErrorsProvided";
+		property test.name.skip.portal.instance = "UpgradeReport#ErrorsLogged";
 		property testcase.url = "http://www.example.com";
 
 		task ("Look for the upgrade report") {
@@ -158,7 +158,7 @@ definition {
 	@priority = "3"
 	test WarningsLogged {
 		property skip.start.app.server = "true";
-		property test.name.skip.portal.instance = "UpgradeReport#WarningsProvided";
+		property test.name.skip.portal.instance = "UpgradeReport#WarningsLogged";
 		property testcase.url = "http://www.example.com";
 
 		task ("Look for the upgrade report") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -174,13 +174,42 @@ definition {
 
 	}
 
-	@description = "LPS-154683: The Upgrade Report logs portal and schema versions."
-	@ignore = "Test Stub"
+	@description = "LPS-158741: The Upgrade Report should list the initial, expected, and final schema versions."
 	@priority = "4"
 	test SchemaVersionsLogged {
+		property skip.start.app.server = "true";
+		property test.name.skip.portal.instance = "UpgradeReport#SchemaVersionsLogged";
+		property testcase.url = "http://www.example.com";
 
-		// TODO The Upgrade Report should list the initial, expected, and final portal versions and schema versions
+		task ("Look for the upgrade report") {
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
 
+			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
+
+			echo("${fileContent}");
+		}
+
+		task ("Read the intial schema version") {
+			if (!(contains("${fileContent}", "Initial portal schema version: 13.1.1"))) {
+				fail("Inital schema version is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the final schema version") {
+			var finalSchemaVersion = Upgrade.getSchemaVersion();
+
+			if (!(contains("${fileContent}", "Final portal schema version: ${finalSchemaVersion}"))) {
+				fail("Final schema version is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the expected schema version") {
+			var expectedSchemaVersion = Upgrade.getSchemaVersion();
+
+			if (!(contains("${fileContent}", "Expected portal schema version: ${expectedSchemaVersion}"))) {
+				fail("Expected schema version is not present in upgrade report.");
+			}
+		}
 	}
 
 	@description = "LPS-154683: The Upgrade Report logs total upgrade runtime."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -10,6 +10,44 @@ definition {
 	property testray.main.component.name = "Database Upgrade Framework";
 	property upgrade.reports.enabled = "true";
 
+	@description = "LPS-158741: Upgrade Report provides the initial, final, and expected portal build number"
+	@priority = "3"
+	test BuildNumberLogged {
+		property skip.start.app.server = "true";
+		property test.name.skip.portal.instance = "UpgradeReport#BuildNumberLogged";
+		property testcase.url = "http://www.example.com";
+
+		task ("Look for the upgrade report") {
+			var liferayHome = PropsUtil.get("liferay.home.dir.name");
+
+			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
+
+			echo("${fileContent}");
+		}
+
+		task ("Read the intial portal build number") {
+			if (!(contains("${fileContent}", "Initial portal build number: 7413"))) {
+				fail("Inital portal build number is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the final portal build number") {
+			var finalBuildVersion = Upgrade.getBuildNumber();
+
+			if (!(contains("${fileContent}", "Final portal build number: ${finalBuildVersion}"))) {
+				fail("Final portal build number is not present in upgrade report.");
+			}
+		}
+
+		task ("Read the expected portal build number") {
+			var expectedBuildVersion = Upgrade.getBuildNumber();
+
+			if (!(contains("${fileContent}", "Expected portal build number: ${expectedBuildVersion}"))) {
+				fail("Expected portal build number is not present in upgrade report.");
+			}
+		}
+	}
+
 	@description = "LPS-154683: Upgrade Report provides the type and version of the database"
 	@priority = "3"
 	test DatabaseLogged {
@@ -75,44 +113,6 @@ definition {
 
 		// TODO The Upgrade Report should list the 20 longest running upgrade process in the upgrade report in descending order
 
-	}
-
-	@description = "LPS-158741: Upgrade Report provides the initial, final, and expected portal build number"
-	@priority = "3"
-	test BuildNumberLogged {
-		property skip.start.app.server = "true";
-		property test.name.skip.portal.instance = "UpgradeReport#BuildNumberLogged";
-		property testcase.url = "http://www.example.com";
-
-		task ("Look for the upgrade report") {
-			var liferayHome = PropsUtil.get("liferay.home.dir.name");
-
-			var fileContent = FileUtil.read("${liferayHome}/tools/portal-tools-db-upgrade-client/reports/upgrade_report.info");
-
-			echo("${fileContent}");
-		}
-
-		task ("Read the intial portal build number") {
-			if (!(contains("${fileContent}", "Initial portal build number: 7413"))) {
-				fail("Inital portal build number is not present in upgrade report.");
-			}
-		}
-
-		task ("Read the final portal build number") {
-			var finalBuildVersion = Upgrade.getBuildNumber();
-
-			if (!(contains("${fileContent}", "Final portal build number: ${finalBuildVersion}"))) {
-				fail("Final portal build number is not present in upgrade report.");
-			}
-		}
-
-		task ("Read the expected portal build number") {
-			var expectedBuildVersion = Upgrade.getBuildNumber();
-
-			if (!(contains("${fileContent}", "Expected portal build number: ${expectedBuildVersion}"))) {
-				fail("Expected portal build number is not present in upgrade report.");
-			}
-		}
 	}
 
 	@description = "LPS-154683: Upgrade Report is created when property is set to true"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UpgradeReport.testcase
@@ -66,7 +66,9 @@ definition {
 		task ("Read the type and version is correct in the report") {
 			var databaseType = PropsUtil.get("database.type");
 
-			if (!(contains("${fileContent}", "Using ${databaseType} version 5.7"))) {
+			var databaseVersion = PropsUtil.get("database.${databaseType}.version");
+
+			if (!(contains("${fileContent}", "Using ${databaseType} version ${databaseVersion}"))) {
 				fail("Database type and version is not present in upgrade report.");
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmailReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmailReport.testcase
@@ -340,8 +340,6 @@ definition {
 			var analyticsCloudURL = PropsUtil.get("analytics.cloud.url");
 
 			Open(locator1 = "${analyticsCloudURL}");
-
-			ACLogin.loginAs(emailAddress = "${emailAddress}");
 		}
 
 		task ("Go to admin page") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualDefinitions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualDefinitions.testcase
@@ -50,7 +50,7 @@ definition {
 		ACDefinitions.goToDefinitionType(definitionType = "Individuals");
 
 		ACDefinitions.assertIndividualAttributesSource(
-			attributeList = "additionalName,address,birthDate,classPK,contactId,createDate,email,familyName,gender,givenName,jobTitle,modifiedDate,telephone,timeZoneId,userId,uuid",
+			attributeList = "additionalName,address,birthDate,classPK,contactId,createDate,email,familyName,gender,givenName,jobTitle,modifiedDate,telephone,userId,uuid",
 			dataSourceName = "${dataSource}");
 	}
 

--- a/test.properties
+++ b/test.properties
@@ -1090,6 +1090,9 @@
 
     test.batch.code.coverage=false
 
+    test.batch.default.test.duration[functional-*]=150000
+    test.batch.default.test.overhead.duration[functional-*]=1200000
+
     test.batch.dist.app.servers=\
         jboss,\
         tomcat,\
@@ -2746,6 +2749,8 @@
     test.batch.size[unit-jdk8]=1
 
     test.batch.slave.label[analytics-cloud-cucumber-tomcat90-mysql57-jdk8]=slave-1
+
+    test.batch.target.axis.duration[functional-*]=2400000
 
     #
     # Acceptance


### PR DESCRIPTION
Motivation
=======

This work solves the problem reported in the [LPS-165245](https://issues.liferay.com/browse/LPS-165245) ticket.
(Passed internal review by @sontruongces)

Proposed Solution
========

Cause:
   - At backend, class `ObjectEntryLocalServiceImpl`, private method `_updateTable`, after updating custom field of `objectEntry`, we did not clear it from cache. So, then, at `ObjectValidationRuleLocalServiceImpl` class, method `validate` will validate old custom field value (not new input).

What we did to solve this problem:
   - Clear cache after updating `objectEntry`

Steps to Verify
========

1. Menu portlet > Control Panel > Objects
2. Create a Custom Object
3. On Custom Object, go to fields tab and add Custom Integer A
4. On Details tab, publish
5. On Validations tab, add Custom Validations with Expression Builder
6. Click on Custom Validation
7. On Basic Info tab, keep inactive
8. On Conditions tab, put on script: `customIntegerA == 1` and add error message
9. Save
10. Go to Custom Object entries
11. Try add entry: Custom Integer A = 1
12. Save (Success)
13. Try add entry: Custom Integer A = 2 
14. Save (failed)
15. Go to entry A = 1 and update the entry with A = 2 
16. Save.

- Expected Results: Message error. It's not possible to add / update with Custom Integer A **!= 1**.
- Actual Results: Entry updated.