### PR TITLE
LPS-191273 I can't submit form if State is defined in Object and State picklist field is not present in form container

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1769,7 +1769,7 @@ public class ObjectEntryLocalServiceImpl
 		List<ObjectField> objectFields, Map<String, Serializable> values) {
 
 		for (ObjectField objectField : objectFields) {
-			if (values.containsKey(objectField.getName())) {
+			if (values.get(objectField.getName()) != null) {
 				continue;
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191273

Although this issue has been reported when trying to create an object entry through a page with a form container, the root cause of the issue is not within the page editor, but within the  objects code.

It can also be reproduced when trying to create an object entry via headless api without specifying the required picklist field for which a default value has been configured.
A 400 is returned with error message:
```
{
  "status": "BAD_REQUEST",
  "title": "No value was provided for required object field \"<nameOfTheRequiredPicklistFieldWithDefaultValue>\""
}
```

I have attempted to fix it. With the fix, creating object entries without specifying any value for the "required picklist field with a default value" works both from a Content Page and via Headless API.

//cc @ealonso @jkappler

