### PR TITLE
[TS] LPS-166196 Unable to return Objects entries with MS SQL Server

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -790,7 +790,9 @@ public class ObjectEntryLocalServiceImpl
 
 		Expression<?>[] selectExpressions = ArrayUtil.append(
 			_getSelectExpressions(dynamicObjectDefinitionTable),
-			_getSelectExpressions(extensionDynamicObjectDefinitionTable));
+			ArrayUtil.remove(
+				_getSelectExpressions(extensionDynamicObjectDefinitionTable),
+				extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()));
 
 		List<Object[]> rows = _list(
 			DSLQueryFactoryUtil.select(
@@ -828,7 +830,9 @@ public class ObjectEntryLocalServiceImpl
 
 		Expression<?>[] selectExpressions = ArrayUtil.append(
 			_getSelectExpressions(dynamicObjectDefinitionTable),
-			_getSelectExpressions(extensionDynamicObjectDefinitionTable),
+			ArrayUtil.remove(
+				_getSelectExpressions(extensionDynamicObjectDefinitionTable),
+				extensionDynamicObjectDefinitionTable.getPrimaryKeyColumn()),
 			_EXPRESSIONS);
 
 		List<Object[]> rows = _list(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166196

MS SQL Server throws error:
```
com.microsoft.sqlserver.jdbc.SQLServerException: The column 'c_newOId_' was specified multiple times for '_temp_table_1'. 
```
because the generated SQL in `ObjectEntryLocalServiceImpl.getValuesList` and `ObjectEntryLocalServiceImpl.getValuesList` methods contains the same primary key column from **O_123_test** and **O_123_test_x** tables.

To avoid the error, as primary key columns of both tables has exactly the same name and values, I am removing the primary key of second O_123_test_x table from the select of the SQL query.

Let me know if you have any question
