### PR TITLE
LPS-166798 Object definitions were leaking to other Companies on the OAuth Scopes Page

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -274,6 +274,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			Arrays.asList(
 				_objectEntryApplicationComponentFactory.newInstance(
 					HashMapDictionaryBuilder.<String, Object>put(
+						"companyId",
+						String.valueOf(objectDefinition.getCompanyId())
+					).put(
 						"liferay.jackson", false
 					).put(
 						"osgi.jaxrs.application.base",


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166798

Sets the `companyId` property to take advantage of the existing filter on companyId in the OAuth Service Tracker [here](https://github.com/liferay/liferay-portal/blob/05589ddef153203dbdbff32dc459afac2f90963d/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/main/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopedServiceTrackerMapFactoryImpl.java#L101)