### PR TITLE
LPS-171815 Replace toString method with the null safe alternative: String.valueOf

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/SystemRelatedModelsTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/SystemRelatedModelsTableFDSView.java
@@ -168,7 +168,7 @@ public class SystemRelatedModelsTableFDSView
 					GetterUtil.getLong(
 						modelAttributes.get(
 							objectDefinition.getPKObjectFieldDBColumnName())),
-					value.toString(), true);
+					String.valueOf(value), true);
 			});
 	}
 


### PR DESCRIPTION
[LPS-171815](https://issues.liferay.com/browse/LPS-171815) 
Currently, because of the problem involving [LPS-171844](https://issues.liferay.com/browse/LPS-171844), the `value` variable is null by the end of the method. 
Since no null-checking was done, calling `toString` was resulting in a `NullPointerException` and the server was returning 404 status.
Obs.: apparently the client is not handling this error properly, as it just displays the loading symbol.

The proposed solution is to replace the `toString` method with the null safe `String.valueOf` method.

(edited)