### PR TITLE
LPS-191310 Call runSQL method that takes a connection reference. Because the method without it would not complete the query

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -494,6 +494,7 @@ public class SQLServerDB extends BaseDB {
 		}
 
 		runSQL(
+			connection,
 			StringBundler.concat(
 				"alter table ", tableName, " drop constraint ",
 				defaultConstraintName));


### PR DESCRIPTION
Related ticket: [LPS-191310](https://liferay.atlassian.net/browse/LPS-191310)

This fix was already internally approved [here](https://github.com/liferay-objects/liferay-portal/pull/2386) and also by core-infra [here](https://liferay.slack.com/archives/C01FP01V5L0/p1691530764066829). 