### PR TITLE
LPS-193918 404 page is shown when navigating to the display page of a company object

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -318,14 +318,16 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					_getDisplayPageURL(objectEntry, themeDisplay)));
 		}
 
-		objectEntryFieldValues.addAll(
-			_getObjectFieldsInfoFieldValues(
-				_getObjectEntry(
-					objectEntry.getExternalReferenceCode(), _objectDefinition,
-					themeDisplay),
-				_objectFieldLocalService.getObjectFields(
-					objectEntry.getObjectDefinitionId(), false),
-				themeDisplay));
+		if (themeDisplay != null) {
+			objectEntryFieldValues.addAll(
+				_getObjectFieldsInfoFieldValues(
+					_getObjectEntry(
+						objectEntry.getExternalReferenceCode(),
+						_objectDefinition, themeDisplay),
+					_objectFieldLocalService.getObjectFields(
+						objectEntry.getObjectDefinitionId(), false),
+					themeDisplay));
+		}
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-169992")) {
 			objectEntryFieldValues.addAll(


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-193918)

Hi Team, @Tim-Cao found this regression, so we are sending it to you for review.

Basically, we just add a check to see if the theme display is not null before adding objectEntryFieldValues. This is because there are times when the theme display is not present in the service context, such as when calling it from the URL Resolver.

Thanks!

## Test Scenario

* Follow the steps in the ticket
