### PR TITLE
LPS-173394 SchemaVersion increase

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.160
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 5.3.1
+Liferay-Require-SchemaVersion: 5.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -396,6 +396,11 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		_persistedModelLocalServiceRegistry.unregister(
 			objectDefinition.getClassName());
+
+		_resourceActions.removeResourceReference(
+			_portletLocalService.getPortletById(
+				objectDefinition.getPortletId()),
+			objectDefinition.getResourceName());
 	}
 
 	private final AccountEntryLocalService _accountEntryLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -305,6 +305,10 @@ public class ObjectServiceUpgradeStepRegistrator
 			"5.3.0", "5.3.1",
 			new com.liferay.object.internal.upgrade.v5_3_1.
 				SchemaUpgradeProcess());
+
+		registry.register(
+			"5.3.1", "5.4.0",
+			new com.liferay.object.internal.upgrade.v5_4_0.UpgradePortletId());
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_4_0/UpgradePortletId.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_4_0/UpgradePortletId.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.upgrade.v5_4_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Pedro Tavares
+ */
+public class UpgradePortletId extends BasePortletIdUpgradeProcess {
+
+	@Override
+	protected String[][] getRenamePortletIdsArray() {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select count(objectDefinitionId) from ObjectDefinition");
+			PreparedStatement preparedStatement2 = connection.prepareStatement(
+				"select companyId, name, objectDefinitionId from " +
+					"ObjectDefinition");
+			ResultSet resultSet1 = preparedStatement1.executeQuery();
+			ResultSet resultSet2 = preparedStatement2.executeQuery()) {
+
+			if (!resultSet1.next()) {
+				return new String[0][0];
+			}
+
+			String[][] renamePortletIdsArray =
+				new String[resultSet1.getInt(1)][2];
+
+			while (resultSet2.next()) {
+				int row = resultSet2.getRow() - 1;
+
+				renamePortletIdsArray[row][0] =
+					_BASEPORTLETID + resultSet2.getString("objectDefinitionId");
+				renamePortletIdsArray[row][1] = StringBundler.concat(
+					_BASEPORTLETID, resultSet2.getString("companyId"), "_",
+					resultSet2.getString("name"));
+			}
+
+			return renamePortletIdsArray;
+		}
+		catch (SQLException sqlException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(sqlException);
+			}
+
+			return new String[0][0];
+		}
+	}
+
+	private static final String _BASEPORTLETID =
+		"com_liferay_object_web_internal_object_definitions_portlet_" +
+			"ObjectDefinitionsPortlet_";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletId.class);
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -96,8 +96,9 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 			throw new UnsupportedOperationException();
 		}
 
-		return "com_liferay_object_web_internal_object_definitions_portlet_" +
-			"ObjectDefinitionsPortlet_" + getObjectDefinitionId();
+		return StringBundler.concat(
+			"com_liferay_object_web_internal_object_definitions_portlet_",
+			"ObjectDefinitionsPortlet_", getCompanyId(), "_", getName());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -609,6 +609,16 @@ public class ResourceActionsImpl implements ResourceActions {
 		}
 	}
 
+	@Override
+	public void removeResourceReference(Portlet portlet, String resourceName) {
+		_resourceReferences.remove(resourceName);
+
+		if (portlet != null) {
+			_portletRootModelResources.remove(portlet.getPortletId());
+			_resourceReferences.remove(portlet.getPortletName());
+		}
+	}
+
 	@BeanReference(type = PortletLocalService.class)
 	protected PortletLocalService portletLocalService;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -130,4 +130,6 @@ public interface ResourceActions {
 
 	public void removeModelResource(String name, String action);
 
+	public void removeResourceReference(Portlet portlet, String resourceName);
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 6.5.0
+version 6.6.0


### PR DESCRIPTION
Follow-up: https://github.com/liferay-objects/liferay-portal/pull/2233

Related ticket: https://liferay.atlassian.net/browse/LPS-173394

Note for reviewer: in the Upgrade startup we get an exception (see photo). In spite of that, the Upgrade executes successfully and, after testing, I did not find any bugs. 
This is probably happening because there is an attempt to deploy the ObjectDefinition before the new Portlet (with new ID) is generated. 

![error-in-upgrade](https://github.com/liferay-objects/liferay-portal/assets/82452840/8a738bdf-5609-44db-bb84-48f88a2e833e)