### PR TITLE
LPS-193250 Publish all Children Objects in a row during their Root Object publication. Block standalone publication for children Objects

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -72,6 +72,10 @@ public interface ObjectDefinition
 
 	public boolean isDefaultStorageType();
 
+	public boolean isNode();
+
+	public boolean isRoot();
+
 	public boolean isUnmodifiableSystemObject();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -965,6 +965,11 @@ public class ObjectDefinitionWrapper
 		return model.isModifiable();
 	}
 
+	@Override
+	public boolean isNode() {
+		return model.isNode();
+	}
+
 	/**
 	 * Returns <code>true</code> if this object definition is portlet.
 	 *
@@ -973,6 +978,11 @@ public class ObjectDefinitionWrapper
 	@Override
 	public boolean isPortlet() {
 		return model.isPortlet();
+	}
+
+	@Override
+	public boolean isRoot() {
+		return model.isRoot();
 	}
 
 	/**

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -156,6 +156,28 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
+	public boolean isNode() {
+		if ((getRootObjectDefinitionId() != 0) &&
+			(getObjectDefinitionId() != getRootObjectDefinitionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isRoot() {
+		if ((getRootObjectDefinitionId() != 0) &&
+			(getObjectDefinitionId() == getRootObjectDefinitionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean isUnmodifiableSystemObject() {
 		if (FeatureFlagManagerUtil.isEnabled("LPS-167253")) {
 			if (!isModifiable() && isSystem()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -962,6 +962,12 @@ public class ObjectDefinitionLocalServiceImpl
 		ObjectDefinition objectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
+		if (rootObjectDefinitionId == 0) {
+			objectDefinition.setRootObjectDefinitionId(0);
+
+			return objectDefinitionPersistence.update(objectDefinition);
+		}
+
 		ObjectDefinition rootObjectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(
 				rootObjectDefinitionId);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -16,6 +16,9 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.deployer.InactiveObjectDefinitionDeployer;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.exception.NoSuchObjectFieldException;
@@ -55,6 +58,7 @@ import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionLocalizationTable
 import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionTable;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
@@ -70,6 +74,7 @@ import com.liferay.object.service.persistence.ObjectFieldPersistence;
 import com.liferay.object.service.persistence.ObjectFolderPersistence;
 import com.liferay.object.service.persistence.ObjectRelationshipPersistence;
 import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.osgi.util.service.Snapshot;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.Table;
@@ -134,6 +139,7 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -715,6 +721,11 @@ public class ObjectDefinitionLocalServiceImpl
 
 		ObjectDefinition objectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
+
+		if (objectDefinition.isNode()) {
+			throw new ObjectDefinitionStatusException(
+				"Node ObjectDefinition cannot be directly published");
+		}
 
 		if (objectDefinition.isUnmodifiableSystemObject()) {
 			throw new ObjectDefinitionStatusException();
@@ -1521,6 +1532,27 @@ public class ObjectDefinitionLocalServiceImpl
 			throw new RequiredObjectFieldException();
 		}
 
+		if (objectDefinition.isRoot()) {
+			TreeFactory treeFactory = _treeFactorySnapshot.get();
+
+			Tree tree = treeFactory.create(
+				objectDefinition.getObjectDefinitionId());
+
+			Iterator<Node> iterator = tree.iterator();
+
+			while (iterator.hasNext()) {
+				Node node = iterator.next();
+
+				if (node.getObjectDefinitionId() !=
+						objectDefinition.getObjectDefinitionId()) {
+
+					_publishObjectDefinition(
+						userId,
+						getObjectDefinition(node.getObjectDefinitionId()));
+				}
+			}
+		}
+
 		objectDefinition.setActive(true);
 		objectDefinition.setStatus(WorkflowConstants.STATUS_APPROVED);
 
@@ -2064,6 +2096,9 @@ public class ObjectDefinitionLocalServiceImpl
 		new MethodKey(
 			ObjectDefinitionLocalServiceUtil.class, "deployObjectDefinition",
 			ObjectDefinition.class);
+	private static final Snapshot<TreeFactory> _treeFactorySnapshot =
+		new Snapshot<>(
+			ObjectDefinitionLocalService.class, TreeFactory.class, null, true);
 	private static final MethodKey _undeployObjectDefinitionMethodKey =
 		new MethodKey(
 			ObjectDefinitionLocalServiceUtil.class, "undeployObjectDefinition",

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -93,6 +93,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -293,20 +294,7 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertFalse(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		Iterator<Node> iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertFalse(
-				_hasTable(nodeObjectDefinition.getDBTableName()));
-			Assert.assertFalse(
-				_hasTable(nodeObjectDefinition.getExtensionDBTableName()));
-		}
+		_assertBoundedObjectDefinitions("databaseTable", tree, false);
 
 		// Before publish, resources
 
@@ -330,55 +318,14 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getClassName()));
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getPortletId()));
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getResourceName()));
-			Assert.assertEquals(
-				1,
-				_resourcePermissionLocalService.getResourcePermissionsCount(
-					nodeObjectDefinition.getCompanyId(),
-					ObjectDefinition.class.getName(),
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(
-						nodeObjectDefinition.getObjectDefinitionId())));
-		}
+		_assertBoundedObjectDefinitions("resources", tree, false);
 
 		// Before publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_DRAFT,
-				nodeObjectDefinition.getStatus());
-		}
+		_assertBoundedObjectDefinitions("status", tree, false);
 
 		// Publish
 
@@ -401,53 +348,19 @@ public class ObjectDefinitionLocalServiceTest {
 				true
 			).build());
 
-		ObjectDefinition rootObjectDefinition = null;
+		_assertBoundedObjectDefinitions("publishFailure", tree, false);
 
-		iterator = tree.iterator();
+		Iterator<Node> iterator = tree.iterator();
 
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
+		Node node = iterator.next();
 
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			ObjectFieldUtil.addCustomObjectField(
-				new TextObjectFieldBuilder(
-				).userId(
-					TestPropsValues.getUserId()
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap("Able")
-				).name(
-					"able"
-				).objectDefinitionId(
-					nodeObjectDefinition.getObjectDefinitionId()
-				).build());
-
-			if (nodeObjectDefinition.getObjectDefinitionId() ==
-					nodeObjectDefinition.getRootObjectDefinitionId()) {
-
-				rootObjectDefinition = nodeObjectDefinition;
-
-				continue;
-			}
-
-			AssertUtils.assertFailure(
-				ObjectDefinitionStatusException.class,
-				"Node ObjectDefinition cannot be directly published",
-				() ->
-					_objectDefinitionLocalService.publishCustomObjectDefinition(
-						TestPropsValues.getUserId(),
-						nodeObjectDefinition.getObjectDefinitionId()));
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_DRAFT,
-				nodeObjectDefinition.getStatus());
-		}
+		ObjectDefinition nodeObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				node.getObjectDefinitionId());
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
-			rootObjectDefinition.getObjectDefinitionId());
+			nodeObjectDefinition.getRootObjectDefinitionId());
 
 		// After publish, database table
 
@@ -471,18 +384,7 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertFalse(
-				_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
-		}
+		_assertBoundedObjectDefinitions("databaseTable", tree, true);
 
 		// After publish, resources
 
@@ -506,55 +408,14 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				4,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getClassName()));
-			Assert.assertEquals(
-				6,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getPortletId()));
-			Assert.assertEquals(
-				2,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getResourceName()));
-			Assert.assertEquals(
-				1,
-				_resourcePermissionLocalService.getResourcePermissionsCount(
-					nodeObjectDefinition.getCompanyId(),
-					ObjectDefinition.class.getName(),
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(
-						nodeObjectDefinition.getObjectDefinitionId())));
-		}
+		_assertBoundedObjectDefinitions("resources", tree, true);
 
 		// After publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectDefinition.getStatus());
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_APPROVED,
-				nodeObjectDefinition.getStatus());
-		}
+		_assertBoundedObjectDefinitions("status", tree, true);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 
@@ -563,7 +424,7 @@ public class ObjectDefinitionLocalServiceTest {
 		iterator = tree.iterator();
 
 		while (iterator.hasNext()) {
-			Node node = iterator.next();
+			node = iterator.next();
 
 			objectDefinitionIds.add(node.getObjectDefinitionId());
 
@@ -2019,6 +1880,128 @@ public class ObjectDefinitionLocalServiceTest {
 				).name(
 					StringUtil.randomId()
 				).build()));
+	}
+
+	private void _assertBoundedObjectDefinitions(
+			String assertType, Tree tree, boolean published)
+		throws Exception {
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			if (Objects.equals(assertType, "databaseTable")) {
+				if (published) {
+					Assert.assertFalse(
+						_hasColumn(objectDefinition.getDBTableName(), "able"));
+					Assert.assertTrue(
+						_hasColumn(objectDefinition.getDBTableName(), "able_"));
+				}
+				else {
+					Assert.assertFalse(
+						_hasTable(objectDefinition.getDBTableName()));
+					Assert.assertFalse(
+						_hasTable(objectDefinition.getExtensionDBTableName()));
+				}
+			}
+			else if (Objects.equals(assertType, "publishFailure")) {
+				ObjectFieldUtil.addCustomObjectField(
+					new TextObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap("Able")
+					).name(
+						"able"
+					).objectDefinitionId(
+						objectDefinition.getObjectDefinitionId()
+					).build());
+
+				if (objectDefinition.getObjectDefinitionId() ==
+						objectDefinition.getRootObjectDefinitionId()) {
+
+					continue;
+				}
+
+				AssertUtils.assertFailure(
+					ObjectDefinitionStatusException.class,
+					"Node ObjectDefinition cannot be directly published",
+					() ->
+						_objectDefinitionLocalService.
+							publishCustomObjectDefinition(
+								TestPropsValues.getUserId(),
+								objectDefinition.getObjectDefinitionId()));
+
+				Assert.assertEquals(
+					WorkflowConstants.STATUS_DRAFT,
+					objectDefinition.getStatus());
+			}
+			else if (Objects.equals(assertType, "resources")) {
+				if (published) {
+					Assert.assertEquals(
+						4,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getClassName()));
+					Assert.assertEquals(
+						6,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getPortletId()));
+					Assert.assertEquals(
+						2,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getResourceName()));
+					Assert.assertEquals(
+						1,
+						_resourcePermissionLocalService.
+							getResourcePermissionsCount(
+								objectDefinition.getCompanyId(),
+								ObjectDefinition.class.getName(),
+								ResourceConstants.SCOPE_INDIVIDUAL,
+								String.valueOf(
+									objectDefinition.getObjectDefinitionId())));
+				}
+				else {
+					Assert.assertEquals(
+						0,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getClassName()));
+					Assert.assertEquals(
+						0,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getPortletId()));
+					Assert.assertEquals(
+						0,
+						_resourceActionLocalService.getResourceActionsCount(
+							objectDefinition.getResourceName()));
+					Assert.assertEquals(
+						1,
+						_resourcePermissionLocalService.
+							getResourcePermissionsCount(
+								objectDefinition.getCompanyId(),
+								ObjectDefinition.class.getName(),
+								ResourceConstants.SCOPE_INDIVIDUAL,
+								String.valueOf(
+									objectDefinition.getObjectDefinitionId())));
+				}
+			}
+			else if (Objects.equals(assertType, "status")) {
+				if (published) {
+					Assert.assertEquals(
+						WorkflowConstants.STATUS_APPROVED,
+						objectDefinition.getStatus());
+				}
+				else {
+					Assert.assertEquals(
+						WorkflowConstants.STATUS_DRAFT,
+						objectDefinition.getStatus());
+				}
+			}
+		}
 	}
 
 	private void _assertFailure(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -11,6 +11,10 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Edge;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
@@ -42,6 +46,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.object.system.BaseSystemObjectDefinitionManager;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.petra.function.UnsafeConsumer;
@@ -80,8 +85,10 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.sql.Connection;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -274,11 +281,32 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertEquals("C_Test", objectDefinition.getName());
 
+		// Before publish, create tree
+
+		Tree tree = TreeTestUtil.createTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_treeFactory);
+
 		// Before publish, database table
 
 		Assert.assertFalse(_hasTable(objectDefinition.getDBTableName()));
 		Assert.assertFalse(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertFalse(
+				_hasTable(nodeObjectDefinition.getDBTableName()));
+			Assert.assertFalse(
+				_hasTable(nodeObjectDefinition.getExtensionDBTableName()));
+		}
 
 		// Before publish, resources
 
@@ -302,10 +330,55 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getClassName()));
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getPortletId()));
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getResourceName()));
+			Assert.assertEquals(
+				1,
+				_resourcePermissionLocalService.getResourcePermissionsCount(
+					nodeObjectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(
+						nodeObjectDefinition.getObjectDefinitionId())));
+		}
+
 		// Before publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
+
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_DRAFT,
+				nodeObjectDefinition.getStatus());
+		}
 
 		// Publish
 
@@ -327,6 +400,54 @@ public class ObjectDefinitionLocalServiceTest {
 			).required(
 				true
 			).build());
+
+		ObjectDefinition rootObjectDefinition = null;
+
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			ObjectFieldUtil.addCustomObjectField(
+				new TextObjectFieldBuilder(
+				).userId(
+					TestPropsValues.getUserId()
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap("Able")
+				).name(
+					"able"
+				).objectDefinitionId(
+					nodeObjectDefinition.getObjectDefinitionId()
+				).build());
+
+			if (nodeObjectDefinition.getObjectDefinitionId() ==
+					nodeObjectDefinition.getRootObjectDefinitionId()) {
+
+				rootObjectDefinition = nodeObjectDefinition;
+
+				continue;
+			}
+
+			AssertUtils.assertFailure(
+				ObjectDefinitionStatusException.class,
+				"Node ObjectDefinition cannot be directly published",
+				() ->
+					_objectDefinitionLocalService.publishCustomObjectDefinition(
+						TestPropsValues.getUserId(),
+						nodeObjectDefinition.getObjectDefinitionId()));
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_DRAFT,
+				nodeObjectDefinition.getStatus());
+		}
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			rootObjectDefinition.getObjectDefinitionId());
 
 		// After publish, database table
 
@@ -350,6 +471,19 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertFalse(
+				_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
+		}
+
 		// After publish, resources
 
 		Assert.assertEquals(
@@ -372,12 +506,91 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				4,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getClassName()));
+			Assert.assertEquals(
+				6,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getPortletId()));
+			Assert.assertEquals(
+				2,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getResourceName()));
+			Assert.assertEquals(
+				1,
+				_resourcePermissionLocalService.getResourcePermissionsCount(
+					nodeObjectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(
+						nodeObjectDefinition.getObjectDefinitionId())));
+		}
+
 		// After publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectDefinition.getStatus());
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED,
+				nodeObjectDefinition.getStatus());
+		}
+
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+
+		List<Long> objectDefinitionIds = new ArrayList<>();
+
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			objectDefinitionIds.add(node.getObjectDefinitionId());
+
+			_objectDefinitionLocalService.updateRootObjectDefinitionId(
+				node.getObjectDefinitionId(), 0);
+
+			if (node.isRoot()) {
+				return;
+			}
+
+			Edge edge = node.getEdge();
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					edge.getObjectRelationshipId());
+
+			_objectRelationshipLocalService.updateObjectRelationship(
+				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getParameterObjectFieldId(),
+				objectRelationship.getDeletionType(), false,
+				objectRelationship.getLabelMap());
+		}
+
+		for (long objectDefinitionId : objectDefinitionIds) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinitionId);
+		}
 	}
 
 	@Test
@@ -2194,5 +2407,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private TreeFactory _treeFactory;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -15,7 +15,6 @@ import com.liferay.object.definition.tree.Edge;
 import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
-import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
 import com.liferay.object.exception.ObjectDefinitionActiveException;
@@ -1632,12 +1631,6 @@ public class ObjectDefinitionLocalServiceTest {
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.addObjectDefinition(
 				_objectDefinitionLocalService);
-
-		AssertUtils.assertFailure(
-			NoSuchObjectDefinitionException.class,
-			"No ObjectDefinition exists with the primary key 0",
-			() -> _objectDefinitionLocalService.updateRootObjectDefinitionId(
-				objectDefinition1.getObjectDefinitionId(), 0));
 
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addObjectDefinition(


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-193250