### PR TITLE
LPS-180922 Enable the translation toggle in add object field modal if the definition is with the localized property enabled

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Toggle.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Toggle.tsx
@@ -19,6 +19,16 @@ import React from 'react';
 
 import './Toggle.scss';
 
+interface ToggleProps {
+	disabled?: boolean;
+	label: string;
+	name?: string;
+	onToggle?: (val: boolean) => void;
+	toggled?: boolean;
+	tooltip?: string;
+	tooltipAlign?: 'bottom' | 'left' | 'right' | 'top';
+}
+
 export function Toggle({
 	disabled,
 	label,
@@ -27,7 +37,7 @@ export function Toggle({
 	toggled,
 	tooltip,
 	tooltipAlign,
-}: IProps) {
+}: ToggleProps) {
 	return (
 		<>
 			<ClayToggle
@@ -53,14 +63,4 @@ export function Toggle({
 			)}
 		</>
 	);
-}
-
-interface IProps {
-	disabled?: boolean;
-	label: string;
-	name: string;
-	onToggle?: (val: boolean) => void;
-	toggled?: boolean;
-	tooltip?: string;
-	tooltipAlign?: 'bottom' | 'left' | 'right' | 'top';
 }

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/types.d.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/types.d.ts
@@ -53,6 +53,7 @@ interface ObjectField {
 	indexedLanguageId: Liferay.Language.Locale | null;
 	label: LocalizedValue<string>;
 	listTypeDefinitionId: number;
+	localized: boolean;
 	name: string;
 	objectFieldSettings?: ObjectFieldSetting[];
 	relationshipType?: unknown;

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/Toggle.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/Toggle.d.ts
@@ -15,6 +15,15 @@
 /// <reference types="react" />
 
 import './Toggle.scss';
+interface ToggleProps {
+	disabled?: boolean;
+	label: string;
+	name?: string;
+	onToggle?: (val: boolean) => void;
+	toggled?: boolean;
+	tooltip?: string;
+	tooltipAlign?: 'bottom' | 'left' | 'right' | 'top';
+}
 export declare function Toggle({
 	disabled,
 	label,
@@ -23,14 +32,5 @@ export declare function Toggle({
 	toggled,
 	tooltip,
 	tooltipAlign,
-}: IProps): JSX.Element;
-interface IProps {
-	disabled?: boolean;
-	label: string;
-	name: string;
-	onToggle?: (val: boolean) => void;
-	toggled?: boolean;
-	tooltip?: string;
-	tooltipAlign?: 'bottom' | 'left' | 'right' | 'top';
-}
+}: ToggleProps): JSX.Element;
 export {};

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AddObjectField.tsx
@@ -14,12 +14,12 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
-import ClayForm, {ClayToggle} from '@clayui/form';
+import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {ClayModalProvider, useModal} from '@clayui/modal';
 import {Observer} from '@clayui/modal/lib/types';
 import {ClayTooltipProvider} from '@clayui/tooltip';
-import {API, Input} from '@liferay/object-js-components-web';
+import {API, Input, Toggle} from '@liferay/object-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 import {defaultLanguageId} from '../../utils/constants';
@@ -177,7 +177,10 @@ function ModalAddObjectField({
 						{Liferay.FeatureFlags['LPS-146755'] &&
 							showEnableTranslationToggle && (
 								<div className="lfr-objects-add-object-field-enable-translations-toggle">
-									<ClayToggle
+									<Toggle
+										disabled={
+											!objectDefinition?.enableLocalization
+										}
 										label={Liferay.Language.get(
 											'enable-entry-translations'
 										)}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/AddObjectField.tsx
@@ -53,6 +53,9 @@ function ModalAddObjectField({
 	onClose,
 }: IModal) {
 	const [error, setError] = useState<string>('');
+	const [objectDefinition, setObjectDefinition] = useState<
+		ObjectDefinition
+	>();
 
 	const initialValues: Partial<ObjectField> = {
 		indexed: true,
@@ -102,6 +105,40 @@ function ModalAddObjectField({
 		values.businessType === 'RichText' ||
 		values.businessType === 'Text';
 
+	useEffect(() => {
+		if (!objectDefinition) {
+			const makeFetch = async () => {
+				const objectDefinitionResponse = await API.getObjectDefinitionByExternalReferenceCode(
+					objectDefinitionExternalReferenceCode
+				);
+
+				setObjectDefinition(objectDefinitionResponse);
+			};
+
+			makeFetch();
+		}
+
+		if (Liferay.FeatureFlags['LPS-146755']) {
+			if (
+				objectDefinition?.enableLocalization &&
+				showEnableTranslationToggle
+			) {
+				setValues({
+					localized: true,
+				});
+
+				return;
+			}
+
+			setValues({
+				localized: false,
+			});
+
+			return;
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [values.businessType]);
+
 	return (
 		<ClayModal observer={observer}>
 			<ClayForm onSubmit={handleSubmit}>
@@ -128,6 +165,7 @@ function ModalAddObjectField({
 					<ObjectFieldFormBase
 						errors={errors}
 						handleChange={handleChange}
+						objectDefinition={objectDefinition}
 						objectDefinitionExternalReferenceCode={
 							objectDefinitionExternalReferenceCode
 						}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.tsx
@@ -20,7 +20,7 @@ import {
 	openToast,
 	saveAndReload,
 } from '@liferay/object-js-components-web';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import './EditObjectField.scss';
 import {AdvancedTab} from './Tabs/Advanced/AdvancedTab';
@@ -37,6 +37,7 @@ interface EditObjectFieldProps {
 	isDefaultStorageType: boolean;
 	objectDefinitionExternalReferenceCode: string;
 	objectField: ObjectField;
+	objectFieldId: number;
 	objectFieldTypes: ObjectFieldType[];
 	objectName: string;
 	objectRelationshipId: number;
@@ -47,6 +48,24 @@ interface EditObjectFieldProps {
 
 const TABS = [Liferay.Language.get('basic-info')];
 
+const initialValues: Partial<ObjectField> = {
+	DBType: '',
+	businessType: 'Text',
+	externalReferenceCode: '',
+	id: 0,
+	indexed: true,
+	indexedAsKeyword: false,
+	indexedLanguageId: 'en_US',
+	label: {en_US: ''},
+	listTypeDefinitionId: 0,
+	name: '',
+	objectFieldSettings: [],
+	relationshipType: '',
+	required: false,
+	state: false,
+	system: false,
+};
+
 export default function EditObjectField({
 	creationLanguageId,
 	filterOperators,
@@ -56,7 +75,7 @@ export default function EditObjectField({
 	isApproved,
 	isDefaultStorageType,
 	objectDefinitionExternalReferenceCode,
-	objectField,
+	objectFieldId,
 	objectFieldTypes,
 	objectName,
 	objectRelationshipId,
@@ -102,7 +121,7 @@ export default function EditObjectField({
 		forbiddenChars,
 		forbiddenLastChars,
 		forbiddenNames,
-		initialValues: objectField,
+		initialValues,
 		onSubmit,
 	});
 
@@ -114,6 +133,17 @@ export default function EditObjectField({
 	) {
 		TABS.push(Liferay.Language.get('advanced'));
 	}
+
+	useEffect(() => {
+		const makeFetch = async () => {
+			const objectFieldResponse = await API.getObjectField(objectFieldId);
+
+			setValues(objectFieldResponse);
+		};
+
+		makeFetch();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [objectFieldId]);
 
 	return (
 		<SidePanelForm

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.tsx
@@ -42,13 +42,14 @@ import {FORMULA_OUTPUT_OPTIONS, FormulaOutput} from './formulaFieldUtil';
 
 import './ObjectFieldFormBase.scss';
 
-interface IProps {
+interface ObjectFieldFormBaseProps {
 	children?: ReactNode;
 	creationLanguageId2?: Liferay.Language.Locale;
 	disabled?: boolean;
 	editingField?: boolean;
 	errors: ObjectFieldErrors;
 	handleChange: ChangeEventHandler<HTMLInputElement>;
+	objectDefinition?: ObjectDefinition;
 	objectDefinitionExternalReferenceCode: string;
 	objectField: Partial<ObjectField>;
 	objectFieldTypes: ObjectFieldType[];
@@ -155,6 +156,7 @@ export default function ObjectFieldFormBase({
 	editingField,
 	errors,
 	handleChange,
+	objectDefinition,
 	objectDefinitionExternalReferenceCode,
 	objectField: values,
 	objectFieldTypes,
@@ -163,7 +165,7 @@ export default function ObjectFieldFormBase({
 	onAggregationFilterChange,
 	onRelationshipChange,
 	setValues,
-}: IProps) {
+}: ObjectFieldFormBaseProps) {
 	const businessTypeMap = useMemo(() => {
 		const businessTypeMap = new Map<string, ObjectFieldType>();
 
@@ -181,9 +183,6 @@ export default function ObjectFieldFormBase({
 		TObjectRelationship
 	>();
 	const [selectedOutput, setSelectedOutput] = useState<string>('');
-	const [objectDefinition, setObjectDefinition] = useState<
-		ObjectDefinition
-	>();
 
 	const validListTypeDefinitionId =
 		values.listTypeDefinitionId !== undefined &&
@@ -259,12 +258,6 @@ export default function ObjectFieldFormBase({
 
 	useEffect(() => {
 		const makeFetch = async () => {
-			const objectDefinitionResponse = await API.getObjectDefinitionByExternalReferenceCode(
-				objectDefinitionExternalReferenceCode
-			);
-
-			setObjectDefinition(objectDefinitionResponse);
-
 			await getFieldSettingsByBusinessType(
 				objectRelationshipId as number,
 				setOneToManyRelationship,
@@ -276,7 +269,7 @@ export default function ObjectFieldFormBase({
 
 		makeFetch();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [objectDefinitionExternalReferenceCode, values.businessType]);
+	}, [values.businessType]);
 
 	const handleStateToggleChange = (toggled: boolean) => {
 		if (Liferay.FeatureFlags['LPS-163716']) {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfo.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfo.tsx
@@ -12,8 +12,13 @@
  * details.
  */
 
-import {Card, Input, InputLocalized} from '@liferay/object-js-components-web';
-import React, {useState} from 'react';
+import {
+	API,
+	Card,
+	Input,
+	InputLocalized,
+} from '@liferay/object-js-components-web';
+import React, {useEffect, useState} from 'react';
 
 import PicklistDefaultValueSelect from '../../../../components/ObjectField/DefaultValueFields/PicklistDefaultValueSelect';
 import {updateFieldSettings} from '../../../../utils/fieldSettings';
@@ -75,6 +80,9 @@ export function BasicInfo({
 	values,
 	workflowStatusJSONArray,
 }: BasicInfoProps) {
+	const [objectDefinition, setObjectDefinition] = useState<
+		Partial<ObjectDefinition>
+	>({enableLocalization: false});
 	const [
 		objectDefinitionExternalReferenceCode2,
 		setObjectDefinitionExternalReferenceCode2,
@@ -100,6 +108,18 @@ export function BasicInfo({
 				{name, value}
 			),
 		});
+
+	useEffect(() => {
+		const makeFetch = async () => {
+			const objectDefinitionResponse = await API.getObjectDefinitionByExternalReferenceCode(
+				objectDefinitionExternalReferenceCode
+			);
+
+			setObjectDefinition(objectDefinitionResponse);
+		};
+
+		makeFetch();
+	}, [objectDefinitionExternalReferenceCode]);
 
 	return (
 		<>
@@ -211,6 +231,7 @@ export function BasicInfo({
 
 			{Liferay.FeatureFlags['LPS-146755'] && (
 				<TranslationOptionsContainer
+					objectDefinition={objectDefinition}
 					published={isApproved}
 					setValues={setValues}
 					values={values}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
@@ -59,12 +59,13 @@ export function TranslationOptionsContainer({
 			<div className="lfr__objects-translation-options-container">
 				<ClayToggle
 					disabled={published || !translatableField}
-					label={Liferay.Language.get('enable-entry-translation')}
+					label={Liferay.Language.get('enable-entry-translations')}
 					onToggle={() =>
 						setValues({
 							localized: !values.localized,
 						})
 					}
+					toggled={values.localized}
 				/>
 
 				<ClayTooltipProvider>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.tsx
@@ -13,22 +13,23 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import {ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import {ClayTooltipProvider} from '@clayui/tooltip';
-import {Card} from '@liferay/object-js-components-web';
+import {Card, Toggle} from '@liferay/object-js-components-web';
 import React from 'react';
 
 import './TranslationOptionsContainer.scss';
 
 interface TranslationOptionsContainerProps {
+	objectDefinition: Partial<ObjectDefinition>;
 	published: boolean;
 	setValues: (values: Partial<ObjectField>) => void;
 	values: Partial<ObjectField>;
 }
 
 export function TranslationOptionsContainer({
+	objectDefinition,
 	published,
 	setValues,
 	values,
@@ -57,8 +58,12 @@ export function TranslationOptionsContainer({
 			)}
 
 			<div className="lfr__objects-translation-options-container">
-				<ClayToggle
-					disabled={published || !translatableField}
+				<Toggle
+					disabled={
+						published ||
+						!translatableField ||
+						!objectDefinition.enableLocalization
+					}
 					label={Liferay.Language.get('enable-entry-translations')}
 					onToggle={() =>
 						setValues({

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
@@ -42,7 +42,7 @@ ObjectField objectField = (ObjectField)request.getAttribute(ObjectWebKeys.OBJECT
 		).put(
 			"objectDefinitionExternalReferenceCode", objectDefinition.getExternalReferenceCode()
 		).put(
-			"objectField", objectDefinitionsFieldsDisplayContext.getObjectFieldJSONObject(objectField)
+			"objectFieldId", objectField.getObjectFieldId()
 		).put(
 			"objectFieldTypes", objectDefinitionsFieldsDisplayContext.getObjectFieldBusinessTypeMaps(Validator.isNotNull(objectField.getRelationshipType()), locale)
 		).put(

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.d.ts
@@ -26,6 +26,7 @@ interface EditObjectFieldProps {
 	isDefaultStorageType: boolean;
 	objectDefinitionExternalReferenceCode: string;
 	objectField: ObjectField;
+	objectFieldId: number;
 	objectFieldTypes: ObjectFieldType[];
 	objectName: string;
 	objectRelationshipId: number;
@@ -42,7 +43,7 @@ export default function EditObjectField({
 	isApproved,
 	isDefaultStorageType,
 	objectDefinitionExternalReferenceCode,
-	objectField,
+	objectFieldId,
 	objectFieldTypes,
 	objectName,
 	objectRelationshipId,

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/ObjectFieldFormBase.d.ts
@@ -15,13 +15,14 @@
 import {FormError} from '@liferay/object-js-components-web';
 import {ChangeEventHandler, ReactNode} from 'react';
 import './ObjectFieldFormBase.scss';
-interface IProps {
+interface ObjectFieldFormBaseProps {
 	children?: ReactNode;
 	creationLanguageId2?: Liferay.Language.Locale;
 	disabled?: boolean;
 	editingField?: boolean;
 	errors: ObjectFieldErrors;
 	handleChange: ChangeEventHandler<HTMLInputElement>;
+	objectDefinition?: ObjectDefinition;
 	objectDefinitionExternalReferenceCode: string;
 	objectField: Partial<ObjectField>;
 	objectFieldTypes: ObjectFieldType[];
@@ -46,6 +47,7 @@ export default function ObjectFieldFormBase({
 	editingField,
 	errors,
 	handleChange,
+	objectDefinition,
 	objectDefinitionExternalReferenceCode,
 	objectField: values,
 	objectFieldTypes,
@@ -54,5 +56,5 @@ export default function ObjectFieldFormBase({
 	onAggregationFilterChange,
 	onRelationshipChange,
 	setValues,
-}: IProps): JSX.Element;
+}: ObjectFieldFormBaseProps): JSX.Element;
 export {};

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.d.ts
@@ -16,11 +16,13 @@
 
 import './TranslationOptionsContainer.scss';
 interface TranslationOptionsContainerProps {
+	objectDefinition: Partial<ObjectDefinition>;
 	published: boolean;
 	setValues: (values: Partial<ObjectField>) => void;
 	values: Partial<ObjectField>;
 }
 export declare function TranslationOptionsContainer({
+	objectDefinition,
 	published,
 	setValues,
 	values,


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-180922