### PR TITLE
LPS-184937 Replace comma separator with point separator

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3072,11 +3072,22 @@ public class ObjectEntryLocalServiceImpl
 				value = BigDecimal.ZERO;
 			}
 
+			String decimalValue = String.valueOf(value);
+
+			String decimalWithPointSeparator = StringUtil.replace(
+				decimalValue, ',', '.');
+
 			preparedStatement.setBigDecimal(
-				index, new BigDecimal(String.valueOf(value)));
+				index, new BigDecimal(decimalWithPointSeparator));
 		}
 		else if (sqlType == Types.DOUBLE) {
-			preparedStatement.setDouble(index, GetterUtil.getDouble(value));
+			String doubleValue = String.valueOf(value);
+
+			String doubleWithPointSeparator = StringUtil.replace(
+				doubleValue, ',', '.');
+
+			preparedStatement.setDouble(
+				index, GetterUtil.getDouble(doubleWithPointSeparator));
 		}
 		else if (sqlType == Types.INTEGER) {
 			preparedStatement.setInt(index, GetterUtil.getInteger(value));


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-184937

Issue:
If a user used a language in which the decimal separator was a comma instead of a dot, the request (when saving a new object entry with decimal or precision decimal field) couldn't be done and a number format exception was returned.
The decimal and precision decimal field worked as intended, these fields didn't let the user write dot decimal separator if the language used the comma separator.
Decimal field used the BigDecimal(String s) constructor, while this constructor can handle dot separator, it can not handle comma separator. Same with Precision Decimal field's value parsing with Double.parseDouble(String s).

Solution:
Replace the comma separator with a dot separator before the constructor gets called.

I tested it in my local environment and the solution worked as expected.

Please review my PR!

Best regards,
Dani