### PR TITLE
LPS-192669 Accounts cannot be deleted if the Account Object has a relationship with an inactive Object

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/deployer/InactiveObjectDefinitionDeployer.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/deployer/InactiveObjectDefinitionDeployer.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.deployer;
+
+import com.liferay.object.model.ObjectDefinition;
+
+import java.util.List;
+
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Michael Bowerman
+ */
+public interface InactiveObjectDefinitionDeployer {
+
+	public List<ServiceRegistration<?>> deploy(
+		ObjectDefinition objectDefinition);
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalService.java
@@ -165,6 +165,9 @@ public interface ObjectDefinitionLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	public void deployInactiveObjectDefinition(
+		ObjectDefinition objectDefinition);
+
 	public void deployObjectDefinition(ObjectDefinition objectDefinition);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceUtil.java
@@ -179,6 +179,12 @@ public class ObjectDefinitionLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static void deployInactiveObjectDefinition(
+		ObjectDefinition objectDefinition) {
+
+		getService().deployInactiveObjectDefinition(objectDefinition);
+	}
+
 	public static void deployObjectDefinition(
 		ObjectDefinition objectDefinition) {
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectDefinitionLocalServiceWrapper.java
@@ -193,6 +193,14 @@ public class ObjectDefinitionLocalServiceWrapper
 	}
 
 	@Override
+	public void deployInactiveObjectDefinition(
+		com.liferay.object.model.ObjectDefinition objectDefinition) {
+
+		_objectDefinitionLocalService.deployInactiveObjectDefinition(
+			objectDefinition);
+	}
+
+	@Override
 	public void deployObjectDefinition(
 		com.liferay.object.model.ObjectDefinition objectDefinition) {
 

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/deployer/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/deployer/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/InactiveObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/InactiveObjectDefinitionDeployerImpl.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.deployer;
+
+import com.liferay.object.deployer.InactiveObjectDefinitionDeployer;
+import com.liferay.object.internal.related.models.ObjectEntry1to1ObjectRelatedModelsProviderImpl;
+import com.liferay.object.internal.related.models.ObjectEntry1toMObjectRelatedModelsProviderImpl;
+import com.liferay.object.internal.related.models.ObjectEntryMtoMObjectRelatedModelsProviderImpl;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.related.models.ManyToOneObjectRelatedModelsProvider;
+import com.liferay.object.related.models.ObjectRelatedModelsProvider;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Michael Bowerman
+ */
+public class InactiveObjectDefinitionDeployerImpl
+	implements InactiveObjectDefinitionDeployer {
+
+	public InactiveObjectDefinitionDeployerImpl(
+		BundleContext bundleContext, ObjectEntryService objectEntryService,
+		ObjectFieldLocalService objectFieldLocalService,
+		ObjectRelationshipLocalService objectRelationshipLocalService) {
+
+		_bundleContext = bundleContext;
+		_objectEntryService = objectEntryService;
+		_objectFieldLocalService = objectFieldLocalService;
+		_objectRelationshipLocalService = objectRelationshipLocalService;
+	}
+
+	@Override
+	public List<ServiceRegistration<?>> deploy(
+		ObjectDefinition objectDefinition) {
+
+		return ListUtil.fromArray(
+			_bundleContext.registerService(
+				ObjectRelatedModelsProvider.class,
+				new ObjectEntry1to1ObjectRelatedModelsProviderImpl(
+					objectDefinition, _objectEntryService,
+					_objectFieldLocalService, _objectRelationshipLocalService),
+				null),
+			_bundleContext.registerService(
+				new String[] {
+					ManyToOneObjectRelatedModelsProvider.class.getName(),
+					ObjectRelatedModelsProvider.class.getName()
+				},
+				new ObjectEntry1toMObjectRelatedModelsProviderImpl(
+					objectDefinition, _objectEntryService,
+					_objectFieldLocalService, _objectRelationshipLocalService),
+				null),
+			_bundleContext.registerService(
+				ObjectRelatedModelsProvider.class,
+				new ObjectEntryMtoMObjectRelatedModelsProviderImpl(
+					objectDefinition, _objectEntryService,
+					_objectRelationshipLocalService),
+				null));
+	}
+
+	private final BundleContext _bundleContext;
+	private final ObjectEntryService _objectEntryService;
+	private final ObjectFieldLocalService _objectFieldLocalService;
+	private final ObjectRelationshipLocalService
+		_objectRelationshipLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.deployer.InactiveObjectDefinitionDeployer;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
@@ -37,6 +38,7 @@ import com.liferay.object.exception.RequiredObjectFieldException;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.internal.dao.db.ObjectDBManagerUtil;
 import com.liferay.object.internal.definition.util.ObjectDefinitionUtil;
+import com.liferay.object.internal.deployer.InactiveObjectDefinitionDeployerImpl;
 import com.liferay.object.internal.deployer.ObjectDefinitionDeployerImpl;
 import com.liferay.object.internal.petra.sql.dsl.DynamicObjectDefinitionLocalizationTableFactory;
 import com.liferay.object.model.ObjectAction;
@@ -714,6 +716,11 @@ public class ObjectDefinitionLocalServiceImpl
 				_workflowStatusModelPreFilterContributor,
 				_userGroupRoleLocalService));
 
+		_addingInactiveObjectDefinitionDeployer(
+			new InactiveObjectDefinitionDeployerImpl(
+				_bundleContext, _objectEntryService, _objectFieldLocalService,
+				_objectRelationshipLocalService));
+
 		_objectDefinitionDeployerServiceTracker = new ServiceTracker<>(
 			_bundleContext, ObjectDefinitionDeployer.class,
 			new ServiceTrackerCustomizer
@@ -908,6 +915,29 @@ public class ObjectDefinitionLocalServiceImpl
 		if (_objectDefinitionDeployerServiceTracker != null) {
 			_objectDefinitionDeployerServiceTracker.close();
 		}
+	}
+
+	private void _addingInactiveObjectDefinitionDeployer(
+		InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer) {
+
+		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			new ConcurrentHashMap<>();
+
+		for (ObjectDefinition objectDefinition :
+				_getInactiveObjectDefinitions()) {
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setWithSafeCloseable(
+						objectDefinition.getCompanyId())) {
+
+				serviceRegistrationsMap.put(
+					objectDefinition.getObjectDefinitionId(),
+					inactiveObjectDefinitionDeployer.deploy(objectDefinition));
+			}
+		}
+
+		_inactiveObjectDefinitionsServiceRegistrationsMaps.put(
+			inactiveObjectDefinitionDeployer, serviceRegistrationsMap);
 	}
 
 	private ObjectDefinitionDeployer _addingObjectDefinitionDeployer(
@@ -1262,6 +1292,17 @@ public class ObjectDefinitionLocalServiceImpl
 
 		return StringBundler.concat(
 			prefix, companyId, StringPool.UNDERLINE, shortName);
+	}
+
+	private List<ObjectDefinition> _getInactiveObjectDefinitions() {
+		List<ObjectDefinition> objectDefinitions = new ArrayList<>();
+
+		_companyLocalService.forEachCompanyId(
+			companyId -> objectDefinitions.addAll(
+				objectDefinitionLocalService.getObjectDefinitions(
+					companyId, false, WorkflowConstants.STATUS_APPROVED)));
+
+		return objectDefinitions;
 	}
 
 	private String _getName(String name, boolean system) {
@@ -1982,6 +2023,12 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	private final Map
+		<InactiveObjectDefinitionDeployer,
+		 Map<Long, List<ServiceRegistration<?>>>>
+			_inactiveObjectDefinitionsServiceRegistrationsMaps =
+				Collections.synchronizedMap(new LinkedHashMap<>());
 
 	@Reference
 	private Language _language;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1597,9 +1597,6 @@ public class ObjectDefinitionLocalServiceImpl
 
 		if (objectDefinition.isApproved()) {
 			if (!active && originalActive) {
-				objectDefinitionLocalService.undeployObjectDefinition(
-					objectDefinition);
-
 				objectDefinitionLocalService.deployInactiveObjectDefinition(
 					objectDefinition);
 			}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -490,6 +490,36 @@ public class ObjectDefinitionLocalServiceImpl
 	}
 
 	@Override
+	public void deployInactiveObjectDefinition(
+		ObjectDefinition objectDefinition) {
+
+		undeployObjectDefinition(objectDefinition);
+
+		for (Map.Entry
+				<InactiveObjectDefinitionDeployer,
+				 Map<Long, List<ServiceRegistration<?>>>> entry :
+					_inactiveObjectDefinitionsServiceRegistrationsMaps.
+						entrySet()) {
+
+			InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
+				entry.getKey();
+			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+				entry.getValue();
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setWithSafeCloseable(
+						objectDefinition.getCompanyId())) {
+
+				serviceRegistrationsMap.computeIfAbsent(
+					objectDefinition.getObjectDefinitionId(),
+					objectDefinitionId ->
+						inactiveObjectDefinitionDeployer.deploy(
+							objectDefinition));
+			}
+		}
+	}
+
+	@Override
 	public void deployObjectDefinition(ObjectDefinition objectDefinition) {
 		undeployObjectDefinition(objectDefinition);
 
@@ -1568,6 +1598,9 @@ public class ObjectDefinitionLocalServiceImpl
 		if (objectDefinition.isApproved()) {
 			if (!active && originalActive) {
 				objectDefinitionLocalService.undeployObjectDefinition(
+					objectDefinition);
+
+				objectDefinitionLocalService.deployInactiveObjectDefinition(
 					objectDefinition);
 			}
 			else if (active) {


### PR DESCRIPTION
Create a new InactiveObjectDefinitionDeployer interface to deploy only those services that are needed for inactive object definitions.

Ticket: [LPS-192669](https://liferay.atlassian.net/browse/LPS-192669)

See [PTR-4182](https://liferay.atlassian.net/browse/PTR-4182) for further context.