### PR TITLE
LPS 188165

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -302,8 +302,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ItemSelectorView.class,
 				new ObjectEntryItemSelectorView(
 					infoPermissionProvider, _itemSelectorViewDescriptorRenderer,
-					objectDefinition, _objectDefinitionLocalService,
-					_objectEntryLocalService,
+					objectDefinition, _objectEntryLocalService,
 					_objectEntryManagerRegistry.getObjectEntryManager(
 						objectDefinition.getStorageType()),
 					_objectRelatedModelsProviderRegistry, _portal),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
@@ -15,6 +15,7 @@
 package com.liferay.object.web.internal.item.selector;
 
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.petra.string.StringBundler;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -59,6 +61,13 @@ public class ObjectEntryItemDescriptor
 
 	@Override
 	public Date getModifiedDate() {
+		if (Objects.equals(
+				_objectDefinition.getStorageType(),
+				ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE)) {
+
+			return null;
+		}
+
 		return _objectEntry.getModifiedDate();
 	}
 
@@ -74,22 +83,29 @@ public class ObjectEntryItemDescriptor
 			"classNameId",
 			_portal.getClassNameId(_objectDefinition.getClassName())
 		).put(
-			"classPK", _objectEntry.getObjectEntryId()
+			"classPK", _getId()
 		).put(
 			"title",
 			StringBundler.concat(
 				_objectDefinition.getLabel(themeDisplay.getLocale()),
-				StringPool.SPACE, _objectEntry.getObjectEntryId())
+				StringPool.SPACE, _getId())
 		).toString();
 	}
 
 	@Override
 	public String getSubtitle(Locale locale) {
-		return String.valueOf(_objectEntry.getObjectEntryId());
+		return _getId();
 	}
 
 	@Override
 	public String getTitle(Locale locale) {
+		if (Objects.equals(
+				_objectDefinition.getStorageType(),
+				ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE)) {
+
+			return _objectEntry.getExternalReferenceCode();
+		}
+
 		try {
 			return _objectEntry.getTitleValue();
 		}
@@ -100,12 +116,37 @@ public class ObjectEntryItemDescriptor
 
 	@Override
 	public long getUserId() {
+		if (Objects.equals(
+				_objectDefinition.getStorageType(),
+				ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE)) {
+
+			return 0;
+		}
+
 		return _objectEntry.getUserId();
 	}
 
 	@Override
 	public String getUserName() {
+		if (Objects.equals(
+				_objectDefinition.getStorageType(),
+				ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE)) {
+
+			return StringPool.BLANK;
+		}
+
 		return _objectEntry.getUserName();
+	}
+
+	private String _getId() {
+		if (Objects.equals(
+				_objectDefinition.getStorageType(),
+				ObjectDefinitionConstants.STORAGE_TYPE_SALESFORCE)) {
+
+			return _objectEntry.getExternalReferenceCode();
+		}
+
+		return String.valueOf(_objectEntry.getObjectEntryId());
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
@@ -17,7 +17,6 @@ package com.liferay.object.web.internal.item.selector;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -39,21 +38,13 @@ public class ObjectEntryItemDescriptor
 
 	public ObjectEntryItemDescriptor(
 		HttpServletRequest httpServletRequest,
-		ObjectDefinitionLocalService objectDefinitionLocalService,
-		ObjectEntry objectEntry, Portal portal) {
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+		Portal portal) {
 
 		_httpServletRequest = httpServletRequest;
+		_objectDefinition = objectDefinition;
 		_objectEntry = objectEntry;
 		_portal = portal;
-
-		try {
-			_objectDefinition =
-				objectDefinitionLocalService.getObjectDefinition(
-					objectEntry.getObjectDefinitionId());
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
-		}
 	}
 
 	@Override

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemDescriptor.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.item.selector;
+
+import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Date;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class ObjectEntryItemDescriptor
+	implements ItemSelectorViewDescriptor.ItemDescriptor {
+
+	public ObjectEntryItemDescriptor(
+		HttpServletRequest httpServletRequest,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntry objectEntry, Portal portal) {
+
+		_httpServletRequest = httpServletRequest;
+		_objectEntry = objectEntry;
+		_portal = portal;
+
+		try {
+			_objectDefinition =
+				objectDefinitionLocalService.getObjectDefinition(
+					objectEntry.getObjectDefinitionId());
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Override
+	public String getIcon() {
+		return null;
+	}
+
+	@Override
+	public String getImageURL() {
+		return null;
+	}
+
+	@Override
+	public Date getModifiedDate() {
+		return _objectEntry.getModifiedDate();
+	}
+
+	@Override
+	public String getPayload() {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return JSONUtil.put(
+			"className", _objectDefinition.getClassName()
+		).put(
+			"classNameId",
+			_portal.getClassNameId(_objectDefinition.getClassName())
+		).put(
+			"classPK", _objectEntry.getObjectEntryId()
+		).put(
+			"title",
+			StringBundler.concat(
+				_objectDefinition.getLabel(themeDisplay.getLocale()),
+				StringPool.SPACE, _objectEntry.getObjectEntryId())
+		).toString();
+	}
+
+	@Override
+	public String getSubtitle(Locale locale) {
+		return String.valueOf(_objectEntry.getObjectEntryId());
+	}
+
+	@Override
+	public String getTitle(Locale locale) {
+		try {
+			return _objectEntry.getTitleValue();
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Override
+	public long getUserId() {
+		return _objectEntry.getUserId();
+	}
+
+	@Override
+	public String getUserName() {
+		return _objectEntry.getUserName();
+	}
+
+	private final HttpServletRequest _httpServletRequest;
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectEntry _objectEntry;
+	private final Portal _portal;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -23,6 +23,7 @@ import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.ActionableInfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
@@ -45,6 +46,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -328,6 +330,18 @@ public class ObjectEntryItemSelectorView
 		@Override
 		public boolean isMultipleSelection() {
 			return _infoItemItemSelectorCriterion.isMultiSelection();
+		}
+
+		@Override
+		public boolean isShowBreadcrumb() {
+			if (StringUtil.equals(
+					_objectDefinition.getScope(),
+					ObjectDefinitionConstants.SCOPE_SITE)) {
+
+				return true;
+			}
+
+			return false;
 		}
 
 		private DTOConverterContext _getDTOConverterContext() {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -393,8 +393,14 @@ public class ObjectEntryItemSelectorView
 			long objectDefinitionId,
 			com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry) {
 
+			Long id = objectEntry.getId();
+
+			if (id == null) {
+				id = 0L;
+			}
+
 			ObjectEntry serviceBuilderObjectEntry =
-				_objectEntryLocalService.createObjectEntry(objectEntry.getId());
+				_objectEntryLocalService.createObjectEntry(id);
 
 			serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -26,7 +26,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -60,7 +59,6 @@ public class ObjectEntryItemSelectorView
 		ItemSelectorViewDescriptorRenderer<InfoItemItemSelectorCriterion>
 			itemSelectorViewDescriptorRenderer,
 		ObjectDefinition objectDefinition,
-		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManager objectEntryManager,
 		ObjectRelatedModelsProviderRegistry objectRelatedModelsProviderRegistry,
@@ -70,7 +68,6 @@ public class ObjectEntryItemSelectorView
 		_itemSelectorViewDescriptorRenderer =
 			itemSelectorViewDescriptorRenderer;
 		_objectDefinition = objectDefinition;
-		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManager = objectEntryManager;
 		_objectRelatedModelsProviderRegistry =
@@ -131,9 +128,8 @@ public class ObjectEntryItemSelectorView
 			new ObjectEntryItemSelectorViewDescriptor(
 				(HttpServletRequest)servletRequest,
 				infoItemItemSelectorCriterion, _objectDefinition,
-				_objectDefinitionLocalService, _objectEntryLocalService,
-				_objectEntryManager, _objectRelatedModelsProviderRegistry,
-				_portal, portletURL));
+				_objectEntryLocalService, _objectEntryManager,
+				_objectRelatedModelsProviderRegistry, _portal, portletURL));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -149,7 +145,6 @@ public class ObjectEntryItemSelectorView
 	private final ItemSelectorViewDescriptorRenderer
 		<InfoItemItemSelectorCriterion> _itemSelectorViewDescriptorRenderer;
 	private final ObjectDefinition _objectDefinition;
-	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryManager _objectEntryManager;
 	private final ObjectRelatedModelsProviderRegistry

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -32,11 +32,9 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -57,7 +55,6 @@ import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -176,92 +173,6 @@ public class ObjectEntryItemSelectorView
 		_objectRelatedModelsProviderRegistry;
 	private final Portal _portal;
 
-	private class ObjectEntryItemDescriptor
-		implements ItemSelectorViewDescriptor.ItemDescriptor {
-
-		public ObjectEntryItemDescriptor(
-			ObjectEntry objectEntry, HttpServletRequest httpServletRequest) {
-
-			_objectEntry = objectEntry;
-			_httpServletRequest = httpServletRequest;
-
-			try {
-				_objectDefinition =
-					_objectDefinitionLocalService.getObjectDefinition(
-						objectEntry.getObjectDefinitionId());
-			}
-			catch (PortalException portalException) {
-				throw new RuntimeException(portalException);
-			}
-		}
-
-		@Override
-		public String getIcon() {
-			return null;
-		}
-
-		@Override
-		public String getImageURL() {
-			return null;
-		}
-
-		@Override
-		public Date getModifiedDate() {
-			return _objectEntry.getModifiedDate();
-		}
-
-		@Override
-		public String getPayload() {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)_httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
-			return JSONUtil.put(
-				"className", _objectDefinition.getClassName()
-			).put(
-				"classNameId",
-				_portal.getClassNameId(_objectDefinition.getClassName())
-			).put(
-				"classPK", _objectEntry.getObjectEntryId()
-			).put(
-				"title",
-				StringBundler.concat(
-					_objectDefinition.getLabel(themeDisplay.getLocale()),
-					StringPool.SPACE, _objectEntry.getObjectEntryId())
-			).toString();
-		}
-
-		@Override
-		public String getSubtitle(Locale locale) {
-			return String.valueOf(_objectEntry.getObjectEntryId());
-		}
-
-		@Override
-		public String getTitle(Locale locale) {
-			try {
-				return _objectEntry.getTitleValue();
-			}
-			catch (PortalException portalException) {
-				throw new RuntimeException(portalException);
-			}
-		}
-
-		@Override
-		public long getUserId() {
-			return _objectEntry.getUserId();
-		}
-
-		@Override
-		public String getUserName() {
-			return _objectEntry.getUserName();
-		}
-
-		private HttpServletRequest _httpServletRequest;
-		private final ObjectDefinition _objectDefinition;
-		private final ObjectEntry _objectEntry;
-
-	}
-
 	private class ObjectItemSelectorViewDescriptor
 		implements ItemSelectorViewDescriptor<ObjectEntry> {
 
@@ -296,7 +207,8 @@ public class ObjectEntryItemSelectorView
 		@Override
 		public ItemDescriptor getItemDescriptor(ObjectEntry objectEntry) {
 			return new ObjectEntryItemDescriptor(
-				objectEntry, _httpServletRequest);
+				_httpServletRequest, _objectDefinitionLocalService, objectEntry,
+				_portal);
 		}
 
 		@Override

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -18,47 +18,29 @@ import com.liferay.info.item.selector.InfoItemSelectorView;
 import com.liferay.info.permission.provider.InfoPermissionProvider;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
-import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.ActionableInfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
-import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.search.SearchContainer;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.JavaConstants;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
-import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.IOException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
 
 import javax.servlet.ServletException;
@@ -146,11 +128,12 @@ public class ObjectEntryItemSelectorView
 		_itemSelectorViewDescriptorRenderer.renderHTML(
 			servletRequest, servletResponse, infoItemItemSelectorCriterion,
 			portletURL, itemSelectedEventName, search,
-			new ObjectItemSelectorViewDescriptor(
+			new ObjectEntryItemSelectorViewDescriptor(
 				(HttpServletRequest)servletRequest,
 				infoItemItemSelectorCriterion, _objectDefinition,
+				_objectDefinitionLocalService, _objectEntryLocalService,
 				_objectEntryManager, _objectRelatedModelsProviderRegistry,
-				portletURL));
+				_portal, portletURL));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -172,164 +155,5 @@ public class ObjectEntryItemSelectorView
 	private final ObjectRelatedModelsProviderRegistry
 		_objectRelatedModelsProviderRegistry;
 	private final Portal _portal;
-
-	private class ObjectItemSelectorViewDescriptor
-		implements ItemSelectorViewDescriptor<ObjectEntry> {
-
-		public ObjectItemSelectorViewDescriptor(
-			HttpServletRequest httpServletRequest,
-			InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
-			ObjectDefinition objectDefinition,
-			ObjectEntryManager objectEntryManager,
-			ObjectRelatedModelsProviderRegistry
-				objectRelatedModelsProviderRegistry,
-			PortletURL portletURL) {
-
-			_httpServletRequest = httpServletRequest;
-			_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
-			_objectDefinition = objectDefinition;
-			_objectEntryManager = objectEntryManager;
-			_objectRelatedModelsProviderRegistry =
-				objectRelatedModelsProviderRegistry;
-			_portletURL = portletURL;
-
-			_portletRequest = (PortletRequest)httpServletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_REQUEST);
-			_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-		}
-
-		@Override
-		public String getDefaultDisplayStyle() {
-			return "descriptive";
-		}
-
-		@Override
-		public ItemDescriptor getItemDescriptor(ObjectEntry objectEntry) {
-			return new ObjectEntryItemDescriptor(
-				_httpServletRequest, _objectDefinitionLocalService, objectEntry,
-				_portal);
-		}
-
-		@Override
-		public ItemSelectorReturnType getItemSelectorReturnType() {
-			return new InfoItemItemSelectorReturnType();
-		}
-
-		@Override
-		public SearchContainer<ObjectEntry> getSearchContainer()
-			throws PortalException {
-
-			SearchContainer<ObjectEntry> searchContainer =
-				new SearchContainer<>(
-					_portletRequest, _portletURL, null,
-					"no-entries-were-found");
-
-			try {
-				searchContainer.setResultsAndTotal(
-					_getObjectEntries(
-						ParamUtil.getLong(
-							_portletRequest, "objectDefinitionId"),
-						searchContainer.getCur(), searchContainer.getDelta()));
-			}
-			catch (Exception exception) {
-				_log.error(exception);
-
-				searchContainer.setResultsAndTotal(ArrayList::new, 0);
-			}
-
-			return searchContainer;
-		}
-
-		@Override
-		public boolean isMultipleSelection() {
-			return _infoItemItemSelectorCriterion.isMultiSelection();
-		}
-
-		@Override
-		public boolean isShowBreadcrumb() {
-			if (StringUtil.equals(
-					_objectDefinition.getScope(),
-					ObjectDefinitionConstants.SCOPE_SITE)) {
-
-				return true;
-			}
-
-			return false;
-		}
-
-		private DTOConverterContext _getDTOConverterContext() {
-			return new DefaultDTOConverterContext(
-				false, null, null, _httpServletRequest, null,
-				_themeDisplay.getLocale(), null, _themeDisplay.getUser());
-		}
-
-		private List<ObjectEntry> _getObjectEntries(
-				long objectDefinitionId, int curPage, int pageSize)
-			throws Exception {
-
-			if (objectDefinitionId == 0) {
-				Group scopeGroup = _themeDisplay.getScopeGroup();
-
-				Page<com.liferay.object.rest.dto.v1_0.ObjectEntry> page =
-					_objectEntryManager.getObjectEntries(
-						_themeDisplay.getCompanyId(), _objectDefinition,
-						scopeGroup.getGroupKey(), null,
-						_getDTOConverterContext(), StringPool.BLANK,
-						Pagination.of(curPage, pageSize), null, null);
-
-				return TransformUtil.transform(
-					page.getItems(),
-					objectEntry -> _toObjectEntry(
-						_objectDefinition.getObjectDefinitionId(),
-						objectEntry));
-			}
-
-			ObjectRelatedModelsProvider objectRelatedModelsProvider =
-				_objectRelatedModelsProviderRegistry.
-					getObjectRelatedModelsProvider(
-						_objectDefinition.getClassName(),
-						_objectDefinition.getCompanyId(),
-						ParamUtil.getString(
-							_portletRequest, "objectRelationshipType"));
-
-			return objectRelatedModelsProvider.getUnrelatedModels(
-				_objectDefinition.getCompanyId(),
-				ParamUtil.getLong(_portletRequest, "groupId"),
-				_objectDefinition,
-				ParamUtil.getLong(_portletRequest, "objectEntryId"),
-				ParamUtil.getLong(_portletRequest, "objectRelationshipId"));
-		}
-
-		private ObjectEntry _toObjectEntry(
-			long objectDefinitionId,
-			com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry) {
-
-			Long id = objectEntry.getId();
-
-			if (id == null) {
-				id = 0L;
-			}
-
-			ObjectEntry serviceBuilderObjectEntry =
-				_objectEntryLocalService.createObjectEntry(id);
-
-			serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
-
-			return serviceBuilderObjectEntry;
-		}
-
-		private final HttpServletRequest _httpServletRequest;
-		private final InfoItemItemSelectorCriterion
-			_infoItemItemSelectorCriterion;
-		private final ObjectDefinition _objectDefinition;
-		private final ObjectEntryManager _objectEntryManager;
-		private final ObjectRelatedModelsProviderRegistry
-			_objectRelatedModelsProviderRegistry;
-		private final PortletRequest _portletRequest;
-		private final PortletURL _portletURL;
-		private final ThemeDisplay _themeDisplay;
-
-	}
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.IOException;
 
@@ -316,7 +317,8 @@ public class ObjectEntryItemSelectorView
 				searchContainer.setResultsAndTotal(
 					_getObjectEntries(
 						ParamUtil.getLong(
-							_portletRequest, "objectDefinitionId")));
+							_portletRequest, "objectDefinitionId"),
+						searchContainer.getCur(), searchContainer.getDelta()));
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -350,7 +352,8 @@ public class ObjectEntryItemSelectorView
 				_themeDisplay.getLocale(), null, _themeDisplay.getUser());
 		}
 
-		private List<ObjectEntry> _getObjectEntries(long objectDefinitionId)
+		private List<ObjectEntry> _getObjectEntries(
+				long objectDefinitionId, int curPage, int pageSize)
 			throws Exception {
 
 			if (objectDefinitionId == 0) {
@@ -360,8 +363,8 @@ public class ObjectEntryItemSelectorView
 					_objectEntryManager.getObjectEntries(
 						_themeDisplay.getCompanyId(), _objectDefinition,
 						scopeGroup.getGroupKey(), null,
-						_getDTOConverterContext(), StringPool.BLANK, null, null,
-						null);
+						_getDTOConverterContext(), StringPool.BLANK,
+						Pagination.of(curPage, pageSize), null, null);
 
 				return TransformUtil.transform(
 					page.getItems(),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
@@ -188,6 +188,8 @@ public class ObjectEntryItemSelectorViewDescriptor
 			_objectEntryLocalService.createObjectEntry(
 				GetterUtil.getLong(objectEntry.getId()));
 
+		serviceBuilderObjectEntry.setExternalReferenceCode(
+			objectEntry.getExternalReferenceCode());
 		serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
 
 		return serviceBuilderObjectEntry;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.item.selector;
+
+import com.liferay.item.selector.ItemSelectorReturnType;
+import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
+import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class ObjectEntryItemSelectorViewDescriptor
+	implements ItemSelectorViewDescriptor<ObjectEntry> {
+
+	public ObjectEntryItemSelectorViewDescriptor(
+		HttpServletRequest httpServletRequest,
+		InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
+		ObjectDefinition objectDefinition,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
+		ObjectEntryManager objectEntryManager,
+		ObjectRelatedModelsProviderRegistry objectRelatedModelsProviderRegistry,
+		Portal portal, PortletURL portletURL) {
+
+		_httpServletRequest = httpServletRequest;
+		_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
+		_objectDefinition = objectDefinition;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
+		_objectEntryManager = objectEntryManager;
+		_objectRelatedModelsProviderRegistry =
+			objectRelatedModelsProviderRegistry;
+		_portal = portal;
+		_portletURL = portletURL;
+
+		_portletRequest = (PortletRequest)httpServletRequest.getAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST);
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	@Override
+	public String getDefaultDisplayStyle() {
+		return "descriptive";
+	}
+
+	@Override
+	public ItemDescriptor getItemDescriptor(ObjectEntry objectEntry) {
+		return new ObjectEntryItemDescriptor(
+			_httpServletRequest, _objectDefinitionLocalService, objectEntry,
+			_portal);
+	}
+
+	@Override
+	public ItemSelectorReturnType getItemSelectorReturnType() {
+		return new InfoItemItemSelectorReturnType();
+	}
+
+	@Override
+	public SearchContainer<ObjectEntry> getSearchContainer()
+		throws PortalException {
+
+		SearchContainer<ObjectEntry> searchContainer = new SearchContainer<>(
+			_portletRequest, _portletURL, null, "no-entries-were-found");
+
+		try {
+			searchContainer.setResultsAndTotal(
+				_getObjectEntries(
+					ParamUtil.getLong(_portletRequest, "objectDefinitionId"),
+					searchContainer.getCur(), searchContainer.getDelta()));
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			searchContainer.setResultsAndTotal(ArrayList::new, 0);
+		}
+
+		return searchContainer;
+	}
+
+	@Override
+	public boolean isMultipleSelection() {
+		return _infoItemItemSelectorCriterion.isMultiSelection();
+	}
+
+	@Override
+	public boolean isShowBreadcrumb() {
+		if (StringUtil.equals(
+				_objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private DTOConverterContext _getDTOConverterContext() {
+		return new DefaultDTOConverterContext(
+			false, null, null, _httpServletRequest, null,
+			_themeDisplay.getLocale(), null, _themeDisplay.getUser());
+	}
+
+	private List<ObjectEntry> _getObjectEntries(
+			long objectDefinitionId, int curPage, int pageSize)
+		throws Exception {
+
+		if (objectDefinitionId == 0) {
+			Group scopeGroup = _themeDisplay.getScopeGroup();
+
+			Page<com.liferay.object.rest.dto.v1_0.ObjectEntry> page =
+				_objectEntryManager.getObjectEntries(
+					_themeDisplay.getCompanyId(), _objectDefinition,
+					scopeGroup.getGroupKey(), null, _getDTOConverterContext(),
+					StringPool.BLANK, Pagination.of(curPage, pageSize), null,
+					null);
+
+			return TransformUtil.transform(
+				page.getItems(),
+				objectEntry -> _toObjectEntry(
+					_objectDefinition.getObjectDefinitionId(), objectEntry));
+		}
+
+		ObjectRelatedModelsProvider objectRelatedModelsProvider =
+			_objectRelatedModelsProviderRegistry.getObjectRelatedModelsProvider(
+				_objectDefinition.getClassName(),
+				_objectDefinition.getCompanyId(),
+				ParamUtil.getString(_portletRequest, "objectRelationshipType"));
+
+		return objectRelatedModelsProvider.getUnrelatedModels(
+			_objectDefinition.getCompanyId(),
+			ParamUtil.getLong(_portletRequest, "groupId"), _objectDefinition,
+			ParamUtil.getLong(_portletRequest, "objectEntryId"),
+			ParamUtil.getLong(_portletRequest, "objectRelationshipId"));
+	}
+
+	private ObjectEntry _toObjectEntry(
+		long objectDefinitionId,
+		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry) {
+
+		Long id = objectEntry.getId();
+
+		if (id == null) {
+			id = 0L;
+		}
+
+		ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.createObjectEntry(id);
+
+		serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
+
+		return serviceBuilderObjectEntry;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryItemSelectorViewDescriptor.class);
+
+	private final HttpServletRequest _httpServletRequest;
+	private final InfoItemItemSelectorCriterion _infoItemItemSelectorCriterion;
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final ObjectEntryManager _objectEntryManager;
+	private final ObjectRelatedModelsProviderRegistry
+		_objectRelatedModelsProviderRegistry;
+	private final Portal _portal;
+	private final PortletRequest _portletRequest;
+	private final PortletURL _portletURL;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
@@ -24,7 +24,6 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
-import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
@@ -63,7 +62,6 @@ public class ObjectEntryItemSelectorViewDescriptor
 		HttpServletRequest httpServletRequest,
 		InfoItemItemSelectorCriterion infoItemItemSelectorCriterion,
 		ObjectDefinition objectDefinition,
-		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManager objectEntryManager,
 		ObjectRelatedModelsProviderRegistry objectRelatedModelsProviderRegistry,
@@ -72,7 +70,6 @@ public class ObjectEntryItemSelectorViewDescriptor
 		_httpServletRequest = httpServletRequest;
 		_infoItemItemSelectorCriterion = infoItemItemSelectorCriterion;
 		_objectDefinition = objectDefinition;
-		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManager = objectEntryManager;
 		_objectRelatedModelsProviderRegistry =
@@ -201,7 +198,6 @@ public class ObjectEntryItemSelectorViewDescriptor
 	private final HttpServletRequest _httpServletRequest;
 	private final InfoItemItemSelectorCriterion _infoItemItemSelectorCriterion;
 	private final ObjectDefinition _objectDefinition;
-	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryManager _objectEntryManager;
 	private final ObjectRelatedModelsProviderRegistry

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -183,14 +184,9 @@ public class ObjectEntryItemSelectorViewDescriptor
 		long objectDefinitionId,
 		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry) {
 
-		Long id = objectEntry.getId();
-
-		if (id == null) {
-			id = 0L;
-		}
-
 		ObjectEntry serviceBuilderObjectEntry =
-			_objectEntryLocalService.createObjectEntry(id);
+			_objectEntryLocalService.createObjectEntry(
+				GetterUtil.getLong(objectEntry.getId()));
 
 		serviceBuilderObjectEntry.setObjectDefinitionId(objectDefinitionId);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorViewDescriptor.java
@@ -93,8 +93,7 @@ public class ObjectEntryItemSelectorViewDescriptor
 	@Override
 	public ItemDescriptor getItemDescriptor(ObjectEntry objectEntry) {
 		return new ObjectEntryItemDescriptor(
-			_httpServletRequest, _objectDefinitionLocalService, objectEntry,
-			_portal);
+			_httpServletRequest, _objectDefinition, objectEntry, _portal);
 	}
 
 	@Override


### PR DESCRIPTION
Motivation
----
Fix item selector for proxy objects when we are selecting them on Display Page creation.

<img width="1573" alt="Employee_-_Liferay_DXP__Editing_" src="https://github.com/liferay-objects/liferay-portal/assets/922631/8223444c-3fce-4275-be66-375f971beafe">

[Link to the issue](https://liferay.atlassian.net/browse/LPS-188165)

Proposed Solution
----
Adapts logic in ObjectEntryItemSelectorView.java to allow selecting proxy objects, also it splits logic into different classes to make it more readable.

How to test it
---
Step-by-Step:

1. Connect with Salesforce Employee object
2. Create a Display Page for Employees
3. Add some fragments and map
4. Try to select a employee object

After the changes it looks like:

<img width="1740" alt="Employee_-_Liferay_DXP__Editing_" src="https://github.com/liferay-objects/liferay-portal/assets/922631/6cd8b952-db50-4b3a-92da-b66729096024">

Comments
---
At this only the selection is working, so if you select a employee the mapped contents are not changing, I'm working on it right now. 

Regarding the logic related with proxy objects, I don't know how to get some information, so I decided to return empty or null values, please complete it if you know how to do it. IMHO, it can be done in a follow up pr, so I can work in more improvements.

