### PR TITLE
LPS-182546 Object's errors in the Page Editor when changing instance default language

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -84,6 +84,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -210,6 +211,9 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 								_getOptions(objectField)
 							).labelInfoLocalizedValue(
 								InfoLocalizedValue.<String>builder(
+								).defaultLocale(
+									LocaleUtil.fromLanguageId(
+										objectField.getDefaultLanguageId())
 								).values(
 									objectField.getLabelMap()
 								).build()

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemDetailsProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemDetailsProvider.java
@@ -21,6 +21,7 @@ import com.liferay.info.item.provider.InfoItemDetailsProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.portal.kernel.util.LocaleUtil;
 
 /**
  * @author Guilherme Camacho
@@ -39,6 +40,9 @@ public class ObjectEntryInfoItemDetailsProvider
 		return new InfoItemClassDetails(
 			_objectDefinition.getClassName(),
 			InfoLocalizedValue.<String>builder(
+			).defaultLocale(
+				LocaleUtil.fromLanguageId(
+					_objectDefinition.getDefaultLanguageId())
 			).values(
 				_objectDefinition.getLabelMap()
 			).build());

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -536,7 +536,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 							listTypeEntry.getName(serviceContext.getLocale()),
 							InfoLocalizedValue.<String>builder(
 							).defaultLocale(
-								serviceContext.getLocale()
+								LocaleUtil.fromLanguageId(
+									listTypeEntry.getDefaultLanguageId())
 							).values(
 								listTypeEntry.getNameMap()
 							).build()));
@@ -559,7 +560,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					listTypeEntry.getName(serviceContext.getLocale()),
 					InfoLocalizedValue.<String>builder(
 					).defaultLocale(
-						serviceContext.getLocale()
+						LocaleUtil.fromLanguageId(
+							listTypeEntry.getDefaultLanguageId())
 					).values(
 						listTypeEntry.getNameMap()
 					).build()));

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -385,6 +386,9 @@ public class ObjectEntryInfoItemFieldValuesProvider
 						objectField.getName()
 					).labelInfoLocalizedValue(
 						InfoLocalizedValue.<String>builder(
+						).defaultLocale(
+							LocaleUtil.fromLanguageId(
+								objectField.getDefaultLanguageId())
 						).values(
 							objectField.getLabelMap()
 						).build()
@@ -456,6 +460,9 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					relatedObjectField.getName()
 				).labelInfoLocalizedValue(
 					InfoLocalizedValue.<String>builder(
+					).defaultLocale(
+						LocaleUtil.fromLanguageId(
+							relatedObjectField.getDefaultLanguageId())
 					).values(
 						relatedObjectField.getLabelMap()
 					).build()

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
@@ -384,6 +385,9 @@ public class ObjectEntryInfoItemFormProvider
 					).build()
 				).labelInfoLocalizedValue(
 					InfoLocalizedValue.<String>builder(
+					).defaultLocale(
+						LocaleUtil.fromLanguageId(
+							objectField.getDefaultLanguageId())
 					).values(
 						objectField.getLabelMap()
 					).build()
@@ -519,6 +523,9 @@ public class ObjectEntryInfoItemFormProvider
 			_infoItemFieldReaderFieldSetProvider.getInfoFieldSet(modelClassName)
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(
+			).defaultLocale(
+				LocaleUtil.fromLanguageId(
+					_objectDefinition.getDefaultLanguageId())
 			).values(
 				_objectDefinition.getLabelMap()
 			).build()
@@ -619,6 +626,9 @@ public class ObjectEntryInfoItemFormProvider
 			}
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(
+			).defaultLocale(
+				LocaleUtil.fromLanguageId(
+					objectDefinition.getDefaultLanguageId())
 			).values(
 				labelMap
 			).build()

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -615,6 +615,9 @@ public class ObjectEntryInfoItemFormProvider
 								editable
 							).labelInfoLocalizedValue(
 								InfoLocalizedValue.<String>builder(
+								).defaultLocale(
+									LocaleUtil.fromLanguageId(
+										objectField.getDefaultLanguageId())
 								).values(
 									objectField.getLabelMap()
 								).build()


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182546

Hi Team 👋 
I have found several bugs related to localization in the Info Framework when the site default locale is not the same as the instance default one.
I have grouped those related to Objects in a ticket --> https://issues.liferay.com/browse/LPS-182546
Please could you review it?
Thank you so much!