### PR TITLE
LPS-168326 - Fix the useEffect which returns the Data Source values

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/Attachments.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/Attachments.tsx
@@ -77,6 +77,23 @@ export function Attachments({setValues, values}: IProps) {
 	};
 
 	useEffect(() => {
+		const makeFetch = async () => {
+			const objectDefinitions = await API.getAllObjectDefinitions();
+
+			const currentObjectDefinition = objectDefinitions?.find(
+				(item) => item.id === values.objectDefinitionId
+			);
+
+			setObjectDefinitions(
+				objectDefinitions?.filter(({system}) => !system)
+			);
+			setSelectedEntity(currentObjectDefinition);
+		};
+
+		makeFetch();
+	}, [values.objectDefinitionId]);
+
+	useEffect(() => {
 		const currentObjectDefinition = objectDefinitions?.find(
 			(item) => item.id === values.objectDefinitionId
 		);
@@ -96,14 +113,6 @@ export function Attachments({setValues, values}: IProps) {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [values.objectDefinitionId]);
-
-	useEffect(() => {
-		API.getAllObjectDefinitions().then((items) => {
-			const objectDefinitions = items.filter(({system}) => !system);
-
-			setObjectDefinitions(objectDefinitions);
-		});
-	}, []);
 
 	useEffect(() => {
 		setValues({


### PR DESCRIPTION
[LPS-168326](https://issues.liferay.com/browse/LPS-168326) - The problem was in the `objectDefinition` which was returning underfined as It wasn't going into useEffect which builds `getAllObjectDefinitions` and sets `objectDefinition`, so I repositioned the useEffect and inside it I added the constant and method that returns the Data Source values