### PR TITLE
LPS-185225 Convert Long type userId to String

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
@@ -211,7 +211,7 @@ public class ObjectEntryVariablesUtil {
 						(Map<String, Object>)payloadJSONObject.get(
 							"objectEntry");
 
-					return objectEntry.get("userId");
+					return String.valueOf(objectEntry.get("userId"));
 				}
 			).put(
 				"currentUserId", payloadJSONObject.get("userId")


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-185225

Issue:
A regression bug coming from: https://issues.liferay.com/browse/LPS-182422.
After this LPS currentUserId and creator didn't match in action conditions when they had the same value. Before the LPS they did. The issue comes from that, before the LPS, the returning value only came from payloadJSONObject, where the userId was a String. After the LPS, the value could come from the objectEntry, where the userId is a Long value. 

Solution:
Convert the long value to String.

I tested it in my local environment and the solution worked as expected.
Tested LPS-182422 too. This fix doesn't break it. 

Please review my PR!

Best regards,
Dani