### PR TITLE
LPS-177741 | LPS-177745 Integration Tests for Object Related Stories

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/ManyToManyObjectRelationshipInfoCollectionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/ManyToManyObjectRelationshipInfoCollectionProviderTest.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.info.collection.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class ManyToManyObjectRelationshipInfoCollectionProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-176083", "true"
+			).build());
+
+		_group = GroupTestUtil.addGroup();
+
+		_objectDefinition1 = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"objectDefinition1TextObjectFieldName"
+			).objectFieldSettings(
+				Collections.emptyList()
+			).build());
+
+		_objectDefinition1 =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId());
+
+		_objectDefinition2 = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"objectDefinition2TextObjectFieldName"
+			).objectFieldSettings(
+				Collections.emptyList()
+			).build());
+
+		_objectDefinition2 =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_objectDefinition2.getObjectDefinitionId());
+
+		_objectRelationship = _addObjectRelationship(
+			_objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+	}
+
+	@After
+	public void tearDown() {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-176083", "false"
+			).build());
+	}
+
+	@Test
+	public void testManyToManyObjectRelationshipRelatedInfoCollectionProvider()
+		throws Exception {
+
+		ObjectEntry objectDefinition1ObjectEntry1 =
+			_objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"objectDefinition1TextObjectFieldName",
+					RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectDefinition1ObjectEntry2 =
+			_objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"objectDefinition1TextObjectFieldName",
+					RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry objectDefinition2ObjectEntry =
+			_objectEntryLocalService.addObjectEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_objectDefinition2.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"objectDefinition2TextObjectFieldName",
+					RandomTestUtil.randomString()
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
+			TestPropsValues.getUserId(),
+			_objectRelationship.getObjectRelationshipId(),
+			objectDefinition2ObjectEntry.getObjectEntryId(),
+			objectDefinition1ObjectEntry1.getObjectEntryId(),
+			new ServiceContext());
+
+		_objectRelationshipLocalService.addObjectRelationshipMappingTableValues(
+			TestPropsValues.getUserId(),
+			_objectRelationship.getObjectRelationshipId(),
+			objectDefinition2ObjectEntry.getObjectEntryId(),
+			objectDefinition1ObjectEntry2.getObjectEntryId(),
+			new ServiceContext());
+
+		_assertRelatedInfoCollectionProvider(
+			_objectDefinition1, objectDefinition1ObjectEntry1,
+			objectDefinition2ObjectEntry);
+		_assertRelatedInfoCollectionProvider(
+			_objectDefinition1, objectDefinition1ObjectEntry2,
+			objectDefinition2ObjectEntry);
+		_assertRelatedInfoCollectionProvider(
+			_objectDefinition2, objectDefinition2ObjectEntry,
+			objectDefinition1ObjectEntry1, objectDefinition1ObjectEntry2);
+	}
+
+	private ObjectDefinition _addObjectDefinition(ObjectField... objectFields)
+		throws Exception {
+
+		return _objectDefinitionLocalService.addCustomObjectDefinition(
+			TestPropsValues.getUserId(), false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"A" + RandomTestUtil.randomString(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionConstants.SCOPE_SITE,
+			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			Arrays.asList(objectFields));
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			ObjectDefinition objectDefinition,
+			ObjectDefinition relatedObjectDefinition, String type)
+		throws Exception {
+
+		return _objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			relatedObjectDefinition.getObjectDefinitionId(),
+			objectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), type);
+	}
+
+	private void _assertRelatedInfoCollectionProvider(
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		ObjectEntry... relatedObjectEntries) {
+
+		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				RelatedInfoItemCollectionProvider.class,
+				StringBundler.concat(
+					ObjectDefinition.class.getName(), StringPool.POUND,
+					objectDefinition.getObjectDefinitionId()));
+
+		Assert.assertNotNull(relatedInfoItemCollectionProvider);
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setPagination(
+			Pagination.of(relatedObjectEntries.length, 0));
+		collectionQuery.setRelatedItemObject(objectEntry);
+
+		InfoPage collectionInfoPage =
+			relatedInfoItemCollectionProvider.getCollectionInfoPage(
+				collectionQuery);
+
+		List<ObjectEntry> objectEntries = collectionInfoPage.getPageItems();
+
+		Assert.assertNotNull(objectEntries);
+
+		Assert.assertEquals(
+			objectEntries.toString(), relatedObjectEntries.length,
+			objectEntries.size());
+
+		Assert.assertEquals(
+			relatedObjectEntries.length, collectionInfoPage.getTotalCount());
+
+		for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
+			Assert.assertTrue(objectEntries.contains(relatedObjectEntry));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectRelationship _objectRelationship;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/info/collection/provider/test/OneToManyObjectRelationshipInfoCollectionProviderTest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.info.collection.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.collection.provider.CollectionQuery;
+import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class OneToManyObjectRelationshipInfoCollectionProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-176083", "true"
+			).build());
+
+		_group = GroupTestUtil.addGroup();
+
+		_childObjectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"childTextObjectFieldName"
+			).objectFieldSettings(
+				Collections.emptyList()
+			).build());
+
+		_childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_childObjectDefinition.getObjectDefinitionId());
+
+		_parentObjectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"parentTextObjectFieldName"
+			).objectFieldSettings(
+				Collections.emptyList()
+			).build());
+
+		_parentObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_parentObjectDefinition.getObjectDefinitionId());
+	}
+
+	@After
+	public void tearDown() {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-176083", "false"
+			).build());
+	}
+
+	@Test
+	public void testOneToManyObjectRelationshipRelatedInfoCollectionProvider()
+		throws Exception {
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_childObjectDefinition, _parentObjectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectEntry parentObjectEntry = _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_parentObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"parentTextObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectEntry childObjectEntry1 = _addChildObjectEntry(
+			_group, _childObjectDefinition, _parentObjectDefinition,
+			parentObjectEntry, objectRelationship);
+
+		ObjectEntry childObjectEntry2 = _addChildObjectEntry(
+			_group, _childObjectDefinition, _parentObjectDefinition,
+			parentObjectEntry, objectRelationship);
+
+		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				RelatedInfoItemCollectionProvider.class,
+				StringBundler.concat(
+					ObjectDefinition.class.getName(), StringPool.POUND,
+					_parentObjectDefinition.getObjectDefinitionId()));
+
+		Assert.assertNotNull(relatedInfoItemCollectionProvider);
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setPagination(Pagination.of(2, 0));
+		collectionQuery.setRelatedItemObject(parentObjectEntry);
+
+		InfoPage collectionInfoPage =
+			relatedInfoItemCollectionProvider.getCollectionInfoPage(
+				collectionQuery);
+
+		List<ObjectEntry> objectEntries = collectionInfoPage.getPageItems();
+
+		Assert.assertNotNull(objectEntries);
+
+		Assert.assertEquals(objectEntries.toString(), 2, objectEntries.size());
+
+		Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+
+		Assert.assertTrue(objectEntries.contains(childObjectEntry1));
+		Assert.assertTrue(objectEntries.contains(childObjectEntry2));
+	}
+
+	private ObjectEntry _addChildObjectEntry(
+			Group group, ObjectDefinition objectDefinition,
+			ObjectDefinition parentObjectDefinition,
+			ObjectEntry parentObjectEntry,
+			ObjectRelationship objectRelationship)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getUserId(), group.getGroupId(),
+			objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"childTextObjectFieldName", RandomTestUtil.randomString()
+			).put(
+				StringBundler.concat(
+					"r_", objectRelationship.getName(), "_",
+					parentObjectDefinition.getPKObjectFieldName()),
+				parentObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectDefinition _addObjectDefinition(ObjectField... objectFields)
+		throws Exception {
+
+		return _objectDefinitionLocalService.addCustomObjectDefinition(
+			TestPropsValues.getUserId(), false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"A" + RandomTestUtil.randomString(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionConstants.SCOPE_SITE,
+			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			Arrays.asList(objectFields));
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			ObjectDefinition objectDefinition,
+			ObjectDefinition relatedObjectDefinition, String type)
+		throws Exception {
+
+		return _objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			relatedObjectDefinition.getObjectDefinitionId(),
+			objectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), type);
+	}
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _childObjectDefinition;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _parentObjectDefinition;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -19,17 +19,22 @@ import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -37,6 +42,7 @@ import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -64,34 +70,43 @@ public class ObjectEntryInfoItemFormProviderTest {
 				"feature.flag.LPS-176083", "true"
 			).build());
 
-		_objectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				TestPropsValues.getUserId(), false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"A" + RandomTestUtil.randomString(), null, null,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				ObjectDefinitionConstants.SCOPE_SITE,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+		_objectDefinition = _addObjectDefinition(
+			new AttachmentObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"attachmentObjectFieldName"
+			).objectFieldSettings(
 				Arrays.asList(
-					new AttachmentObjectFieldBuilder(
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).name(
-						"attachmentObjectFieldName"
-					).objectFieldSettings(
-						Arrays.asList(
-							_createObjectFieldSetting(
-								"acceptedFileExtensions", "txt"),
-							_createObjectFieldSetting(
-								"fileSource", "documentsAndMedia"),
-							_createObjectFieldSetting("maximumFileSize", "100"))
-					).build()));
+					_createObjectFieldSetting("acceptedFileExtensions", "txt"),
+					_createObjectFieldSetting(
+						"fileSource", "documentsAndMedia"),
+					_createObjectFieldSetting("maximumFileSize", "100"))
+			).build());
 
 		_objectDefinition =
 			_objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
 				_objectDefinition.getObjectDefinitionId());
+
+		_parentObjectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"parentTextObjectFieldName"
+			).objectFieldSettings(
+				Collections.emptyList()
+			).build());
+
+		_parentObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				_parentObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationship = _addObjectRelationship(
+			_objectDefinition, _parentObjectDefinition,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	@After
@@ -103,9 +118,7 @@ public class ObjectEntryInfoItemFormProviderTest {
 	}
 
 	@Test
-	public void testObjectEntryInfoItemFormProviderWithAttachment()
-		throws Exception {
-
+	public void testObjectEntryInfoItemFormProvider() throws Exception {
 		InfoItemFormProvider<?> infoItemFormProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
 				InfoItemFormProvider.class, _objectDefinition.getClassName());
@@ -133,6 +146,36 @@ public class ObjectEntryInfoItemFormProviderTest {
 				objectField.getObjectFieldId() + "#mimeType"));
 		Assert.assertNotNull(
 			infoForm.getInfoField(objectField.getObjectFieldId() + "#size"));
+
+		Assert.assertNotNull(
+			infoForm.getInfoField("parentTextObjectFieldName"));
+	}
+
+	private ObjectDefinition _addObjectDefinition(ObjectField... objectFields)
+		throws Exception {
+
+		return _objectDefinitionLocalService.addCustomObjectDefinition(
+			TestPropsValues.getUserId(), false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"A" + RandomTestUtil.randomString(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionConstants.SCOPE_SITE,
+			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			Arrays.asList(objectFields));
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			ObjectDefinition objectDefinition,
+			ObjectDefinition relatedObjectDefinition, String type)
+		throws Exception {
+
+		return _objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			relatedObjectDefinition.getObjectDefinitionId(),
+			objectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), type);
 	}
 
 	private ObjectFieldSetting _createObjectFieldSetting(
@@ -161,5 +204,14 @@ public class ObjectEntryInfoItemFormProviderTest {
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectRelationship _objectRelationship;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _parentObjectDefinition;
 
 }


### PR DESCRIPTION
Dear Team, this PR contains integration tests for the following stories

[LPS-161646 Page builder to support relationship tables](https://issues.liferay.com/browse/LPS-161646)
[LPS-174863 Enable users to map related item properties from the relationship fields to fragments](https://issues.liferay.com/browse/LPS-174863)

After this, we could close them pending QA review. Please let me know what you think and if changes should be made.

Thanks as always for all the help!
