### PR TITLE
LPS-176117 Picklist Key Field Does Not Accept First Character Upper Case

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
@@ -13,20 +13,6 @@
  */
 
 /**
- * Transform first letter in lowercase
- */
-export function firstLetterLowercase(str: string): string {
-	return str.charAt(0).toLowerCase() + str.slice(1);
-}
-
-/**
- * Transform first letter in uppercase
- */
-export function firstLetterUppercase(str: string): string {
-	return str.charAt(0).toUpperCase() + str.slice(1);
-}
-
-/**
  *
  * Check if the first letter of a string is uppercase
  */
@@ -80,14 +66,12 @@ export function toCamelCase(
 	removeSpecialCharacters?: boolean
 ): string {
 	const split = str.split(' ');
-	const capitalizeFirstLetters = split.map((str: string) =>
-		firstLetterUppercase(str)
-	);
+	const capitalizeFirstLetters = split.map((str: string) => str);
 	const join = capitalizeFirstLetters.join('');
 
 	if (removeSpecialCharacters) {
-		return firstLetterLowercase(removeAllSpecialCharacters(join));
+		return removeAllSpecialCharacters(join);
 	}
 
-	return firstLetterLowercase(join);
+	return join;
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
@@ -13,6 +13,13 @@
  */
 
 /**
+ * Transform first letter in uppercase
+ */
+export function firstLetterUppercase(str: string): string {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
  *
  * Check if the first letter of a string is uppercase
  */
@@ -66,12 +73,14 @@ export function toCamelCase(
 	removeSpecialCharacters?: boolean
 ): string {
 	const split = str.split(' ');
-	const capitalizeFirstLetters = split.map((str: string) => str);
+	const capitalizeFirstLetters = split.map((str: string) =>
+		firstLetterUppercase(str)
+	);
 	const join = capitalizeFirstLetters.join('');
 
 	if (removeSpecialCharacters) {
-		return removeAllSpecialCharacters(join);
+		return firstLetterLowercase(removeAllSpecialCharacters(join));
 	}
 
-	return join;
+	return firstLetterLowercase(join);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
@@ -73,14 +73,12 @@ export function toCamelCase(
 	removeSpecialCharacters?: boolean
 ): string {
 	const split = str.split(' ');
-	const capitalizeFirstLetters = split.map((str: string) =>
-		firstLetterUppercase(str)
-	);
+	const capitalizeFirstLetters = split.map((str: string) => str);
 	const join = capitalizeFirstLetters.join('');
 
 	if (removeSpecialCharacters) {
-		return firstLetterLowercase(removeAllSpecialCharacters(join));
+		return removeAllSpecialCharacters(join);
 	}
 
-	return firstLetterLowercase(join);
+	return join;
 }

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/utils/string.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/utils/string.d.ts
@@ -13,16 +13,6 @@
  */
 
 /**
- * Transform first letter in lowercase
- */
-export declare function firstLetterLowercase(str: string): string;
-
-/**
- * Transform first letter in uppercase
- */
-export declare function firstLetterUppercase(str: string): string;
-
-/**
  *
  * Check if the first letter of a string is uppercase
  */

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/utils/string.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/utils/string.d.ts
@@ -13,6 +13,11 @@
  */
 
 /**
+ * Transform first letter in uppercase
+ */
+export declare function firstLetterUppercase(str: string): string;
+
+/**
  *
  * Check if the first letter of a string is uppercase
  */


### PR DESCRIPTION
[LPS-176117](https://issues.liferay.com/browse/LPS-176117) Removing validation firstLetterLowercase and firstLetterUppercase, thus the user will be able to type a lower case letter or a upper case letter as the first letter of a word.