### PR TITLE
LPS-168865,LPS-168318

### DIFF
--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectRelationship.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectRelationship.java
@@ -210,6 +210,39 @@ public class ObjectRelationship implements Serializable {
 	protected String name;
 
 	@Schema
+	public String getObjectDefinitionExternalReferenceCode1() {
+		return objectDefinitionExternalReferenceCode1;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode1(
+		String objectDefinitionExternalReferenceCode1) {
+
+		this.objectDefinitionExternalReferenceCode1 =
+			objectDefinitionExternalReferenceCode1;
+	}
+
+	@JsonIgnore
+	public void setObjectDefinitionExternalReferenceCode1(
+		UnsafeSupplier<String, Exception>
+			objectDefinitionExternalReferenceCode1UnsafeSupplier) {
+
+		try {
+			objectDefinitionExternalReferenceCode1 =
+				objectDefinitionExternalReferenceCode1UnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String objectDefinitionExternalReferenceCode1;
+
+	@Schema
 	public String getObjectDefinitionExternalReferenceCode2() {
 		return objectDefinitionExternalReferenceCode2;
 	}
@@ -499,6 +532,20 @@ public class ObjectRelationship implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		if (objectDefinitionExternalReferenceCode1 != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectDefinitionExternalReferenceCode1\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(objectDefinitionExternalReferenceCode1));
 
 			sb.append("\"");
 		}

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectRelationship.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectRelationship.java
@@ -388,6 +388,36 @@ public class ObjectRelationship implements Serializable {
 	protected Long parameterObjectFieldId;
 
 	@Schema
+	public String getParameterObjectFieldName() {
+		return parameterObjectFieldName;
+	}
+
+	public void setParameterObjectFieldName(String parameterObjectFieldName) {
+		this.parameterObjectFieldName = parameterObjectFieldName;
+	}
+
+	@JsonIgnore
+	public void setParameterObjectFieldName(
+		UnsafeSupplier<String, Exception>
+			parameterObjectFieldNameUnsafeSupplier) {
+
+		try {
+			parameterObjectFieldName =
+				parameterObjectFieldNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String parameterObjectFieldName;
+
+	@Schema
 	public Boolean getReverse() {
 		return reverse;
 	}
@@ -606,6 +636,20 @@ public class ObjectRelationship implements Serializable {
 			sb.append("\"parameterObjectFieldId\": ");
 
 			sb.append(parameterObjectFieldId);
+		}
+
+		if (parameterObjectFieldName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parameterObjectFieldName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(parameterObjectFieldName));
+
+			sb.append("\"");
 		}
 
 		if (reverse != null) {

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectFieldResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectFieldResource.java
@@ -56,6 +56,11 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ObjectFieldResource {
 
+	public Page<ObjectField>
+			getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+				String objectDefinitionExternalReferenceCode)
+		throws Exception;
+
 	public Page<ObjectField> getObjectDefinitionObjectFieldsPage(
 			Long objectDefinitionId, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)

--- a/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-admin-rest-api/src/main/resources/com/liferay/object/admin/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectRelationship.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectRelationship.java
@@ -281,6 +281,29 @@ public class ObjectRelationship implements Cloneable, Serializable {
 
 	protected Long parameterObjectFieldId;
 
+	public String getParameterObjectFieldName() {
+		return parameterObjectFieldName;
+	}
+
+	public void setParameterObjectFieldName(String parameterObjectFieldName) {
+		this.parameterObjectFieldName = parameterObjectFieldName;
+	}
+
+	public void setParameterObjectFieldName(
+		UnsafeSupplier<String, Exception>
+			parameterObjectFieldNameUnsafeSupplier) {
+
+		try {
+			parameterObjectFieldName =
+				parameterObjectFieldNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String parameterObjectFieldName;
+
 	public Boolean getReverse() {
 		return reverse;
 	}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectRelationship.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/dto/v1_0/ObjectRelationship.java
@@ -145,6 +145,32 @@ public class ObjectRelationship implements Cloneable, Serializable {
 
 	protected String name;
 
+	public String getObjectDefinitionExternalReferenceCode1() {
+		return objectDefinitionExternalReferenceCode1;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode1(
+		String objectDefinitionExternalReferenceCode1) {
+
+		this.objectDefinitionExternalReferenceCode1 =
+			objectDefinitionExternalReferenceCode1;
+	}
+
+	public void setObjectDefinitionExternalReferenceCode1(
+		UnsafeSupplier<String, Exception>
+			objectDefinitionExternalReferenceCode1UnsafeSupplier) {
+
+		try {
+			objectDefinitionExternalReferenceCode1 =
+				objectDefinitionExternalReferenceCode1UnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String objectDefinitionExternalReferenceCode1;
+
 	public String getObjectDefinitionExternalReferenceCode2() {
 		return objectDefinitionExternalReferenceCode2;
 	}

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectFieldResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectFieldResource.java
@@ -40,6 +40,16 @@ public interface ObjectFieldResource {
 		return new Builder();
 	}
 
+	public Page<ObjectField>
+			getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+				String objectDefinitionExternalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPageHttpResponse(
+				String objectDefinitionExternalReferenceCode)
+		throws Exception;
+
 	public Page<ObjectField> getObjectDefinitionObjectFieldsPage(
 			Long objectDefinitionId, String search, String filterString,
 			Pagination pagination, String sortString)
@@ -187,6 +197,93 @@ public interface ObjectFieldResource {
 	}
 
 	public static class ObjectFieldResourceImpl implements ObjectFieldResource {
+
+		public Page<ObjectField>
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+					String objectDefinitionExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPageHttpResponse(
+					objectDefinitionExternalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, ObjectFieldSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPageHttpResponse(
+					String objectDefinitionExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/object-admin/v1.0/object-definitions/by-external-reference-code/{objectDefinitionExternalReferenceCode}/object-fields");
+
+			httpInvoker.path(
+				"objectDefinitionExternalReferenceCode",
+				objectDefinitionExternalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
 
 		public Page<ObjectField> getObjectDefinitionObjectFieldsPage(
 				Long objectDefinitionId, String search, String filterString,

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectRelationshipSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectRelationshipSerDes.java
@@ -195,6 +195,21 @@ public class ObjectRelationshipSerDes {
 			sb.append(objectRelationship.getParameterObjectFieldId());
 		}
 
+		if (objectRelationship.getParameterObjectFieldName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parameterObjectFieldName\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(objectRelationship.getParameterObjectFieldName()));
+
+			sb.append("\"");
+		}
+
 		if (objectRelationship.getReverse() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -339,6 +354,16 @@ public class ObjectRelationshipSerDes {
 				String.valueOf(objectRelationship.getParameterObjectFieldId()));
 		}
 
+		if (objectRelationship.getParameterObjectFieldName() == null) {
+			map.put("parameterObjectFieldName", null);
+		}
+		else {
+			map.put(
+				"parameterObjectFieldName",
+				String.valueOf(
+					objectRelationship.getParameterObjectFieldName()));
+		}
+
 		if (objectRelationship.getReverse() == null) {
 			map.put("reverse", null);
 		}
@@ -456,6 +481,14 @@ public class ObjectRelationshipSerDes {
 				if (jsonParserFieldValue != null) {
 					objectRelationship.setParameterObjectFieldId(
 						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "parameterObjectFieldName")) {
+
+				if (jsonParserFieldValue != null) {
+					objectRelationship.setParameterObjectFieldName(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "reverse")) {

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectRelationshipSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectRelationshipSerDes.java
@@ -113,6 +113,25 @@ public class ObjectRelationshipSerDes {
 			sb.append("\"");
 		}
 
+		if (objectRelationship.getObjectDefinitionExternalReferenceCode1() !=
+				null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"objectDefinitionExternalReferenceCode1\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(
+					objectRelationship.
+						getObjectDefinitionExternalReferenceCode1()));
+
+			sb.append("\"");
+		}
+
 		if (objectRelationship.getObjectDefinitionExternalReferenceCode2() !=
 				null) {
 
@@ -258,6 +277,19 @@ public class ObjectRelationshipSerDes {
 			map.put("name", String.valueOf(objectRelationship.getName()));
 		}
 
+		if (objectRelationship.getObjectDefinitionExternalReferenceCode1() ==
+				null) {
+
+			map.put("objectDefinitionExternalReferenceCode1", null);
+		}
+		else {
+			map.put(
+				"objectDefinitionExternalReferenceCode1",
+				String.valueOf(
+					objectRelationship.
+						getObjectDefinitionExternalReferenceCode1()));
+		}
+
 		if (objectRelationship.getObjectDefinitionExternalReferenceCode2() ==
 				null) {
 
@@ -372,6 +404,16 @@ public class ObjectRelationshipSerDes {
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				if (jsonParserFieldValue != null) {
 					objectRelationship.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"objectDefinitionExternalReferenceCode1")) {
+
+				if (jsonParserFieldValue != null) {
+					objectRelationship.
+						setObjectDefinitionExternalReferenceCode1(
+							(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -334,6 +334,8 @@ components:
                     type: object
                 name:
                     type: string
+                objectDefinitionExternalReferenceCode1:
+                    type: string
                 objectDefinitionExternalReferenceCode2:
                     type: string
                 objectDefinitionId1:

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -734,7 +734,7 @@ paths:
             tags: ["ObjectDefinition"]
     "/object-definitions/by-external-reference-code/{objectDefinitionExternalReferenceCode}/object-fields":
         get:
-            operationId: getObjectDefinitionObjectDefinitionExternalReferenceCodeObjectFieldsPage
+            operationId: getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage
             parameters:
                 - in: path
                   name: objectDefinitionExternalReferenceCode

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -732,6 +732,28 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectDefinition"
             tags: ["ObjectDefinition"]
+    "/object-definitions/by-external-reference-code/{objectDefinitionExternalReferenceCode}/object-fields":
+        get:
+            operationId: getObjectDefinitionObjectDefinitionExternalReferenceCodeObjectFieldsPage
+            parameters:
+                - in: path
+                  name: objectDefinitionExternalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectField"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectField"
+                                type: array
     "/object-definitions/{objectDefinitionId}":
         delete:
             operationId: deleteObjectDefinition

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -349,6 +349,8 @@ components:
                 parameterObjectFieldId:
                     format: int64
                     type: integer
+                parameterObjectFieldName:
+                    type: string
                 reverse:
                     readOnly: true
                     type: boolean

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectRelationshipDTOConverter.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/converter/ObjectRelationshipDTOConverter.java
@@ -51,7 +51,11 @@ public class ObjectRelationshipDTOConverter
 			return null;
 		}
 
-		ObjectDefinition objectDefinition =
+		ObjectDefinition objectDefinition1 =
+			_objectDefinitionLocalService.getObjectDefinition(
+				serviceBuilderObjectRelationship.getObjectDefinitionId1());
+
+		ObjectDefinition objectDefinition2 =
 			_objectDefinitionLocalService.getObjectDefinition(
 				serviceBuilderObjectRelationship.getObjectDefinitionId2());
 
@@ -64,13 +68,15 @@ public class ObjectRelationshipDTOConverter
 				label = LocalizedMapUtil.getLanguageIdMap(
 					serviceBuilderObjectRelationship.getLabelMap());
 				name = serviceBuilderObjectRelationship.getName();
+				objectDefinitionExternalReferenceCode1 =
+					objectDefinition1.getExternalReferenceCode();
 				objectDefinitionExternalReferenceCode2 =
-					objectDefinition.getExternalReferenceCode();
+					objectDefinition2.getExternalReferenceCode();
 				objectDefinitionId1 =
 					serviceBuilderObjectRelationship.getObjectDefinitionId1();
 				objectDefinitionId2 =
 					serviceBuilderObjectRelationship.getObjectDefinitionId2();
-				objectDefinitionName2 = objectDefinition.getShortName();
+				objectDefinitionName2 = objectDefinition2.getShortName();
 				parameterObjectFieldId =
 					serviceBuilderObjectRelationship.
 						getParameterObjectFieldId();

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
@@ -338,7 +338,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectRelationship(objectRelationshipId: ___){actions, deletionType, id, label, name, objectDefinitionExternalReferenceCode2, objectDefinitionId1, objectDefinitionId2, objectDefinitionName2, parameterObjectFieldId, reverse, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectRelationship(objectRelationshipId: ___){actions, deletionType, id, label, name, objectDefinitionExternalReferenceCode1, objectDefinitionExternalReferenceCode2, objectDefinitionId1, objectDefinitionId2, objectDefinitionName2, parameterObjectFieldId, reverse, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public ObjectRelationship objectRelationship(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
@@ -230,6 +230,27 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFields(objectDefinitionExternalReferenceCode: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public ObjectFieldPage
+			objectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFields(
+				@GraphQLName("objectDefinitionExternalReferenceCode") String
+					objectDefinitionExternalReferenceCode)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_objectFieldResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			objectFieldResource -> new ObjectFieldPage(
+				objectFieldResource.
+					getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+						objectDefinitionExternalReferenceCode)));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectDefinitionObjectFields(filter: ___, objectDefinitionId: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/query/v1_0/Query.java
@@ -359,7 +359,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectRelationship(objectRelationshipId: ___){actions, deletionType, id, label, name, objectDefinitionExternalReferenceCode1, objectDefinitionExternalReferenceCode2, objectDefinitionId1, objectDefinitionId2, objectDefinitionName2, parameterObjectFieldId, reverse, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {objectRelationship(objectRelationshipId: ___){actions, deletionType, id, label, name, objectDefinitionExternalReferenceCode1, objectDefinitionExternalReferenceCode2, objectDefinitionId1, objectDefinitionId2, objectDefinitionName2, parameterObjectFieldId, parameterObjectFieldName, reverse, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField
 	public ObjectRelationship objectRelationship(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -79,6 +79,37 @@ public abstract class BaseObjectFieldResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/by-external-reference-code/{objectDefinitionExternalReferenceCode}/object-fields'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectDefinitionExternalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/object-definitions/by-external-reference-code/{objectDefinitionExternalReferenceCode}/object-fields"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ObjectField>
+			getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@javax.validation.constraints.NotNull
+				@javax.ws.rs.PathParam("objectDefinitionExternalReferenceCode")
+				String objectDefinitionExternalReferenceCode)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-fields'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -134,7 +134,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -334,7 +334,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/object-admin/v1.0/object-relationships/{objectRelationshipId}' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/object-admin/v1.0/object-relationships/{objectRelationshipId}' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -134,7 +134,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "parameterObjectFieldName": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -334,7 +334,7 @@ public abstract class BaseObjectRelationshipResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/object-admin/v1.0/object-relationships/{objectRelationshipId}' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/object-admin/v1.0/object-relationships/{objectRelationshipId}' -d $'{"deletionType": ___, "label": ___, "name": ___, "objectDefinitionExternalReferenceCode1": ___, "objectDefinitionExternalReferenceCode2": ___, "objectDefinitionId1": ___, "objectDefinitionId2": ___, "objectDefinitionName2": ___, "parameterObjectFieldId": ___, "parameterObjectFieldName": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFieldResourceImpl.java
@@ -74,6 +74,25 @@ public class ObjectFieldResourceImpl
 		return _entityModel;
 	}
 
+	@Override
+	public Page<ObjectField>
+			getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+				String objectDefinitionExternalReferenceCode)
+		throws Exception {
+
+		com.liferay.object.model.ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode,
+					contextCompany.getCompanyId());
+
+		return Page.of(
+			transform(
+				_objectFieldService.getObjectFields(
+					objectDefinition.getObjectDefinitionId()),
+				this::_toObjectField));
+	}
+
 	@NestedField(parentClass = ObjectDefinition.class, value = "objectFields")
 	@Override
 	public Page<ObjectField> getObjectDefinitionObjectFieldsPage(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -35,6 +35,8 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.util.Objects;
+
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.osgi.service.component.annotations.Component;
@@ -127,6 +129,20 @@ public class ObjectRelationshipResourceImpl
 	public ObjectRelationship postObjectDefinitionObjectRelationship(
 			Long objectDefinitionId, ObjectRelationship objectRelationship)
 		throws Exception {
+
+		if (!Objects.isNull(
+				objectRelationship.
+					getObjectDefinitionExternalReferenceCode1())) {
+
+			com.liferay.object.model.ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						contextCompany.getCompanyId(),
+						objectRelationship.
+							getObjectDefinitionExternalReferenceCode1());
+
+			objectDefinitionId = objectDefinition.getObjectDefinitionId();
+		}
 
 		long objectDefinitionId2 = GetterUtil.getLong(
 			objectRelationship.getObjectDefinitionId2());

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectRelationshipResourceImpl.java
@@ -19,7 +19,9 @@ import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
 import com.liferay.object.admin.rest.internal.dto.v1_0.converter.ObjectRelationshipDTOConverter;
 import com.liferay.object.admin.rest.internal.odata.entity.v1_0.ObjectRelationshipEntityModel;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.object.util.LocalizedMapUtil;
 import com.liferay.portal.kernel.search.Field;
@@ -137,9 +139,9 @@ public class ObjectRelationshipResourceImpl
 			com.liferay.object.model.ObjectDefinition objectDefinition =
 				_objectDefinitionLocalService.
 					getObjectDefinitionByExternalReferenceCode(
-						contextCompany.getCompanyId(),
 						objectRelationship.
-							getObjectDefinitionExternalReferenceCode1());
+							getObjectDefinitionExternalReferenceCode1(),
+						contextCompany.getCompanyId());
 
 			objectDefinitionId = objectDefinition.getObjectDefinitionId();
 		}
@@ -169,11 +171,20 @@ public class ObjectRelationshipResourceImpl
 			objectDefinitionId2 = objectDefinition.getObjectDefinitionId();
 		}
 
+		long parameterObjectFieldId = 0L;
+
+		ObjectField parameterObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				objectDefinitionId2,
+				objectRelationship.getParameterObjectFieldName());
+
+		if (!Objects.isNull(parameterObjectField)) {
+			parameterObjectFieldId = parameterObjectField.getObjectFieldId();
+		}
+
 		return _toObjectRelationship(
 			_objectRelationshipService.addObjectRelationship(
-				objectDefinitionId, objectDefinitionId2,
-				GetterUtil.getLong(
-					objectRelationship.getParameterObjectFieldId()),
+				objectDefinitionId, objectDefinitionId2, parameterObjectFieldId,
 				objectRelationship.getDeletionTypeAsString(),
 				LocalizedMapUtil.getLocalizedMap(objectRelationship.getLabel()),
 				objectRelationship.getName(),
@@ -220,6 +231,9 @@ public class ObjectRelationshipResourceImpl
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private ObjectRelationshipDTOConverter _objectRelationshipDTOConverter;

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -206,6 +206,91 @@ public abstract class BaseObjectFieldResourceTestCase {
 	}
 
 	@Test
+	public void testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage()
+		throws Exception {
+
+		String objectDefinitionExternalReferenceCode =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getObjectDefinitionExternalReferenceCode();
+		String irrelevantObjectDefinitionExternalReferenceCode =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getIrrelevantObjectDefinitionExternalReferenceCode();
+
+		Page<ObjectField> page =
+			objectFieldResource.
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+					objectDefinitionExternalReferenceCode);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		if (irrelevantObjectDefinitionExternalReferenceCode != null) {
+			ObjectField irrelevantObjectField =
+				testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+					irrelevantObjectDefinitionExternalReferenceCode,
+					randomIrrelevantObjectField());
+
+			page =
+				objectFieldResource.
+					getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+						irrelevantObjectDefinitionExternalReferenceCode);
+
+			Assert.assertEquals(1, page.getTotalCount());
+
+			assertEquals(
+				Arrays.asList(irrelevantObjectField),
+				(List<ObjectField>)page.getItems());
+			assertValid(page);
+		}
+
+		ObjectField objectField1 =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				objectDefinitionExternalReferenceCode, randomObjectField());
+
+		ObjectField objectField2 =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				objectDefinitionExternalReferenceCode, randomObjectField());
+
+		page =
+			objectFieldResource.
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+					objectDefinitionExternalReferenceCode);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(objectField1, objectField2),
+			(List<ObjectField>)page.getItems());
+		assertValid(page);
+
+		objectFieldResource.deleteObjectField(objectField1.getId());
+
+		objectFieldResource.deleteObjectField(objectField2.getId());
+	}
+
+	protected ObjectField
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				String objectDefinitionExternalReferenceCode,
+				ObjectField objectField)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getIrrelevantObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		return null;
+	}
+
+	@Test
 	public void testGetObjectDefinitionObjectFieldsPage() throws Exception {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectFieldsPage_getObjectDefinitionId();

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -185,6 +185,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		ObjectRelationship objectRelationship = randomObjectRelationship();
 
 		objectRelationship.setName(regex);
+		objectRelationship.setObjectDefinitionExternalReferenceCode1(regex);
 		objectRelationship.setObjectDefinitionExternalReferenceCode2(regex);
 		objectRelationship.setObjectDefinitionName2(regex);
 
@@ -195,6 +196,9 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		objectRelationship = ObjectRelationshipSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, objectRelationship.getName());
+		Assert.assertEquals(
+			regex,
+			objectRelationship.getObjectDefinitionExternalReferenceCode1());
 		Assert.assertEquals(
 			regex,
 			objectRelationship.getObjectDefinitionExternalReferenceCode2());
@@ -789,6 +793,19 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 			}
 
 			if (Objects.equals(
+					"objectDefinitionExternalReferenceCode1",
+					additionalAssertFieldName)) {
+
+				if (objectRelationship.
+						getObjectDefinitionExternalReferenceCode1() == null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"objectDefinitionExternalReferenceCode2",
 					additionalAssertFieldName)) {
 
@@ -1000,6 +1017,22 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				if (!Objects.deepEquals(
 						objectRelationship1.getName(),
 						objectRelationship2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"objectDefinitionExternalReferenceCode1",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						objectRelationship1.
+							getObjectDefinitionExternalReferenceCode1(),
+						objectRelationship2.
+							getObjectDefinitionExternalReferenceCode1())) {
 
 					return false;
 				}
@@ -1223,6 +1256,17 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("objectDefinitionExternalReferenceCode1")) {
+			sb.append("'");
+			sb.append(
+				String.valueOf(
+					objectRelationship.
+						getObjectDefinitionExternalReferenceCode1()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("objectDefinitionExternalReferenceCode2")) {
 			sb.append("'");
 			sb.append(
@@ -1314,6 +1358,8 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 			{
 				id = RandomTestUtil.randomLong();
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				objectDefinitionExternalReferenceCode1 = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				objectDefinitionExternalReferenceCode2 = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				objectDefinitionId1 = RandomTestUtil.randomLong();

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -188,6 +188,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		objectRelationship.setObjectDefinitionExternalReferenceCode1(regex);
 		objectRelationship.setObjectDefinitionExternalReferenceCode2(regex);
 		objectRelationship.setObjectDefinitionName2(regex);
+		objectRelationship.setParameterObjectFieldName(regex);
 
 		String json = ObjectRelationshipSerDes.toJSON(objectRelationship);
 
@@ -204,6 +205,8 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 			objectRelationship.getObjectDefinitionExternalReferenceCode2());
 		Assert.assertEquals(
 			regex, objectRelationship.getObjectDefinitionName2());
+		Assert.assertEquals(
+			regex, objectRelationship.getParameterObjectFieldName());
 	}
 
 	@Test
@@ -858,6 +861,16 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"parameterObjectFieldName", additionalAssertFieldName)) {
+
+				if (objectRelationship.getParameterObjectFieldName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("reverse", additionalAssertFieldName)) {
 				if (objectRelationship.getReverse() == null) {
 					valid = false;
@@ -1108,6 +1121,19 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"parameterObjectFieldName", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						objectRelationship1.getParameterObjectFieldName(),
+						objectRelationship2.getParameterObjectFieldName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("reverse", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						objectRelationship1.getReverse(),
@@ -1302,6 +1328,16 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("parameterObjectFieldName")) {
+			sb.append("'");
+			sb.append(
+				String.valueOf(
+					objectRelationship.getParameterObjectFieldName()));
+			sb.append("'");
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("reverse")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1367,6 +1403,8 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				objectDefinitionName2 = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				parameterObjectFieldId = RandomTestUtil.randomLong();
+				parameterObjectFieldName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				reverse = RandomTestUtil.randomBoolean();
 			}
 		};

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFieldResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,6 +72,66 @@ public class ObjectFieldResourceTest extends BaseObjectFieldResourceTestCase {
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				_objectDefinition.getObjectDefinitionId());
 		}
+	}
+
+	@Override
+	@Test
+	public void testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage()
+		throws Exception {
+
+		String objectDefinitionExternalReferenceCode =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getObjectDefinitionExternalReferenceCode();
+		String irrelevantObjectDefinitionExternalReferenceCode =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getIrrelevantObjectDefinitionExternalReferenceCode();
+
+		Page<ObjectField> page =
+			objectFieldResource.
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+					objectDefinitionExternalReferenceCode);
+
+		Assert.assertEquals(6, page.getTotalCount());
+
+		if (irrelevantObjectDefinitionExternalReferenceCode != null) {
+			ObjectField irrelevantObjectField =
+				testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+					irrelevantObjectDefinitionExternalReferenceCode,
+					randomIrrelevantObjectField());
+
+			page =
+				objectFieldResource.
+					getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+						irrelevantObjectDefinitionExternalReferenceCode);
+
+			Assert.assertEquals(1, page.getTotalCount());
+
+			assertEquals(
+				Arrays.asList(irrelevantObjectField),
+				(List<ObjectField>)page.getItems());
+			assertValid(page);
+		}
+
+		ObjectField objectField1 =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				objectDefinitionExternalReferenceCode, randomObjectField());
+
+		ObjectField objectField2 =
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				objectDefinitionExternalReferenceCode, randomObjectField());
+
+		page =
+			objectFieldResource.
+				getObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage(
+					objectDefinitionExternalReferenceCode);
+
+		Assert.assertEquals(8, page.getTotalCount());
+
+		assertContains(objectField1, (List<ObjectField>)page.getItems());
+		assertContains(objectField2, (List<ObjectField>)page.getItems());
+		assertValid(page);
+
+		objectFieldResource.deleteObjectField(objectField1.getId());
+
+		objectFieldResource.deleteObjectField(objectField2.getId());
 	}
 
 	@Override
@@ -222,6 +283,22 @@ public class ObjectFieldResourceTest extends BaseObjectFieldResourceTestCase {
 		throws Exception {
 
 		return _addObjectField();
+	}
+
+	protected ObjectField
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_addObjectField(
+				String objectDefinitionExternalReferenceCode,
+				ObjectField objectField)
+		throws Exception {
+
+		return _addObjectField();
+	}
+
+	protected String
+			testGetObjectDefinitionByExternalReferenceCodeObjectDefinitionExternalReferenceCodeObjectFieldsPage_getObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		return _objectDefinition.getExternalReferenceCode();
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldService.java
@@ -69,6 +69,10 @@ public interface ObjectFieldService extends BaseService {
 	public ObjectField getObjectField(long objectFieldId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<ObjectField> getObjectFields(long objectDefinitionId)
+		throws PortalException;
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldServiceUtil.java
@@ -68,6 +68,12 @@ public class ObjectFieldServiceUtil {
 		return getService().getObjectField(objectFieldId);
 	}
 
+	public static List<ObjectField> getObjectFields(long objectDefinitionId)
+		throws PortalException {
+
+		return getService().getObjectFields(objectDefinitionId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectFieldServiceWrapper.java
@@ -69,6 +69,14 @@ public class ObjectFieldServiceWrapper
 		return _objectFieldService.getObjectField(objectFieldId);
 	}
 
+	@Override
+	public java.util.List<com.liferay.object.model.ObjectField> getObjectFields(
+			long objectDefinitionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectFieldService.getObjectFields(objectDefinitionId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
@@ -58,8 +58,8 @@ interface ObjectRelationship {
 	id: number;
 	label: LocalizedValue<string>;
 	name: string;
-	objectDefinitionId1: number;
-	objectDefinitionId2: number;
+	objectDefinitionExternalReferenceCode1: string;
+	objectDefinitionExternalReferenceCode2: string;
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;
@@ -180,6 +180,14 @@ export async function getObjectField(objectFieldId: number) {
 export async function getObjectFields(objectDefinitionId: number) {
 	return await getList<ObjectField>(
 		`/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/object-fields?pageSize=-1`
+	);
+}
+
+export async function getObjectFieldsByExternalReferenceCode(
+	objectDefinitionExternalReferenceCode: string
+) {
+	return await getList<ObjectField>(
+		`/o/object-admin/v1.0/object-definitions/by-external-reference-code/${objectDefinitionExternalReferenceCode}/object-fields`
 	);
 }
 

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
@@ -44,8 +44,8 @@ interface ObjectRelationship {
 	id: number;
 	label: LocalizedValue<string>;
 	name: string;
-	objectDefinitionId1: number;
-	objectDefinitionId2: number;
+	objectDefinitionExternalReferenceCode1: string;
+	objectDefinitionExternalReferenceCode2: string;
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;
@@ -101,6 +101,9 @@ export declare function getObjectField(
 ): Promise<ObjectField>;
 export declare function getObjectFields(
 	objectDefinitionId: number
+): Promise<ObjectField[]>;
+export declare function getObjectFieldsByExternalReferenceCode(
+	objectDefinitionExternalReferenceCode: string
 ): Promise<ObjectField[]>;
 export declare function getObjectRelationships(
 	objectDefinitionId: number

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectFieldServiceHttp.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/http/ObjectFieldServiceHttp.java
@@ -177,6 +177,48 @@ public class ObjectFieldServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.object.model.ObjectField>
+			getObjectFields(
+				HttpPrincipal httpPrincipal, long objectDefinitionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				ObjectFieldServiceUtil.class, "getObjectFields",
+				_getObjectFieldsParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, objectDefinitionId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List<com.liferay.object.model.ObjectField>)
+				returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.object.model.ObjectField updateObjectField(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long objectFieldId, long listTypeDefinitionId, String businessType,
@@ -191,7 +233,7 @@ public class ObjectFieldServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				ObjectFieldServiceUtil.class, "updateObjectField",
-				_updateObjectFieldParameterTypes3);
+				_updateObjectFieldParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, objectFieldId,
@@ -241,7 +283,9 @@ public class ObjectFieldServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getObjectFieldParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateObjectFieldParameterTypes3 =
+	private static final Class<?>[] _getObjectFieldsParameterTypes3 =
+		new Class[] {long.class};
+	private static final Class<?>[] _updateObjectFieldParameterTypes4 =
 		new Class[] {
 			String.class, long.class, long.class, String.class, String.class,
 			String.class, boolean.class, boolean.class, String.class,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldServiceImpl.java
@@ -104,6 +104,16 @@ public class ObjectFieldServiceImpl extends ObjectFieldServiceBaseImpl {
 	}
 
 	@Override
+	public List<ObjectField> getObjectFields(long objectDefinitionId)
+		throws PortalException {
+
+		_objectDefinitionModelResourcePermission.check(
+			getPermissionChecker(), objectDefinitionId, ActionKeys.VIEW);
+
+		return objectFieldLocalService.getObjectFields(objectDefinitionId);
+	}
+
+	@Override
 	public ObjectField updateObjectField(
 			String externalReferenceCode, long objectFieldId,
 			long listTypeDefinitionId, String businessType, String dbType,

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
@@ -128,6 +128,10 @@ public class ObjectDefinitionsRelationshipsDisplayContext
 			ObjectRelationship objectRelationship)
 		throws PortalException {
 
+		ObjectDefinition objectDefinition1 =
+			_objectDefinitionService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId1());
+
 		ObjectDefinition objectDefinition2 =
 			_objectDefinitionService.getObjectDefinition(
 				objectRelationship.getObjectDefinitionId2());
@@ -139,11 +143,11 @@ public class ObjectDefinitionsRelationshipsDisplayContext
 		).put(
 			"name", objectRelationship.getName()
 		).put(
-			"objectDefinitionId1",
-			Long.valueOf(objectRelationship.getObjectDefinitionId1())
+			"objectDefinitionExternalReferenceCode1",
+			objectDefinition1.getExternalReferenceCode()
 		).put(
-			"objectDefinitionId2",
-			Long.valueOf(objectRelationship.getObjectDefinitionId2())
+			"objectDefinitionExternalReferenceCode2",
+			objectDefinition2.getExternalReferenceCode()
 		).put(
 			"objectDefinitionName2", objectDefinition2.getShortName()
 		).put(

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/index.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/index.tsx
@@ -83,7 +83,7 @@ type TNormalizeObjectRelationships = ({
 	objectRelationships,
 }: {
 	objectLayoutTabs: TObjectLayoutTab[];
-	objectRelationships: TObjectRelationship[];
+	objectRelationships: ObjectRelationship[];
 }) => TObjectRelationship[];
 
 const normalizeObjectRelationships: TNormalizeObjectRelationships = ({
@@ -92,7 +92,9 @@ const normalizeObjectRelationships: TNormalizeObjectRelationships = ({
 }) => {
 	const objectRelationshipIds = objectRelationships.map(({id}) => id);
 
-	const normalizedObjectRelationships = [...objectRelationships];
+	const normalizedObjectRelationships: TObjectRelationship[] = [
+		...objectRelationships,
+	];
 
 	objectLayoutTabs.forEach(({objectRelationshipId}) => {
 		if (objectRelationshipId) {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.tsx
@@ -30,14 +30,16 @@ interface IAggregationSourcePropertyProps {
 	objectDefinitionId: number;
 	objectFieldSettings: ObjectFieldSetting[];
 	onAggregationFilterChange?: (aggregationFilterArray: []) => void;
-	onRelationshipChange?: (objectDefinitionId2: number) => void;
+	onRelationshipChange?: (
+		objectDefinitionExternalReferenceCode2: string
+	) => void;
 	setValues: (values: Partial<ObjectField>) => void;
 }
 
 type TObjectRelationship = {
 	label: LocalizedValue<string>;
 	name: string;
-	objectDefinitionId2: number;
+	objectDefinitionExternalReferenceCode2: string;
 };
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
@@ -129,8 +131,8 @@ export function AggregationFormBase({
 						!(
 							objectRelationship.type === 'manyToMany' &&
 							objectRelationship.reverse &&
-							objectRelationship.objectDefinitionId1 ===
-								objectRelationship.objectDefinitionId2
+							objectRelationship.objectDefinitionExternalReferenceCode1 ===
+								objectRelationship.objectDefinitionExternalReferenceCode2
 						)
 				)
 			);
@@ -154,8 +156,8 @@ export function AggregationFormBase({
 						aggregationFunction.value === settings.function
 				);
 
-				const relatedFields = await API.getObjectFields(
-					currentRelatedObjectRelationship.objectDefinitionId2
+				const relatedFields = await API.getObjectFieldsByExternalReferenceCode(
+					currentRelatedObjectRelationship.objectDefinitionExternalReferenceCode2
 				);
 
 				const currentSummarizeField = relatedFields.find(
@@ -165,7 +167,7 @@ export function AggregationFormBase({
 
 				if (onRelationshipChange) {
 					onRelationshipChange(
-						currentRelatedObjectRelationship.objectDefinitionId2
+						currentRelatedObjectRelationship.objectDefinitionExternalReferenceCode2
 					);
 				}
 
@@ -207,8 +209,8 @@ export function AggregationFormBase({
 		setSelectRelatedObjectRelationship(objectRelationship);
 		setSelectedSummarizeField('');
 
-		const relatedFields = await API.getObjectFields(
-			objectRelationship.objectDefinitionId2
+		const relatedFields = await API.getObjectFieldsByExternalReferenceCode(
+			objectRelationship.objectDefinitionExternalReferenceCode2
 		);
 
 		const numericFields = relatedFields.filter(
@@ -249,7 +251,9 @@ export function AggregationFormBase({
 		});
 
 		if (onRelationshipChange) {
-			onRelationshipChange(objectRelationship.objectDefinitionId2);
+			onRelationshipChange(
+				objectRelationship.objectDefinitionExternalReferenceCode2
+			);
 		}
 	};
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
@@ -48,7 +48,9 @@ interface IProps {
 	objectName: string;
 	objectRelationshipId?: number;
 	onAggregationFilterChange?: (aggregationFilterArray: []) => void;
-	onRelationshipChange?: (objectDefinitionId2: number) => void;
+	onRelationshipChange?: (
+		objectDefinitionExternalReferenceCode2: string
+	) => void;
 	setValues: (values: Partial<ObjectField>) => void;
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfo.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfo.tsx
@@ -95,7 +95,10 @@ export function BasicInfo({
 
 	const [editingFilter, setEditingFilter] = useState(false);
 	const [objectFields, setObjectFields] = useState<ObjectField[]>();
-	const [objectDefinitionId2, setObjectDefinitionId2] = useState<number>();
+	const [
+		objectDefinitionExternalReferenceCode2,
+		setObjectDefinitionExternalReferenceCode2,
+	] = useState<string>();
 	const [aggregationFilters, setAggregationFilters] = useState<
 		AggregationFilters[]
 	>([]);
@@ -356,10 +359,15 @@ export function BasicInfo({
 	};
 
 	useEffect(() => {
-		if (values.businessType === 'Aggregation' && objectDefinitionId2) {
-			API.getObjectFields(objectDefinitionId2).then(setObjectFields);
+		if (
+			values.businessType === 'Aggregation' &&
+			objectDefinitionExternalReferenceCode2
+		) {
+			API.getObjectFieldsByExternalReferenceCode(
+				objectDefinitionExternalReferenceCode2
+			).then(setObjectFields);
 		}
-	}, [values.businessType, objectDefinitionId2]);
+	}, [values.businessType, objectDefinitionExternalReferenceCode2]);
 
 	useEffect(() => {
 		if (values.businessType === 'Aggregation') {
@@ -524,7 +532,9 @@ export function BasicInfo({
 					objectName={objectName}
 					objectRelationshipId={objectRelationshipId}
 					onAggregationFilterChange={setAggregationFilters}
-					onRelationshipChange={setObjectDefinitionId2}
+					onRelationshipChange={
+						setObjectDefinitionExternalReferenceCode2
+					}
 					setValues={setValues}
 				>
 					{values.businessType === 'Attachment' && (

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
@@ -32,8 +32,8 @@ const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
 function ModalAddObjectRelationship({
 	apiURL,
+	externalReferenceCode,
 	ffOneToOneRelationshipConfigurationEnabled,
-	objectDefinitionId,
 	observer,
 	onClose,
 	parameterRequired,
@@ -41,7 +41,7 @@ function ModalAddObjectRelationship({
 	const [error, setError] = useState<string>('');
 
 	const initialValues: Partial<ObjectRelationship> = {
-		objectDefinitionId1: Number(objectDefinitionId),
+		objectDefinitionExternalReferenceCode1: externalReferenceCode,
 	};
 
 	const onSubmit = async ({label, name, ...others}: ObjectRelationship) => {
@@ -115,7 +115,9 @@ function ModalAddObjectRelationship({
 						values.type === ObjectRelationshipType.ONE_TO_MANY && (
 							<SelectRelationship
 								error={errors.parameterObjectFieldId}
-								objectDefinitionId={values.objectDefinitionId2}
+								objectDefinitionExternalReferenceCode={
+									values.objectDefinitionExternalReferenceCode2
+								}
 								onChange={(parameterObjectFieldId) =>
 									setValues({parameterObjectFieldId})
 								}
@@ -147,6 +149,7 @@ function ModalAddObjectRelationship({
 
 export default function AddRelationship({
 	apiURL,
+	externalReferenceCode,
 	ffOneToOneRelationshipConfigurationEnabled,
 	objectDefinitionId,
 	parameterRequired,
@@ -169,6 +172,7 @@ export default function AddRelationship({
 			{visibleModal && (
 				<ModalAddObjectRelationship
 					apiURL={apiURL}
+					externalReferenceCode={externalReferenceCode}
 					ffOneToOneRelationshipConfigurationEnabled={
 						ffOneToOneRelationshipConfigurationEnabled
 					}
@@ -184,6 +188,7 @@ export default function AddRelationship({
 
 interface IProps {
 	apiURL: string;
+	externalReferenceCode: string;
 	ffOneToOneRelationshipConfigurationEnabled: boolean;
 	objectDefinitionId: number;
 	observer: Observer;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
@@ -114,14 +114,14 @@ function ModalAddObjectRelationship({
 					{parameterRequired &&
 						values.type === ObjectRelationshipType.ONE_TO_MANY && (
 							<SelectRelationship
-								error={errors.parameterObjectFieldId}
+								error={errors.parameterObjectFieldName}
 								objectDefinitionExternalReferenceCode={
 									values.objectDefinitionExternalReferenceCode2
 								}
-								onChange={(parameterObjectFieldId) =>
-									setValues({parameterObjectFieldId})
+								onChange={(parameterObjectFieldName) =>
+									setValues({parameterObjectFieldName})
 								}
-								value={values.parameterObjectFieldId}
+								value={values.parameterObjectFieldName}
 							/>
 						)}
 				</ClayModal.Body>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
@@ -134,14 +134,14 @@ export default function EditRelationship({
 						/>
 
 						<SelectRelationship
-							error={errors.parameterObjectFieldId}
+							error={errors.parameterObjectFieldName}
 							objectDefinitionExternalReferenceCode={
 								values.objectDefinitionExternalReferenceCode2
 							}
-							onChange={(parameterObjectFieldId) =>
-								setValues({parameterObjectFieldId})
+							onChange={(parameterObjectFieldName) =>
+								setValues({parameterObjectFieldName})
 							}
-							value={values.parameterObjectFieldId}
+							value={values.parameterObjectFieldName}
 						/>
 					</Card>
 				)}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
@@ -135,7 +135,9 @@ export default function EditRelationship({
 
 						<SelectRelationship
 							error={errors.parameterObjectFieldId}
-							objectDefinitionId={values.objectDefinitionId2}
+							objectDefinitionExternalReferenceCode={
+								values.objectDefinitionExternalReferenceCode2
+							}
 							onChange={(parameterObjectFieldId) =>
 								setValues({parameterObjectFieldId})
 							}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -87,9 +87,9 @@ export function useObjectRelationshipForm({
 		if (
 			parameterRequired &&
 			relationship.type === ObjectRelationshipType.ONE_TO_MANY &&
-			!relationship.parameterObjectFieldId
+			!relationship.parameterObjectFieldName
 		) {
-			errors.parameterObjectFieldId = REQUIRED_MSG;
+			errors.parameterObjectFieldName = REQUIRED_MSG;
 		}
 
 		return errors;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -80,8 +80,8 @@ export function useObjectRelationshipForm({
 			errors.type = REQUIRED_MSG;
 		}
 
-		if (!relationship.objectDefinitionId2) {
-			errors.objectDefinitionId2 = REQUIRED_MSG;
+		if (!relationship.objectDefinitionExternalReferenceCode2) {
+			errors.objectDefinitionExternalReferenceCode2 = REQUIRED_MSG;
 		}
 
 		if (
@@ -113,7 +113,7 @@ export function ObjectRelationshipFormBase({
 	values,
 }: IPros) {
 	const [objectDefinitions, setObjectDefinitions] = useState<
-		ObjectDefinition[]
+		Partial<ObjectDefinition>[]
 	>([]);
 	const [query, setQuery] = useState<string>('');
 
@@ -131,7 +131,9 @@ export function ObjectRelationshipFormBase({
 			const items = await API.getAllObjectDefinitions();
 
 			const currentObjectDefinition = items.find(
-				({id}) => values.objectDefinitionId1 === id
+				({externalReferenceCode}) =>
+					values.objectDefinitionExternalReferenceCode1 ===
+					externalReferenceCode
 			)!;
 
 			const objectDefinitions = items.filter(
@@ -148,7 +150,8 @@ export function ObjectRelationshipFormBase({
 		if (readonly) {
 			setObjectDefinitions([
 				{
-					id: values.objectDefinitionId2 as number,
+					externalReferenceCode:
+						values.objectDefinitionExternalReferenceCode2,
 					label: values.label as LocalizedValue<string>,
 					name: values.objectDefinitionName2 as string,
 					system: false,
@@ -159,7 +162,7 @@ export function ObjectRelationshipFormBase({
 			fetchObjectDefinitions();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [readonly, values.objectDefinitionId1]);
+	}, [readonly, values.objectDefinitionExternalReferenceCode1]);
 
 	const filteredRelationships = useMemo(() => {
 		return filterArrayByQuery(objectDefinitions, 'label', query);
@@ -192,13 +195,14 @@ export function ObjectRelationshipFormBase({
 				emptyStateMessage={Liferay.Language.get(
 					'no-objects-were-found'
 				)}
-				error={errors.objectDefinitionId2}
+				error={errors.objectDefinitionExternalReferenceCode2}
 				items={filteredRelationships}
 				label={Liferay.Language.get('object')}
 				onChangeQuery={setQuery}
 				onSelectItem={(item) => {
 					setValues({
-						objectDefinitionId2: item.id,
+						objectDefinitionExternalReferenceCode2:
+							item.externalReferenceCode,
 						objectDefinitionName2: item.name,
 					});
 				}}
@@ -236,10 +240,3 @@ interface IPros {
 	setValues: (values: Partial<ObjectRelationship>) => void;
 	values: Partial<ObjectRelationship>;
 }
-
-type ObjectDefinition = {
-	id: number;
-	label: LocalizedValue<string>;
-	name: string;
-	system: boolean;
-};

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.tsx
@@ -20,8 +20,8 @@ const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 interface IProps {
 	error?: string;
 	objectDefinitionExternalReferenceCode?: string;
-	onChange: (objectFieldId: number) => void;
-	value?: number;
+	onChange: (objectFieldName: string) => void;
+	value?: string;
 }
 
 export default function SelectRelationship({
@@ -43,7 +43,7 @@ export default function SelectRelationship({
 		[fields]
 	);
 	const selectedValue = useMemo(() => {
-		return fields.find(({id}) => id === value);
+		return fields.find(({name}) => name === value);
 	}, [fields, value]);
 
 	useEffect(() => {
@@ -69,7 +69,7 @@ export default function SelectRelationship({
 			error={error}
 			label={Liferay.Language.get('parameter')}
 			onChange={({target: {value}}) => {
-				onChange(fields.find(({name}) => name === value)?.id!);
+				onChange(fields.find(({name}) => name === value)?.name!);
 			}}
 			options={options}
 			required

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.tsx
@@ -19,14 +19,14 @@ const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
 interface IProps {
 	error?: string;
-	objectDefinitionId?: number;
+	objectDefinitionExternalReferenceCode?: string;
 	onChange: (objectFieldId: number) => void;
 	value?: number;
 }
 
 export default function SelectRelationship({
 	error,
-	objectDefinitionId,
+	objectDefinitionExternalReferenceCode,
 	onChange,
 	value,
 	...otherProps
@@ -47,18 +47,22 @@ export default function SelectRelationship({
 	}, [fields, value]);
 
 	useEffect(() => {
-		if (objectDefinitionId) {
-			API.getObjectFields(objectDefinitionId).then((fields) => {
-				const options = fields.filter(
+		const makeFetch = async () => {
+			if (objectDefinitionExternalReferenceCode) {
+				const objectFields = await API.getObjectFieldsByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode
+				);
+				const options = objectFields?.filter(
 					({businessType}) => businessType === 'Relationship'
 				);
 				setFields(options);
-			});
-		}
-		else {
-			setFields([]);
-		}
-	}, [objectDefinitionId]);
+			}
+			else {
+				setFields([]);
+			}
+		};
+		makeFetch();
+	}, [objectDefinitionExternalReferenceCode]);
 
 	return (
 		<Select

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -251,7 +251,7 @@ interface ObjectRelationship {
 	objectDefinitionExternalReferenceCode2: string;
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
-	parameterObjectFieldId?: number;
+	parameterObjectFieldName?: string;
 	reverse: boolean;
 	type: ObjectRelationshipType;
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -109,6 +109,7 @@ interface ObjectDefinition {
 	dateCreated: string;
 	dateModified: string;
 	enableCategorization: boolean;
+	externalReferenceCode: string;
 	id: number;
 	label: LocalizedValue<string>;
 	name: string;
@@ -246,8 +247,8 @@ interface ObjectRelationship {
 	id: number;
 	label: LocalizedValue<string>;
 	name: string;
-	objectDefinitionId1: number;
-	objectDefinitionId2: number;
+	objectDefinitionExternalReferenceCode1: string;
+	objectDefinitionExternalReferenceCode2: string;
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
 	parameterObjectFieldId?: number;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
@@ -50,9 +50,9 @@ renderResponse.setTitle(objectDefinition.getLabel(locale, true));
 			HashMapBuilder.<String, Object>put(
 				"apiURL", objectDefinitionsRelationshipsDisplayContext.getAPIURL()
 			).put(
-				"ffOneToOneRelationshipConfigurationEnabled", objectDefinitionsRelationshipsDisplayContext.isFFOneToOneRelationshipConfigurationEnabled()
+				"externalReferenceCode", objectDefinition.getExternalReferenceCode()
 			).put(
-				"objectDefinitionId", objectDefinition.getObjectDefinitionId()
+				"ffOneToOneRelationshipConfigurationEnabled", objectDefinitionsRelationshipsDisplayContext.isFFOneToOneRelationshipConfigurationEnabled()
 			).put(
 				"parameterRequired", objectDefinitionsRelationshipsDisplayContext.isParameterRequired(objectDefinition)
 			).build()

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/AggregationFormBase.d.ts
@@ -22,7 +22,9 @@ interface IAggregationSourcePropertyProps {
 	objectDefinitionId: number;
 	objectFieldSettings: ObjectFieldSetting[];
 	onAggregationFilterChange?: (aggregationFilterArray: []) => void;
-	onRelationshipChange?: (objectDefinitionId2: number) => void;
+	onRelationshipChange?: (
+		objectDefinitionExternalReferenceCode2: string
+	) => void;
 	setValues: (values: Partial<ObjectField>) => void;
 }
 export declare function AggregationFormBase({

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.d.ts
@@ -27,7 +27,9 @@ interface IProps {
 	objectName: string;
 	objectRelationshipId?: number;
 	onAggregationFilterChange?: (aggregationFilterArray: []) => void;
-	onRelationshipChange?: (objectDefinitionId2: number) => void;
+	onRelationshipChange?: (
+		objectDefinitionExternalReferenceCode2: string
+	) => void;
 	setValues: (values: Partial<ObjectField>) => void;
 }
 export declare type ObjectFieldErrors = FormError<

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.d.ts
@@ -17,12 +17,14 @@
 import {Observer} from '@clayui/modal/lib/types';
 export default function AddRelationship({
 	apiURL,
+	externalReferenceCode,
 	ffOneToOneRelationshipConfigurationEnabled,
 	objectDefinitionId,
 	parameterRequired,
 }: IProps): JSX.Element;
 interface IProps {
 	apiURL: string;
+	externalReferenceCode: string;
 	ffOneToOneRelationshipConfigurationEnabled: boolean;
 	objectDefinitionId: number;
 	observer: Observer;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.d.ts
@@ -16,13 +16,13 @@
 
 interface IProps {
 	error?: string;
-	objectDefinitionId?: number;
+	objectDefinitionExternalReferenceCode?: string;
 	onChange: (objectFieldId: number) => void;
 	value?: number;
 }
 export default function SelectRelationship({
 	error,
-	objectDefinitionId,
+	objectDefinitionExternalReferenceCode,
 	onChange,
 	value,
 	...otherProps

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectRelationship.d.ts
@@ -17,8 +17,8 @@
 interface IProps {
 	error?: string;
 	objectDefinitionExternalReferenceCode?: string;
-	onChange: (objectFieldId: number) => void;
-	value?: number;
+	onChange: (objectFieldName: string) => void;
+	value?: string;
 }
 export default function SelectRelationship({
 	error,


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-168865

**Summary:**
- Use objectDefinitionERC1 instead objectDefinitionId1;
- Use objectDefinitionERC2 instead objectDefinitionId2;
- Use parameterObjectFieldName instead parameterObjectFieldId;

All of these changes apply in ObjectRelationship Rest Layer/DTO and front end
