### PR TITLE
LPS-190903 [WIP] Allow users to edit account restriction field after creation

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -31,7 +31,6 @@ import com.liferay.object.constants.ObjectFilterConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.exception.ObjectDefinitionAccountEntryRestrictedException;
-import com.liferay.object.exception.ObjectEntryValuesException;
 import com.liferay.object.exception.ObjectRelationshipDeletionTypeException;
 import com.liferay.object.exception.RequiredObjectRelationshipException;
 import com.liferay.object.field.builder.AggregationObjectFieldBuilder;
@@ -2393,19 +2392,6 @@ public class DefaultObjectEntryManagerImplTest
 		Role role = _addRoleUser(
 			new String[] {ActionKeys.UPDATE, ActionKeys.VIEW},
 			_objectDefinition3, _user);
-
-		AssertUtils.assertFailure(
-			ObjectEntryValuesException.UnmodifiableAccountEntryObjectField.
-				class,
-			"The object field r_oneToManyRelationshipName_accountEntryId is " +
-				"unmodifiable because it is the account entry restrictor",
-			() -> _defaultObjectEntryManager.updateObjectEntry(
-				_simpleDTOConverterContext, _objectDefinition3,
-				objectEntry1.getId(), objectEntry2));
-
-		_defaultObjectEntryManager.updateObjectEntry(
-			_simpleDTOConverterContext, _objectDefinition3,
-			objectEntry1.getId(), objectEntry1);
 
 		_resourcePermissionLocalService.removeResourcePermission(
 			companyId, _objectDefinition3.getClassName(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4225,16 +4225,6 @@ public class ObjectEntryLocalServiceImpl
 
 				return;
 			}
-
-			Map<String, Serializable> originalValues = objectEntry.getValues();
-
-			if (!Objects.equals(
-					GetterUtil.getLong(originalValues.get(entry.getKey())),
-					GetterUtil.getLong(entry.getValue()))) {
-
-				throw new ObjectEntryValuesException.
-					UnmodifiableAccountEntryObjectField(objectField.getName());
-			}
 		}
 		else if (StringUtil.equals(
 					objectField.getDBType(),


### PR DESCRIPTION
LPS-190903
After discussing some use cases, we identified that the fact that we don’t allow the update of this field have more negative consequences than allowing.
Users having the permission to update, but not to add an entry is a very edge case.
While, use cases where users need to change this field are more common.
For that reason, we decided to change the behavior to allow users to edit the account restriction field.