### PR TITLE
LPS-189995 Triggering update on object, with attachment left blank, runs into error. 

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java
@@ -24,6 +24,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -141,10 +142,15 @@ public class AttachmentObjectFieldBusinessType
 			fileEntryId = MapUtil.getLong((Map<String, Object>)value, "id");
 		}
 		else {
-			JSONObject jsonObject = jsonFactory.createJSONObject(
-				MapUtil.getString(values, objectField.getName()));
+			String stringValue = MapUtil.getString(
+				values, objectField.getName());
 
-			fileEntryId = GetterUtil.getLong(jsonObject.get("id"));
+			if (JSONUtil.isJSONObject(stringValue)) {
+				JSONObject jsonObject = jsonFactory.createJSONObject(
+					stringValue);
+
+				fileEntryId = GetterUtil.getLong(jsonObject.get("id"));
+			}
 		}
 
 		if (fileEntryId > 0) {


### PR DESCRIPTION
PR for https://liferay.atlassian.net/browse/LPS-189995.

The issue is that when we update an object with an attachment field and we leave it blank, it gives an error. The integer 0 value is causing at https://github.com/liferay/liferay-portal/blob/f18b6b9631a79db27829ce933b66d963bcd9e3d6/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AttachmentObjectFieldBusinessType.java#L144 when trying to use that in JSONFactory.

The solution: when the file entry is already zero and it is not an instance of a Map, it doesn’t need to change the value to JSON format and back, so I included a isJSONObject before.

This worked locally.

BR,
Gege