### PR TITLE
LPS-192303

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -380,7 +380,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				LayoutDisplayPageProvider.class,
 				new ObjectEntryLayoutDisplayPageProvider(
-					objectDefinition, _objectEntryLocalService,
+					objectDefinition, _objectDefinitionLocalService,
+					_objectEntryLocalService,
 					_objectEntryManagerRegistry.getObjectEntryManager(
 						objectDefinition.getStorageType()),
 					_userLocalService),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -668,7 +668,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				return StringPool.BLANK;
 			}
 
-			return dlFileEntry.getFileName();
+			return dlFileEntry.getFileEntryId();
 		}
 		else if (Objects.equals(
 					objectField.getDBType(),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -14,6 +14,7 @@ import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.web.internal.util.ObjectEntryUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -33,11 +34,13 @@ public class ObjectEntryLayoutDisplayPageProvider
 
 	public ObjectEntryLayoutDisplayPageProvider(
 		ObjectDefinition objectDefinition,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryManager objectEntryManager,
 		UserLocalService userLocalService) {
 
 		_objectDefinition = objectDefinition;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryManager = objectEntryManager;
 		_userLocalService = userLocalService;
@@ -73,8 +76,12 @@ public class ObjectEntryLayoutDisplayPageProvider
 				return null;
 			}
 
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					objectEntry.getObjectDefinitionId());
+
 			return new ObjectEntryLayoutDisplayPageObjectProvider(
-				_objectDefinition, objectEntry);
+				objectDefinition, objectEntry);
 		}
 
 		ERCInfoItemIdentifier ercInfoItemIdentifier =
@@ -142,6 +149,7 @@ public class ObjectEntryLayoutDisplayPageProvider
 		ObjectEntryLayoutDisplayPageProvider.class);
 
 	private final ObjectDefinition _objectDefinition;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryManager _objectEntryManager;
 	private final UserLocalService _userLocalService;


### PR DESCRIPTION
Motivation
----
Allow editing attachment on display page templates

[Link](https://liferay.atlassian.net/browse/LPS-191357)

Proposed Solution
----
Instead of returning the file name as value for attachments return the file entry id, since we already have all document information, but for the moment it is under LPS-176083 Feature Flag.

Also, fix a problem related with Display Pages, it is because when we get a display page for an ObjectEntry we are using the same ObjectDefinition, so we need to use the object definition of the object entry, it is happening when we call: 

```
BaseAssetDisplayPageFriendlyURLResolver.java

private LayoutDisplayPageObjectProvider<?>
		_getLayoutDisplayPageObjectProvider(
			LayoutDisplayPageProvider<?> layoutDisplayPageProvider,
			long groupId, String friendlyURL, String version) {

		return layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
			groupId, _getUrlTitle(friendlyURL), version);
	}
```
this layoutDisplayPageProvider is always the same since we are registering all providers under "l" friendly URL, so we are getting always the same.

Please let me know if you have any question.
