### PR TITLE
LPS-193330 It is not possible to use Object Proxy Salesforce with Account Restriction with more than 1 account

### DIFF
--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -222,7 +222,7 @@ public class SalesforceObjectEntryManagerImpl
 
 						return accountEntry.getExternalReferenceCode();
 					}),
-				", '"),
+				"', '"),
 			"')");
 	}
 


### PR DESCRIPTION
Hey guys!

We are facing this issue on U88 when we try to use the account restriction with object proxy salesforce. The fix is simple, because the error is related with the string created after merging the external reference code