### PR TITLE
LPS-171289 Fix parameter validation in Object Relationship using parameterObjectFieldName instead of ID

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
@@ -114,7 +114,7 @@ function ModalAddObjectRelationship({
 					{parameterRequired &&
 						values.type === ObjectRelationshipType.ONE_TO_MANY && (
 							<SelectRelationship
-								error={errors.parameterObjectFieldId}
+								error={errors.parameterObjectFieldName}
 								objectDefinitionExternalReferenceCode={
 									values.objectDefinitionExternalReferenceCode2 as string
 								}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditRelationship.tsx
@@ -134,7 +134,7 @@ export default function EditRelationship({
 						/>
 
 						<SelectRelationship
-							error={errors.parameterObjectFieldId}
+							error={errors.parameterObjectFieldName}
 							objectDefinitionExternalReferenceCode={
 								values.objectDefinitionExternalReferenceCode2 as string
 							}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -87,9 +87,9 @@ export function useObjectRelationshipForm({
 		if (
 			parameterRequired &&
 			relationship.type === ObjectRelationshipType.ONE_TO_MANY &&
-			!relationship.parameterObjectFieldId
+			!relationship.parameterObjectFieldName
 		) {
-			errors.parameterObjectFieldId = REQUIRED_MSG;
+			errors.parameterObjectFieldName = REQUIRED_MSG;
 		}
 
 		return errors;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -258,7 +258,6 @@ interface ObjectRelationship {
 	objectDefinitionId2: number;
 	readonly objectDefinitionName2: string;
 	objectRelationshipId: number;
-	parameterObjectFieldId?: number;
 	parameterObjectFieldName?: string;
 	reverse: boolean;
 	type: ObjectRelationshipType;


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-171289