### PR TITLE
LPS-167929 Uses class to build the constant

### DIFF
--- a/modules/apps/info/info-taglib/src/main/resources/META-INF/resources/info_list_basic_table/init.jsp
+++ b/modules/apps/info/info-taglib/src/main/resources/META-INF/resources/info_list_basic_table/init.jsp
@@ -14,10 +14,13 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.info.item.renderer.InfoItemRenderer" %><%@
+page import="com.liferay.portal.kernel.util.ListUtil" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 
 <%@ page import="java.util.List" %>

--- a/modules/apps/info/info-taglib/src/main/resources/META-INF/resources/info_list_basic_table/page.jsp
+++ b/modules/apps/info/info-taglib/src/main/resources/META-INF/resources/info_list_basic_table/page.jsp
@@ -16,44 +16,46 @@
 
 <%@ include file="/info_list_basic_table/init.jsp" %>
 
-<div class="table-responsive">
-	<table class="table table-autofit">
-		<thead>
-			<tr>
+<c:if test="<%= ListUtil.isNotEmpty(infoListObjectColumnNames) && ListUtil.isNotEmpty(infoListObjects) %>">
+	<div class="table-responsive">
+		<table class="table table-autofit">
+			<thead>
+				<tr>
+
+					<%
+					for (String infoListObjectColumnName : infoListObjectColumnNames) {
+					%>
+
+						<th class="table-cell-expand-smallest">
+							<liferay-ui:message key="<%= infoListObjectColumnName %>" />
+						</th>
+
+					<%
+					}
+					%>
+
+				</tr>
+			</thead>
+
+			<tbody>
 
 				<%
-				for (String infoListObjectColumnName : infoListObjectColumnNames) {
+				for (Object infoListObject : infoListObjects) {
 				%>
 
-					<th class="table-cell-expand-smallest">
-						<liferay-ui:message key="<%= infoListObjectColumnName %>" />
-					</th>
+					<tr>
+
+						<%
+						infoItemRenderer.render(infoListObject, request, PipingServletResponseFactory.createPipingServletResponse(pageContext));
+						%>
+
+					</tr>
 
 				<%
 				}
 				%>
 
-			</tr>
-		</thead>
-
-		<tbody>
-
-			<%
-			for (Object infoListObject : infoListObjects) {
-			%>
-
-				<tr>
-
-					<%
-					infoItemRenderer.render(infoListObject, request, PipingServletResponseFactory.createPipingServletResponse(pageContext));
-					%>
-
-				</tr>
-
-			<%
-			}
-			%>
-
-		</tbody>
-	</table>
-</div>
+			</tbody>
+		</table>
+	</div>
+</c:if>

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
@@ -103,7 +103,7 @@ public class AddInfoItemStrutsActionTest {
 
 		_classNameId = String.valueOf(
 			_portal.getClassNameId(
-				"com.liferay.object.model.ObjectDefinition#" +
+				ObjectDefinition.class.getName() + "#" +
 					_objectDefinition.getObjectDefinitionId()));
 
 		_layout = _addLayout();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -680,7 +680,9 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 				_objectDefinition.getObjectDefinitionId());
 		}
 		catch (PortalException portalException) {
-			_log.error(portalException);
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
 
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -15,6 +15,7 @@
 package com.liferay.object.internal.search.spi.model.query.contributor;
 
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectView;
 import com.liferay.object.model.ObjectViewColumn;
@@ -94,9 +95,7 @@ public class ObjectEntryKeywordQueryContributor
 		if (objectDefinitionId == 0) {
 			String className = keywordQueryContributorHelper.getClassName();
 
-			if (className.startsWith(
-					"com.liferay.object.model.ObjectDefinition#")) {
-
+			if (className.startsWith(ObjectDefinition.class.getName() + "#")) {
 				String[] parts = StringUtil.split(className, "#");
 
 				objectDefinitionId = Long.valueOf(parts[1]);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -49,8 +49,7 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 
 	@Override
 	public String getModelClassName() {
-		return "com.liferay.object.model.ObjectDefinition#" +
-			getObjectDefinitionId();
+		return ObjectDefinition.class.getName() + "#" + getObjectDefinitionId();
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1004,8 +1004,7 @@ public class ObjectDefinitionLocalServiceImpl
 			return className;
 		}
 
-		return "com.liferay.object.model.ObjectDefinition#" +
-			objectDefinitionId;
+		return ObjectDefinition.class.getName() + "#" + objectDefinitionId;
 	}
 
 	private String _getDBTableName(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -104,13 +104,13 @@ public class ObjectEntryInfoItemFieldValuesProvider
 			_getInfoFieldValues(objectEntry)
 		).infoFieldValues(
 			_infoItemFieldReaderFieldSetProvider.getInfoFieldValues(
-				ObjectEntry.class.getName(), objectEntry)
+				objectEntry.getModelClassName(), objectEntry)
 		).infoFieldValues(
 			_templateInfoItemFieldSetProvider.getInfoFieldValues(
 				objectEntry.getModelClassName(), objectEntry)
 		).infoItemReference(
 			new InfoItemReference(
-				ObjectEntry.class.getName(), objectEntry.getObjectEntryId())
+				objectEntry.getModelClassName(), objectEntry.getObjectEntryId())
 		).build();
 	}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -343,7 +343,7 @@ public class ObjectEntryInfoItemFormProvider
 		throws NoSuchFormVariationException {
 
 		String objectDefinitionClassName =
-			"com.liferay.object.model.ObjectDefinition#" + objectDefinitionId;
+			ObjectDefinition.class.getName() + "#" + objectDefinitionId;
 
 		return InfoForm.builder(
 		).infoFieldSetEntry(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -342,6 +342,9 @@ public class ObjectEntryInfoItemFormProvider
 	private InfoForm _getInfoForm(long objectDefinitionId)
 		throws NoSuchFormVariationException {
 
+		String objectDefinitionClassName =
+			"com.liferay.object.model.ObjectDefinition#" + objectDefinitionId;
+
 		return InfoForm.builder(
 		).infoFieldSetEntry(
 			_getBasicInformationInfoFieldSet()
@@ -354,20 +357,19 @@ public class ObjectEntryInfoItemFormProvider
 			}
 		).infoFieldSetEntry(
 			_templateInfoItemFieldSetProvider.getInfoFieldSet(
-				"com.liferay.object.model.ObjectDefinition#" +
-					objectDefinitionId)
+				objectDefinitionClassName)
 		).infoFieldSetEntry(
 			_getDisplayPageInfoFieldSet()
 		).infoFieldSetEntry(
 			_infoItemFieldReaderFieldSetProvider.getInfoFieldSet(
-				ObjectEntry.class.getName())
+				objectDefinitionClassName)
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(
 			).values(
 				_objectDefinition.getLabelMap()
 			).build()
 		).name(
-			_objectDefinition.getClassName()
+			objectDefinitionClassName
 		).build();
 	}
 


### PR DESCRIPTION
Motivation
---
Fix some issues related with objects and collections. There are 3 bug fixes in this pr.

[Link to the issue](https://issues.liferay.com/browse/LPS-167929) 

Proposed solution
---
1. Avoid null pointer exception when there are no object entries in table renderer.
2. Change log level, since objectLayout can not exist and we are logging unnecessary errors always.
3. Uses correct classNames, that means use `com.liferay.object.model.ObjectDefinition#objectDefinitionId` instead of `ObjectEntry.class.getName()`.

Steps to reproduce
---
**For 1 and 2:**

1. Menu > Control Panel > Picklists
2. Create a Custom Picklist
3. Add fields on Custom Picklist
4. Menu > Control Panel > Objects
5. Create a Custom Object
6. On Custom Object, add Custom Field (Picklist) related to the Custom Picklist
7. Publish it
8. Go to Menu side > Site builder > Pages
9. Add a new page (Blank)
10. Go to Fragments and Widgets
11. Search for Collection Display
12. Select collection > Collection Providers > Custom Object
13. Change Style Display to Table
14. View table

**For 3:**

1. Create a simple Object (e.g.: Bookmark)
2. Add a text field
3. Save and Publish this Object
4. Go to the page editor
5. Add a Collection Display
6. Go to Collections → Collection Provider
7. Select Bookmarks as Collection Provider
