### PR TITLE
LPS-176815 Enable users to map related item properties from the relationship fields to fragments

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -207,8 +207,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					_dlFileEntryLocalService, _dlURLHelper,
 					_infoItemFieldReaderFieldSetProvider, _jsonFactory,
 					_listTypeEntryLocalService, objectDefinition,
-					_objectEntryLocalService, _objectEntryManagerRegistry,
-					_objectFieldLocalService, _objectRelationshipLocalService,
+					_objectDefinitionLocalService, _objectEntryLocalService,
+					_objectEntryManagerRegistry, _objectFieldLocalService,
+					_objectRelationshipLocalService,
 					_templateInfoItemFieldSetProvider, _userLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -434,6 +434,11 @@ public class ObjectEntryInfoItemFieldValuesProvider
 			_objectDefinitionLocalService.getObjectDefinition(
 				relatedObjectEntry.getObjectDefinitionId());
 
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByObjectFieldId2(
+					objectField.getObjectFieldId());
+
 		Map<String, ?> relatedObjectEntryValues =
 			relatedObjectEntry.getValues();
 
@@ -447,8 +452,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				).namespace(
 					StringBundler.concat(
 						ObjectRelationship.class.getSimpleName(),
-						StringPool.POUND,
-						objectDefinition.getExternalReferenceCode())
+						StringPool.POUND, objectDefinition.getName(),
+						StringPool.POUND, objectRelationship.getName())
 				).name(
 					relatedObjectField.getName()
 				).labelInfoLocalizedValue(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -67,8 +67,6 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 
-import java.io.Serializable;
-
 import java.text.Format;
 
 import java.util.ArrayList;
@@ -302,37 +300,11 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					_getDisplayPageURL(objectEntry, themeDisplay)));
 		}
 
-		Map<String, Serializable> values = objectEntry.getValues();
-
-		List<ObjectField> objectFields =
-			_objectFieldLocalService.getObjectFields(
-				objectEntry.getObjectDefinitionId(), false);
-
-		for (ObjectField objectField : objectFields) {
-			objectEntryFieldValues.add(
-				new InfoFieldValue<>(
-					InfoField.builder(
-					).infoFieldType(
-						ObjectFieldDBTypeUtil.getInfoFieldType(objectField)
-					).namespace(
-						ObjectField.class.getSimpleName()
-					).name(
-						objectField.getName()
-					).labelInfoLocalizedValue(
-						InfoLocalizedValue.<String>builder(
-						).values(
-							objectField.getLabelMap()
-						).build()
-					).build(),
-					_getValue(objectField, values)));
-
-			List<InfoFieldValue<Object>> attachmentInfoFieldValues =
-				_getAttachmentInfoFieldValues(objectField, values);
-
-			if (ListUtil.isNotEmpty(attachmentInfoFieldValues)) {
-				objectEntryFieldValues.addAll(attachmentInfoFieldValues);
-			}
-		}
+		objectEntryFieldValues.addAll(
+			_getObjectFieldsInfoFieldValues(
+				_objectFieldLocalService.getObjectFields(
+					objectEntry.getObjectDefinitionId(), false),
+				objectEntry.getValues()));
 
 		return objectEntryFieldValues;
 	}
@@ -380,14 +352,24 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				ObjectEntryInfoItemFields.displayPageURLInfoField,
 				_getDisplayPageURL(serviceBuilderObjectEntry, themeDisplay)));
 
-		Map<String, Object> properties = objectEntry.getProperties();
+		objectEntryFieldValues.addAll(
+			_getObjectFieldsInfoFieldValues(
+				_objectFieldLocalService.getObjectFields(
+					serviceBuilderObjectEntry.getObjectDefinitionId()),
+				objectEntry.getProperties()));
 
-		List<ObjectField> objectFields =
-			_objectFieldLocalService.getObjectFields(
-				serviceBuilderObjectEntry.getObjectDefinitionId());
+		return objectEntryFieldValues;
+	}
+
+	private List<InfoFieldValue<Object>> _getObjectFieldsInfoFieldValues(
+			List<ObjectField> objectFields, Map<String, ?> values)
+		throws Exception {
+
+		List<InfoFieldValue<Object>> objectFieldsInfoFieldValues =
+			new ArrayList<>();
 
 		for (ObjectField objectField : objectFields) {
-			objectEntryFieldValues.add(
+			objectFieldsInfoFieldValues.add(
 				new InfoFieldValue<>(
 					InfoField.builder(
 					).infoFieldType(
@@ -402,17 +384,17 @@ public class ObjectEntryInfoItemFieldValuesProvider
 							objectField.getLabelMap()
 						).build()
 					).build(),
-					_getValue(objectField, properties)));
+					_getValue(objectField, values)));
 
 			List<InfoFieldValue<Object>> attachmentInfoFieldValues =
-				_getAttachmentInfoFieldValues(objectField, properties);
+				_getAttachmentInfoFieldValues(objectField, values);
 
 			if (ListUtil.isNotEmpty(attachmentInfoFieldValues)) {
-				objectEntryFieldValues.addAll(attachmentInfoFieldValues);
+				objectFieldsInfoFieldValues.addAll(attachmentInfoFieldValues);
 			}
 		}
 
-		return objectEntryFieldValues;
+		return objectFieldsInfoFieldValues;
 	}
 
 	private ThemeDisplay _getThemeDisplay() {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -355,7 +355,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 		objectEntryFieldValues.addAll(
 			_getObjectFieldsInfoFieldValues(
 				_objectFieldLocalService.getObjectFields(
-					serviceBuilderObjectEntry.getObjectDefinitionId()),
+					serviceBuilderObjectEntry.getObjectDefinitionId(), false),
 				objectEntry.getProperties()));
 
 		return objectEntryFieldValues;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -663,8 +663,8 @@ public class ObjectEntryInfoItemFormProvider
 				_getObjectDefinitionInfoFieldSet(
 					StringBundler.concat(
 						ObjectRelationship.class.getSimpleName(),
-						StringPool.POUND,
-						relatedObjectDefinition.getExternalReferenceCode()),
+						StringPool.POUND, relatedObjectDefinition.getName(),
+						StringPool.POUND, objectRelationship.getName()),
 					relatedObjectDefinition));
 		}
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-176815)

Please note that this is a proof of concept, and most likely can be simplified

When creating experiences for object entries, users are only allowed to leverage information from one object, when there are relationships, the most that users can do is to map the related item title to display in the "current" object experiences. With these changes the user has access to mapping the fields of the parent object

## Change summary:

* Change form provider to include the fields sets for the parent object
* Change field values provider to include the mapped values of the parent object


## Test Scenario

* Create two objects, and add a one to many relationship to them. An example can be Country and Cities, where a city belongs to a country
* Create several countries and cities
* Add a collection fragment to a page and configure it so that it shows cities
* Add a fragment to the collection provider and map it
* The fields for country should be available as a fieldset
 
![mapping](https://user-images.githubusercontent.com/4267448/222153830-f3c6087f-09e7-435b-a6a1-004f7065433e.gif)
