### PR TITLE
LPS-180788 When created an action in Commerce Product, the product's name won't pass from model to page.

### DIFF
--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -91,7 +91,7 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 					</c:otherwise>
 				</c:choose>
 
-				<aui:input defaultLanguageId="<%= defaultLanguageId %>" label="name" localized="<%= true %>" name="nameMapAsXML" type="text">
+				<aui:input defaultLanguageId="<%= defaultLanguageId %>" label="name" localized="<%= true %>" name="urlTitleMapAsXML" required="<%= true %>" type="text" value="<%= HttpComponentsUtil.decodeURL(cpDefinitionsDisplayContext.getUrlTitleMapAsXML()) %>">
 					<aui:validator name="required" />
 				</aui:input>
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-180788