### PR TITLE
LPS-170159 Replace PUT request with PATCH request

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/form.jsp
@@ -86,14 +86,13 @@ portletDisplay.setURLBack(backURL);
 
 			const postPath = scope === 'site' ? pathScopedBySite : contextPath;
 
-			let putPath = scope === 'site' ? pathScopedBySite : contextPath;
+			let patchPath = scope === 'site' ? pathScopedBySite : contextPath;
 
-			putPath = putPath.concat(
-				'/by-external-reference-code/',
-				`\${externalReferenceCode}`
+			patchPath = patchPath.concat(
+				'/<%= (objectEntry == null) ? "" : objectEntry.getId() %>'
 			);
 
-			return externalReferenceCode ? putPath : postPath;
+			return externalReferenceCode ? patchPath : postPath;
 		}
 
 		function <portlet:namespace />getValues(fields) {
@@ -191,7 +190,7 @@ portletDisplay.setURLBack(backURL);
 									'Accept': 'application/json',
 									'Content-Type': 'application/json',
 								}),
-								method: externalReferenceCode ? 'PUT' : 'POST',
+								method: externalReferenceCode ? 'PATCH' : 'POST',
 							})
 								.then((response) => {
 									if (response.status === 401) {


### PR DESCRIPTION
[LPS-170159](https://issues.liferay.com/browse/LPS-170159)

The bug is happening because the client in making a PUT request passing only partial data on the object entry (because each tab has its own form element). Since the PUT endpoint requires the whole resource (at least with all mandatory fields), the request fails.
The proposed solution is to make a PATCH request instead, since it supports partial data from the client on the resource to be updated.