### PR TITLE
[TS] LPS-166675 DB2 Error after deleting a Field from an Object

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/petra/sql/dsl/DynamicObjectDefinitionTable.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/petra/sql/dsl/DynamicObjectDefinitionTable.java
@@ -60,23 +60,6 @@ public class DynamicObjectDefinitionTable
 		return sql;
 	}
 
-	/**
-	 * @see com.liferay.portal.dao.db.BaseDB#alterTableDropColumn(
-	 *      java.sql.Connection, String, String)
-	 */
-	public static String getAlterTableDropColumnSQL(
-		String tableName, String columnName) {
-
-		String sql = StringBundler.concat(
-			"alter table ", tableName, " drop column ", columnName);
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("SQL: " + sql);
-		}
-
-		return sql;
-	}
-
 	public static Class<?> getJavaClass(String type) {
 		Class<?> javaClass = _javaClasses.get(type);
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -55,7 +55,10 @@ import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -73,6 +76,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
+
+import java.sql.Connection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -756,6 +761,20 @@ public class ObjectFieldLocalServiceImpl
 				newObjectField.getObjectFieldId()));
 	}
 
+	private void _alterTableDropColumn(String tableName, String columnName) {
+		try {
+			Connection connection = _currentConnection.getConnection(
+				objectFieldPersistence.getDataSource());
+
+			DB db = objectFieldPersistence.getDB();
+
+			db.alterTableDropColumn(connection, tableName, columnName);
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+	}
+
 	private ObjectField _deleteObjectField(ObjectField objectField)
 		throws PortalException {
 
@@ -843,10 +862,8 @@ public class ObjectFieldLocalServiceImpl
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION)) {
 
-			runSQL(
-				DynamicObjectDefinitionTable.getAlterTableDropColumnSQL(
-					objectField.getDBTableName(),
-					objectField.getDBColumnName()));
+			_alterTableDropColumn(
+				objectField.getDBTableName(), objectField.getDBColumnName());
 		}
 
 		return objectField;
@@ -1099,6 +1116,9 @@ public class ObjectFieldLocalServiceImpl
 	).put(
 		"String", "Text"
 	).build();
+
+	@Reference
+	private CurrentConnection _currentConnection;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;


### PR DESCRIPTION
**Relevant issue**: [LPS-166675](https://issues.liferay.com/browse/LPS-166675)

---

Hi @liferay-objects!

There is an issue after deleting a Field from an Object in DB2. This is because, after some alterations, DB2 needs a _table reorganization_. See [LPS-166675](https://issues.liferay.com/browse/LPS-166675), and IBM documentation about [altering tables](https://www.ibm.com/docs/en/db2/11.5?topic=tables-altering) and [SQLCODE=-668](https://www.ibm.com/docs/en/db2/11.5?topic=messages-sql0500-sql0749#sql0668n) for details.

Instead of getting the SQL String from the `DynamicObjectDefinitionTable.java` class, I have changed the logic in `ObjectFieldLocalServiceImpl.java` so that it uses the DB abstraction provided by `com.liferay.portal.kernel.dao.db.DB`. This way, every DB will take care of its specifics. In this case, DB2 will call `reorg` command in [DB2DB#runSQL](https://github.com/liferay/liferay-portal/blob/d5dbe3e5e51aa86f8c5cba36ef367fb570441425/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java#L238-L247).

What are your views on that?

Thanks!