### PR TITLE
LPS-184883 The Edit action in Objects admin interface is labeled as "View" and uses the wrong icon, which might confuse users

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
@@ -98,8 +98,11 @@ public class ObjectDefinitionsActionsDisplayContext
 				).setWindowState(
 					LiferayWindowState.POP_UP
 				).buildString(),
-				"view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-actions/{id}", "trash", "delete",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsActionsDisplayContext.java
@@ -87,6 +87,8 @@ public class ObjectDefinitionsActionsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				PortletURLBuilder.create(
@@ -98,11 +100,11 @@ public class ObjectDefinitionsActionsDisplayContext
 				).setWindowState(
 					LiferayWindowState.POP_UP
 				).buildString(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-actions/{id}", "trash", "delete",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
@@ -124,8 +124,12 @@ public class ObjectDefinitionsFieldsDisplayContext
 
 		return Arrays.asList(
 			new FDSActionDropdownItem(
-				getEditObjectFieldURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectFieldURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			fdsActionDropdownItem);
 	}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsFieldsDisplayContext.java
@@ -110,6 +110,8 @@ public class ObjectDefinitionsFieldsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		FDSActionDropdownItem fdsActionDropdownItem = new FDSActionDropdownItem(
 			null, "trash", "deleteObjectField",
 			LanguageUtil.get(objectRequestHelper.getRequest(), "delete"),
@@ -125,11 +127,11 @@ public class ObjectDefinitionsFieldsDisplayContext
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				getEditObjectFieldURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			fdsActionDropdownItem);
 	}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsLayoutsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsLayoutsDisplayContext.java
@@ -66,8 +66,12 @@ public class ObjectDefinitionsLayoutsDisplayContext
 
 		return Arrays.asList(
 			new FDSActionDropdownItem(
-				getEditObjectLayoutsURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectLayoutsURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-layouts/{id}", "trash", "delete",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsLayoutsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsLayoutsDisplayContext.java
@@ -64,14 +64,16 @@ public class ObjectDefinitionsLayoutsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				getEditObjectLayoutsURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-layouts/{id}", "trash", "delete",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
@@ -90,14 +90,16 @@ public class ObjectDefinitionsRelationshipsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				getEditObjectRelationshipURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				null, "trash", "deleteObjectRelationship",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
@@ -92,8 +92,12 @@ public class ObjectDefinitionsRelationshipsDisplayContext
 
 		return Arrays.asList(
 			new FDSActionDropdownItem(
-				getEditObjectRelationshipURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectRelationshipURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				null, "trash", "deleteObjectRelationship",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsStateManagerDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsStateManagerDisplayContext.java
@@ -73,8 +73,12 @@ public class ObjectDefinitionsStateManagerDisplayContext
 
 		return Collections.singletonList(
 			new FDSActionDropdownItem(
-				getEditObjectValidationURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectValidationURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"));
 	}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsStateManagerDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsStateManagerDisplayContext.java
@@ -71,14 +71,16 @@ public class ObjectDefinitionsStateManagerDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Collections.singletonList(
 			new FDSActionDropdownItem(
 				getEditObjectValidationURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"));
 	}
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
@@ -75,8 +75,12 @@ public class ObjectDefinitionsValidationsDisplayContext
 
 		return Arrays.asList(
 			new FDSActionDropdownItem(
-				getEditObjectValidationURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectValidationURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-validation-rules/{id}", "trash",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsValidationsDisplayContext.java
@@ -73,14 +73,16 @@ public class ObjectDefinitionsValidationsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				getEditObjectValidationURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-validation-rules/{id}", "trash",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsViewsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsViewsDisplayContext.java
@@ -62,8 +62,12 @@ public class ObjectDefinitionsViewsDisplayContext
 
 		return Arrays.asList(
 			new FDSActionDropdownItem(
-				getEditObjectViewsURL(), "view", "view",
-				LanguageUtil.get(objectRequestHelper.getRequest(), "view"),
+				getEditObjectViewsURL(),
+				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
+				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				LanguageUtil.get(
+					objectRequestHelper.getRequest(),
+					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-views/{id}/copy", "copy", "copy",

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsViewsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsViewsDisplayContext.java
@@ -60,14 +60,16 @@ public class ObjectDefinitionsViewsDisplayContext
 	public List<FDSActionDropdownItem> getFDSActionDropdownItems()
 		throws Exception {
 
+		boolean hasUpdatePermission = hasUpdateObjectDefinitionPermission();
+
 		return Arrays.asList(
 			new FDSActionDropdownItem(
 				getEditObjectViewsURL(),
-				hasUpdateObjectDefinitionPermission() ? "pencil" : "view",
-				hasUpdateObjectDefinitionPermission() ? "edit" : "view",
+				hasUpdatePermission ? "pencil" : "view",
+				hasUpdatePermission ? "edit" : "view",
 				LanguageUtil.get(
 					objectRequestHelper.getRequest(),
-					hasUpdateObjectDefinitionPermission() ? "edit" : "view"),
+					hasUpdatePermission ? "edit" : "view"),
 				"get", null, "sidePanel"),
 			new FDSActionDropdownItem(
 				"/o/object-admin/v1.0/object-views/{id}/copy", "copy", "copy",


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-184883

Julia Lira asked to change the icons from the eye (_view_) to pencil (_edit_) if the user had permission to edit.

~~So, I added a check using _hasUpdateobjectDefinitionPermission_ from _BaseObjectDefinitionsDisplayContext.java_ to check for the permission and set the icon accordingly.~~

So, I added a premission check in the beginning of the method as requested by @guilhermedcamacho and used this boolean instead of calling the method itself.

I talked to Murilo Stodolni and he talked to the team and told me that I could send the fix for the context inside the Object and open a new ticket for the alteration in _ViewObjectDefinitionsDisplayContext_ that requires a little more work.
