### PR TITLE
LPS-181610 When adding an picklist-state field to an object with already existing entries, I can't assign a value to these already existing entries.

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3272,10 +3272,13 @@ public class ObjectEntryLocalServiceImpl
 
 		Map<String, Serializable> values = objectEntry.getValues();
 
+		String key = _getValue(String.valueOf(values.get(entry.getKey())));
+
 		ListTypeEntry originalListTypeEntry =
 			_listTypeEntryLocalService.getListTypeEntry(
 				listTypeDefinitionId,
-				_getValue(String.valueOf(values.get(entry.getKey()))));
+				key.isEmpty() ? _getValue(String.valueOf(entry.getValue())) :
+					key);
 
 		ObjectStateFlow objectStateFlow =
 			_objectStateFlowLocalService.fetchObjectFieldObjectStateFlow(


### PR DESCRIPTION
**Related issue:** [LPS-181610](https://issues.liferay.com/browse/LPS-181610)

**Motivation:** The [previous solution](https://github.com/liferay-objects/liferay-portal/pull/2011)  was always assigning the `entry.getValue()` to `originalListTypeEntry` which fixed the bug, but by doing so, it would make the `sourceObjectState.getObjectStateId() == targetObjectState.getObjectStateId()` verification always true, making it no longer possible to get the `invalidObjectStateTransition` cases.

**Proposed solution:**  To solve this, I proposed to add a verification to only assign the `entry.getValue()` to `originalListTypeEntry` when the `entry.getKey()` is empty, which would cover the bug fix and the also get the `invalidObjectStateTransition` cases.
