### PR TITLE
LPS-170656 Assign the 'ERC' value before Validation step | LPS-179226 Assign 'Uuid' value in 'ERC' field, when this field receive blank string

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -247,7 +247,7 @@ public class ObjectEntryLocalServiceImpl
 
 		ObjectEntry objectEntry = objectEntryPersistence.create(objectEntryId);
 
-		_setExternalReferenceCode(objectEntry, values);
+		_setExternalReferenceCode(objectDefinitionId, objectEntry, values);
 
 		objectEntry.setGroupId(groupId);
 		objectEntry.setCompanyId(user.getCompanyId());
@@ -1186,7 +1186,8 @@ public class ObjectEntryLocalServiceImpl
 
 		objectEntry = objectEntryPersistence.findByPrimaryKey(objectEntryId);
 
-		_setExternalReferenceCode(objectEntry, values);
+		_setExternalReferenceCode(
+			objectEntry.getObjectDefinitionId(), objectEntry, values);
 
 		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
 
@@ -3036,7 +3037,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _setExternalReferenceCode(
-			ObjectEntry objectEntry, Map<String, Serializable> values)
+			long objectDefinitionId, ObjectEntry objectEntry,
+			Map<String, Serializable> values)
 		throws PortalException {
 
 		for (Map.Entry<String, Serializable> entry : values.entrySet()) {
@@ -3044,16 +3046,16 @@ public class ObjectEntryLocalServiceImpl
 				String externalReferenceCode = String.valueOf(entry.getValue());
 
 				if (Validator.isNull(externalReferenceCode)) {
-					externalReferenceCode = String.valueOf(
-						objectEntry.getObjectEntryId());
+					break;
 				}
 
 				_validateExternalReferenceCode(
 					externalReferenceCode, objectEntry.getCompanyId(),
-					objectEntry.getObjectDefinitionId(),
-					objectEntry.getObjectEntryId());
+					objectDefinitionId, objectEntry.getObjectEntryId());
 
 				objectEntry.setExternalReferenceCode(externalReferenceCode);
+
+				return;
 			}
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -154,6 +154,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
@@ -3041,22 +3042,17 @@ public class ObjectEntryLocalServiceImpl
 			Map<String, Serializable> values)
 		throws PortalException {
 
-		for (Map.Entry<String, Serializable> entry : values.entrySet()) {
-			if (StringUtil.equals(entry.getKey(), "externalReferenceCode")) {
-				String externalReferenceCode = String.valueOf(entry.getValue());
+		String externalReferenceCode = MapUtil.getString(
+			values, "externalReferenceCode");
 
-				if (Validator.isNull(externalReferenceCode)) {
-					break;
-				}
+		if (Validator.isNotNull(externalReferenceCode)) {
+			_validateExternalReferenceCode(
+				externalReferenceCode, objectEntry.getCompanyId(),
+				objectDefinitionId, objectEntry.getObjectEntryId());
 
-				_validateExternalReferenceCode(
-					externalReferenceCode, objectEntry.getCompanyId(),
-					objectDefinitionId, objectEntry.getObjectEntryId());
+			objectEntry.setExternalReferenceCode(externalReferenceCode);
 
-				objectEntry.setExternalReferenceCode(externalReferenceCode);
-
-				return;
-			}
+			return;
 		}
 
 		if (Validator.isNull(objectEntry.getExternalReferenceCode())) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3056,6 +3056,10 @@ public class ObjectEntryLocalServiceImpl
 				objectEntry.setExternalReferenceCode(externalReferenceCode);
 			}
 		}
+
+		if (Validator.isNull(objectEntry.getExternalReferenceCode())) {
+			objectEntry.setExternalReferenceCode(objectEntry.getUuid());
+		}
 	}
 
 	private void _startWorkflowInstance(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -648,7 +648,7 @@ public class ObjectEntryLocalServiceTest {
 				objectEntryValuesException.getMessage());
 		}
 
-		ObjectEntry objectEntry1 = _addObjectEntry(
+		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddressRequired", "john@liferay.com"
 			).put(
@@ -658,11 +658,11 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
 		Assert.assertEquals(
-			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+			objectEntry.getUuid(), objectEntry.getExternalReferenceCode());
 
-		objectEntry1 = _addObjectEntry(
+		objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddressRequired", "john@liferay.com"
 			).put(
@@ -674,11 +674,11 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
 		Assert.assertEquals(
-			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+			objectEntry.getUuid(), objectEntry.getExternalReferenceCode());
 
-		objectEntry1 = _addObjectEntry(
+		objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddressRequired", "john@liferay.com"
 			).put(
@@ -690,10 +690,9 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
 		Assert.assertEquals(
-			"newExternalReferenceCode",
-			objectEntry1.getExternalReferenceCode());
+			"newExternalReferenceCode", objectEntry.getExternalReferenceCode());
 
 		try {
 			_addObjectEntry(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -35,6 +35,7 @@ import com.liferay.object.constants.ObjectValidationRuleConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.exception.ObjectDefinitionScopeException;
 import com.liferay.object.exception.ObjectEntryValuesException;
+import com.liferay.object.exception.ObjectValidationRuleEngineException;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -849,6 +850,43 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		Assert.assertNotNull(objectEntry);
+
+		_objectValidationRuleLocalService.addObjectValidationRule(
+			TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), true,
+			ObjectValidationRuleConstants.ENGINE_TYPE_DDM,
+			LocalizedMapUtil.getLocalizedMap("Error"),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"numberOfBooksWritten > externalReferenceCode");
+
+		try {
+			_addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"birthday", "2000-12-25"
+				).put(
+					"emailAddressRequired", "bob@liferay.com"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).put(
+					"numberOfBooksWritten", "123"
+				).build());
+
+			Assert.fail();
+		}
+		catch (ModelListenerException modelListenerException) {
+			Throwable throwable = modelListenerException.getCause();
+
+			Assert.assertTrue(
+				throwable instanceof
+					ObjectValidationRuleEngineException.InvalidScript);
+
+			String message =
+				((ObjectValidationRuleEngineException.InvalidScript)throwable).
+					getMessageKey();
+
+			Assert.assertTrue(
+				message.contains("there-was-an-error-validating-your-data"));
+		}
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -647,6 +647,8 @@ public class ObjectEntryLocalServiceTest {
 					"\"listTypeEntryKeyRequired\"",
 				objectEntryValuesException.getMessage());
 		}
+
+		_testAddObjectEntryExternalReferenceCode();
 	}
 
 	@Test
@@ -874,18 +876,17 @@ public class ObjectEntryLocalServiceTest {
 			Assert.fail();
 		}
 		catch (ModelListenerException modelListenerException) {
-			Throwable throwable = modelListenerException.getCause();
-
 			Assert.assertTrue(
-				throwable instanceof
+				modelListenerException.getCause() instanceof
 					ObjectValidationRuleEngineException.InvalidScript);
 
-			String message =
-				((ObjectValidationRuleEngineException.InvalidScript)throwable).
-					getMessageKey();
+			ObjectValidationRuleEngineException.InvalidScript invalidScript =
+				(ObjectValidationRuleEngineException.InvalidScript)
+					modelListenerException.getCause();
 
-			Assert.assertTrue(
-				message.contains("there-was-an-error-validating-your-data"));
+			Assert.assertEquals(
+				"there-was-an-error-validating-your-data",
+				invalidScript.getMessageKey());
 		}
 	}
 
@@ -2539,6 +2540,75 @@ public class ObjectEntryLocalServiceTest {
 		return values;
 	}
 
+	private void _testAddObjectEntryExternalReferenceCode() throws Exception {
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+
+		objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"externalReferenceCode", ""
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+
+		objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"externalReferenceCode", "newExternalReferenceCode"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			"newExternalReferenceCode",
+			objectEntry1.getExternalReferenceCode());
+
+		try {
+			_addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddressRequired", "matthew@liferay.com"
+				).put(
+					"externalReferenceCode", "newExternalReferenceCode"
+				).put(
+					"firstName", "Matthew"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey2"
+				).build());
+		}
+		catch (ObjectEntryValuesException.MustNotBeDuplicate
+					objectEntryValuesException) {
+
+			Assert.assertEquals(
+				"Duplicate value newExternalReferenceCode",
+				objectEntryValuesException.getMessage());
+		}
+	}
+
 	private void _testScope(long groupId, String scope, boolean expectSuccess)
 		throws Exception {
 
@@ -2619,12 +2689,6 @@ public class ObjectEntryLocalServiceTest {
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
 			).build());
 
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
-		Assert.assertEquals(
-			String.valueOf(objectEntry1.getUuid()),
-			objectEntry1.getExternalReferenceCode());
-
 		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
 			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
@@ -2646,7 +2710,7 @@ public class ObjectEntryLocalServiceTest {
 			).build());
 
 		try {
-			objectEntry2 = _objectEntryLocalService.updateObjectEntry(
+			_objectEntryLocalService.updateObjectEntry(
 				TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"externalReferenceCode", "newExternalReferenceCode"
@@ -2669,33 +2733,7 @@ public class ObjectEntryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 
 		Assert.assertEquals(
-			String.valueOf(objectEntry2.getObjectEntryId()),
-			objectEntry2.getExternalReferenceCode());
-
-		objectEntry2 = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode",
-				String.valueOf(objectEntry1.getObjectEntryId())
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		try {
-			objectEntry1 = _objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
-				HashMapBuilder.<String, Serializable>put(
-					"externalReferenceCode", ""
-				).build(),
-				ServiceContextTestUtil.getServiceContext());
-		}
-		catch (ObjectEntryValuesException.MustNotBeDuplicate
-					objectEntryValuesException) {
-
-			Assert.assertEquals(
-				"Duplicate value " +
-					String.valueOf(objectEntry1.getObjectEntryId()),
-				objectEntryValuesException.getMessage());
-		}
+			objectEntry2.getUuid(), objectEntry2.getExternalReferenceCode());
 
 		int randomInt = RandomTestUtil.randomInt();
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -648,7 +648,72 @@ public class ObjectEntryLocalServiceTest {
 				objectEntryValuesException.getMessage());
 		}
 
-		_testAddObjectEntryExternalReferenceCode();
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+
+		objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"externalReferenceCode", ""
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
+
+		objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"externalReferenceCode", "newExternalReferenceCode"
+			).put(
+				"firstName", "John"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		Assert.assertNotNull(
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
+		Assert.assertEquals(
+			"newExternalReferenceCode",
+			objectEntry1.getExternalReferenceCode());
+
+		try {
+			_addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddressRequired", "matthew@liferay.com"
+				).put(
+					"externalReferenceCode", "newExternalReferenceCode"
+				).put(
+					"firstName", "Matthew"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey2"
+				).build());
+		}
+		catch (ObjectEntryValuesException.MustNotBeDuplicate
+					objectEntryValuesException) {
+
+			Assert.assertEquals(
+				"Duplicate value newExternalReferenceCode",
+				objectEntryValuesException.getMessage());
+		}
 	}
 
 	@Test
@@ -1961,7 +2026,7 @@ public class ObjectEntryLocalServiceTest {
 	public void testUpdateObjectEntry() throws Exception {
 		_assertCount(0);
 
-		ObjectEntry objectEntry = _addObjectEntry(
+		ObjectEntry objectEntry1 = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
 				"emailAddressRequired", "john@liferay.com"
 			).put(
@@ -1977,17 +2042,17 @@ public class ObjectEntryLocalServiceTest {
 		_assertCount(1);
 
 		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
 
-		_getValuesFromCacheField(objectEntry);
+		_getValuesFromCacheField(objectEntry1);
 
 		//Assert.assertNotNull(
 		//	ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
 
 		_messages.clear();
 
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"firstName", "João"
 			).put(
@@ -2005,15 +2070,15 @@ public class ObjectEntryLocalServiceTest {
 
 		_assertCount(1);
 
-		objectEntry = _objectEntryLocalService.getObjectEntry(
-			objectEntry.getObjectEntryId());
+		objectEntry1 = _objectEntryLocalService.getObjectEntry(
+			objectEntry1.getObjectEntryId());
 
 		Assert.assertNull(
-			ReflectionTestUtil.getFieldValue(objectEntry, "_values"));
+			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
 
-		Map<String, Serializable> values = objectEntry.getValues();
+		Map<String, Serializable> values = objectEntry1.getValues();
 
-		Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
+		Assert.assertEquals(_getValuesFromCacheField(objectEntry1), values);
 		Assert.assertEquals(0L, values.get("ageOfDeath"));
 		Assert.assertFalse((boolean)values.get("authorOfGospel"));
 		Assert.assertEquals(null, values.get("birthday"));
@@ -2036,7 +2101,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(0L, values.get("upload"));
 		Assert.assertEquals(0D, values.get("weight"));
 		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
+			objectEntry1.getObjectEntryId(),
 			values.get(_objectDefinition.getPKObjectFieldName()));
 		Assert.assertEquals(values.toString(), 20, values.size());
 
@@ -2051,7 +2116,7 @@ public class ObjectEntryLocalServiceTest {
 		FileEntry fileEntry = _addTempFileEntry(StringUtil.randomString());
 
 		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"ageOfDeath", "94"
 			).put(
@@ -2086,7 +2151,7 @@ public class ObjectEntryLocalServiceTest {
 		_assertCount(1);
 
 		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
+			objectEntry1.getObjectEntryId());
 
 		Assert.assertEquals(94L, values.get("ageOfDeath"));
 		Assert.assertTrue((boolean)values.get("authorOfGospel"));
@@ -2112,7 +2177,7 @@ public class ObjectEntryLocalServiceTest {
 			fileEntry.getFileEntryId(), values.get("upload"));
 		Assert.assertEquals(60D, values.get("weight"));
 		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
+			objectEntry1.getObjectEntryId(),
 			values.get(_objectDefinition.getPKObjectFieldName()));
 		Assert.assertEquals(values.toString(), 20, values.size());
 
@@ -2135,7 +2200,7 @@ public class ObjectEntryLocalServiceTest {
 		}
 
 		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				"state", "listTypeEntryKey3"
 			).put(
@@ -2148,7 +2213,7 @@ public class ObjectEntryLocalServiceTest {
 		_assertCount(1);
 
 		values = _objectEntryLocalService.getValues(
-			objectEntry.getObjectEntryId());
+			objectEntry1.getObjectEntryId());
 
 		Assert.assertEquals(94L, values.get("ageOfDeath"));
 		Assert.assertTrue((boolean)values.get("authorOfGospel"));
@@ -2173,7 +2238,7 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(0L, values.get("upload"));
 		Assert.assertEquals(65D, values.get("weight"));
 		Assert.assertEquals(
-			objectEntry.getObjectEntryId(),
+			objectEntry1.getObjectEntryId(),
 			values.get(_objectDefinition.getPKObjectFieldName()));
 		Assert.assertEquals(values.toString(), 20, values.size());
 
@@ -2191,12 +2256,12 @@ public class ObjectEntryLocalServiceTest {
 		}
 
 		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			new HashMap<String, Serializable>(),
 			ServiceContextTestUtil.getServiceContext());
 
 		_objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 			HashMapBuilder.<String, Serializable>put(
 				_objectDefinition.getPKObjectFieldName(), ""
 			).put(
@@ -2206,7 +2271,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"numberOfBooksWritten", "2147483648"
 				).build(),
@@ -2224,7 +2289,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"numberOfBooksWritten", "-2147483649"
 				).build(),
@@ -2242,7 +2307,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"ageOfDeath", "9007199254740992"
 				).build(),
@@ -2260,7 +2325,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"ageOfDeath", "-9007199254740992"
 				).build(),
@@ -2279,7 +2344,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"ageOfDeath", "9223372036854775808"
 				).build(),
@@ -2297,7 +2362,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"ageOfDeath", "-9223372036854775809"
 				).build(),
@@ -2315,7 +2380,7 @@ public class ObjectEntryLocalServiceTest {
 
 		try {
 			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
 				HashMapBuilder.<String, Serializable>put(
 					"firstName", RandomTestUtil.randomString(281)
 				).build(),
@@ -2332,7 +2397,69 @@ public class ObjectEntryLocalServiceTest {
 				objectEntryValuesException.getMessage());
 		}
 
-		_testUpdateObjectEntryExternalReferenceCode();
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", "newExternalReferenceCode"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			"newExternalReferenceCode",
+			objectEntry1.getExternalReferenceCode());
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "matthew@liferay.com"
+			).put(
+				"firstName", "Matthew"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey2"
+			).build());
+
+		try {
+			_objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
+				HashMapBuilder.<String, Serializable>put(
+					"externalReferenceCode", "newExternalReferenceCode"
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+		catch (ObjectEntryValuesException.MustNotBeDuplicate
+					objectEntryValuesException) {
+
+			Assert.assertEquals(
+				"Duplicate value newExternalReferenceCode",
+				objectEntryValuesException.getMessage());
+		}
+
+		objectEntry2 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", ""
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			objectEntry2.getUuid(), objectEntry2.getExternalReferenceCode());
+
+		int randomInt = RandomTestUtil.randomInt();
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
+			HashMapBuilder.<String, Serializable>put(
+				"externalReferenceCode", randomInt
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			String.valueOf(randomInt), objectEntry1.getExternalReferenceCode());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry1.getObjectEntryId());
+
+		_objectEntryLocalService.deleteObjectEntry(
+			objectEntry2.getObjectEntryId());
 		_testUpdateObjectEntryObjectStateTransitions();
 	}
 
@@ -2540,75 +2667,6 @@ public class ObjectEntryLocalServiceTest {
 		return values;
 	}
 
-	private void _testAddObjectEntryExternalReferenceCode() throws Exception {
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build());
-
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
-		Assert.assertEquals(
-			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
-
-		objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"externalReferenceCode", ""
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build());
-
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
-		Assert.assertEquals(
-			objectEntry1.getUuid(), objectEntry1.getExternalReferenceCode());
-
-		objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"externalReferenceCode", "newExternalReferenceCode"
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build());
-
-		Assert.assertNotNull(
-			ReflectionTestUtil.getFieldValue(objectEntry1, "_values"));
-		Assert.assertEquals(
-			"newExternalReferenceCode",
-			objectEntry1.getExternalReferenceCode());
-
-		try {
-			_addObjectEntry(
-				HashMapBuilder.<String, Serializable>put(
-					"emailAddressRequired", "matthew@liferay.com"
-				).put(
-					"externalReferenceCode", "newExternalReferenceCode"
-				).put(
-					"firstName", "Matthew"
-				).put(
-					"listTypeEntryKeyRequired", "listTypeEntryKey2"
-				).build());
-		}
-		catch (ObjectEntryValuesException.MustNotBeDuplicate
-					objectEntryValuesException) {
-
-			Assert.assertEquals(
-				"Duplicate value newExternalReferenceCode",
-				objectEntryValuesException.getMessage());
-		}
-	}
-
 	private void _testScope(long groupId, String scope, boolean expectSuccess)
 		throws Exception {
 
@@ -2675,83 +2733,6 @@ public class ObjectEntryLocalServiceTest {
 		}
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
-	}
-
-	private void _testUpdateObjectEntryExternalReferenceCode()
-		throws Exception {
-
-		ObjectEntry objectEntry1 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"firstName", "John"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).build());
-
-		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode", "newExternalReferenceCode"
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			"newExternalReferenceCode",
-			objectEntry1.getExternalReferenceCode());
-
-		ObjectEntry objectEntry2 = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "matthew@liferay.com"
-			).put(
-				"firstName", "Matthew"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey2"
-			).build());
-
-		try {
-			_objectEntryLocalService.updateObjectEntry(
-				TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
-				HashMapBuilder.<String, Serializable>put(
-					"externalReferenceCode", "newExternalReferenceCode"
-				).build(),
-				ServiceContextTestUtil.getServiceContext());
-		}
-		catch (ObjectEntryValuesException.MustNotBeDuplicate
-					objectEntryValuesException) {
-
-			Assert.assertEquals(
-				"Duplicate value newExternalReferenceCode",
-				objectEntryValuesException.getMessage());
-		}
-
-		objectEntry2 = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode", ""
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			objectEntry2.getUuid(), objectEntry2.getExternalReferenceCode());
-
-		int randomInt = RandomTestUtil.randomInt();
-
-		objectEntry1 = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
-			HashMapBuilder.<String, Serializable>put(
-				"externalReferenceCode", randomInt
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertEquals(
-			String.valueOf(randomInt), objectEntry1.getExternalReferenceCode());
-
-		_objectEntryLocalService.deleteObjectEntry(
-			objectEntry1.getObjectEntryId());
-
-		_objectEntryLocalService.deleteObjectEntry(
-			objectEntry2.getObjectEntryId());
 	}
 
 	private void _testUpdateObjectEntryObjectStateTransitions()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -2459,6 +2459,7 @@ public class ObjectEntryLocalServiceTest {
 
 		_objectEntryLocalService.deleteObjectEntry(
 			objectEntry2.getObjectEntryId());
+
 		_testUpdateObjectEntryObjectStateTransitions();
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -153,6 +153,7 @@ public class ObjectEntryInfoItemFormProviderTest {
 				objectField.getObjectFieldId() + "#mimeType"));
 		Assert.assertNotNull(
 			infoForm.getInfoField(objectField.getObjectFieldId() + "#size"));
+
 		Assert.assertNotNull(
 			infoForm.getInfoField("parentTextObjectFieldName"));
 	}


### PR DESCRIPTION
Related issues:
https://issues.liferay.com/browse/LPS-170656;
https://issues.liferay.com/browse/LPS-179226.