### PR TITLE
LPS-182206 Notification Template screen broken on large displays

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.scss
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.scss
@@ -35,6 +35,7 @@
 }
 
 @include responsiveCards(3840px, 40rem);
+@include responsiveCards(2560px, 40rem);
 @include responsiveCards(2160px, 29rem);
 @include responsiveCards(1920px, 21rem);
 @include responsiveCards(1600px, 11rem);


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-182206

To reproduce this bug, change your monitor resolution to (2560 x 1440).