### PR TITLE
LPS-188387 Hide M:M relationship option in SystemObjectDefinition Address

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
@@ -1077,6 +1078,17 @@ public class ObjectRelationshipLocalServiceImpl
 				throw new ObjectRelationshipTypeException(
 					"Inverse type already exists");
 			}
+		}
+
+		if (Objects.equals(
+				type, ObjectRelationshipConstants.TYPE_MANY_TO_MANY) &&
+			(Objects.equals(
+				objectDefinition1.getClassName(), Address.class.getName()) ||
+			 Objects.equals(
+				 objectDefinition2.getClassName(), Address.class.getName()))) {
+
+			throw new ObjectRelationshipTypeException(
+				"Many to many relationship are not allowed with Address");
 		}
 
 		_validateParameterObjectFieldId(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.db.IndexMetadataFactoryUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -224,6 +225,34 @@ public class ObjectRelationshipLocalServiceTest {
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
 				ObjectRelationshipConstants.TYPE_ONE_TO_ONE));
+
+		ObjectDefinition addressObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				TestPropsValues.getCompanyId(), Address.class.getName());
+
+		AssertUtils.assertFailure(
+			ObjectRelationshipTypeException.class,
+			"Many to many relationship are not allowed with Address",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				addressObjectDefinition.getObjectDefinitionId(),
+				_objectDefinition1.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
+
+		AssertUtils.assertFailure(
+			ObjectRelationshipTypeException.class,
+			"Many to many relationship are not allowed with Address",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				addressObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
 
 		AssertUtils.assertFailure(
 			ObjectRelationshipTypeException.class,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.db.IndexMetadataFactoryUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -151,30 +152,24 @@ public class ObjectRelationshipLocalServiceTest {
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				"able", ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			DuplicateObjectRelationshipException.class, "Duplicate name able",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				_objectDefinition2.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"able", ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (DuplicateObjectRelationshipException
-					duplicateObjectRelationshipException) {
-
-			Assert.assertEquals(
-				"Duplicate name able",
-				duplicateObjectRelationshipException.getMessage());
-		}
+				"able", ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
 
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Object definition " + _objectDefinition1.getName() +
+				" does not allow a parameter object field ID",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				_objectDefinition2.getObjectDefinitionId(),
@@ -182,65 +177,65 @@ public class ObjectRelationshipLocalServiceTest {
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Object relationship type " +
-					ObjectRelationshipConstants.TYPE_MANY_TO_MANY +
-						" does not allow a parameter object field ID",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
-
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(),
-				RandomTestUtil.randomLong(),
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Object definition " + _objectDefinition1.getName() +
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Object relationship type " +
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY +
 					" does not allow a parameter object field ID",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
+			() -> _objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(),
+				RandomTestUtil.randomLong(),
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
 	}
 
 	@Test
 	public void testAddSystemObjectRelationship() throws Exception {
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Object relationship type " +
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY +
+					" does not allow a parameter object field ID",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				_systemObjectDefinition1.getObjectDefinitionId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				RandomTestUtil.randomLong(),
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
+
+		AssertUtils.assertFailure(
+			ObjectRelationshipTypeException.class,
+			"Invalid type for system object definition " +
+				_systemObjectDefinition2.getObjectDefinitionId(),
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_systemObjectDefinition2.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_ONE);
+				ObjectRelationshipConstants.TYPE_ONE_TO_ONE));
 
-			Assert.fail();
-		}
-		catch (ObjectRelationshipTypeException
-					objectRelationshipTypeException) {
-
-			String message = objectRelationshipTypeException.getMessage();
-
-			Assert.assertTrue(
-				message.contains("Invalid type for system object definition"));
-		}
+		AssertUtils.assertFailure(
+			ObjectRelationshipTypeException.class,
+			"Relationships are not allowed between system objects",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				_systemObjectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY));
 
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
@@ -262,49 +257,6 @@ public class ObjectRelationshipLocalServiceTest {
 		_testCreateManyToManyObjectRelationshipTable(_systemObjectDefinition2);
 
 		_testSystemObjectRelationshipOneToMany();
-
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
-				_systemObjectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipTypeException
-					objectRelationshipTypeException) {
-
-			Assert.assertEquals(
-				"Relationships are not allowed between system objects",
-				objectRelationshipTypeException.getMessage());
-		}
-
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				RandomTestUtil.randomLong(),
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Object relationship type " +
-					ObjectRelationshipConstants.TYPE_MANY_TO_MANY +
-						" does not allow a parameter object field ID",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
 	}
 
 	@Test
@@ -343,22 +295,14 @@ public class ObjectRelationshipLocalServiceTest {
 			objectRelationship1.getLabelMap(),
 			reverseObjectRelationship.getLabelMap());
 
-		try {
-			_objectRelationshipLocalService.updateObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipReverseException.class,
+			"Reverse object relationships cannot be updated",
+			() -> _objectRelationshipLocalService.updateObjectRelationship(
 				reverseObjectRelationship.getObjectRelationshipId(), 0,
 				reverseObjectRelationship.getDeletionType(),
 				LocalizedMapUtil.getLocalizedMap(
-					RandomTestUtil.randomString()));
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipReverseException
-					objectRelationshipReverseException) {
-
-			Assert.assertEquals(
-				"Reverse object relationships cannot be updated",
-				objectRelationshipReverseException.getMessage());
-		}
+					RandomTestUtil.randomString())));
 
 		ObjectRelationship objectRelationship2 =
 			_objectRelationshipLocalService.addObjectRelationship(
@@ -504,19 +448,11 @@ public class ObjectRelationshipLocalServiceTest {
 		Assert.assertEquals(
 			objectRelationship.getType(), reverseObjectRelationship.getType());
 
-		try {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				reverseObjectRelationship);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipReverseException
-					objectRelationshipReverseException) {
-
-			Assert.assertEquals(
-				"Reverse object relationships cannot be deleted",
-				objectRelationshipReverseException.getMessage());
-		}
+		AssertUtils.assertFailure(
+			ObjectRelationshipReverseException.class,
+			"Reverse object relationships cannot be deleted",
+			() -> _objectRelationshipLocalService.deleteObjectRelationship(
+				reverseObjectRelationship));
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);
@@ -676,31 +612,26 @@ public class ObjectRelationshipLocalServiceTest {
 	}
 
 	private void _testSystemObjectRelationshipOneToMany() throws Exception {
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Object definition " + _systemObjectDefinition1.getName() +
+				" requires a parameter object field ID",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_systemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Object definition " + _systemObjectDefinition1.getName() +
-					" requires a parameter object field ID",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 
 		long parameterObjectFieldId = RandomTestUtil.randomLong();
 
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Parameter object field ID " + parameterObjectFieldId +
+				" does not exist",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_systemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
@@ -708,76 +639,48 @@ public class ObjectRelationshipLocalServiceTest {
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Parameter object field ID " + parameterObjectFieldId +
-					" does not exist",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 
 		List<ObjectField> objectFields =
 			_objectFieldLocalService.getObjectFields(
 				_objectDefinition2.getObjectDefinitionId());
 
-		ObjectField objectField = objectFields.get(0);
+		ObjectField objectField1 = objectFields.get(0);
 
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			StringBundler.concat(
+				"Parameter object field ID ", objectField1.getObjectFieldId(),
+				" does not belong to object definition ",
+				_objectDefinition1.getName()),
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_systemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
-				objectField.getObjectFieldId(),
+				objectField1.getObjectFieldId(),
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				StringBundler.concat(
-					"Parameter object field ID ",
-					objectField.getObjectFieldId(),
-					" does not belong to object definition ",
-					_objectDefinition1.getName()),
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 
 		objectFields = _objectFieldLocalService.getObjectFields(
 			_objectDefinition1.getObjectDefinitionId());
 
-		objectField = objectFields.get(0);
+		ObjectField objectField2 = objectFields.get(0);
 
-		try {
-			_objectRelationshipLocalService.addObjectRelationship(
+		AssertUtils.assertFailure(
+			ObjectRelationshipParameterObjectFieldIdException.class,
+			"Parameter object field ID " + objectField2.getObjectFieldId() +
+				" does not belong to a relationship object field",
+			() -> _objectRelationshipLocalService.addObjectRelationship(
 				TestPropsValues.getUserId(),
 				_systemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
-				objectField.getObjectFieldId(),
+				objectField2.getObjectFieldId(),
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-			Assert.fail();
-		}
-		catch (ObjectRelationshipParameterObjectFieldIdException
-					objectRelationshipParameterObjectFieldIdException) {
-
-			Assert.assertEquals(
-				"Parameter object field ID " + objectField.getObjectFieldId() +
-					" does not belong to a relationship object field",
-				objectRelationshipParameterObjectFieldIdException.getMessage());
-		}
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
 
 		String objectRelationshipName = StringUtil.randomId();
 
@@ -790,7 +693,7 @@ public class ObjectRelationshipLocalServiceTest {
 			objectRelationshipName,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		objectField = _objectFieldLocalService.getObjectField(
+		ObjectField objectField3 = _objectFieldLocalService.getObjectField(
 			_objectDefinition2.getObjectDefinitionId(),
 			StringBundler.concat(
 				"r_", objectRelationshipName, "_",
@@ -800,7 +703,7 @@ public class ObjectRelationshipLocalServiceTest {
 			TestPropsValues.getUserId(),
 			_systemObjectDefinition1.getObjectDefinitionId(),
 			_objectDefinition2.getObjectDefinitionId(),
-			objectField.getObjectFieldId(),
+			objectField3.getObjectFieldId(),
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			StringUtil.randomId(),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/display/context/ObjectDefinitionsRelationshipsDisplayContext.java
@@ -34,9 +34,11 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Arrays;
@@ -208,6 +210,18 @@ public class ObjectDefinitionsRelationshipsDisplayContext
 			systemObjectDefinitionManager.getJaxRsApplicationDescriptor();
 
 		return jaxRsApplicationDescriptor.getRESTContextPath();
+	}
+
+	public boolean isAddressSystemObjectDefinition() {
+		ObjectDefinition objectDefinition = getObjectDefinition();
+
+		if (StringUtil.equals(
+				objectDefinition.getClassName(), Address.class.getName())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isFFOneToOneRelationshipConfigurationEnabled() {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.tsx
@@ -31,6 +31,7 @@ import SelectRelationship from './SelectRelationship';
 
 function ModalAddObjectRelationship({
 	ffOneToOneRelationshipConfigurationEnabled,
+	isAddressSystemObjectDefinition,
 	objectDefinitionExternalReferenceCode,
 	observer,
 	onClose,
@@ -100,6 +101,9 @@ function ModalAddObjectRelationship({
 							ffOneToOneRelationshipConfigurationEnabled
 						}
 						handleChange={handleChange}
+						isAddressSystemObjectDefinition={
+							isAddressSystemObjectDefinition
+						}
 						setValues={setValues}
 						values={{
 							...values,
@@ -150,6 +154,7 @@ function ModalAddObjectRelationship({
 
 export default function AddRelationship({
 	ffOneToOneRelationshipConfigurationEnabled,
+	isAddressSystemObjectDefinition,
 	objectDefinitionExternalReferenceCode,
 	parameterRequired,
 }: IProps) {
@@ -173,6 +178,9 @@ export default function AddRelationship({
 					ffOneToOneRelationshipConfigurationEnabled={
 						ffOneToOneRelationshipConfigurationEnabled
 					}
+					isAddressSystemObjectDefinition={
+						isAddressSystemObjectDefinition
+					}
 					objectDefinitionExternalReferenceCode={
 						objectDefinitionExternalReferenceCode
 					}
@@ -187,6 +195,7 @@ export default function AddRelationship({
 
 interface IProps {
 	ffOneToOneRelationshipConfigurationEnabled: boolean;
+	isAddressSystemObjectDefinition: boolean;
 	objectDefinitionExternalReferenceCode: string;
 	observer: Observer;
 	onClose: () => void;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -33,6 +33,7 @@ interface ObjectRelationshipFormBaseProps {
 	errors: FormError<ObjectRelationship>;
 	ffOneToOneRelationshipConfigurationEnabled?: boolean;
 	handleChange: React.ChangeEventHandler<HTMLInputElement>;
+	isAddressSystemObjectDefinition?: boolean;
 	readonly?: boolean;
 	setValues: (values: Partial<ObjectRelationship>) => void;
 	values: Partial<ObjectRelationship>;
@@ -122,6 +123,7 @@ export function ObjectRelationshipFormBase({
 	errors,
 	ffOneToOneRelationshipConfigurationEnabled,
 	handleChange,
+	isAddressSystemObjectDefinition,
 	readonly,
 	setValues,
 	values,
@@ -136,13 +138,21 @@ export function ObjectRelationshipFormBase({
 	const [query, setQuery] = useState<string>('');
 
 	const [types, selectedType] = useMemo(() => {
-		const types = [ONE_TO_MANY, MANY_TO_MANY];
+		const types = [ONE_TO_MANY];
 		if (ffOneToOneRelationshipConfigurationEnabled) {
 			types.push(ONE_TO_ONE);
 		}
 
+		if (!isAddressSystemObjectDefinition) {
+			types.push(MANY_TO_MANY);
+		}
+
 		return [types, types.find(({value}) => value === values.type)?.label];
-	}, [ffOneToOneRelationshipConfigurationEnabled, values.type]);
+	}, [
+		ffOneToOneRelationshipConfigurationEnabled,
+		isAddressSystemObjectDefinition,
+		values.type,
+	]);
 
 	const filteredRelationships = useMemo(() => {
 		return filterArrayByQuery({

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/relationships.jsp
@@ -61,6 +61,8 @@ renderResponse.setTitle(objectDefinition.getLabel(locale, true));
 			HashMapBuilder.<String, Object>put(
 				"ffOneToOneRelationshipConfigurationEnabled", objectDefinitionsRelationshipsDisplayContext.isFFOneToOneRelationshipConfigurationEnabled()
 			).put(
+				"isAddressSystemObjectDefinition", objectDefinitionsRelationshipsDisplayContext.isAddressSystemObjectDefinition()
+			).put(
 				"objectDefinitionExternalReferenceCode", objectDefinition.getExternalReferenceCode()
 			).put(
 				"parameterRequired", objectDefinitionsRelationshipsDisplayContext.isParameterRequired(objectDefinition)

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/AddRelationship.d.ts
@@ -17,11 +17,13 @@
 import {Observer} from '@clayui/modal/lib/types';
 export default function AddRelationship({
 	ffOneToOneRelationshipConfigurationEnabled,
+	isAddressSystemObjectDefinition,
 	objectDefinitionExternalReferenceCode,
 	parameterRequired,
 }: IProps): JSX.Element;
 interface IProps {
 	ffOneToOneRelationshipConfigurationEnabled: boolean;
+	isAddressSystemObjectDefinition: boolean;
 	objectDefinitionExternalReferenceCode: string;
 	observer: Observer;
 	onClose: () => void;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.d.ts
@@ -18,6 +18,7 @@ interface ObjectRelationshipFormBaseProps {
 	errors: FormError<ObjectRelationship>;
 	ffOneToOneRelationshipConfigurationEnabled?: boolean;
 	handleChange: React.ChangeEventHandler<HTMLInputElement>;
+	isAddressSystemObjectDefinition?: boolean;
 	readonly?: boolean;
 	setValues: (values: Partial<ObjectRelationship>) => void;
 	values: Partial<ObjectRelationship>;
@@ -47,6 +48,7 @@ export declare function ObjectRelationshipFormBase({
 	errors,
 	ffOneToOneRelationshipConfigurationEnabled,
 	handleChange,
+	isAddressSystemObjectDefinition,
 	readonly,
 	setValues,
 	values,


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-188387