### PR TITLE
LPS-185898 Hide oldValue function in readOnly Expression Builder and Make readOnly property not required

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -666,7 +666,7 @@ public class ObjectFieldLocalServiceImpl
 		newObjectField.setIndexedAsKeyword(indexedAsKeyword);
 		newObjectField.setIndexedLanguageId(indexedLanguageId);
 		newObjectField.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
-		newObjectField.setReadOnly(_getReadOnly(businessType, readOnly, false));
+		newObjectField.setReadOnly(_getReadOnly(businessType, readOnly));
 		newObjectField.setReadOnlyConditionExpression(
 			_getReadOnlyConditionExpression(
 				readOnly, readOnlyConditionExpression));
@@ -803,7 +803,7 @@ public class ObjectFieldLocalServiceImpl
 		objectField.setLocalized(localized);
 		objectField.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
 		objectField.setName(name);
-		objectField.setReadOnly(_getReadOnly(businessType, readOnly, system));
+		objectField.setReadOnly(_getReadOnly(businessType, readOnly));
 		objectField.setReadOnlyConditionExpression(
 			_getReadOnlyConditionExpression(
 				readOnly, readOnlyConditionExpression));
@@ -1056,13 +1056,7 @@ public class ObjectFieldLocalServiceImpl
 		return null;
 	}
 
-	private String _getReadOnly(
-		String businessType, String readOnly, boolean system) {
-
-		if (system || FeatureFlagManagerUtil.isEnabled("LPS-170122")) {
-			return readOnly;
-		}
-
+	private String _getReadOnly(String businessType, String readOnly) {
 		if (Objects.equals(
 				businessType, ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) ||
 			Objects.equals(
@@ -1071,7 +1065,11 @@ public class ObjectFieldLocalServiceImpl
 			return ObjectFieldConstants.READ_ONLY_TRUE;
 		}
 
-		return ObjectFieldConstants.READ_ONLY_FALSE;
+		if (Validator.isNull(readOnly)) {
+			return ObjectFieldConstants.READ_ONLY_FALSE;
+		}
+
+		return readOnly;
 	}
 
 	private String _getReadOnlyConditionExpression(
@@ -1345,7 +1343,12 @@ public class ObjectFieldLocalServiceImpl
 			String readOnlyConditionExpression)
 		throws PortalException {
 
-		if (!FeatureFlagManagerUtil.isEnabled("LPS-170122")) {
+		if (Objects.equals(
+				businessType, ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) ||
+			Objects.equals(
+				businessType, ObjectFieldConstants.BUSINESS_TYPE_FORMULA) ||
+			Validator.isNull(readOnly)) {
+
 			return;
 		}
 
@@ -1356,19 +1359,6 @@ public class ObjectFieldLocalServiceImpl
 
 			throw new ObjectFieldReadOnlyException(
 				"Unknown read only: " + readOnly);
-		}
-
-		if ((Objects.equals(
-				businessType, ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION) ||
-			 Objects.equals(
-				 businessType, ObjectFieldConstants.BUSINESS_TYPE_FORMULA)) &&
-			!Objects.equals(readOnly, ObjectFieldConstants.READ_ONLY_TRUE)) {
-
-			throw new ObjectFieldReadOnlyException(
-				StringBundler.concat(
-					"Read only \"", readOnly,
-					"\" is not allowed for business type \"", businessType,
-					"\""));
 		}
 
 		if (Objects.equals(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -797,6 +797,8 @@ public class ObjectRelationshipLocalServiceImpl
 		objectField.setIndexedLanguageId(null);
 		objectField.setLabelMap(labelMap, LocaleUtil.getSiteDefault());
 		objectField.setName(dbColumnName);
+		objectField.setReadOnly(ObjectFieldConstants.READ_ONLY_FALSE);
+		objectField.setReadOnlyConditionExpression(StringPool.BLANK);
 		objectField.setRelationshipType(type);
 		objectField.setRequired(false);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
@@ -105,7 +105,7 @@ public class ObjectDefinitionsActionsDisplayContext
 
 	public List<Map<String, Object>> getObjectActionCodeEditorElements() {
 		return ObjectCodeEditorUtil.getCodeEditorElements(
-			true, true, objectRequestHelper.getLocale(),
+			StringPool.BLANK, true, true, objectRequestHelper.getLocale(),
 			getObjectDefinitionId(),
 			objectField -> !objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION));

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
@@ -27,6 +27,7 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.object.definitions.display.context.util.ObjectCodeEditorUtil;
 import com.liferay.object.web.internal.util.ObjectFieldBusinessTypeUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -164,6 +165,14 @@ public class ObjectDefinitionsFieldsDisplayContext
 					 includeRelationshipObjectFieldBusinessType)));
 	}
 
+	public List<Map<String, Object>> getObjectFieldCodeEditorElements() {
+		return ObjectCodeEditorUtil.getCodeEditorElements(
+			"old-value", true, true, objectRequestHelper.getLocale(),
+			getObjectDefinitionId(),
+			objectField -> !objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION));
+	}
+
 	public List<Map<String, Object>> getObjectFieldCodeEditorElements(
 		String businessType) {
 
@@ -181,7 +190,7 @@ public class ObjectDefinitionsFieldsDisplayContext
 		}
 
 		return ObjectCodeEditorUtil.getCodeEditorElements(
-			true, false, objectRequestHelper.getLocale(),
+			StringPool.BLANK, true, false, objectRequestHelper.getLocale(),
 			getObjectDefinitionId(), objectField -> !objectField.isSystem());
 	}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.object.validation.rule.ObjectValidationRuleEngineRegistry;
 import com.liferay.object.web.internal.object.definitions.display.context.util.ObjectCodeEditorUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -165,7 +166,7 @@ public class ObjectDefinitionsValidationsDisplayContext
 		}
 
 		return ObjectCodeEditorUtil.getCodeEditorElements(
-			includeDDMExpressionBuilderElements, true,
+			StringPool.BLANK, includeDDMExpressionBuilderElements, true,
 			objectRequestHelper.getLocale(), getObjectDefinitionId(),
 			objectField -> !objectField.compareBusinessType(
 				ObjectFieldConstants.BUSINESS_TYPE_AGGREGATION));

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.tsx
@@ -42,6 +42,7 @@ interface EditObjectFieldProps {
 	objectName: string;
 	objectRelationshipId: number;
 	readOnly: boolean;
+	readOnlySidebarElements: SidebarCategory[];
 	sidebarElements: SidebarCategory[];
 	workflowStatusJSONArray: LabelValueObject[];
 }
@@ -81,6 +82,7 @@ export default function EditObjectField({
 	objectName,
 	objectRelationshipId,
 	readOnly,
+	readOnlySidebarElements,
 	sidebarElements,
 	workflowStatusJSONArray,
 }: EditObjectFieldProps) {
@@ -197,6 +199,9 @@ export default function EditObjectField({
 							<AdvancedTab
 								creationLanguageId={creationLanguageId}
 								errors={errors}
+								readOnlySidebarElements={
+									readOnlySidebarElements
+								}
 								setValues={setValues}
 								sidebarElements={sidebarElements}
 								values={values}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/AdvancedTab.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/AdvancedTab.tsx
@@ -22,6 +22,7 @@ import {ReadOnlyContainer} from './ReadOnlyContainer';
 interface AdvancedTabProps {
 	creationLanguageId: Liferay.Language.Locale;
 	errors: ObjectFieldErrors;
+	readOnlySidebarElements: SidebarCategory[];
 	setValues: (value: Partial<ObjectField>) => void;
 	sidebarElements: SidebarCategory[];
 	values: Partial<ObjectField>;
@@ -30,6 +31,7 @@ interface AdvancedTabProps {
 export function AdvancedTab({
 	creationLanguageId,
 	errors,
+	readOnlySidebarElements,
 	setValues,
 	sidebarElements,
 	values,
@@ -43,6 +45,7 @@ export function AdvancedTab({
 						values.businessType === 'Aggregation' ||
 						values.businessType === 'Formula'
 					}
+					readOnlySidebarElements={readOnlySidebarElements}
 					requiredField={values.required as boolean}
 					setValues={setValues}
 					values={values}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/ReadOnlyContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/ReadOnlyContainer.tsx
@@ -13,11 +13,16 @@
  */
 
 import {ClayRadio, ClayRadioGroup} from '@clayui/form';
-import {Card, ExpressionBuilder} from '@liferay/object-js-components-web';
+import {
+	Card,
+	ExpressionBuilder,
+	SidebarCategory,
+} from '@liferay/object-js-components-web';
 import React from 'react';
 
 interface ReadOnlyContainerProps {
 	disabled?: boolean;
+	readOnlySidebarElements: SidebarCategory[];
 	requiredField: boolean;
 	setValues: (value: Partial<ObjectField>) => void;
 	values: Partial<ObjectField>;
@@ -25,6 +30,7 @@ interface ReadOnlyContainerProps {
 
 export function ReadOnlyContainer({
 	disabled,
+	readOnlySidebarElements,
 	requiredField,
 	setValues,
 	values,
@@ -86,6 +92,7 @@ export function ReadOnlyContainer({
 								parentWindow.Liferay.fire(
 									'openExpressionBuilderModal',
 									{
+										eventSidebarElements: readOnlySidebarElements,
 										header: Liferay.Language.get(
 											'expression-builder'
 										),

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
@@ -52,6 +52,8 @@ ObjectField objectField = (ObjectField)request.getAttribute(ObjectWebKeys.OBJECT
 		).put(
 			"readOnly", !objectDefinitionsFieldsDisplayContext.hasUpdateObjectDefinitionPermission()
 		).put(
+			"readOnlySidebarElements", objectDefinitionsFieldsDisplayContext.getObjectFieldCodeEditorElements()
+		).put(
 			"sidebarElements", objectDefinitionsFieldsDisplayContext.getObjectFieldCodeEditorElements(objectField.getBusinessType())
 		).put(
 			"workflowStatusJSONArray", LocalizedJSONArrayUtil.getWorkflowStatusJSONArray(locale)

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.d.ts
@@ -31,6 +31,7 @@ interface EditObjectFieldProps {
 	objectName: string;
 	objectRelationshipId: number;
 	readOnly: boolean;
+	readOnlySidebarElements: SidebarCategory[];
 	sidebarElements: SidebarCategory[];
 	workflowStatusJSONArray: LabelValueObject[];
 }
@@ -48,6 +49,7 @@ export default function EditObjectField({
 	objectName,
 	objectRelationshipId,
 	readOnly,
+	readOnlySidebarElements,
 	sidebarElements,
 	workflowStatusJSONArray,
 }: EditObjectFieldProps): JSX.Element;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/AdvancedTab.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/AdvancedTab.d.ts
@@ -19,6 +19,7 @@ import {ObjectFieldErrors} from '../../ObjectFieldFormBase';
 interface AdvancedTabProps {
 	creationLanguageId: Liferay.Language.Locale;
 	errors: ObjectFieldErrors;
+	readOnlySidebarElements: SidebarCategory[];
 	setValues: (value: Partial<ObjectField>) => void;
 	sidebarElements: SidebarCategory[];
 	values: Partial<ObjectField>;
@@ -26,6 +27,7 @@ interface AdvancedTabProps {
 export declare function AdvancedTab({
 	creationLanguageId,
 	errors,
+	readOnlySidebarElements,
 	setValues,
 	sidebarElements,
 	values,

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/ReadOnlyContainer.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/Advanced/ReadOnlyContainer.d.ts
@@ -14,14 +14,17 @@
 
 /// <reference types="react" />
 
+import {SidebarCategory} from '@liferay/object-js-components-web';
 interface ReadOnlyContainerProps {
 	disabled?: boolean;
+	readOnlySidebarElements: SidebarCategory[];
 	requiredField: boolean;
 	setValues: (value: Partial<ObjectField>) => void;
 	values: Partial<ObjectField>;
 }
 export declare function ReadOnlyContainer({
 	disabled,
+	readOnlySidebarElements,
 	requiredField,
 	setValues,
 	values,


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-185898