### PR TITLE
LPS-183453 DB naming of the 1:M relationships fields should not add underscore after publishing

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -637,7 +637,13 @@ public class ObjectFieldLocalServiceImpl
 		_setBusinessTypeAndDBType(businessType, dbType, newObjectField);
 
 		newObjectField.setListTypeDefinitionId(listTypeDefinitionId);
-		newObjectField.setDBColumnName(name + StringPool.UNDERLINE);
+
+		if (!businessType.equals(
+				ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
+
+			newObjectField.setDBColumnName(name + StringPool.UNDERLINE);
+		}
+
 		newObjectField.setLocalized(localized);
 		newObjectField.setName(name);
 		newObjectField.setRequired(required);


### PR DESCRIPTION
[LPS-183453](https://issues.liferay.com/browse/LPS-183453)