### PR TITLE
LPS-179233 It's possible to see only 20 items when the picklist is marked as state

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
@@ -251,7 +251,7 @@ export async function getPickList(pickListId: number): Promise<PickList> {
 
 export async function getPickListItems(pickListId: number) {
 	return await getList<PickListItem>(
-		`/o/headless-admin-list-type/v1.0/list-type-definitions/${pickListId}/list-type-entries`
+		`/o/headless-admin-list-type/v1.0/list-type-definitions/${pickListId}/list-type-entries?pageSize=-1`
 	);
 }
 


### PR DESCRIPTION
Hello Reviewer!
Related Issue: https://issues.liferay.com/browse/LPS-179233


To solve this we added **pageSize=-1** to the url of `getPickListItems()`, so that all items are shown.

