### PR TITLE
LPS-184713 Get the user locale for the errorLabel

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -236,10 +236,16 @@ public class ObjectValidationRuleLocalServiceImpl
 			}
 
 			if (GetterUtil.getBoolean(results.get("invalidFields"))) {
+				Locale locale = LocaleUtil.getMostRelevantLocale();
+
 				User user = _userLocalService.fetchUser(userId);
 
+				if (user != null) {
+					locale = user.getLocale();
+				}
+
 				throw new ObjectValidationRuleEngineException.InvalidFields(
-					objectValidationRule.getErrorLabel(user.getLocale()));
+					objectValidationRule.getErrorLabel(locale));
 			}
 
 			if (GetterUtil.getBoolean(results.get("invalidScript"))) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -236,9 +236,10 @@ public class ObjectValidationRuleLocalServiceImpl
 			}
 
 			if (GetterUtil.getBoolean(results.get("invalidFields"))) {
+				User user = _userLocalService.fetchUser(userId);
+
 				throw new ObjectValidationRuleEngineException.InvalidFields(
-					objectValidationRule.getErrorLabel(
-						LocaleUtil.getMostRelevantLocale()));
+					objectValidationRule.getErrorLabel(user.getLocale()));
 			}
 
 			if (GetterUtil.getBoolean(results.get("invalidScript"))) {


### PR DESCRIPTION
[LPS-184713 - Object validation error messages are displayed always in English](https://issues.liferay.com/browse/LPS-184713)

1. Create an object, set some Panel Category Key, add any field and publish the object
2. Edit the object and add a validation for the object:
Type:groovy
enable active validation
under conditions tab insert the following code (groovy)
invalidFields = true;
and add error message to English and to your selected language.
3. Go to the object entries (from Panel Category Key you set) and try to create an entry
4. Change you account's language from account settings to language you added the error message translation
User profile -> Account Settings -> Language
5. Repeat step 3

_**Actual behavior:**_ The error message is in user language

_**Expected behavior:**_ The error message is always in English 