### PR TITLE
[TS] LPS-179191 | master

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectLayoutResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.object.admin.rest.dto.v1_0.ObjectLayoutRow;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectLayoutTab;
 import com.liferay.object.admin.rest.internal.dto.v1_0.util.ObjectLayoutUtil;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectLayoutResource;
+import com.liferay.object.exception.ObjectLayoutColumnFielNameException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -227,7 +228,8 @@ public class ObjectLayoutResourceImpl
 	}
 
 	private com.liferay.object.model.ObjectLayoutBox _toObjectLayoutBox(
-		long objectDefinitionId, ObjectLayoutBox objectLayoutBox) {
+			long objectDefinitionId, ObjectLayoutBox objectLayoutBox)
+		throws PortalException {
 
 		com.liferay.object.model.ObjectLayoutBox serviceBuilderObjectLayoutBox =
 			_objectLayoutBoxPersistence.create(0L);
@@ -250,7 +252,8 @@ public class ObjectLayoutResourceImpl
 	}
 
 	private com.liferay.object.model.ObjectLayoutColumn _toObjectLayoutColumn(
-		long objectDefinitionId, ObjectLayoutColumn objectLayoutColumn) {
+			long objectDefinitionId, ObjectLayoutColumn objectLayoutColumn)
+		throws PortalException {
 
 		com.liferay.object.model.ObjectLayoutColumn
 			serviceBuilderObjectLayoutColumn =
@@ -258,6 +261,12 @@ public class ObjectLayoutResourceImpl
 
 		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
 			objectDefinitionId, objectLayoutColumn.getObjectFieldName());
+
+		if (objectField == null) {
+			throw new ObjectLayoutColumnFielNameException(
+				"There is no object field with the name: " +
+					objectLayoutColumn.getObjectFieldName());
+		}
 
 		serviceBuilderObjectLayoutColumn.setObjectFieldId(
 			objectField.getObjectFieldId());
@@ -271,7 +280,8 @@ public class ObjectLayoutResourceImpl
 	}
 
 	private com.liferay.object.model.ObjectLayoutRow _toObjectLayoutRow(
-		long objectDefinitionId, ObjectLayoutRow objectLayoutRow) {
+			long objectDefinitionId, ObjectLayoutRow objectLayoutRow)
+		throws PortalException {
 
 		com.liferay.object.model.ObjectLayoutRow serviceBuilderObjectLayoutRow =
 			_objectLayoutRowPersistence.create(0L);
@@ -288,7 +298,8 @@ public class ObjectLayoutResourceImpl
 	}
 
 	private com.liferay.object.model.ObjectLayoutTab _toObjectLayoutTab(
-		long objectDefinitionId, ObjectLayoutTab objectLayoutTab) {
+			long objectDefinitionId, ObjectLayoutTab objectLayoutTab)
+		throws PortalException {
 
 		com.liferay.object.model.ObjectLayoutTab serviceBuilderObjectLayoutTab =
 			_objectLayoutTabPersistence.create(0L);

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 59.0.1
+Bundle-Version: 59.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectLayoutColumnFielNameException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/ObjectLayoutColumnFielNameException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Sergio Alonso
+ */
+public class ObjectLayoutColumnFielNameException extends PortalException {
+
+	public ObjectLayoutColumnFielNameException() {
+	}
+
+	public ObjectLayoutColumnFielNameException(String msg) {
+		super(msg);
+	}
+
+	public ObjectLayoutColumnFielNameException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public ObjectLayoutColumnFielNameException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 16.1.0
+version 16.2.0


### PR DESCRIPTION
Hi team,

This issue seems to happen when an object layout uses a field derived from a relationship from another object.

Right now, product throws a _NPE_ when the object is imported and the original object has not been imported previously.

**Proposed solution:**
Check the possible null value and throw a (new) _ObjectLayoutColumnFielNameException_ which tells what field is the origin of the issue while importing.

Reference:
https://issues.liferay.com/browse/LPS-179191
