### PR TITLE
[TECHNICAL SUPPORT] LPS-170195 No NotificationRecipient entries created during upgrade because of wrong column

### DIFF
--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/v3_0_0/util/NotificationRecipientTable.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/v3_0_0/util/NotificationRecipientTable.java
@@ -39,6 +39,6 @@ public class NotificationRecipientTable {
 	private static final String _TABLE_NAME = "NotificationRecipient";
 
 	private static final String _TABLE_SQL_CREATE =
-		"create table NotificationRecipient (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,notificationRecipientId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classPK LONG,className VARCHAR(75) null)";
+		"create table NotificationRecipient (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,notificationRecipientId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,classPK LONG,classNameId LONG)";
 
 }


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
[NotificationRecipientTable](https://github.com/liferay/liferay-portal/blob/master/modules/apps/notification/notification-api/src/main/java/com/liferay/notification/model/NotificationRecipientTable.java) creates the table with the className column.
This is incorrect because the NotificationRecipient model has a className**Id** field instead of className.
Because of this, the insert [statement](https://github.com/liferay/liferay-portal/blob/master/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/v3_0_0/NotificationRecipientUpgradeProcess.java#L63) in the upgrade process will fail due to the mismatching columns.

`java.sql.BatchUpdateException: Unknown column 'classNameId' in 'field list'`

No entries will be inserted into the NotificationRecipient table.

https://issues.liferay.com/browse/LPS-170195

Proposed Solution
========
I [switched](https://github.com/liferay-objects/liferay-portal/commit/c8a28dd207c6299d38a0122b979495c28c8a2fb0) className to classNameId in the create table statement in NotificationRecipientTable.java.
However, this will not solve the issue for users who have already upgraded.

Alternative Solutions
========
I considered adding an upgrade process that creates the NotificationRecipient entries after the fact, but because there is no data to establish the NotificationTemplate-NotificationRecipient-NotificationRecipientSetting connection, this is not possible.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.

Thank you and best regards,
István