### PR TITLE
LPS-168374 Register the InfoItemObjectProvider under the ObjectEntry class name since some callers are still expecting that

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -399,6 +399,18 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext, PortletResourcePermission.class, "resource.name");
+
+		_bundleContext.registerService(
+			InfoItemObjectProvider.class,
+			new ObjectEntryInfoItemObjectProvider(_objectEntryLocalService),
+			HashMapDictionaryBuilder.<String, Object>put(
+				Constants.SERVICE_RANKING, 100
+			).put(
+				"info.item.identifier",
+				"com.liferay.info.item.ClassPKInfoItemIdentifier"
+			).put(
+				"item.class.name", ObjectEntry.class.getName()
+			).build());
 	}
 
 	@Deactivate


### PR DESCRIPTION
The Collection Display fragment was throwing a NullPointerException [here](https://github.com/liferay/liferay-portal/blob/825edf5929b8a9ac64f527b527c8f46df7785a7a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java#L380) because `infoItemObjectProvider` was null, because it was expecting to find it under the ObjectEntry class name.