### PR TITLE
LPS-173061 Use parentheses when anding/oring two expressions together so that they get parsed the same way as the OData filter had them

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -465,10 +465,14 @@ public class PredicateExpressionVisitorImpl
 		Predicate predicate = null;
 
 		if (Objects.equals(BinaryExpression.Operation.AND, operation)) {
-			predicate = Predicate.and((Predicate)left, (Predicate)right);
+			predicate = Predicate.and(
+				Predicate.withParentheses((Predicate)left),
+				Predicate.withParentheses((Predicate)right));
 		}
 		else if (Objects.equals(BinaryExpression.Operation.OR, operation)) {
-			predicate = Predicate.or((Predicate)left, (Predicate)right);
+			predicate = Predicate.or(
+				Predicate.withParentheses((Predicate)left),
+				Predicate.withParentheses((Predicate)right));
 		}
 		else {
 			ObjectField objectField = _objectFieldLocalService.fetchObjectField(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -1237,6 +1237,24 @@ public class DefaultObjectEntryManagerImplTest {
 				"sort", "textObjectFieldName:desc"
 			).build(),
 			childObjectEntry2, childObjectEntry1);
+
+		// And/Or with Parentheses
+
+		_testGetObjectEntries(
+			HashMapBuilder.put(
+				"filter",
+				StringBundler.concat(
+					_buildEqualsExpressionFilterString(
+						"picklistObjectFieldName", picklistObjectFieldValue1),
+					" and (",
+					_buildEqualsExpressionFilterString(
+						"picklistObjectFieldName", picklistObjectFieldValue1),
+					" or ",
+					_buildEqualsExpressionFilterString(
+						"picklistObjectFieldName", picklistObjectFieldValue2),
+					")")
+			).build(),
+			childObjectEntry1);
 	}
 
 	@Test


### PR DESCRIPTION
Ticket: [LPS-173061](https://issues.liferay.com/browse/LPS-173061)

I think we really probably only need to use `withParentheses` on the right-hand expression, but using it on both shouldn't hurt and looks cleaner.