### PR TITLE
LPS-171355 - Help text for attachment fields on objects is translated incorrectly

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -18146,7 +18146,7 @@ upload-a-logo-for-the-organization-pages-that-is-used-instead-of-the-default-ent
 upload-a-logo-for-the-private-pages-that-is-used-instead-of-the-default-enterprise-logo=Faça upload da logo para as páginas privadas que são usadas ao invés da logo padrão da empresa.
 upload-a-logo-for-the-public-pages-that-is-used-instead-of-the-default-enterprise-logo=Faça upload da logo para as páginas públicas que são usadas ao invés da logo padrão da empresa.
 upload-a-war-file-to-install-a-layout-template,-portlet,-or-theme=Faça upload de um arquivo WAR para instalar um layout template, portlet ou tema.
-upload-a-x-no-larger-than-x-mb=Envie um(a) {0} não maior do que {0} MB.
+upload-a-x-no-larger-than-x-mb=Envie um(a) {0} não maior do que {1} MB.
 upload-another-file=Fazer o upload de outro arquivo
 upload-certificate=Carregar Certificado
 upload-completed=Upload completo


### PR DESCRIPTION
[LPS-171355](https://issues.liferay.com/browse/LPS-171355)