### PR TITLE
LPS-191310 Call runSQL method that takes a connection reference. Because the method without it would not complete the query

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -488,6 +488,7 @@ public class SQLServerDB extends BaseDB {
 		}
 
 		runSQL(
+			connection,
 			StringBundler.concat(
 				"alter table ", tableName, " drop constraint ",
 				defaultConstraintName));


### PR DESCRIPTION
Related ticket: [LPS-191310](https://liferay.atlassian.net/browse/LPS-191310)