### PR TITLE
LPS-176135 Keep the ddmFormValues order

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
@@ -361,7 +362,14 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		Fields fields = _toFields(ddmStructure, ddmFormValues);
 
-		for (Field field : fields) {
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(true);
+
+		for (Map.Entry<String, List<DDMFormFieldValue>> entry :
+				ddmFormFieldValuesMap.entrySet()) {
+
+			Field field = fields.get(entry.getKey());
+
 			try {
 				String indexType = ddmStructure.getFieldProperty(
 					field.getName(), "indexType");


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-176135

Hi Team,

could you please review my fix?

**Reproduction Steps**

1. Setup Liferaybundle
2. Go to the Search page > Search portlet > Configuration
    Check Display Results in Document Form > Save
3. Create a structure
4. Add 3 text fields to it
   From top to bottom set the fieldname/field reference to Field1, Field2, Field3
   Click on Save
5. Start creating a web content with the structure, title: TestWebContent
6. content of Field1: Heading
7. content of Field2: Subheading
8. leave the last field empty
9. Click on Publish
10. Go to the Home page
11. Enter test in the search field > Enter
12. Assert that TestWebContent appears on the top
13. Click on the Details link
14. Check the content of the content_en_US key

**Expected Behavior** The order is Heading Subheading.
**Actual Behavior** The order is Subheading Heading.

**Fix**

Instead of iterate the Fields map iterate on the DDMFormValues 

Thanks, Roland

https://issues.liferay.com/browse/LPS-176135