### PR TITLE
LPS-175974 Use notificationTemplateExternalReferenceCode instead of notificationTemplateId on the frontend, since that's what the backend now expects

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/ThenContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/ThenContainer.tsx
@@ -72,12 +72,14 @@ export function ThenContainer({
 	const [objectsOptions, setObjectOptions] = useState<ObjectsOptionsList>([]);
 
 	const [notificationTemplates, setNotificationTemplates] = useState<
-		CustomItem<number>[]
+		CustomItem<string>[]
 	>([]);
 
 	const notificationTemplateLabel = useMemo(() => {
 		return notificationTemplates.find(
-			({value}) => value === values.parameters?.notificationTemplateId
+			({value}) =>
+				value ===
+				values.parameters?.notificationTemplateExternalReferenceCode
 		)?.label;
 	}, [notificationTemplates, values.parameters]);
 
@@ -106,11 +108,13 @@ export function ThenContainer({
 				}
 
 				setNotificationTemplates(
-					notificationArray.map(({id, name, type}) => ({
-						label: name,
-						type,
-						value: id,
-					}))
+					notificationArray.map(
+						({externalReferenceCode, name, type}) => ({
+							label: name,
+							type,
+							value: externalReferenceCode,
+						})
+					)
 				);
 			};
 
@@ -235,14 +239,14 @@ export function ThenContainer({
 				)}
 
 				{values.objectActionExecutorKey === 'notification' && (
-					<SingleSelect<CustomItem<number>>
+					<SingleSelect<CustomItem<string>>
 						className="lfr-object__action-builder-notification-then"
 						error={errors.objectActionExecutorKey}
 						onChange={({value}) => {
 							setValues({
 								parameters: {
 									...values.parameters,
-									notificationTemplateId: value,
+									notificationTemplateExternalReferenceCode: value,
 								},
 							});
 						}}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -21,6 +21,7 @@ type NotificationTemplate = {
 	body: LocalizedValue<string>;
 	cc: string;
 	description: string;
+	externalReferenceCode: string;
 	from: string;
 	fromName: LocalizedValue<string>;
 	id: number;
@@ -49,6 +50,7 @@ interface ObjectAction {
 
 interface ObjectActionParameters {
 	lineCount?: number;
+	notificationTemplateExternalReferenceCode?: string;
 	notificationTemplateId?: number;
 	objectDefinitionExternalReferenceCode?: string;
 	objectDefinitionId?: number;


### PR DESCRIPTION
Ticket: [LPS-175974](https://issues.liferay.com/browse/LPS-175974)

Finishes the work on [LPS-169369](https://issues.liferay.com/browse/LPS-169369), which was incomplete because we did not update the frontend to also use externalReferenceCode...