### PR TITLE
LPS-166558 - changed index that indicates which box should be deleted

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/objectLayoutContext.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/objectLayoutContext.tsx
@@ -343,7 +343,7 @@ const layoutReducer = (state: TState, action: TAction) => {
 			const visitor = new RowsVisitor(
 				newState.objectLayout.objectLayoutTabs[
 					tabIndex
-				].objectLayoutBoxes[tabIndex]
+				].objectLayoutBoxes[boxIndex]
 			);
 
 			visitor.mapFields((field) => {


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-166558

I changed the index that indicates which box should be excluded, because before the code was getting the index of the position of the tab (tabIndex) and not of the box (boxIndex). This way, it leaves the fields of this box free again
