### PR TITLE
LPS-180046 Locale is null when using email notification template with FreeMarker

### DIFF
--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
@@ -404,6 +404,10 @@ public class EmailNotificationType extends BaseNotificationType {
 				persistedModelLocalService.getPersistedModel(
 					notificationContext.getClassPK()));
 
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(siteDefaultLocale);
+
 		for (InfoFieldValue<Object> infoFieldValue :
 				infoItemFieldValues.getInfoFieldValues()) {
 
@@ -417,7 +421,7 @@ public class EmailNotificationType extends BaseNotificationType {
 			}
 
 			TemplateNode templateNode = _templateNodeFactory.createTemplateNode(
-				infoFieldValue, new ThemeDisplay());
+				infoFieldValue, themeDisplay);
 
 			template.put(infoField.getName(), templateNode);
 			template.put(infoField.getUniqueId(), templateNode);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
No locale is set for [the ThemeDisplay created](https://github.com/liferay/liferay-portal/blob/master/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java#L420) when the notification email body is assembled. This will lead to a NullPointerException later when [a locale is about to be referenced](https://github.com/liferay/liferay-portal/blob/master/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/field/transformer/DateInfoFieldTypeTemplateNodeTransformer.java#L123-L125). 

Proposed Solution
========
Setting a locale for the `ThemeDisplay`.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180046

Thank you and best regards,
István