### PR TITLE
LPS-189269 Deal with duplicated references of a RichText ObjectField in the values map| LPS-189273 Consider readOnly as false, when the readOnlyConditionExpression is semantically invalid at runtime

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -230,7 +230,8 @@ public class ObjectFieldUtil {
 
 			ObjectField objectField = objectFieldsMap.get(entry.getKey());
 
-			if (Objects.equals(
+			if ((objectField == null) ||
+				Objects.equals(
 					objectField.getReadOnly(),
 					ObjectFieldConstants.READ_ONLY_FALSE)) {
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -16,6 +16,7 @@ package com.liferay.object.web.internal.object.entries.display.context;
 
 import com.liferay.dynamic.data.mapping.expression.CreateExpressionRequest;
 import com.liferay.dynamic.data.mapping.expression.DDMExpression;
+import com.liferay.dynamic.data.mapping.expression.DDMExpressionException;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
@@ -1230,18 +1231,24 @@ public class ObjectEntryDisplayContextImpl
 			existingValues.put("currentUserId", _themeDisplay.getUserId());
 		}
 
-		DDMExpression<Boolean> ddmExpression =
-			_ddmExpressionFactory.createExpression(
-				CreateExpressionRequest.Builder.newBuilder(
-					objectField.getReadOnlyConditionExpression()
-				).withDDMExpressionFieldAccessor(
-					new ObjectEntryDDMExpressionFieldAccessor(existingValues)
-				).build());
+		try {
+			DDMExpression<Boolean> ddmExpression =
+				_ddmExpressionFactory.createExpression(
+					CreateExpressionRequest.Builder.newBuilder(
+						objectField.getReadOnlyConditionExpression()
+					).withDDMExpressionFieldAccessor(
+						new ObjectEntryDDMExpressionFieldAccessor(
+							existingValues)
+					).build());
 
-		ddmExpression.setVariables(existingValues);
+			ddmExpression.setVariables(existingValues);
 
-		if (ddmExpression.evaluate()) {
-			return true;
+			if (ddmExpression.evaluate()) {
+				return true;
+			}
+		}
+		catch (DDMExpressionException ddmExpressionException) {
+			_log.error(ddmExpressionException);
 		}
 
 		return false;


### PR DESCRIPTION
Related issues:
https://liferay.atlassian.net/browse/LPS-189269;
https://liferay.atlassian.net/browse/LPS-189273.