### PR TITLE
LPS-192177 Failed upgrade process for module com.liferay.object.service error column xxxx does not exist when upgrading to U77 or newer with a self-referenced object relationship

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_2_0/ObjectRelationshipUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_2_0/ObjectRelationshipUpgradeProcess.java
@@ -23,18 +23,21 @@ public class ObjectRelationshipUpgradeProcess extends UpgradeProcess {
 
 		processConcurrently(
 			StringBundler.concat(
-				"select ObjectDefinition.pkObjectFieldDBColumnName, ",
-				"ObjectRelationship.dbTableName from ObjectDefinition inner ",
-				"join ObjectRelationship on ObjectRelationship.type_ = '",
+				"select distinct ObjectDefinition.pkObjectFieldDBColumnName, ",
+				"ObjectRelationship.dbTableName, ",
+				"ObjectRelationship.objectDefinitionId1, ",
+				"ObjectRelationship.objectDefinitionId2 from ObjectDefinition ",
+				"inner join ObjectRelationship on ObjectRelationship.type_ = '",
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, "' where ",
 				"ObjectDefinition.objectDefinitionId = ",
 				"ObjectRelationship.objectDefinitionId1"),
 			resultSet -> new Object[] {
-				resultSet.getString(1), resultSet.getString(2)
+				resultSet.getString(1), resultSet.getString(2),
+				resultSet.getLong(3), resultSet.getLong(4)
 			},
 			values -> _createIndex(
 				String.valueOf(values[0]), dbInspector,
-				String.valueOf(values[1])),
+				String.valueOf(values[1]), (long)values[2], (long)values[3]),
 			null);
 	}
 
@@ -48,6 +51,20 @@ public class ObjectRelationshipUpgradeProcess extends UpgradeProcess {
 
 		if (!dbInspector.hasIndex(tableName, indexMetadata.getIndexName())) {
 			runSQL(indexMetadata.getCreateSQL(null));
+		}
+	}
+
+	private void _createIndex(
+			String columnName, DBInspector dbInspector, String tableName,
+			long objectDefinitionId1, long objectDefinitionId2)
+		throws Exception {
+
+		if (objectDefinitionId1 != objectDefinitionId2) {
+			_createIndex(columnName, dbInspector, tableName);
+		}
+		else {
+			_createIndex(columnName.concat("1"), dbInspector, tableName);
+			_createIndex(columnName.concat("2"), dbInspector, tableName);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_2_0/ObjectRelationshipUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v5_2_0/ObjectRelationshipUpgradeProcess.java
@@ -7,6 +7,7 @@ package com.liferay.object.internal.upgrade.v5_2_0;
 
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.db.IndexMetadataFactoryUtil;
@@ -22,15 +23,19 @@ public class ObjectRelationshipUpgradeProcess extends UpgradeProcess {
 		DBInspector dbInspector = new DBInspector(connection);
 
 		processConcurrently(
-			StringBundler.concat(
-				"select distinct ObjectDefinition.pkObjectFieldDBColumnName, ",
-				"ObjectRelationship.dbTableName, ",
-				"ObjectRelationship.objectDefinitionId1, ",
-				"ObjectRelationship.objectDefinitionId2 from ObjectDefinition ",
-				"inner join ObjectRelationship on ObjectRelationship.type_ = '",
-				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, "' where ",
-				"ObjectDefinition.objectDefinitionId = ",
-				"ObjectRelationship.objectDefinitionId1"),
+			SQLTransformer.transform(
+				StringBundler.concat(
+					"select distinct ",
+					"ObjectDefinition.pkObjectFieldDBColumnName, ",
+					"ObjectRelationship.dbTableName, ",
+					"ObjectRelationship.objectDefinitionId1, ",
+					"ObjectRelationship.objectDefinitionId2 from ",
+					"ObjectDefinition inner join ObjectRelationship on ",
+					"ObjectRelationship.type_ = '",
+					ObjectRelationshipConstants.TYPE_MANY_TO_MANY, "' where ",
+					"ObjectDefinition.active_ = [$TRUE$] and ",
+					"ObjectDefinition.objectDefinitionId = ",
+					"ObjectRelationship.objectDefinitionId1")),
 			resultSet -> new Object[] {
 				resultSet.getString(1), resultSet.getString(2),
 				resultSet.getLong(3), resultSet.getLong(4)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-192177

This bug was caused by the `ObjectRelationshipUpgradeProcess` upgrade step implemented on [LPS-183217](https://liferay.atlassian.net/browse/LPS-183217)

This upgrade process is not correctly handling the self-referenced relationships.

After doing some tests I also noticed it is not correctly handling relationships of Objects in draft status either.

To solve it I am adding two commits:

- d4bb9fdf947360f7eea60f47ca6d90853d32b3bd => Handle the self-referenced relationships properly in the same way is done in the `ObjectRelationshipUtil.getPKObjectFieldDBColumnNames` method, concatenating 1 and 2
- 9d5ae9db78942f2d3e0b157e4800a69b9b15f7c3 => Filter draft objects to avoid the upgrade error of trying to create an index in the null table as draft objects don't have table yet

Let me know if you have any question