### PR TITLE
LPS-167070 Revert of "Un-deprecate Bookmarks"

### DIFF
--- a/modules/apps/bookmarks/app.bnd
+++ b/modules/apps/bookmarks/app.bnd
@@ -1,15 +1,15 @@
 Liferay-Releng-App-Description: %liferay-releng-app-description
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Bookmarks
-Liferay-Releng-Bundle: true
+Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Communication
 Liferay-Releng-Demo-Url:
-Liferay-Releng-Deprecated: false
-Liferay-Releng-Fix-Delivery-Method: core
+Liferay-Releng-Deprecated: true
+Liferay-Releng-Fix-Delivery-Method:
 Liferay-Releng-Labs: false
-Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: true
+Liferay-Releng-Marketplace: false
+Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite: collaboration
+Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
After a discussion with @marco-leo, we've decided to deprecate Bookmarks again for 7.4

Instead, we'll leverage the solution of Objects by creating a system object called Bookmark and providing most of the original bookmarks functionalities.