### PR TITLE
[TS] LPS-170099 Ensure there is a map available before trying to modify it

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryRelatedObjectsResourceImpl.java
@@ -154,6 +154,10 @@ public class ObjectEntryRelatedObjectsResourceImpl
 
 			Map<String, String> map = entry.getValue();
 
+			if (map == null) {
+				continue;
+			}
+
 			String href = map.get("href");
 
 			map.put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -538,6 +538,10 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 
 			Map<String, String> map = entry.getValue();
 
+			if (map == null) {
+				continue;
+			}
+
 			String href = map.get("href");
 
 			map.put(


### PR DESCRIPTION
When fetching a related object as a user with minimal permissions not all actions are available to them (eg Permissions, Update, Delete). Due to this the `map` might be null. This added check avoids an NPE when dealing with this situation and still allows the actions that the user can perform to be returned.

The full steps are quite long but can be viewed on https://issues.liferay.com/browse/LPS-170099

Please let me know if there are any questions or concerns.