### PR TITLE
LPS-171435 Translation on System Fields is not working with the auto generated view

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
@@ -103,11 +103,13 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 
 				if ((objectField == null) || objectField.isSystem()) {
 					_addNonbjectField(
-						fdsTableSchemaBuilder, label,
+						fdsTableSchemaBuilder, _filterLabel(label),
 						objectViewColumn.getObjectFieldName());
 				}
 				else {
-					_addObjectField(fdsTableSchemaBuilder, label, objectField);
+					_addObjectField(
+						fdsTableSchemaBuilder,
+						objectField.getLabel(locale, true), objectField);
 				}
 			}
 		);
@@ -118,26 +120,54 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 	private void _addAllObjectFields(
 		FDSTableSchemaBuilder fdsTableSchemaBuilder, Locale locale) {
 
-		if (_objectDefinition.isDefaultStorageType()) {
-			_addNonbjectField(fdsTableSchemaBuilder, "id", "id");
-		}
-		else {
-			_addNonbjectField(
-				fdsTableSchemaBuilder, "externalReferenceCode",
-				"externalReferenceCode");
-		}
-
 		List<ObjectField> objectFields =
 			_objectFieldLocalService.getObjectFields(
 				_objectDefinition.getObjectDefinitionId());
+
+		String objectFieldId = null;
+		String objectFieldERC = null;
+		String objectFieldCreator = null;
+		String objectFieldStatus = null;
+
+		for (ObjectField objectField : objectFields) {
+			if (Objects.equals(objectField.getName(), "id")) {
+				objectFieldId = _filterLabel(
+					objectField.getLabel(locale, true));
+			}
+
+			if (Objects.equals(
+					objectField.getName(), "externalReferenceCode")) {
+
+				objectFieldERC = _filterLabel(
+					objectField.getLabel(locale, true));
+			}
+
+			if (Objects.equals(objectField.getName(), "creator")) {
+				objectFieldCreator = _filterLabel(
+					objectField.getLabel(locale, true));
+			}
+
+			if (Objects.equals(objectField.getName(), "status")) {
+				objectFieldStatus = _filterLabel(
+					objectField.getLabel(locale, true));
+			}
+		}
+
+		if (_objectDefinition.isDefaultStorageType()) {
+			_addNonbjectField(fdsTableSchemaBuilder, objectFieldId, "id");
+		}
+		else {
+			_addNonbjectField(
+				fdsTableSchemaBuilder, objectFieldERC, "externalReferenceCode");
+		}
 
 		objectFields.forEach(
 			objectField -> _addObjectField(
 				fdsTableSchemaBuilder, objectField.getLabel(locale, true),
 				objectField));
 
-		_addNonbjectField(fdsTableSchemaBuilder, "status", "status");
-		_addNonbjectField(fdsTableSchemaBuilder, "author", "creator");
+		_addNonbjectField(fdsTableSchemaBuilder, objectFieldStatus, "status");
+		_addNonbjectField(fdsTableSchemaBuilder, objectFieldCreator, "creator");
 	}
 
 	private void _addFDSTableSchemaField(
@@ -311,6 +341,34 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 					label, false, false);
 			}
 		}
+	}
+
+	private String _filterLabel(String label) {
+		if (label.equals("Id")) {
+			label = "id";
+		}
+
+		if (label.equals("External Reference Code")) {
+			label = "external-reference-code";
+		}
+
+		if (label.equals("Author")) {
+			label = "author";
+		}
+
+		if (label.equals("Status")) {
+			label = "status";
+		}
+
+		if (label.equals("Create Date")) {
+			label = "create-date";
+		}
+
+		if (label.equals("Modified Date")) {
+			label = "modified-date";
+		}
+
+		return label;
 	}
 
 	private String _getContentRenderer(String fieldName) {


### PR DESCRIPTION
[LPS-171435](https://issues.liferay.com/browse/LPS-171435)

**Description:**
Custom translation on System Fields is not working with the auto-generated view and when changed to a custom view, only custom translations are working.


**Proposed solution:**

**For the first case(auto-generated view):** the issue is that when the `_addAllObjectFields` method is called, it only sets the _Label Key_ as the `fieldLabel`, so when a custom translation is set the method ignores it. The solution found for this case was to add a method(`_filterLabel`) that filters the _Label_ and if it matches a _System Field_, it returns its _label key_ and return the original _Label_ if it doesn't. This method was added to a loop to check each `objectField.getName()` and assign it to the appropriate local variable that will be added as the `fieldLabel` in each `_addNonbjectField` calls.

**For the second case(custom view):** the issue for this case is the other way around. When the `getFDSTableSchema` method is called, it only sets the `objectField.getLabel()` as the `fieldLabel`, so when a _System Field_ is set, it won't get its _Label Key_ and therefore, won't translate it if it's not a custom translation. The solution for this case was to use the same `_filterLabel` method to filter the `label` parameter so it returns the _Label Key_ if that's the case.