### PR TITLE
LPS-184665 Added test case for checking the failing behaviour

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/SystemObjectRelatedObjectEntriesTest.java
@@ -440,6 +440,41 @@ public class SystemObjectRelatedObjectEntriesTest {
 	}
 
 	@Test
+	public void testPostSystemObjectEntryWithNestedCustomObjectEntriesInManyToOneRelationshipWithoutNestedFieldContent()
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectDefinition, _userSystemObjectDefinition,
+				_user.getUserId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectRelationships.add(objectRelationship);
+
+		JSONObject jsonObject = UserAccountTestUtil.addUserAccountJSONObject(
+			_userSystemObjectDefinitionManager,
+			HashMapBuilder.<String, Serializable>put(
+				objectRelationship.getName(),
+				JSONFactoryUtil.createJSONObject(
+					JSONUtil.put(
+						_OBJECT_FIELD_NAME, _NEW_OBJECT_FIELD_VALUE_1
+					).put(
+						"externalReferenceCode", _ERC_VALUE_1
+					).toString())
+			).build());
+
+		jsonObject = HTTPTestUtil.invoke(
+			null,
+			StringBundler.concat(
+				_getLocation(), StringPool.SLASH, jsonObject.getString("id")),
+			Http.Method.GET);
+
+		Assert.assertNotNull(
+			jsonObject.getJSONObject(objectRelationship.getName())
+		);
+	}
+
+	@Test
 	public void testPostSystemObjectWithObjectRelationshipName()
 		throws Exception {
 


### PR DESCRIPTION
**What's new:**
- Added a new test case that checks if the related elements are returned as nested fields in a many to one relationship

**NOTE:**
This is better explained in a thread located in the headless-objects-collaboration channel

This is **related to** the following [Jira Ticket](https://issues.liferay.com/browse/LPS-184665)