### PR TITLE
LPS-178448 Change namings of field sets when mapping objects

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -72,7 +72,10 @@ import java.math.BigDecimal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
@@ -494,6 +497,8 @@ public class ObjectEntryInfoItemFormProvider
 
 					unsafeConsumer.accept(
 						_getObjectDefinitionInfoFieldSet(
+							objectDefinition.getLabelMap(),
+							objectDefinition.getName(),
 							ObjectField.class.getSimpleName(),
 							objectDefinition));
 				}
@@ -557,7 +562,8 @@ public class ObjectEntryInfoItemFormProvider
 	}
 
 	private InfoFieldSet _getObjectDefinitionInfoFieldSet(
-		String namespace, ObjectDefinition objectDefinition) {
+		Map<Locale, String> labelMap, String name, String namespace,
+		ObjectDefinition objectDefinition) {
 
 		return InfoFieldSet.builder(
 		).infoFieldSetEntry(
@@ -611,10 +617,10 @@ public class ObjectEntryInfoItemFormProvider
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(
 			).values(
-				objectDefinition.getLabelMap()
+				labelMap
 			).build()
 		).name(
-			objectDefinition.getName()
+			name
 		).build();
 	}
 
@@ -672,8 +678,24 @@ public class ObjectEntryInfoItemFormProvider
 				continue;
 			}
 
+			Map<Locale, String> fieldSetLabelMap = new HashMap<>();
+
+			Map<Locale, String> labelMap = objectDefinition1.getLabelMap();
+
+			for (Map.Entry<Locale, String> entry : labelMap.entrySet()) {
+				Locale locale = entry.getKey();
+
+				fieldSetLabelMap.put(
+					locale,
+					StringBundler.concat(
+						objectRelationship.getLabel(locale), StringPool.SPACE,
+						StringPool.OPEN_PARENTHESIS, entry.getValue(),
+						StringPool.CLOSE_PARENTHESIS));
+			}
+
 			infoFieldSetEntries.add(
 				_getObjectDefinitionInfoFieldSet(
+					fieldSetLabelMap, objectRelationship.getName(),
 					StringBundler.concat(
 						ObjectRelationship.class.getSimpleName(),
 						StringPool.POUND, objectDefinition1.getName(),


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-178448)

This is a follow up task to https://issues.liferay.com/browse/LPS-176815 which enables the mapping of related items in collection providers.

Based on the designs of the story, the naming of the definitions should include "Fields" for the object definition that is being shown in the collection provider, and "Relationship Fields" for related definition


## Change summary:

* Change the order of the field sets based on design. Fields for the object definition should come before basic information
* Add translated label to the field sets


## Test Scenario

* Create two objects, and add a one to many relationship to them. An example can be Country and Cities, where a city belongs to a country
* Create several countries and cities
* Add a collection fragment to a page and configure it so that it shows cities
* Add a fragment to the collection provider and map it
* The fields for city should be available as a fieldset under "City Fields"
* The fields for country should be available as a fieldset under "Country Relationship Fields"

![Screenshot 2023-03-14 at 11 55 20](https://user-images.githubusercontent.com/4267448/224983506-d88109f5-b548-4399-ac5e-419ef339bd55.png)
