### PR TITLE
LPS-174182 Adjust the SalesforceObjectEntryManagerImpl class to consider the ERC field of the ListTypeEntry entity

### DIFF
--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -475,7 +475,12 @@ public class SalesforceObjectEntryManagerImpl
 
 				Map<String, String> valueMap = (HashMap<String, String>)value;
 
-				value = valueMap.get("key");
+				ListTypeEntry listTypeEntry =
+					_listTypeEntryLocalService.getListTypeEntry(
+						objectField.getListTypeDefinitionId(),
+						valueMap.get("key"));
+
+				value = listTypeEntry.getExternalReferenceCode();
 			}
 
 			map.put(


### PR DESCRIPTION
Ticket Related: [LPS-174182](https://issues.liferay.com/browse/LPS-174182)

Updating SalesForce Proxy for the usage of externalReferenceCodes in Picklist entries