### PR TITLE
LPS-189265  Expression builder not showing required field error message at read only configuration

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyConditionExpressionExceptionMapper.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyConditionExpressionExceptionMapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.admin.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectFieldReadOnlyConditionExpressionException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Diogo Melo
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Object.Admin.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Object.Admin.REST.ObjectFieldReadOnlyConditionExpressionExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ObjectFieldReadOnlyConditionExpressionExceptionMapper
+	extends BaseExceptionMapper
+		<ObjectFieldReadOnlyConditionExpressionException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectFieldReadOnlyConditionExpressionException
+			objectFieldReadOnlyConditionExpressionException) {
+
+		return new Problem(objectFieldReadOnlyConditionExpressionException);
+	}
+
+}


### PR DESCRIPTION
[LPS-189265](https://liferay.atlassian.net/browse/LPS-189265)