### PR TITLE
LPS-181995 Avoid looking for parent objectEntry/systemModel if the child have no parent

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/notification/term/contributor/ObjectDefinitionNotificationTermEvaluator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/notification/term/contributor/ObjectDefinitionNotificationTermEvaluator.java
@@ -199,25 +199,28 @@ public class ObjectDefinitionNotificationTermEvaluator
 				continue;
 			}
 
-			User user = null;
-
 			ObjectField objectField = _objectFieldLocalService.getObjectField(
 				objectRelationship.getObjectFieldId2());
+
+			long primaryKey = GetterUtil.getLong(
+				termValues.get(objectField.getName()));
+
+			if (Objects.isNull(primaryKey)) {
+				return StringPool.BLANK;
+			}
+
+			User user = null;
 
 			if (objectDefinition.isSystem()) {
 				user = _userLocalService.getUser(
 					MapUtil.getLong(
 						_objectEntryLocalService.getSystemModelAttributes(
-							objectDefinition,
-							GetterUtil.getLong(
-								termValues.get(objectField.getName()))),
+							objectDefinition, primaryKey),
 						"creator"));
 			}
 			else {
 				ObjectEntry objectEntry =
-					_objectEntryLocalService.getObjectEntry(
-						GetterUtil.getLong(
-							termValues.get(objectField.getName())));
+					_objectEntryLocalService.getObjectEntry(primaryKey);
 
 				user = _userLocalService.getUser(objectEntry.getUserId());
 			}
@@ -286,16 +289,22 @@ public class ObjectDefinitionNotificationTermEvaluator
 			return null;
 		}
 
+		long primaryKey = GetterUtil.getLong(
+			termValues.get(objectField2.getName()));
+
+		if (Objects.isNull(primaryKey)) {
+			return StringPool.BLANK;
+		}
+
 		if (objectDefinition.isSystem()) {
 			return MapUtil.getString(
 				_objectEntryLocalService.getSystemModelAttributes(
-					objectDefinition,
-					GetterUtil.getLong(termValues.get(objectField2.getName()))),
+					objectDefinition, primaryKey),
 				objectFieldName);
 		}
 
 		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
-			GetterUtil.getLong(termValues.get(objectField2.getName())));
+			primaryKey);
 
 		return MapUtil.getString(
 			HashMapBuilder.putAll(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-181995