### PR TITLE
LPS-193250 Publish all Children Objects in a row during their Root Object publication. Block standalone publication for children Objects

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/Tree.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/Tree.java
@@ -67,6 +67,10 @@ public class Tree {
 		return new BreadthFirstIterator(rootNode);
 	}
 
+	public Iterator<Node> iterator(long objectDefinitionId) {
+		return new BreadthFirstIterator(getNode(objectDefinitionId));
+	}
+
 	protected final Node rootNode;
 
 	private static class BreadthFirstIterator implements Iterator<Node> {

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/TreeFactory.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/TreeFactory.java
@@ -5,11 +5,13 @@
 
 package com.liferay.object.definition.tree;
 
+import com.liferay.portal.kernel.exception.PortalException;
+
 /**
  * @author Feliphe Marinho
  */
 public interface TreeFactory {
 
-	public Tree create(long objectDefinitionId);
+	public Tree create(long objectDefinitionId) throws PortalException;
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -72,6 +72,10 @@ public interface ObjectDefinition
 
 	public boolean isDefaultStorageType();
 
+	public boolean isNode();
+
+	public boolean isRoot();
+
 	public boolean isUnmodifiableSystemObject();
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -965,6 +965,11 @@ public class ObjectDefinitionWrapper
 		return model.isModifiable();
 	}
 
+	@Override
+	public boolean isNode() {
+		return model.isNode();
+	}
+
 	/**
 	 * Returns <code>true</code> if this object definition is portlet.
 	 *
@@ -973,6 +978,11 @@ public class ObjectDefinitionWrapper
 	@Override
 	public boolean isPortlet() {
 		return model.isPortlet();
+	}
+
+	@Override
+	public boolean isRoot() {
+		return model.isRoot();
 	}
 
 	/**

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/tree/TreeFactoryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/tree/TreeFactoryImpl.java
@@ -9,6 +9,7 @@ import com.liferay.object.definition.tree.Edge;
 import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.exception.ObjectDefinitionRootObjectDefinitionIdException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -36,7 +37,9 @@ public class TreeFactoryImpl implements TreeFactory {
 				objectDefinitionId);
 
 		if (objectDefinition.getRootObjectDefinitionId() == 0) {
-			return null;
+			throw new ObjectDefinitionRootObjectDefinitionIdException(
+				"The object definition id " + objectDefinitionId +
+					" is not inside a hierarchical structure.");
 		}
 
 		Node rootNode = new Node(null, objectDefinitionId, null);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/tree/TreeFactoryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/tree/TreeFactoryImpl.java
@@ -9,8 +9,11 @@ import com.liferay.object.definition.tree.Edge;
 import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.LinkedList;
@@ -27,7 +30,15 @@ import org.osgi.service.component.annotations.Reference;
 public class TreeFactoryImpl implements TreeFactory {
 
 	@Override
-	public Tree create(long objectDefinitionId) {
+	public Tree create(long objectDefinitionId) throws PortalException {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinitionId);
+
+		if (objectDefinition.getRootObjectDefinitionId() == 0) {
+			return null;
+		}
+
 		Node rootNode = new Node(null, objectDefinitionId, null);
 
 		Queue<Node> queue = new LinkedList<>();
@@ -57,6 +68,9 @@ public class TreeFactoryImpl implements TreeFactory {
 				new Edge(objectRelationship.getObjectRelationshipId()),
 				objectRelationship.getObjectDefinitionId2(), node));
 	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -156,6 +156,28 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
+	public boolean isNode() {
+		if ((getRootObjectDefinitionId() != 0) &&
+			(getObjectDefinitionId() != getRootObjectDefinitionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isRoot() {
+		if ((getRootObjectDefinitionId() != 0) &&
+			(getObjectDefinitionId() == getRootObjectDefinitionId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean isUnmodifiableSystemObject() {
 		if (FeatureFlagManagerUtil.isEnabled("LPS-167253")) {
 			if (!isModifiable() && isSystem()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -396,6 +396,12 @@ public class ObjectDefinitionLocalServiceImpl
 			throw new RequiredObjectDefinitionException();
 		}
 
+		if (objectDefinition.getRootObjectDefinitionId() != 0) {
+			throw new ObjectDefinitionRootObjectDefinitionIdException(
+				"Object Definitions that belong to a hierarchical structure " +
+					"cannot be deleted");
+		}
+
 		_objectActionLocalService.deleteObjectActions(
 			objectDefinition.getObjectDefinitionId());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -962,6 +962,12 @@ public class ObjectDefinitionLocalServiceImpl
 		ObjectDefinition objectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
+		if (rootObjectDefinitionId == 0) {
+			objectDefinition.setRootObjectDefinitionId(0);
+
+			return objectDefinitionPersistence.update(objectDefinition);
+		}
+
 		ObjectDefinition rootObjectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(
 				rootObjectDefinitionId);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -16,6 +16,9 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.deployer.InactiveObjectDefinitionDeployer;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.exception.NoSuchObjectFieldException;
@@ -70,6 +73,7 @@ import com.liferay.object.service.persistence.ObjectFieldPersistence;
 import com.liferay.object.service.persistence.ObjectFolderPersistence;
 import com.liferay.object.service.persistence.ObjectRelationshipPersistence;
 import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.osgi.util.service.Snapshot;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.Table;
@@ -134,6 +138,7 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -721,6 +726,11 @@ public class ObjectDefinitionLocalServiceImpl
 
 		ObjectDefinition objectDefinition =
 			objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
+
+		if (objectDefinition.isNode()) {
+			throw new ObjectDefinitionStatusException(
+				"Node ObjectDefinition cannot be directly published");
+		}
 
 		if (objectDefinition.isUnmodifiableSystemObject()) {
 			throw new ObjectDefinitionStatusException();
@@ -1527,6 +1537,27 @@ public class ObjectDefinitionLocalServiceImpl
 			throw new RequiredObjectFieldException();
 		}
 
+		if (objectDefinition.isRoot()) {
+			TreeFactory treeFactory = _treeFactorySnapshot.get();
+
+			Tree tree = treeFactory.create(
+				objectDefinition.getObjectDefinitionId());
+
+			Iterator<Node> iterator = tree.iterator();
+
+			while (iterator.hasNext()) {
+				Node node = iterator.next();
+
+				if (node.getObjectDefinitionId() !=
+						objectDefinition.getObjectDefinitionId()) {
+
+					_publishObjectDefinition(
+						userId,
+						getObjectDefinition(node.getObjectDefinitionId()));
+				}
+			}
+		}
+
 		objectDefinition.setActive(true);
 		objectDefinition.setStatus(WorkflowConstants.STATUS_APPROVED);
 
@@ -2070,6 +2101,10 @@ public class ObjectDefinitionLocalServiceImpl
 		new MethodKey(
 			ObjectDefinitionLocalServiceUtil.class, "deployObjectDefinition",
 			ObjectDefinition.class);
+	private static final Snapshot<TreeFactory> _treeFactorySnapshot =
+		new Snapshot<>(
+			ObjectDefinitionLocalServiceImpl.class, TreeFactory.class, null,
+			true);
 	private static final MethodKey _undeployObjectDefinitionMethodKey =
 		new MethodKey(
 			ObjectDefinitionLocalServiceUtil.class, "undeployObjectDefinition",

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -279,6 +279,11 @@ public class ObjectRelationshipLocalServiceImpl
 
 		// TODO When should we allow an object relationship to be deleted?
 
+		if (objectRelationship.isEdge()) {
+			throw new ObjectRelationshipEdgeException(
+				"Edge object relationships cannot be deleted");
+		}
+
 		if (objectRelationship.isReverse()) {
 			throw new ObjectRelationshipReverseException(
 				"Reverse object relationships cannot be deleted");

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/definition/tree/test/TreeFactoryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/definition/tree/test/TreeFactoryTest.java
@@ -6,24 +6,20 @@
 package com.liferay.object.internal.definition.tree.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.object.definition.tree.Node;
-import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
-import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Queue;
+import javax.portlet.PortletException;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,27 +37,24 @@ public class TreeFactoryTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testCreate() throws PortalException {
-		Queue<String> queue = new LinkedList<>(
-			Arrays.asList("A", "AA", "AB", "AAA", "AAB"));
-
-		Tree tree = TreeTestUtil.createTree(
-			_objectDefinitionLocalService, _objectRelationshipLocalService,
-			_treeFactory);
-
-		Iterator<Node> iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(queue.poll(), objectDefinition.getShortName());
-		}
-
-		Assert.assertTrue(queue.isEmpty());
+	public void testCreate() throws PortalException, PortletException {
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA", "AB"}
+			).put(
+				"AA", new String[] {"AAA", "AAB"}
+			).put(
+				"AB", new String[0]
+			).put(
+				"AAA", new String[0]
+			).put(
+				"AAB", new String[0]
+			).build(),
+			TreeTestUtil.createTree(
+				_mvcResourceCommand, _objectDefinitionLocalService,
+				_objectRelationshipLocalService, _portletLocalService,
+				_treeFactory),
+			_objectDefinitionLocalService);
 	}
 
 	@Inject
@@ -70,6 +63,14 @@ public class TreeFactoryTest {
 	@Inject
 	private static ObjectRelationshipLocalService
 		_objectRelationshipLocalService;
+
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/bind_object_definitions"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
 
 	@Inject
 	private TreeFactory _treeFactory;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -1089,6 +1089,15 @@ public class ObjectDefinitionLocalServiceTest {
 						ObjectFieldConstants.DB_TYPE_STRING,
 						RandomTestUtil.randomString(), StringUtil.randomId())));
 
+		AssertUtils.assertFailure(
+			ObjectDefinitionRootObjectDefinitionIdException.class,
+			"Object Definitions that belongs to a hierarchical structure " +
+				"cannot be deleted",
+			() -> _objectDefinitionLocalService.deleteObjectDefinition(
+				_objectDefinitionLocalService.updateRootObjectDefinitionId(
+					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getObjectDefinitionId())));
+
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
 			objectDefinition.getObjectDefinitionId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -11,7 +11,6 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
-import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
 import com.liferay.object.exception.ObjectDefinitionActiveException;
@@ -1091,7 +1090,7 @@ public class ObjectDefinitionLocalServiceTest {
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionRootObjectDefinitionIdException.class,
-			"Object Definitions that belongs to a hierarchical structure " +
+			"Object Definitions that belong to a hierarchical structure " +
 				"cannot be deleted",
 			() -> _objectDefinitionLocalService.deleteObjectDefinition(
 				_objectDefinitionLocalService.updateRootObjectDefinitionId(
@@ -1567,12 +1566,6 @@ public class ObjectDefinitionLocalServiceTest {
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.addObjectDefinition(
 				_objectDefinitionLocalService);
-
-		AssertUtils.assertFailure(
-			NoSuchObjectDefinitionException.class,
-			"No ObjectDefinition exists with the primary key 0",
-			() -> _objectDefinitionLocalService.updateRootObjectDefinitionId(
-				objectDefinition1.getObjectDefinitionId(), 0));
 
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addObjectDefinition(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -293,20 +293,14 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertFalse(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		Iterator<Node> iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertFalse(
-				_hasTable(nodeObjectDefinition.getDBTableName()));
-			Assert.assertFalse(
-				_hasTable(nodeObjectDefinition.getExtensionDBTableName()));
-		}
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> {
+				Assert.assertFalse(
+					_hasTable(nodeObjectDefinition.getExtensionDBTableName()));
+				Assert.assertFalse(
+					_hasTable(nodeObjectDefinition.getDBTableName()));
+			});
 
 		// Before publish, resources
 
@@ -330,55 +324,41 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getClassName()));
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getPortletId()));
-			Assert.assertEquals(
-				0,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getResourceName()));
-			Assert.assertEquals(
-				1,
-				_resourcePermissionLocalService.getResourcePermissionsCount(
-					nodeObjectDefinition.getCompanyId(),
-					ObjectDefinition.class.getName(),
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(
-						nodeObjectDefinition.getObjectDefinitionId())));
-		}
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> {
+				Assert.assertEquals(
+					0,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getClassName()));
+				Assert.assertEquals(
+					0,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getPortletId()));
+				Assert.assertEquals(
+					0,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getResourceName()));
+				Assert.assertEquals(
+					1,
+					_resourcePermissionLocalService.getResourcePermissionsCount(
+						nodeObjectDefinition.getCompanyId(),
+						ObjectDefinition.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(
+							nodeObjectDefinition.getObjectDefinitionId())));
+			});
 
 		// Before publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> Assert.assertEquals(
 				WorkflowConstants.STATUS_DRAFT,
-				nodeObjectDefinition.getStatus());
-		}
+				nodeObjectDefinition.getStatus()));
 
 		// Publish
 
@@ -401,53 +381,51 @@ public class ObjectDefinitionLocalServiceTest {
 				true
 			).build());
 
-		ObjectDefinition rootObjectDefinition = null;
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> {
+				ObjectFieldUtil.addCustomObjectField(
+					new TextObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap("Able")
+					).name(
+						"able"
+					).objectDefinitionId(
+						nodeObjectDefinition.getObjectDefinitionId()
+					).build());
 
-		iterator = tree.iterator();
+				if (nodeObjectDefinition.getObjectDefinitionId() !=
+						nodeObjectDefinition.getRootObjectDefinitionId()) {
 
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
+					AssertUtils.assertFailure(
+						ObjectDefinitionStatusException.class,
+						"Node ObjectDefinition cannot be directly published",
+						() ->
+							_objectDefinitionLocalService.
+								publishCustomObjectDefinition(
+									TestPropsValues.getUserId(),
+									nodeObjectDefinition.
+										getObjectDefinitionId()));
 
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
+					Assert.assertEquals(
+						WorkflowConstants.STATUS_DRAFT,
+						nodeObjectDefinition.getStatus());
+				}
+			});
 
-			ObjectFieldUtil.addCustomObjectField(
-				new TextObjectFieldBuilder(
-				).userId(
-					TestPropsValues.getUserId()
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap("Able")
-				).name(
-					"able"
-				).objectDefinitionId(
-					nodeObjectDefinition.getObjectDefinitionId()
-				).build());
+		Iterator<Node> iterator = tree.iterator();
 
-			if (nodeObjectDefinition.getObjectDefinitionId() ==
-					nodeObjectDefinition.getRootObjectDefinitionId()) {
+		Node node = iterator.next();
 
-				rootObjectDefinition = nodeObjectDefinition;
-
-				continue;
-			}
-
-			AssertUtils.assertFailure(
-				ObjectDefinitionStatusException.class,
-				"Node ObjectDefinition cannot be directly published",
-				() ->
-					_objectDefinitionLocalService.publishCustomObjectDefinition(
-						TestPropsValues.getUserId(),
-						nodeObjectDefinition.getObjectDefinitionId()));
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_DRAFT,
-				nodeObjectDefinition.getStatus());
-		}
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				node.getObjectDefinitionId());
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
-			rootObjectDefinition.getObjectDefinitionId());
+			rootObjectDefinition.getRootObjectDefinitionId());
 
 		// After publish, database table
 
@@ -471,18 +449,14 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertFalse(
-				_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
-		}
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> {
+				Assert.assertFalse(
+					_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
+				Assert.assertTrue(
+					_hasColumn(nodeObjectDefinition.getDBTableName(), "able_"));
+			});
 
 		// After publish, resources
 
@@ -506,55 +480,41 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
-				4,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getClassName()));
-			Assert.assertEquals(
-				6,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getPortletId()));
-			Assert.assertEquals(
-				2,
-				_resourceActionLocalService.getResourceActionsCount(
-					nodeObjectDefinition.getResourceName()));
-			Assert.assertEquals(
-				1,
-				_resourcePermissionLocalService.getResourcePermissionsCount(
-					nodeObjectDefinition.getCompanyId(),
-					ObjectDefinition.class.getName(),
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(
-						nodeObjectDefinition.getObjectDefinitionId())));
-		}
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> {
+				Assert.assertEquals(
+					4,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getClassName()));
+				Assert.assertEquals(
+					6,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getPortletId()));
+				Assert.assertEquals(
+					2,
+					_resourceActionLocalService.getResourceActionsCount(
+						nodeObjectDefinition.getResourceName()));
+				Assert.assertEquals(
+					1,
+					_resourcePermissionLocalService.getResourcePermissionsCount(
+						nodeObjectDefinition.getCompanyId(),
+						ObjectDefinition.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(
+							nodeObjectDefinition.getObjectDefinitionId())));
+			});
 
 		// After publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectDefinition.getStatus());
 
-		iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			ObjectDefinition nodeObjectDefinition =
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId());
-
-			Assert.assertEquals(
+		_assertBoundedObjectDefinitions(
+			tree,
+			nodeObjectDefinition -> Assert.assertEquals(
 				WorkflowConstants.STATUS_APPROVED,
-				nodeObjectDefinition.getStatus());
-		}
+				nodeObjectDefinition.getStatus()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 
@@ -1992,6 +1952,22 @@ public class ObjectDefinitionLocalServiceTest {
 				).name(
 					StringUtil.randomId()
 				).build()));
+	}
+
+	private void _assertBoundedObjectDefinitions(
+			Tree tree,
+			UnsafeConsumer<ObjectDefinition, Exception> unsafeConsumer)
+		throws Exception {
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			unsafeConsumer.accept(
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId()));
+		}
 	}
 
 	private void _assertFailure(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -11,6 +11,9 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.exception.NoSuchObjectFieldException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
 import com.liferay.object.exception.ObjectDefinitionActiveException;
@@ -41,6 +44,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.object.system.BaseSystemObjectDefinitionManager;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.petra.function.UnsafeConsumer;
@@ -60,6 +64,8 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.model.UserNotificationEventTable;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
@@ -81,6 +87,7 @@ import java.sql.Connection;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -273,11 +280,33 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertEquals("C_Test", objectDefinition.getName());
 
+		// Before publish, create tree
+
+		Tree tree = TreeTestUtil.createTree(
+			_bindObjectDefinitionsMVCResourceCommand,
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_portletLocalService, _treeFactory);
+
 		// Before publish, database table
 
 		Assert.assertFalse(_hasTable(objectDefinition.getDBTableName()));
 		Assert.assertFalse(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertFalse(
+				_hasTable(nodeObjectDefinition.getDBTableName()));
+			Assert.assertFalse(
+				_hasTable(nodeObjectDefinition.getExtensionDBTableName()));
+		}
 
 		// Before publish, resources
 
@@ -301,10 +330,55 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getClassName()));
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getPortletId()));
+			Assert.assertEquals(
+				0,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getResourceName()));
+			Assert.assertEquals(
+				1,
+				_resourcePermissionLocalService.getResourcePermissionsCount(
+					nodeObjectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(
+						nodeObjectDefinition.getObjectDefinitionId())));
+		}
+
 		// Before publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
+
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_DRAFT,
+				nodeObjectDefinition.getStatus());
+		}
 
 		// Publish
 
@@ -326,6 +400,54 @@ public class ObjectDefinitionLocalServiceTest {
 			).required(
 				true
 			).build());
+
+		ObjectDefinition rootObjectDefinition = null;
+
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			ObjectFieldUtil.addCustomObjectField(
+				new TextObjectFieldBuilder(
+				).userId(
+					TestPropsValues.getUserId()
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap("Able")
+				).name(
+					"able"
+				).objectDefinitionId(
+					nodeObjectDefinition.getObjectDefinitionId()
+				).build());
+
+			if (nodeObjectDefinition.getObjectDefinitionId() ==
+					nodeObjectDefinition.getRootObjectDefinitionId()) {
+
+				rootObjectDefinition = nodeObjectDefinition;
+
+				continue;
+			}
+
+			AssertUtils.assertFailure(
+				ObjectDefinitionStatusException.class,
+				"Node ObjectDefinition cannot be directly published",
+				() ->
+					_objectDefinitionLocalService.publishCustomObjectDefinition(
+						TestPropsValues.getUserId(),
+						nodeObjectDefinition.getObjectDefinitionId()));
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_DRAFT,
+				nodeObjectDefinition.getStatus());
+		}
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			rootObjectDefinition.getObjectDefinitionId());
 
 		// After publish, database table
 
@@ -349,6 +471,19 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertFalse(
+				_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
+		}
+
 		// After publish, resources
 
 		Assert.assertEquals(
@@ -371,12 +506,61 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				4,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getClassName()));
+			Assert.assertEquals(
+				6,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getPortletId()));
+			Assert.assertEquals(
+				2,
+				_resourceActionLocalService.getResourceActionsCount(
+					nodeObjectDefinition.getResourceName()));
+			Assert.assertEquals(
+				1,
+				_resourcePermissionLocalService.getResourcePermissionsCount(
+					nodeObjectDefinition.getCompanyId(),
+					ObjectDefinition.class.getName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(
+						nodeObjectDefinition.getObjectDefinitionId())));
+		}
+
 		// After publish, status
 
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectDefinition.getStatus());
 
+		iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition nodeObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED,
+				nodeObjectDefinition.getStatus());
+		}
+
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+
+		TreeTestUtil.unbind(
+			_objectDefinitionLocalService, rootObjectDefinition.getName(),
+			_portletLocalService, _unbindObjectDefinitionMVCResourceCommand);
 	}
 
 	@Test
@@ -2176,6 +2360,11 @@ public class ObjectDefinitionLocalServiceTest {
 			null, false, pluralLabelMap, scope);
 	}
 
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/bind_object_definitions"
+	)
+	private MVCResourceCommand _bindObjectDefinitionsMVCResourceCommand;
+
 	@Inject
 	private MessageBus _messageBus;
 
@@ -2192,9 +2381,20 @@ public class ObjectDefinitionLocalServiceTest {
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
 	private ResourceActionLocalService _resourceActionLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private TreeFactory _treeFactory;
+
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/unbind_object_definition"
+	)
+	private MVCResourceCommand _unbindObjectDefinitionMVCResourceCommand;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -27,6 +27,7 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.system.TestSystemObjectDefinitionManager;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -262,6 +263,46 @@ public class ObjectRelationshipLocalServiceTest {
 		_testCreateManyToManyObjectRelationshipTable(_systemObjectDefinition2);
 
 		_testSystemObjectRelationshipOneToMany();
+	}
+
+	@Test
+	public void testDeleteObjectRelationship() {
+		AssertUtils.assertFailure(
+			ObjectRelationshipEdgeException.class,
+			"Edge object relationships cannot be deleted",
+			() -> {
+				ObjectRelationship objectRelationship =
+					ObjectRelationshipTestUtil.addObjectRelationship(
+						_objectRelationshipLocalService, _objectDefinition1,
+						_objectDefinition2);
+
+				_objectRelationshipLocalService.deleteObjectRelationship(
+					_objectRelationshipLocalService.updateObjectRelationship(
+						objectRelationship.getObjectRelationshipId(),
+						objectRelationship.getParameterObjectFieldId(),
+						objectRelationship.getDeletionType(), true,
+						objectRelationship.getLabelMap()));
+			});
+		AssertUtils.assertFailure(
+			ObjectRelationshipReverseException.class,
+			"Reverse object relationships cannot be deleted",
+			() -> {
+				ObjectRelationship objectRelationship =
+					_objectRelationshipLocalService.addObjectRelationship(
+						TestPropsValues.getUserId(),
+						_objectDefinition1.getObjectDefinitionId(),
+						_objectDefinition2.getObjectDefinitionId(), 0,
+						ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString()),
+						StringUtil.randomId(),
+						ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+				_objectRelationshipLocalService.deleteObjectRelationship(
+					_objectRelationshipLocalService.
+						fetchReverseObjectRelationship(
+							objectRelationship, true));
+			});
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/ObjectRelationshipTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/ObjectRelationshipTestUtil.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.service.test.util;
+
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class ObjectRelationshipTestUtil {
+
+	public static ObjectRelationship addObjectRelationship(
+			ObjectRelationshipLocalService objectRelationshipLocalService,
+			ObjectDefinition objectDefinition1,
+			ObjectDefinition objectDefinition2)
+		throws PortalException {
+
+		return objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			objectDefinition1.getObjectDefinitionId(),
+			objectDefinition2.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+	}
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
@@ -5,7 +5,7 @@
 
 package com.liferay.object.service.test.util;
 
-import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.definition.tree.Edge;
 import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
@@ -14,55 +14,125 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.PortletException;
 
 /**
  * @author Feliphe Marinho
  */
 public class TreeTestUtil {
 
+	public static void assertTree(
+			Map<String, String[]> expectedMap, Tree actualTree,
+			ObjectDefinitionLocalService objectDefinitionLocalService)
+		throws PortalException {
+
+		Map<String, String[]> actualMap = new LinkedHashMap<>();
+
+		Iterator<Node> iterator = actualTree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			actualMap.put(
+				_getShortName(node, objectDefinitionLocalService),
+				TransformUtil.transformToArray(
+					node.getChildNodes(),
+					childNode -> _getShortName(
+						childNode, objectDefinitionLocalService),
+					String.class));
+		}
+
+		AssertUtils.assertEquals(expectedMap, actualMap);
+	}
+
+	public static void bind(
+			MVCResourceCommand mvcResourceCommand,
+			List<ObjectRelationship> objectRelationships,
+			PortletLocalService portletLocalService)
+		throws PortletException {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				portletLocalService.getPortletById(
+					ObjectPortletKeys.OBJECT_DEFINITIONS),
+				null));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
+		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockLiferayResourceRequest.addParameter(
+			"objectRelationshipIds",
+			TransformUtil.transformToArray(
+				objectRelationships,
+				objectRelationship -> String.valueOf(
+					objectRelationship.getObjectRelationshipId()),
+				String.class));
+
+		mvcResourceCommand.serveResource(mockLiferayResourceRequest, null);
+	}
+
 	public static Tree createTree(
+			MVCResourceCommand bindObjectDefinitionsMVCResourceCommand,
 			ObjectDefinitionLocalService objectDefinitionLocalService,
 			ObjectRelationshipLocalService objectRelationshipLocalService,
-			TreeFactory treeFactory)
-		throws PortalException {
+			PortletLocalService portletLocalService, TreeFactory treeFactory)
+		throws PortalException, PortletException {
 
 		ObjectDefinition objectDefinitionA =
 			ObjectDefinitionTestUtil.addObjectDefinition(
 				"A", objectDefinitionLocalService);
 
-		objectDefinitionLocalService.updateRootObjectDefinitionId(
-			objectDefinitionA.getObjectDefinitionId(),
-			objectDefinitionA.getObjectDefinitionId());
-
 		ObjectDefinition objectDefinitionAA =
 			ObjectDefinitionTestUtil.addObjectDefinition(
 				"AA", objectDefinitionLocalService);
 
-		_bind(
-			objectDefinitionAA, objectDefinitionLocalService,
-			objectRelationshipLocalService, objectDefinitionA,
-			objectDefinitionA);
-		_bind(
-			ObjectDefinitionTestUtil.addObjectDefinition(
-				"AAA", objectDefinitionLocalService),
-			objectDefinitionLocalService, objectRelationshipLocalService,
-			objectDefinitionAA, objectDefinitionA);
-		_bind(
-			ObjectDefinitionTestUtil.addObjectDefinition(
-				"AAB", objectDefinitionLocalService),
-			objectDefinitionLocalService, objectRelationshipLocalService,
-			objectDefinitionAA, objectDefinitionA);
-
-		_bind(
-			ObjectDefinitionTestUtil.addObjectDefinition(
-				"AB", objectDefinitionLocalService),
-			objectDefinitionLocalService, objectRelationshipLocalService,
-			objectDefinitionA, objectDefinitionA);
+		bind(
+			bindObjectDefinitionsMVCResourceCommand,
+			Arrays.asList(
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					objectRelationshipLocalService, objectDefinitionA,
+					objectDefinitionAA),
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					objectRelationshipLocalService, objectDefinitionAA,
+					ObjectDefinitionTestUtil.addObjectDefinition(
+						"AAA", objectDefinitionLocalService)),
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					objectRelationshipLocalService, objectDefinitionAA,
+					ObjectDefinitionTestUtil.addObjectDefinition(
+						"AAB", objectDefinitionLocalService)),
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					objectRelationshipLocalService, objectDefinitionA,
+					ObjectDefinitionTestUtil.addObjectDefinition(
+						"AB", objectDefinitionLocalService))),
+			portletLocalService);
 
 		return treeFactory.create(objectDefinitionA.getObjectDefinitionId());
 	}
@@ -81,32 +151,16 @@ public class TreeTestUtil {
 			edge.getObjectRelationshipId());
 	}
 
-	private static ObjectDefinition _bind(
-			ObjectDefinition objectDefinition,
-			ObjectDefinitionLocalService objectDefinitionLocalService,
-			ObjectRelationshipLocalService objectRelationshipLocalService,
-			ObjectDefinition parentObjectDefinition,
-			ObjectDefinition rootObjectDefinition)
+	private static String _getShortName(
+			Node node,
+			ObjectDefinitionLocalService objectDefinitionLocalService)
 		throws PortalException {
 
-		ObjectRelationship objectRelationship =
-			objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				parentObjectDefinition.getObjectDefinitionId(),
-				objectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		ObjectDefinition objectDefinition =
+			objectDefinitionLocalService.getObjectDefinition(
+				node.getObjectDefinitionId());
 
-		objectRelationshipLocalService.updateObjectRelationship(
-			objectRelationship.getObjectRelationshipId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-			objectRelationship.getLabelMap());
-
-		return objectDefinitionLocalService.updateRootObjectDefinitionId(
-			objectDefinition.getObjectDefinitionId(),
-			rootObjectDefinition.getObjectDefinitionId());
+		return objectDefinition.getShortName();
 	}
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
@@ -73,6 +73,14 @@ public class TreeTestUtil {
 		MockLiferayResourceRequest mockLiferayResourceRequest =
 			new MockLiferayResourceRequest();
 
+		mockLiferayResourceRequest.addParameter(
+			"objectRelationshipIds",
+			TransformUtil.transformToArray(
+				objectRelationships,
+				objectRelationship -> String.valueOf(
+					objectRelationship.getObjectRelationshipId()),
+				String.class));
+
 		mockLiferayResourceRequest.setAttribute(
 			JavaConstants.JAVAX_PORTLET_CONFIG,
 			PortletConfigFactoryUtil.create(
@@ -87,14 +95,6 @@ public class TreeTestUtil {
 
 		mockLiferayResourceRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
-
-		mockLiferayResourceRequest.addParameter(
-			"objectRelationshipIds",
-			TransformUtil.transformToArray(
-				objectRelationships,
-				objectRelationship -> String.valueOf(
-					objectRelationship.getObjectRelationshipId()),
-				String.class));
 
 		mvcResourceCommand.serveResource(mockLiferayResourceRequest, null);
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
@@ -21,11 +21,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.TimeZoneUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -87,14 +83,6 @@ public class TreeTestUtil {
 				portletLocalService.getPortletById(
 					ObjectPortletKeys.OBJECT_DEFINITIONS),
 				null));
-
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
-		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
-
-		mockLiferayResourceRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		mvcResourceCommand.serveResource(mockLiferayResourceRequest, null);
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
@@ -21,7 +21,12 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -137,6 +142,43 @@ public class TreeTestUtil {
 
 		return objectRelationshipLocalService.getObjectRelationship(
 			edge.getObjectRelationshipId());
+	}
+
+	public static void unbind(
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			String objectDefinitionName,
+			PortletLocalService portletLocalService,
+			MVCResourceCommand unbindObjectDefinitionMVCResourceCommand)
+		throws Exception {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), objectDefinitionName);
+
+		mockLiferayResourceRequest.addParameter(
+			"objectDefinitionId",
+			String.valueOf(objectDefinition.getObjectDefinitionId()));
+
+		mockLiferayResourceRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				portletLocalService.getPortletById(
+					ObjectPortletKeys.OBJECT_DEFINITIONS),
+				null));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
+		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		unbindObjectDefinitionMVCResourceCommand.serveResource(
+			mockLiferayResourceRequest, null);
 	}
 
 	private static String _getShortName(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/BindObjectDefinitionsMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/BindObjectDefinitionsMVCResourceCommandTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.service.test.util.TreeTestUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Arrays;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Feliphe Marinho
+ */
+@RunWith(Arquillian.class)
+public class BindObjectDefinitionsMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final TestRule testRule = new LiferayIntegrationTestRule();
+
+	@Test
+	public void testBindObjectDefinitions() throws Exception {
+
+		// Bind object definitions creating a new hierarchical structure
+
+		ObjectDefinition objectDefinitionA =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"A", _objectDefinitionLocalService);
+
+		ObjectDefinition objectDefinitionAA =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"AA", _objectDefinitionLocalService);
+
+		ObjectRelationship objectRelationshipA_AA =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinitionA,
+				objectDefinitionAA);
+
+		TreeTestUtil.bind(
+			_mvcResourceCommand,
+			Arrays.asList(
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService, objectDefinitionAA,
+					ObjectDefinitionTestUtil.addObjectDefinition(
+						"AAA", _objectDefinitionLocalService)),
+				objectRelationshipA_AA),
+			_portletLocalService);
+
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[] {"AAA"}
+			).put(
+				"AAA", new String[0]
+			).build(),
+			_treeFactory.create(objectDefinitionA.getObjectDefinitionId()),
+			_objectDefinitionLocalService);
+
+		// Bind one object definition to an existing hierarchical structure
+
+		TreeTestUtil.bind(
+			_mvcResourceCommand,
+			Arrays.asList(
+				ObjectRelationshipTestUtil.addObjectRelationship(
+					_objectRelationshipLocalService, objectDefinitionAA,
+					ObjectDefinitionTestUtil.addObjectDefinition(
+						"AAB", _objectDefinitionLocalService)),
+				objectRelationshipA_AA),
+			_portletLocalService);
+
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[] {"AAA", "AAB"}
+			).put(
+				"AAA", new String[0]
+			).put(
+				"AAB", new String[0]
+			).build(),
+			_treeFactory.create(objectDefinitionA.getObjectDefinitionId()),
+			_objectDefinitionLocalService);
+	}
+
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/bind_object_definitions"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private TreeFactory _treeFactory;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -27,12 +27,9 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.TimeZoneUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -247,14 +244,6 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 				_portletLocalService.getPortletById(
 					ObjectPortletKeys.OBJECT_DEFINITIONS),
 				null));
-
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
-		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
-
-		mockLiferayResourceRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		MockLiferayResourceResponse mockLiferayResourceResponse =
 			new MockLiferayResourceResponse();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -62,8 +62,9 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 		// Object definition, hierarchical structure, maximum height
 
 		Tree tree = TreeTestUtil.createTree(
+			_bindObjectDefinitionsMVCResourceCommand,
 			_objectDefinitionLocalService, _objectRelationshipLocalService,
-			_treeFactory);
+			_portletLocalService, _treeFactory);
 
 		ObjectDefinition objectDefinitionAAA =
 			_objectDefinitionLocalService.fetchObjectDefinition(
@@ -258,7 +259,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 		MockLiferayResourceResponse mockLiferayResourceResponse =
 			new MockLiferayResourceResponse();
 
-		_mvcResourceCommand.serveResource(
+		_getObjectRelationshipEdgeCandidatesMVCResourceCommand.serveResource(
 			mockLiferayResourceRequest, mockLiferayResourceResponse);
 
 		ByteArrayOutputStream byteArrayOutputStream =
@@ -266,7 +267,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 				mockLiferayResourceResponse.getPortletOutputStream();
 
 		return JSONFactoryUtil.createJSONArray(
-			new String(byteArrayOutputStream.toByteArray()));
+			byteArrayOutputStream.toString());
 	}
 
 	@Inject
@@ -276,13 +277,19 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 	private static ObjectRelationshipLocalService
 		_objectRelationshipLocalService;
 
-	@Inject
-	private JSONFactory _jsonFactory;
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/bind_object_definitions"
+	)
+	private MVCResourceCommand _bindObjectDefinitionsMVCResourceCommand;
 
 	@Inject(
 		filter = "mvc.command.name=/object_definitions/get_object_relationship_edge_candidates"
 	)
-	private MVCResourceCommand _mvcResourceCommand;
+	private MVCResourceCommand
+		_getObjectRelationshipEdgeCandidatesMVCResourceCommand;
+
+	@Inject
+	private JSONFactory _jsonFactory;
 
 	@Inject
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.portlet.action.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.exception.ObjectDefinitionRootObjectDefinitionIdException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -15,6 +16,7 @@ import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -26,7 +28,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,8 +97,13 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		_unbind("C_A");
 
-		Assert.assertNull(
-			_treeFactory.create(objectDefinition.getObjectDefinitionId()));
+		AssertUtils.assertFailure(
+			ObjectDefinitionRootObjectDefinitionIdException.class,
+			"The object definition id " +
+				objectDefinition.getObjectDefinitionId() +
+					" is not inside a hierarchical structure.",
+			() -> _treeFactory.create(
+				objectDefinition.getObjectDefinitionId()));
 	}
 
 	private void _unbind(String objectDefinitionName) throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
@@ -66,7 +66,7 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 				_portletLocalService, _treeFactory),
 			_objectDefinitionLocalService);
 
-		_unbindObjectDefinition("C_AA");
+		_unbind("C_AA");
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
@@ -83,7 +83,7 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		// Unbind object definition leaf node
 
-		_unbindObjectDefinition("C_AB");
+		_unbind("C_AB");
 
 		TreeTestUtil.assertTree(
 			LinkedHashMapBuilder.put(
@@ -94,15 +94,13 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		// Unbind object definition root node
 
-		_unbindObjectDefinition("C_A");
+		_unbind("C_A");
 
 		Assert.assertNull(
 			_treeFactory.create(objectDefinition.getObjectDefinitionId()));
 	}
 
-	private void _unbindObjectDefinition(String objectDefinitionName)
-		throws Exception {
-
+	private void _unbind(String objectDefinitionName) throws Exception {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				TestPropsValues.getCompanyId(), objectDefinitionName);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.test.util.TreeTestUtil;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Feliphe Marinho
+ */
+@RunWith(Arquillian.class)
+public class UnbindObjectDefinitionMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final TestRule testRule = new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUnbindObjectDefinition() throws Exception {
+
+		// Unbind object definition internal node
+
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA", "AB"}
+			).put(
+				"AA", new String[] {"AAA", "AAB"}
+			).put(
+				"AB", new String[0]
+			).put(
+				"AAA", new String[0]
+			).put(
+				"AAB", new String[0]
+			).build(),
+			TreeTestUtil.createTree(
+				_bindObjectDefinitionsMVCResourceCommand,
+				_objectDefinitionLocalService, _objectRelationshipLocalService,
+				_portletLocalService, _treeFactory),
+			_objectDefinitionLocalService);
+
+		_unbindObjectDefinition("C_AA");
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AB"}
+			).put(
+				"AB", new String[0]
+			).build(),
+			_treeFactory.create(objectDefinition.getObjectDefinitionId()),
+			_objectDefinitionLocalService);
+
+		// Unbind object definition leaf node
+
+		_unbindObjectDefinition("C_AB");
+
+		TreeTestUtil.assertTree(
+			LinkedHashMapBuilder.put(
+				"A", new String[0]
+			).build(),
+			_treeFactory.create(objectDefinition.getObjectDefinitionId()),
+			_objectDefinitionLocalService);
+
+		// Unbind object definition root node
+
+		_unbindObjectDefinition("C_A");
+
+		Assert.assertNull(
+			_treeFactory.create(objectDefinition.getObjectDefinitionId()));
+	}
+
+	private void _unbindObjectDefinition(String objectDefinitionName)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), objectDefinitionName);
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				_portletLocalService.getPortletById(
+					ObjectPortletKeys.OBJECT_DEFINITIONS),
+				null));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
+		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockLiferayResourceRequest.addParameter(
+			"objectDefinitionId",
+			String.valueOf(objectDefinition.getObjectDefinitionId()));
+
+		_unbindObjectDefinitionMVCResourceCommand.serveResource(
+			mockLiferayResourceRequest, null);
+	}
+
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/bind_object_definitions"
+	)
+	private MVCResourceCommand _bindObjectDefinitionsMVCResourceCommand;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private TreeFactory _treeFactory;
+
+	@Inject(
+		filter = "mvc.command.name=/object_definitions/unbind_object_definition"
+	)
+	private MVCResourceCommand _unbindObjectDefinitionMVCResourceCommand;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
@@ -101,12 +101,16 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 	}
 
 	private void _unbind(String objectDefinitionName) throws Exception {
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				TestPropsValues.getCompanyId(), objectDefinitionName);
 
-		MockLiferayResourceRequest mockLiferayResourceRequest =
-			new MockLiferayResourceRequest();
+		mockLiferayResourceRequest.addParameter(
+			"objectDefinitionId",
+			String.valueOf(objectDefinition.getObjectDefinitionId()));
 
 		mockLiferayResourceRequest.setAttribute(
 			JavaConstants.JAVAX_PORTLET_CONFIG,
@@ -122,10 +126,6 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		mockLiferayResourceRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
-
-		mockLiferayResourceRequest.addParameter(
-			"objectDefinitionId",
-			String.valueOf(objectDefinition.getObjectDefinitionId()));
 
 		_unbindObjectDefinitionMVCResourceCommand.serveResource(
 			mockLiferayResourceRequest, null);

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/UnbindObjectDefinitionMVCResourceCommandTest.java
@@ -6,25 +6,17 @@
 package com.liferay.object.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.object.constants.ObjectPortletKeys;
 import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.exception.ObjectDefinitionRootObjectDefinitionIdException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.TreeTestUtil;
-import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
-import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.TimeZoneUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -67,7 +59,9 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 				_portletLocalService, _treeFactory),
 			_objectDefinitionLocalService);
 
-		_unbind("C_AA");
+		TreeTestUtil.unbind(
+			_objectDefinitionLocalService, "C_AA", _portletLocalService,
+			_unbindObjectDefinitionMVCResourceCommand);
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
@@ -84,7 +78,9 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		// Unbind object definition leaf node
 
-		_unbind("C_AB");
+		TreeTestUtil.unbind(
+			_objectDefinitionLocalService, "C_AB", _portletLocalService,
+			_unbindObjectDefinitionMVCResourceCommand);
 
 		TreeTestUtil.assertTree(
 			LinkedHashMapBuilder.put(
@@ -95,7 +91,9 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 
 		// Unbind object definition root node
 
-		_unbind("C_A");
+		TreeTestUtil.unbind(
+			_objectDefinitionLocalService, "C_A", _portletLocalService,
+			_unbindObjectDefinitionMVCResourceCommand);
 
 		AssertUtils.assertFailure(
 			ObjectDefinitionRootObjectDefinitionIdException.class,
@@ -104,37 +102,6 @@ public class UnbindObjectDefinitionMVCResourceCommandTest {
 					" is not inside a hierarchical structure.",
 			() -> _treeFactory.create(
 				objectDefinition.getObjectDefinitionId()));
-	}
-
-	private void _unbind(String objectDefinitionName) throws Exception {
-		MockLiferayResourceRequest mockLiferayResourceRequest =
-			new MockLiferayResourceRequest();
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				TestPropsValues.getCompanyId(), objectDefinitionName);
-
-		mockLiferayResourceRequest.addParameter(
-			"objectDefinitionId",
-			String.valueOf(objectDefinition.getObjectDefinitionId()));
-
-		mockLiferayResourceRequest.setAttribute(
-			JavaConstants.JAVAX_PORTLET_CONFIG,
-			PortletConfigFactoryUtil.create(
-				_portletLocalService.getPortletById(
-					ObjectPortletKeys.OBJECT_DEFINITIONS),
-				null));
-
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
-		themeDisplay.setTimeZone(TimeZoneUtil.getDefault());
-
-		mockLiferayResourceRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, themeDisplay);
-
-		_unbindObjectDefinitionMVCResourceCommand.serveResource(
-			mockLiferayResourceRequest, null);
 	}
 
 	@Inject(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/BindObjectDefinitionsMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/BindObjectDefinitionsMVCResourceCommand.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.object.definitions.portlet.action;
+
+import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + ObjectPortletKeys.OBJECT_DEFINITIONS,
+		"mvc.command.name=/object_definitions/bind_object_definitions"
+	},
+	service = MVCResourceCommand.class
+)
+public class BindObjectDefinitionsMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		long[] objectRelationshipIds = ParamUtil.getLongValues(
+			resourceRequest, "objectRelationshipIds");
+
+		ObjectRelationship rootObjectRelationship =
+			_objectRelationshipLocalService.getObjectRelationship(
+				objectRelationshipIds[objectRelationshipIds.length - 1]);
+
+		long rootObjectDefinitionId =
+			rootObjectRelationship.getObjectDefinitionId1();
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				rootObjectDefinitionId);
+
+		if (rootObjectDefinition.getRootObjectDefinitionId() == 0) {
+			_objectDefinitionLocalService.updateRootObjectDefinitionId(
+				rootObjectDefinitionId, rootObjectDefinitionId);
+		}
+
+		for (long objectRelationshipId : objectRelationshipIds) {
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					objectRelationshipId);
+
+			if (objectRelationship.isEdge()) {
+				continue;
+			}
+
+			_objectRelationshipLocalService.updateObjectRelationship(
+				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getParameterObjectFieldId(),
+				objectRelationship.getDeletionType(), true,
+				objectRelationship.getLabelMap());
+
+			ObjectDefinition objectDefinition1 =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId1());
+
+			if (objectDefinition1.getRootObjectDefinitionId() == 0) {
+				_objectDefinitionLocalService.updateRootObjectDefinitionId(
+					objectDefinition1.getObjectDefinitionId(),
+					rootObjectDefinitionId);
+			}
+
+			ObjectDefinition objectDefinition2 =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId2());
+
+			_objectDefinitionLocalService.updateRootObjectDefinitionId(
+				objectDefinition2.getObjectDefinitionId(),
+				rootObjectDefinitionId);
+		}
+	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
@@ -55,29 +55,27 @@ public class UnbindObjectDefinitionMVCResourceCommand
 			objectDefinition.getObjectDefinitionId());
 
 		while (iterator.hasNext()) {
-			_unbind(iterator.next());
+			Node node = iterator.next();
+
+			_objectDefinitionLocalService.updateRootObjectDefinitionId(
+				node.getObjectDefinitionId(), 0);
+
+			if (node.isRoot()) {
+				continue;
+			}
+
+			Edge edge = node.getEdge();
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					edge.getObjectRelationshipId());
+
+			_objectRelationshipLocalService.updateObjectRelationship(
+				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getParameterObjectFieldId(),
+				objectRelationship.getDeletionType(), false,
+				objectRelationship.getLabelMap());
 		}
-	}
-
-	private void _unbind(Node node) throws Exception {
-		_objectDefinitionLocalService.updateRootObjectDefinitionId(
-			node.getObjectDefinitionId(), 0);
-
-		if (node.isRoot()) {
-			return;
-		}
-
-		Edge edge = node.getEdge();
-
-		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.getObjectRelationship(
-				edge.getObjectRelationshipId());
-
-		_objectRelationshipLocalService.updateObjectRelationship(
-			objectRelationship.getObjectRelationshipId(),
-			objectRelationship.getParameterObjectFieldId(),
-			objectRelationship.getDeletionType(), false,
-			objectRelationship.getLabelMap());
 	}
 
 	@Reference

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.object.definitions.portlet.action;
+
+import com.liferay.object.constants.ObjectPortletKeys;
+import com.liferay.object.definition.tree.Edge;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import java.util.Iterator;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Feliphe Marinho
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + ObjectPortletKeys.OBJECT_DEFINITIONS,
+		"mvc.command.name=/object_definitions/unbind_object_definition"
+	},
+	service = MVCResourceCommand.class
+)
+public class UnbindObjectDefinitionMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				ParamUtil.getLong(resourceRequest, "objectDefinitionId"));
+
+		Tree tree = _treeFactory.create(
+			objectDefinition.getRootObjectDefinitionId());
+
+		Iterator<Node> iterator = tree.iterator(
+			objectDefinition.getObjectDefinitionId());
+
+		while (iterator.hasNext()) {
+			_unbindNode(iterator.next());
+		}
+	}
+
+	private void _unbindNode(Node node) throws Exception {
+		_objectDefinitionLocalService.updateRootObjectDefinitionId(
+			node.getObjectDefinitionId(), 0);
+
+		if (node.isRoot()) {
+			return;
+		}
+
+		Edge edge = node.getEdge();
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.getObjectRelationship(
+				edge.getObjectRelationshipId());
+
+		_objectRelationshipLocalService.updateObjectRelationship(
+			objectRelationship.getObjectRelationshipId(),
+			objectRelationship.getParameterObjectFieldId(),
+			objectRelationship.getDeletionType(), false,
+			objectRelationship.getLabelMap());
+	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private TreeFactory _treeFactory;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/UnbindObjectDefinitionMVCResourceCommand.java
@@ -55,11 +55,11 @@ public class UnbindObjectDefinitionMVCResourceCommand
 			objectDefinition.getObjectDefinitionId());
 
 		while (iterator.hasNext()) {
-			_unbindNode(iterator.next());
+			_unbind(iterator.next());
 		}
 	}
 
-	private void _unbindNode(Node node) throws Exception {
+	private void _unbind(Node node) throws Exception {
 		_objectDefinitionLocalService.updateRootObjectDefinitionId(
 			node.getObjectDefinitionId(), 0);
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-193250

Starts in: [8c0cf18](https://github.com/liferay-objects/liferay-portal/pull/2505/commits/8c0cf18e4e168dd606e81cc9cf511aa22cce7eb9)