### PR TITLE
LPS-176408 Adds one to many and many to many info collection providers for objects

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 57.0.2
+Bundle-Version: 57.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -15,6 +15,7 @@
 package com.liferay.object.service;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
@@ -373,6 +374,9 @@ public interface ObjectRelationshipLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
+
+	public void registerObjectRelationshipsRelatedInfoCollectionProviders(
+		ObjectDefinition objectDefinition);
 
 	@Indexable(type = IndexableType.REINDEX)
 	public ObjectRelationship updateObjectRelationship(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -465,6 +465,14 @@ public class ObjectRelationshipLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static void
+		registerObjectRelationshipsRelatedInfoCollectionProviders(
+			com.liferay.object.model.ObjectDefinition objectDefinition) {
+
+		getService().registerObjectRelationshipsRelatedInfoCollectionProviders(
+			objectDefinition);
+	}
+
 	public static ObjectRelationship updateObjectRelationship(
 			long objectRelationshipId, long parameterObjectFieldId,
 			String deletionType, Map<java.util.Locale, String> labelMap)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -539,6 +539,15 @@ public class ObjectRelationshipLocalServiceWrapper
 	}
 
 	@Override
+	public void registerObjectRelationshipsRelatedInfoCollectionProviders(
+		com.liferay.object.model.ObjectDefinition objectDefinition) {
+
+		_objectRelationshipLocalService.
+			registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectRelationship updateObjectRelationship(
 			long objectRelationshipId, long parameterObjectFieldId,
 			String deletionType,

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 37.2.0
+version 37.3.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -413,6 +413,30 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 								"item.class.name",
 								objectDefinition.getClassName()
 							).build()));
+
+					ObjectRelationship reverseObjectRelationship =
+						_objectRelationshipLocalService.getObjectRelationship(
+							objectRelationship.getObjectDefinitionId2(),
+							objectRelationship.getName());
+
+					ObjectDefinition objectDefinition2 =
+						_objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId2());
+
+					serviceRegistrations.add(
+						_bundleContext.registerService(
+							RelatedInfoItemCollectionProvider.class,
+							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+								objectDefinition2,
+								_objectDefinitionLocalService,
+								_objectEntryLocalService,
+								reverseObjectRelationship),
+							HashMapDictionaryBuilder.<String, Object>put(
+								"company.id", objectDefinition2.getCompanyId()
+							).put(
+								"item.class.name",
+								objectDefinition2.getClassName()
+							).build()));
 				}
 				else if (Objects.equals(
 							objectRelationship.getType(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -401,31 +401,35 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						objectRelationship.getType(),
 						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
-					_bundleContext.registerService(
-						RelatedInfoItemCollectionProvider.class,
-						new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-							objectDefinition, _objectDefinitionLocalService,
-							_objectEntryLocalService, objectRelationship),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"company.id", objectDefinition.getCompanyId()
-						).put(
-							"item.class.name", objectDefinition.getClassName()
-						).build());
+					serviceRegistrations.add(
+						_bundleContext.registerService(
+							RelatedInfoItemCollectionProvider.class,
+							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+								objectDefinition, _objectDefinitionLocalService,
+								_objectEntryLocalService, objectRelationship),
+							HashMapDictionaryBuilder.<String, Object>put(
+								"company.id", objectDefinition.getCompanyId()
+							).put(
+								"item.class.name",
+								objectDefinition.getClassName()
+							).build()));
 				}
 				else if (Objects.equals(
 							objectRelationship.getType(),
 							ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-					_bundleContext.registerService(
-						RelatedInfoItemCollectionProvider.class,
-						new OneToManyObjectRelationshipRelatedInfoCollectionProvider(
-							objectDefinition, _objectDefinitionLocalService,
-							_objectEntryLocalService, objectRelationship),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"company.id", objectDefinition.getCompanyId()
-						).put(
-							"item.class.name", objectDefinition.getClassName()
-						).build());
+					serviceRegistrations.add(
+						_bundleContext.registerService(
+							RelatedInfoItemCollectionProvider.class,
+							new OneToManyObjectRelationshipRelatedInfoCollectionProvider(
+								objectDefinition, _objectDefinitionLocalService,
+								_objectEntryLocalService, objectRelationship),
+							HashMapDictionaryBuilder.<String, Object>put(
+								"company.id", objectDefinition.getCompanyId()
+							).put(
+								"item.class.name",
+								objectDefinition.getClassName()
+							).build()));
 				}
 			}
 			catch (PortalException portalException) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -399,8 +399,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			try {
 				if (Objects.equals(
 						objectRelationship.getType(),
-						ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
-					!objectRelationship.isReverse()) {
+						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
 					_bundleContext.registerService(
 						RelatedInfoItemCollectionProvider.class,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -20,15 +20,11 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
-import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.notification.handler.NotificationHandler;
 import com.liferay.notification.term.evaluator.NotificationTermEvaluator;
-import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
-import com.liferay.object.internal.info.collection.provider.ManyToManyObjectRelationshipRelatedInfoCollectionProvider;
 import com.liferay.object.internal.info.collection.provider.ObjectEntrySingleFormVariationInfoCollectionProvider;
-import com.liferay.object.internal.info.collection.provider.OneToManyObjectRelationshipRelatedInfoCollectionProvider;
 import com.liferay.object.internal.notification.handler.ObjectDefinitionNotificationHandler;
 import com.liferay.object.internal.notification.term.contributor.ObjectDefinitionNotificationTermEvaluator;
 import com.liferay.object.internal.persistence.ObjectDefinitionTableArgumentsResolver;
@@ -49,7 +45,6 @@ import com.liferay.object.internal.security.permission.resource.util.ObjectDefin
 import com.liferay.object.internal.workflow.ObjectEntryWorkflowHandler;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectLayout;
-import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.rest.context.path.RESTContextPathResolver;
@@ -68,8 +63,6 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.ArgumentsResolver;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
@@ -96,7 +89,6 @@ import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -391,75 +383,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					objectDefinition, objectLayout.getObjectLayoutTabs());
 		}
 
-		List<ObjectRelationship> objectRelationships =
-			_objectRelationshipLocalService.getObjectRelationships(
-				objectDefinition.getObjectDefinitionId());
-
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			try {
-				if (Objects.equals(
-						objectRelationship.getType(),
-						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
-
-					serviceRegistrations.add(
-						_bundleContext.registerService(
-							RelatedInfoItemCollectionProvider.class,
-							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-								objectDefinition, _objectDefinitionLocalService,
-								_objectEntryLocalService, objectRelationship),
-							HashMapDictionaryBuilder.<String, Object>put(
-								"company.id", objectDefinition.getCompanyId()
-							).put(
-								"item.class.name",
-								objectDefinition.getClassName()
-							).build()));
-
-					ObjectRelationship reverseObjectRelationship =
-						_objectRelationshipLocalService.getObjectRelationship(
-							objectRelationship.getObjectDefinitionId2(),
-							objectRelationship.getName());
-
-					ObjectDefinition objectDefinition2 =
-						_objectDefinitionLocalService.getObjectDefinition(
-							objectRelationship.getObjectDefinitionId2());
-
-					serviceRegistrations.add(
-						_bundleContext.registerService(
-							RelatedInfoItemCollectionProvider.class,
-							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-								objectDefinition2,
-								_objectDefinitionLocalService,
-								_objectEntryLocalService,
-								reverseObjectRelationship),
-							HashMapDictionaryBuilder.<String, Object>put(
-								"company.id", objectDefinition2.getCompanyId()
-							).put(
-								"item.class.name",
-								objectDefinition2.getClassName()
-							).build()));
-				}
-				else if (Objects.equals(
-							objectRelationship.getType(),
-							ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
-
-					serviceRegistrations.add(
-						_bundleContext.registerService(
-							RelatedInfoItemCollectionProvider.class,
-							new OneToManyObjectRelationshipRelatedInfoCollectionProvider(
-								objectDefinition, _objectDefinitionLocalService,
-								_objectEntryLocalService, objectRelationship),
-							HashMapDictionaryBuilder.<String, Object>put(
-								"company.id", objectDefinition.getCompanyId()
-							).put(
-								"item.class.name",
-								objectDefinition.getClassName()
-							).build()));
-				}
-			}
-			catch (PortalException portalException) {
-				_log.error(portalException);
-			}
-		}
+		_objectRelationshipLocalService.
+			registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition);
 
 		return serviceRegistrations;
 	}
@@ -477,9 +403,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_persistedModelLocalServiceRegistry.unregister(
 			objectDefinition.getClassName());
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ObjectDefinitionDeployerImpl.class);
 
 	private final AccountEntryLocalService _accountEntryLocalService;
 	private final AccountEntryOrganizationRelLocalService

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -359,51 +359,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				"item.class.name", objectDefinition.getClassName()
 			).build());
 
-		List<ObjectRelationship> objectRelationships =
-			_objectRelationshipLocalService.getObjectRelationships(
-				objectDefinition.getObjectDefinitionId());
-
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			try {
-				if (Objects.equals(
-						objectRelationship.getType(),
-						ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
-					!objectRelationship.isReverse()) {
-
-					_bundleContext.registerService(
-						RelatedInfoItemCollectionProvider.class,
-						new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-							objectDefinition, objectRelationship,
-							_objectDefinitionLocalService,
-							_objectEntryLocalService),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"company.id", objectDefinition.getCompanyId()
-						).put(
-							"item.class.name", objectDefinition.getClassName()
-						).build());
-				}
-				else if (Objects.equals(
-							objectRelationship.getType(),
-							ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
-
-					_bundleContext.registerService(
-						RelatedInfoItemCollectionProvider.class,
-						new OneToManyObjectRelationshipRelatedInfoCollectionProvider(
-							objectDefinition, objectRelationship,
-							_objectDefinitionLocalService,
-							_objectEntryLocalService),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"company.id", objectDefinition.getCompanyId()
-						).put(
-							"item.class.name", objectDefinition.getClassName()
-						).build());
-				}
-			}
-			catch (PortalException portalException) {
-				_log.error(portalException);
-			}
-		}
-
 		try {
 			for (Locale locale : LanguageUtil.getAvailableLocales()) {
 				String languageId = LocaleUtil.toLanguageId(locale);
@@ -434,6 +389,49 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_objectLayoutTabLocalService.
 				registerObjectLayoutTabScreenNavigationCategories(
 					objectDefinition, objectLayout.getObjectLayoutTabs());
+		}
+
+		List<ObjectRelationship> objectRelationships =
+			_objectRelationshipLocalService.getObjectRelationships(
+				objectDefinition.getObjectDefinitionId());
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			try {
+				if (Objects.equals(
+						objectRelationship.getType(),
+						ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
+					!objectRelationship.isReverse()) {
+
+					_bundleContext.registerService(
+						RelatedInfoItemCollectionProvider.class,
+						new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+							objectDefinition, _objectDefinitionLocalService,
+							_objectEntryLocalService, objectRelationship),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"company.id", objectDefinition.getCompanyId()
+						).put(
+							"item.class.name", objectDefinition.getClassName()
+						).build());
+				}
+				else if (Objects.equals(
+							objectRelationship.getType(),
+							ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+					_bundleContext.registerService(
+						RelatedInfoItemCollectionProvider.class,
+						new OneToManyObjectRelationshipRelatedInfoCollectionProvider(
+							objectDefinition, _objectDefinitionLocalService,
+							_objectEntryLocalService, objectRelationship),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"company.id", objectDefinition.getCompanyId()
+						).put(
+							"item.class.name", objectDefinition.getClassName()
+						).build());
+				}
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
+			}
 		}
 
 		return serviceRegistrations;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.info.collection.provider;
+
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.util.Collections;
+import java.util.Locale;
+
+/**
+ * @author Feliphe Marinho
+ */
+public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
+	implements RelatedInfoItemCollectionProvider {
+
+	public BaseObjectRelationshipRelatedInfoCollectionProvider(
+			ObjectDefinition objectDefinition,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectRelationship objectRelationship)
+		throws PortalException {
+
+		this.objectEntryLocalService = objectEntryLocalService;
+		this.objectRelationship = objectRelationship;
+
+		_objectDefinition = objectDefinition;
+
+		_relatedObjectDefinition =
+			objectDefinitionLocalService.getObjectDefinition(
+				this.objectRelationship.getObjectDefinitionId2());
+	}
+
+	@Override
+	public InfoPage<ObjectEntry> getCollectionInfoPage(
+		CollectionQuery collectionQuery) {
+
+		Object relatedItem = collectionQuery.getRelatedItem();
+
+		if (!(relatedItem instanceof ObjectEntry)) {
+			return InfoPage.of(
+				Collections.emptyList(), collectionQuery.getPagination(), 0);
+		}
+
+		try {
+			return getCollectionInfoPage(
+				(ObjectEntry)relatedItem, collectionQuery.getPagination());
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return InfoPage.of(
+			Collections.emptyList(), collectionQuery.getPagination(), 0);
+	}
+
+	@Override
+	public String getCollectionItemClassName() {
+		return _relatedObjectDefinition.getClassName();
+	}
+
+	@Override
+	public String getKey() {
+		return StringBundler.concat(
+			RelatedInfoItemCollectionProvider.super.getKey(), "_",
+			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
+			"_", objectRelationship.getName());
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _relatedObjectDefinition.getLabel(locale);
+	}
+
+	@Override
+	public String getSourceItemClassName() {
+		return _objectDefinition.getClassName();
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-176083") ||
+			(_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	protected InfoPage<ObjectEntry> getCollectionInfoPage(
+			ObjectEntry objectEntry, Pagination pagination)
+		throws PortalException {
+
+		return null;
+	}
+
+	protected final ObjectEntryLocalService objectEntryLocalService;
+	protected final ObjectRelationship objectRelationship;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseObjectRelationshipRelatedInfoCollectionProvider.class);
+
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinition _relatedObjectDefinition;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -14,8 +14,6 @@
 
 package com.liferay.object.internal.info.collection.provider;
 
-import com.liferay.info.collection.provider.CollectionQuery;
-import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.info.pagination.InfoPage;
 import com.liferay.info.pagination.Pagination;
 import com.liferay.object.model.ObjectDefinition;
@@ -23,21 +21,13 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-
-import java.util.Collections;
-import java.util.Locale;
 
 /**
  * @author Jürgen Kappler
  */
 public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
-	implements RelatedInfoItemCollectionProvider {
+	extends BaseObjectRelationshipRelatedInfoCollectionProvider {
 
 	public ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
 			ObjectDefinition objectDefinition,
@@ -46,94 +36,29 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 			ObjectEntryLocalService objectEntryLocalService)
 		throws PortalException {
 
-		_objectDefinition = objectDefinition;
-		_objectRelationship = objectRelationship;
-		_objectEntryLocalService = objectEntryLocalService;
-
-		_relatedObjectDefinition =
-			objectDefinitionLocalService.getObjectDefinition(
-				_objectRelationship.getObjectDefinitionId2());
+		super(
+			objectDefinition, objectDefinitionLocalService,
+			objectEntryLocalService, objectRelationship);
 	}
 
 	@Override
-	public InfoPage<ObjectEntry> getCollectionInfoPage(
-		CollectionQuery collectionQuery) {
-
-		Object relatedItem = collectionQuery.getRelatedItem();
-
-		if (!(relatedItem instanceof ObjectEntry)) {
-			return InfoPage.of(
-				Collections.emptyList(), collectionQuery.getPagination(), 0);
-		}
-
-		ObjectEntry objectEntry = (ObjectEntry)relatedItem;
-
-		Pagination pagination = collectionQuery.getPagination();
-
-		try {
-			return InfoPage.of(
-				_objectEntryLocalService.getManyToManyObjectEntries(
-					objectEntry.getGroupId(),
-					_objectRelationship.getObjectRelationshipId(),
-					objectEntry.getObjectEntryId(), true,
-					_objectRelationship.isReverse(), pagination.getStart(),
-					pagination.getEnd()),
-				collectionQuery.getPagination(),
-				_objectEntryLocalService.getManyToManyObjectEntriesCount(
-					objectEntry.getGroupId(),
-					_objectRelationship.getObjectRelationshipId(),
-					objectEntry.getObjectEntryId(), true,
-					_objectRelationship.isReverse()));
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
+	protected InfoPage<ObjectEntry> getCollectionInfoPage(
+			ObjectEntry objectEntry, Pagination pagination)
+		throws PortalException {
 
 		return InfoPage.of(
-			Collections.emptyList(), collectionQuery.getPagination(), 0);
+			objectEntryLocalService.getManyToManyObjectEntries(
+				objectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				objectEntry.getObjectEntryId(), true,
+				objectRelationship.isReverse(), pagination.getStart(),
+				pagination.getEnd()),
+			pagination,
+			objectEntryLocalService.getManyToManyObjectEntriesCount(
+				objectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				objectEntry.getObjectEntryId(), true,
+				objectRelationship.isReverse()));
 	}
-
-	@Override
-	public String getCollectionItemClassName() {
-		return _relatedObjectDefinition.getClassName();
-	}
-
-	@Override
-	public String getKey() {
-		return StringBundler.concat(
-			RelatedInfoItemCollectionProvider.super.getKey(), "_",
-			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
-			"_", _objectRelationship.getName());
-	}
-
-	@Override
-	public String getLabel(Locale locale) {
-		return _relatedObjectDefinition.getPluralLabel(locale);
-	}
-
-	@Override
-	public String getSourceItemClassName() {
-		return _objectDefinition.getClassName();
-	}
-
-	@Override
-	public boolean isAvailable() {
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-176083") ||
-			(_objectDefinition.getCompanyId() !=
-				CompanyThreadLocal.getCompanyId())) {
-
-			return false;
-		}
-
-		return true;
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ManyToManyObjectRelationshipRelatedInfoCollectionProvider.class);
-
-	private final ObjectDefinition _objectDefinition;
-	private final ObjectEntryLocalService _objectEntryLocalService;
-	private final ObjectRelationship _objectRelationship;
-	private final ObjectDefinition _relatedObjectDefinition;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -103,8 +103,7 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 		return StringBundler.concat(
 			RelatedInfoItemCollectionProvider.super.getKey(), "_",
 			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
-			"_", _relatedObjectDefinition.getName(), "_",
-			_objectRelationship.getType());
+			"_", _objectRelationship.getName());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -31,9 +31,9 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	public ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
 			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship,
 			ObjectDefinitionLocalService objectDefinitionLocalService,
-			ObjectEntryLocalService objectEntryLocalService)
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectRelationship objectRelationship)
 		throws PortalException {
 
 		super(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -25,11 +25,10 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -120,7 +119,7 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	public boolean isAvailable() {
-		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-176083")) ||
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-176083") ||
 			(_objectDefinition.getCompanyId() !=
 				CompanyThreadLocal.getCompanyId())) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -118,8 +120,9 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	public boolean isAvailable() {
-		if (_objectDefinition.getCompanyId() !=
-				CompanyThreadLocal.getCompanyId()) {
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-176083")) ||
+			(_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId())) {
 
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.info.collection.provider;
+
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.util.Collections;
+import java.util.Locale;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
+	implements RelatedInfoItemCollectionProvider {
+
+	public ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+			ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryLocalService objectEntryLocalService)
+		throws PortalException {
+
+		_objectDefinition = objectDefinition;
+		_objectRelationship = objectRelationship;
+		_objectEntryLocalService = objectEntryLocalService;
+
+		_relatedObjectDefinition =
+			objectDefinitionLocalService.getObjectDefinition(
+				_objectRelationship.getObjectDefinitionId2());
+	}
+
+	@Override
+	public InfoPage<ObjectEntry> getCollectionInfoPage(
+		CollectionQuery collectionQuery) {
+
+		Object relatedItem = collectionQuery.getRelatedItem();
+
+		if (!(relatedItem instanceof ObjectEntry)) {
+			return InfoPage.of(
+				Collections.emptyList(), collectionQuery.getPagination(), 0);
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)relatedItem;
+
+		Pagination pagination = collectionQuery.getPagination();
+
+		try {
+			return InfoPage.of(
+				_objectEntryLocalService.getManyToManyObjectEntries(
+					objectEntry.getGroupId(),
+					_objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(), true,
+					_objectRelationship.isReverse(), pagination.getStart(),
+					pagination.getEnd()),
+				collectionQuery.getPagination(),
+				_objectEntryLocalService.getManyToManyObjectEntriesCount(
+					objectEntry.getGroupId(),
+					_objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(), true,
+					_objectRelationship.isReverse()));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return InfoPage.of(
+			Collections.emptyList(), collectionQuery.getPagination(), 0);
+	}
+
+	@Override
+	public String getCollectionItemClassName() {
+		return _relatedObjectDefinition.getClassName();
+	}
+
+	@Override
+	public String getKey() {
+		return StringBundler.concat(
+			RelatedInfoItemCollectionProvider.super.getKey(), "_",
+			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
+			"_", _relatedObjectDefinition.getName(), "_",
+			_objectRelationship.getType());
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _relatedObjectDefinition.getPluralLabel(locale);
+	}
+
+	@Override
+	public String getSourceItemClassName() {
+		return _objectDefinition.getClassName();
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId()) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ManyToManyObjectRelationshipRelatedInfoCollectionProvider.class);
+
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final ObjectRelationship _objectRelationship;
+	private final ObjectDefinition _relatedObjectDefinition;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -28,6 +28,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -116,8 +118,9 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	public boolean isAvailable() {
-		if (_objectDefinition.getCompanyId() !=
-				CompanyThreadLocal.getCompanyId()) {
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-176083")) ||
+			(_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId())) {
 
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.info.collection.provider;
+
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+
+import java.util.Collections;
+import java.util.Locale;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
+	implements RelatedInfoItemCollectionProvider {
+
+	public OneToManyObjectRelationshipRelatedInfoCollectionProvider(
+			ObjectDefinition objectDefinition,
+			ObjectRelationship objectRelationship,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryLocalService objectEntryLocalService)
+		throws PortalException {
+
+		_objectDefinition = objectDefinition;
+		_objectRelationship = objectRelationship;
+		_objectEntryLocalService = objectEntryLocalService;
+
+		_relatedObjectDefinition =
+			objectDefinitionLocalService.getObjectDefinition(
+				_objectRelationship.getObjectDefinitionId2());
+	}
+
+	@Override
+	public InfoPage<ObjectEntry> getCollectionInfoPage(
+		CollectionQuery collectionQuery) {
+
+		Object relatedItem = collectionQuery.getRelatedItem();
+
+		if (!(relatedItem instanceof ObjectEntry)) {
+			return InfoPage.of(
+				Collections.emptyList(), collectionQuery.getPagination(), 0);
+		}
+
+		ObjectEntry objectEntry = (ObjectEntry)relatedItem;
+
+		Pagination pagination = collectionQuery.getPagination();
+
+		try {
+			return InfoPage.of(
+				_objectEntryLocalService.getOneToManyObjectEntries(
+					objectEntry.getGroupId(),
+					_objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(), true, pagination.getStart(),
+					pagination.getEnd()),
+				collectionQuery.getPagination(),
+				_objectEntryLocalService.getOneToManyObjectEntriesCount(
+					objectEntry.getGroupId(),
+					_objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(), true));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return InfoPage.of(
+			Collections.emptyList(), collectionQuery.getPagination(), 0);
+	}
+
+	@Override
+	public String getCollectionItemClassName() {
+		return _relatedObjectDefinition.getClassName();
+	}
+
+	@Override
+	public String getKey() {
+		return StringBundler.concat(
+			RelatedInfoItemCollectionProvider.super.getKey(), "_",
+			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
+			"_", _relatedObjectDefinition.getName(), "_",
+			_objectRelationship.getType());
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _relatedObjectDefinition.getPluralLabel(locale);
+	}
+
+	@Override
+	public String getSourceItemClassName() {
+		return _objectDefinition.getClassName();
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId()) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OneToManyObjectRelationshipRelatedInfoCollectionProvider.class);
+
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final ObjectRelationship _objectRelationship;
+	private final ObjectDefinition _relatedObjectDefinition;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -14,8 +14,6 @@
 
 package com.liferay.object.internal.info.collection.provider;
 
-import com.liferay.info.collection.provider.CollectionQuery;
-import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.info.pagination.InfoPage;
 import com.liferay.info.pagination.Pagination;
 import com.liferay.object.model.ObjectDefinition;
@@ -23,21 +21,13 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-
-import java.util.Collections;
-import java.util.Locale;
 
 /**
  * @author Jürgen Kappler
  */
 public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
-	implements RelatedInfoItemCollectionProvider {
+	extends BaseObjectRelationshipRelatedInfoCollectionProvider {
 
 	public OneToManyObjectRelationshipRelatedInfoCollectionProvider(
 			ObjectDefinition objectDefinition,
@@ -46,92 +36,27 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 			ObjectEntryLocalService objectEntryLocalService)
 		throws PortalException {
 
-		_objectDefinition = objectDefinition;
-		_objectRelationship = objectRelationship;
-		_objectEntryLocalService = objectEntryLocalService;
-
-		_relatedObjectDefinition =
-			objectDefinitionLocalService.getObjectDefinition(
-				_objectRelationship.getObjectDefinitionId2());
+		super(
+			objectDefinition, objectDefinitionLocalService,
+			objectEntryLocalService, objectRelationship);
 	}
 
 	@Override
-	public InfoPage<ObjectEntry> getCollectionInfoPage(
-		CollectionQuery collectionQuery) {
-
-		Object relatedItem = collectionQuery.getRelatedItem();
-
-		if (!(relatedItem instanceof ObjectEntry)) {
-			return InfoPage.of(
-				Collections.emptyList(), collectionQuery.getPagination(), 0);
-		}
-
-		ObjectEntry objectEntry = (ObjectEntry)relatedItem;
-
-		Pagination pagination = collectionQuery.getPagination();
-
-		try {
-			return InfoPage.of(
-				_objectEntryLocalService.getOneToManyObjectEntries(
-					objectEntry.getGroupId(),
-					_objectRelationship.getObjectRelationshipId(),
-					objectEntry.getObjectEntryId(), true, pagination.getStart(),
-					pagination.getEnd()),
-				collectionQuery.getPagination(),
-				_objectEntryLocalService.getOneToManyObjectEntriesCount(
-					objectEntry.getGroupId(),
-					_objectRelationship.getObjectRelationshipId(),
-					objectEntry.getObjectEntryId(), true));
-		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
-		}
+	protected InfoPage<ObjectEntry> getCollectionInfoPage(
+			ObjectEntry objectEntry, Pagination pagination)
+		throws PortalException {
 
 		return InfoPage.of(
-			Collections.emptyList(), collectionQuery.getPagination(), 0);
+			objectEntryLocalService.getOneToManyObjectEntries(
+				objectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				objectEntry.getObjectEntryId(), true, pagination.getStart(),
+				pagination.getEnd()),
+			pagination,
+			objectEntryLocalService.getOneToManyObjectEntriesCount(
+				objectEntry.getGroupId(),
+				objectRelationship.getObjectRelationshipId(),
+				objectEntry.getObjectEntryId(), true));
 	}
-
-	@Override
-	public String getCollectionItemClassName() {
-		return _relatedObjectDefinition.getClassName();
-	}
-
-	@Override
-	public String getKey() {
-		return StringBundler.concat(
-			RelatedInfoItemCollectionProvider.super.getKey(), "_",
-			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
-			"_", _objectRelationship.getName());
-	}
-
-	@Override
-	public String getLabel(Locale locale) {
-		return _relatedObjectDefinition.getPluralLabel(locale);
-	}
-
-	@Override
-	public String getSourceItemClassName() {
-		return _objectDefinition.getClassName();
-	}
-
-	@Override
-	public boolean isAvailable() {
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-176083") ||
-			(_objectDefinition.getCompanyId() !=
-				CompanyThreadLocal.getCompanyId())) {
-
-			return false;
-		}
-
-		return true;
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		OneToManyObjectRelationshipRelatedInfoCollectionProvider.class);
-
-	private final ObjectDefinition _objectDefinition;
-	private final ObjectEntryLocalService _objectEntryLocalService;
-	private final ObjectRelationship _objectRelationship;
-	private final ObjectDefinition _relatedObjectDefinition;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -101,8 +101,7 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 		return StringBundler.concat(
 			RelatedInfoItemCollectionProvider.super.getKey(), "_",
 			_objectDefinition.getCompanyId(), "_", _objectDefinition.getName(),
-			"_", _relatedObjectDefinition.getName(), "_",
-			_objectRelationship.getType());
+			"_", _objectRelationship.getName());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -31,9 +31,9 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	public OneToManyObjectRelationshipRelatedInfoCollectionProvider(
 			ObjectDefinition objectDefinition,
-			ObjectRelationship objectRelationship,
 			ObjectDefinitionLocalService objectDefinitionLocalService,
-			ObjectEntryLocalService objectEntryLocalService)
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectRelationship objectRelationship)
 		throws PortalException {
 
 		super(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -25,11 +25,10 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -118,7 +117,7 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	public boolean isAvailable() {
-		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-176083")) ||
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-176083") ||
 			(_objectDefinition.getCompanyId() !=
 				CompanyThreadLocal.getCompanyId())) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -615,56 +615,64 @@ public class ObjectRelationshipLocalServiceImpl
 						objectRelationship.getType(),
 						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
-					ManyToManyObjectRelationshipRelatedInfoCollectionProvider
-						manyToManyObjectRelationshipRelatedInfoCollectionProvider =
-							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-								objectDefinition, _objectDefinitionLocalService,
-								_objectEntryLocalService, objectRelationship);
-
-					_serviceRegistrations.computeIfAbsent(
-						_getServiceRegistrationKey(objectRelationship),
-						serviceRegistrationKey ->
-							_bundleContext.registerService(
-								RelatedInfoItemCollectionProvider.class,
-								manyToManyObjectRelationshipRelatedInfoCollectionProvider,
-								HashMapDictionaryBuilder.<String, Object>put(
-									"company.id",
-									objectDefinition.getCompanyId()
-								).put(
-									"item.class.name",
-									objectDefinition.getClassName()
-								).build()));
-
-					ObjectRelationship reverseObjectRelationship =
-						objectRelationshipLocalService.getObjectRelationship(
-							objectRelationship.getObjectDefinitionId2(),
-							objectRelationship.getName());
-
 					ObjectDefinition objectDefinition2 =
 						_objectDefinitionLocalService.getObjectDefinition(
 							objectRelationship.getObjectDefinitionId2());
 
-					ManyToManyObjectRelationshipRelatedInfoCollectionProvider
-						reverseManyToManyObjectRelationshipRelatedInfoCollectionProvider =
-							new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
-								objectDefinition2,
-								_objectDefinitionLocalService,
-								_objectEntryLocalService,
-								reverseObjectRelationship);
+					if (!objectDefinition2.isSystem()) {
+						ManyToManyObjectRelationshipRelatedInfoCollectionProvider
+							manyToManyObjectRelationshipRelatedInfoCollectionProvider =
+								new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+									objectDefinition,
+									_objectDefinitionLocalService,
+									_objectEntryLocalService,
+									objectRelationship);
 
-					_serviceRegistrations.computeIfAbsent(
-						_getServiceRegistrationKey(reverseObjectRelationship),
-						serviceRegistrationKey ->
-							_bundleContext.registerService(
-								RelatedInfoItemCollectionProvider.class,
-								reverseManyToManyObjectRelationshipRelatedInfoCollectionProvider,
-								HashMapDictionaryBuilder.<String, Object>put(
-									"company.id",
-									objectDefinition2.getCompanyId()
-								).put(
-									"item.class.name",
-									objectDefinition2.getClassName()
-								).build()));
+						_serviceRegistrations.computeIfAbsent(
+							_getServiceRegistrationKey(objectRelationship),
+							serviceRegistrationKey ->
+								_bundleContext.registerService(
+									RelatedInfoItemCollectionProvider.class,
+									manyToManyObjectRelationshipRelatedInfoCollectionProvider,
+									HashMapDictionaryBuilder.
+										<String, Object>put(
+											"company.id",
+											objectDefinition.getCompanyId()
+										).put(
+											"item.class.name",
+											objectDefinition.getClassName()
+										).build()));
+
+						ObjectRelationship reverseObjectRelationship =
+							objectRelationshipLocalService.
+								getObjectRelationship(
+									objectRelationship.getObjectDefinitionId2(),
+									objectRelationship.getName());
+
+						ManyToManyObjectRelationshipRelatedInfoCollectionProvider
+							reverseManyToManyObjectRelationshipRelatedInfoCollectionProvider =
+								new ManyToManyObjectRelationshipRelatedInfoCollectionProvider(
+									objectDefinition2,
+									_objectDefinitionLocalService,
+									_objectEntryLocalService,
+									reverseObjectRelationship);
+
+						_serviceRegistrations.computeIfAbsent(
+							_getServiceRegistrationKey(
+								reverseObjectRelationship),
+							serviceRegistrationKey ->
+								_bundleContext.registerService(
+									RelatedInfoItemCollectionProvider.class,
+									reverseManyToManyObjectRelationshipRelatedInfoCollectionProvider,
+									HashMapDictionaryBuilder.
+										<String, Object>put(
+											"company.id",
+											objectDefinition2.getCompanyId()
+										).put(
+											"item.class.name",
+											objectDefinition2.getClassName()
+										).build()));
+					}
 				}
 				else if (Objects.equals(
 							objectRelationship.getType(),


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-176408)

Dear Team, this PR adds 2 new related info collection providers for object relationship. One for One to Many, the other for Many to Many. Please see the parent LPS for more details on it. I have also included two gifs for the feature. One is for many to many, the other for one to many relationship

## Change summary:

* Adds 2 new related info collection providers for object relationship
* Register the providers in object deployer

## Notes

Feature is behind epic, to enable: feature.flag.LPS-176083=true

## Test Scenario One to Many

* Create 2 objects and establish a one to many relationship between them
* Add a new collection provider to the page and select the collection provider for the parent object definition
* Add a collection provider inside the previous collection provider, and configure it to show the relationship
* When the page is published the information is shown correctly

![onetomany](https://user-images.githubusercontent.com/4267448/220665484-57c3b948-2985-42bc-a774-e032e86ce754.gif)


## Test Scenario Many to Many - V1

* Create 2 objects and establish a many to many relationship between them
* Add a new collection provider to the page and select the collection provider for the parent object definition
* Add a collection provider inside the previous collection provider, and configure it to show the relationship
* When the page is published the information is shown correctly

![manytomany](https://user-images.githubusercontent.com/4267448/220662968-5d6ac7c9-c6a8-4782-8e72-16c8bb820f42.gif)


## Test Scenario Many to Many - V2

* Create 2 objects and establish a many to many relationship between them
* Add a new collection provider to the page and select the collection provider for the parent object definition
* Add a collection provider inside the previous collection provider, and configure it to show the relationship
* When the page is published the information is shown correctly
* Add a new collection provider to the page and select the collection provider for the child object definition
* Add a collection provider inside the previous collection provider, and configure it to show the relationship
* When the page is published the information is shown correctly

![manytomany](https://user-images.githubusercontent.com/4267448/222123605-5a4041f6-75c3-4c43-b87c-7f53d6a348ce.gif)


## Notes

* Integration tests and poshi tests are not included and will be sent in a follow up task