### PR TITLE
LPS-192516 Cannot use entity fields as variable for Recipient field when separating variables by comma and space or semicolon

### DIFF
--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
@@ -243,8 +243,7 @@ public class EmailNotificationType extends BaseNotificationType {
 					}
 
 					return _formatTo(
-						formatLocalizedContent(to, notificationContext),
-						notificationContext);
+						formatLocalizedContent(to, notificationContext));
 				}
 			).build();
 
@@ -492,9 +491,7 @@ public class EmailNotificationType extends BaseNotificationType {
 		return stringWriter.toString();
 	}
 
-	private String _formatTo(String to, NotificationContext notificationContext)
-		throws PortalException {
-
+	private String _formatTo(String to) {
 		if (Validator.isNull(to)) {
 			return StringPool.BLANK;
 		}
@@ -507,8 +504,7 @@ public class EmailNotificationType extends BaseNotificationType {
 			emailAddresses.add(matcher.group());
 		}
 
-		return formatLocalizedContent(
-			StringUtil.merge(emailAddresses), notificationContext);
+		return StringUtil.merge(emailAddresses);
 	}
 
 	private List<Long> _getFileEntryIds(

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
@@ -234,17 +234,16 @@ public class EmailNotificationType extends BaseNotificationType {
 									getNotificationRecipientId(),
 								"to");
 
-					String to = _formatTo(
-						notificationRecipientSetting.getValue(user.getLocale()),
-						notificationContext);
+					String to = notificationRecipientSetting.getValue(
+						user.getLocale());
 
-					if (Validator.isNotNull(to)) {
-						return to;
+					if (Validator.isNull(to)) {
+						to = notificationRecipientSetting.getValue(
+							siteDefaultLocale);
 					}
 
-					return formatLocalizedContent(
-						notificationRecipientSetting.getValue(
-							siteDefaultLocale),
+					return _formatTo(
+						formatLocalizedContent(to, notificationContext),
 						notificationContext);
 				}
 			).build();

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/BaseNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/BaseNotificationTypeTest.java
@@ -110,6 +110,10 @@ public class BaseNotificationTypeTest {
 				return simpleDateFormat.format(RandomTestUtil.nextDate());
 			}
 		).put(
+			"emailTextObjectField",
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) +
+				"@liferay.com"
+		).put(
 			"integerObjectField", RandomTestUtil.nextInt()
 		).put(
 			"picklistObjectField",
@@ -191,6 +195,13 @@ public class BaseNotificationTypeTest {
 						"picklistObjectField"
 					).listTypeDefinitionId(
 						_listTypeDefinition.getListTypeDefinitionId()
+					).build(),
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"emailTextObjectField"
 					).build(),
 					new TextObjectFieldBuilder(
 					).labelMap(
@@ -377,6 +388,7 @@ public class BaseNotificationTypeTest {
 			Arrays.asList(
 				getTermName("booleanObjectField"),
 				getTermName("dateObjectField"),
+				getTermName("emailTextObjectField"),
 				getTermName("integerObjectField"),
 				getTermName("picklistObjectField"),
 				getTermName("textObjectField"),

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -97,8 +97,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 				user1.getEmailAddress(), StringPool.SEMICOLON,
 				user2.getEmailAddress()));
 
-		// Multiples emails for each main recipient, with terms and comma
-		// separator
+		// Multiples emails for each main recipient, terms, comma separator
 
 		_testSendNotification(
 			2,
@@ -111,8 +110,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			"[%CURRENT_USER_EMAIL_ADDRESS%]," +
 				getTermName("emailTextObjectField"));
 
-		// Multiples emails for each main recipient, with terms and comma and
-		// space separator
+		// Multiples emails for each main recipient, terms, comma and space
+		// separator
 
 		_testSendNotification(
 			2,
@@ -125,8 +124,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			"[%CURRENT_USER_EMAIL_ADDRESS%], " +
 				getTermName("emailTextObjectField"));
 
-		// Multiples emails for each main recipient, with terms and semicolon
-		// separator
+		// Multiples emails for each main recipient, terms, semicolon separator
 
 		_testSendNotification(
 			2,
@@ -279,8 +277,9 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	}
 
 	private void _testSendNotification(
-			int expectedCount, List<String> expectedToEmailAddress,
-			boolean singleRecipient, String to)
+			int expectedNotificationQueueEntriesCount,
+			List<String> expectedToEmailAddresses, boolean singleRecipient,
+			String to)
 		throws Exception {
 
 		_executeNotificationObjectAction(
@@ -303,16 +302,17 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 				}));
 
 		Assert.assertEquals(
-			notificationQueueEntries.toString(), expectedCount,
+			notificationQueueEntries.toString(),
+			expectedNotificationQueueEntriesCount,
 			notificationQueueEntries.size());
 
 		_assertNotificationQueueEntry(
-			singleRecipient, expectedToEmailAddress.get(0),
+			singleRecipient, expectedToEmailAddresses.get(0),
 			notificationQueueEntries.get(0));
 
 		if (singleRecipient) {
 			_assertNotificationQueueEntry(
-				singleRecipient, expectedToEmailAddress.get(1),
+				singleRecipient, expectedToEmailAddresses.get(1),
 				notificationQueueEntries.get(1));
 		}
 

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -58,11 +58,6 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 	@Test
 	public void testSendNotification() throws Exception {
-		Assert.assertEquals(
-			0,
-			notificationQueueEntryLocalService.
-				getNotificationQueueEntriesCount());
-
 		NotificationTemplate notificationTemplate = _addNotificationTemplate(
 			false);
 

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -135,26 +135,16 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		// One email including all main recipients
 
-		_executeNotificationObjectAction(_addNotificationTemplate(false));
-
-		List<NotificationQueueEntry> notificationQueueEntries =
-			notificationQueueEntryLocalService.getNotificationEntries(
-				NotificationConstants.TYPE_EMAIL,
-				NotificationQueueEntryConstants.STATUS_SENT);
-
-		Assert.assertEquals(
-			notificationQueueEntries.toString(), 1,
-			notificationQueueEntries.size());
-
-		_assertNotificationQueueEntry(
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					StringBundler.concat(
+						user1.getEmailAddress(), StringPool.COMMA,
+						user2.getEmailAddress()))),
 			false,
 			StringBundler.concat(
 				user1.getEmailAddress(), StringPool.COMMA,
-				user2.getEmailAddress()),
-			notificationQueueEntries.get(0));
-
-		notificationQueueEntryLocalService.deleteNotificationQueueEntry(
-			notificationQueueEntries.get(0));
+				user2.getEmailAddress()));
 	}
 
 	private NotificationTemplate _addNotificationTemplate(
@@ -318,16 +308,25 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 						notificationRecipientSettingsMap.get("to"));
 				}));
 
+		int expectedCount = 1;
+
+		if (singleRecipient) {
+			expectedCount = 2;
+		}
+
 		Assert.assertEquals(
-			notificationQueueEntries.toString(), 2,
+			notificationQueueEntries.toString(), expectedCount,
 			notificationQueueEntries.size());
 
 		_assertNotificationQueueEntry(
 			singleRecipient, expectedToEmailAddress.get(0),
 			notificationQueueEntries.get(0));
-		_assertNotificationQueueEntry(
-			singleRecipient, expectedToEmailAddress.get(1),
-			notificationQueueEntries.get(1));
+
+		if (singleRecipient) {
+			_assertNotificationQueueEntry(
+				singleRecipient, expectedToEmailAddress.get(1),
+				notificationQueueEntries.get(1));
+		}
 
 		for (NotificationQueueEntry notificationQueueEntry :
 				notificationQueueEntries) {

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -127,6 +128,19 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			boolean singleRecipient)
 		throws Exception {
 
+		return _addNotificationTemplate(
+			singleRecipient,
+			Collections.singletonMap(
+				LocaleUtil.US,
+				StringBundler.concat(
+					user1.getEmailAddress(), StringPool.COMMA,
+					user2.getEmailAddress())));
+	}
+
+	private NotificationTemplate _addNotificationTemplate(
+			boolean singleRecipient, Map<Locale, String> to)
+		throws Exception {
+
 		return notificationTemplateLocalService.addNotificationTemplate(
 			NotificationTemplateUtil.createNotificationContext(
 				TestPropsValues.getUser(),
@@ -146,13 +160,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 							LocaleUtil.US, "[%CURRENT_USER_FIRST_NAME%]")),
 					createNotificationRecipientSetting(
 						"singleRecipient", String.valueOf(singleRecipient)),
-					createNotificationRecipientSetting(
-						"to",
-						Collections.singletonMap(
-							LocaleUtil.US,
-							StringBundler.concat(
-								user1.getEmailAddress(), StringPool.COMMA,
-								user2.getEmailAddress())))),
+					createNotificationRecipientSetting("to", to)),
 				ListUtil.toString(getTermNames(), StringPool.BLANK),
 				NotificationConstants.TYPE_EMAIL));
 	}

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -61,6 +61,72 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	@Test
 	public void testSendNotification() throws Exception {
 
+		// Multiples emails for each main recipient, comma separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.COMMA,
+				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipient, comma and space separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.COMMA_AND_SPACE,
+				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipient, semicolon separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.SEMICOLON,
+				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipient, with terms and comma
+		// separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%]," +
+				getTermName("emailTextObjectField"));
+
+		// Multiples emails for each main recipient, with terms and comma and
+		// space separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%], " +
+				getTermName("emailTextObjectField"));
+
+		// Multiples emails for each main recipient, with terms and semicolon
+		// separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%];" +
+				getTermName("emailTextObjectField"));
+
 		// One email including all main recipients
 
 		_executeNotificationObjectAction(_addNotificationTemplate(false));
@@ -83,72 +149,6 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		notificationQueueEntryLocalService.deleteNotificationQueueEntry(
 			notificationQueueEntries.get(0));
-
-		// Multiples emails for each main recipients, comma separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user1.getEmailAddress(), user2.getEmailAddress())),
-			StringBundler.concat(
-				user1.getEmailAddress(), StringPool.COMMA,
-				user2.getEmailAddress()));
-
-		// Multiples emails for each main recipients, comma and space separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user1.getEmailAddress(), user2.getEmailAddress())),
-			StringBundler.concat(
-				user1.getEmailAddress(), StringPool.COMMA_AND_SPACE,
-				user2.getEmailAddress()));
-
-		// Multiples emails for each main recipients, semicolon separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user1.getEmailAddress(), user2.getEmailAddress())),
-			StringBundler.concat(
-				user1.getEmailAddress(), StringPool.SEMICOLON,
-				user2.getEmailAddress()));
-
-		// Multiples emails for each main recipients, with terms and comma
-		// separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user2.getEmailAddress(),
-					GetterUtil.getString(
-						childObjectEntryValues.get("emailTextObjectField")))),
-			"[%CURRENT_USER_EMAIL_ADDRESS%]," +
-				getTermName("emailTextObjectField"));
-
-		// Multiples emails for each main recipients, with terms and comma and
-		// space separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user2.getEmailAddress(),
-					GetterUtil.getString(
-						childObjectEntryValues.get("emailTextObjectField")))),
-			"[%CURRENT_USER_EMAIL_ADDRESS%], " +
-				getTermName("emailTextObjectField"));
-
-		// Multiples emails for each main recipients, with terms and semicolon
-		// separator
-
-		_testSendNotification(
-			ListUtil.sort(
-				Arrays.asList(
-					user2.getEmailAddress(),
-					GetterUtil.getString(
-						childObjectEntryValues.get("emailTextObjectField")))),
-			"[%CURRENT_USER_EMAIL_ADDRESS%];" +
-				getTermName("emailTextObjectField"));
 	}
 
 	private NotificationTemplate _addNotificationTemplate(
@@ -288,7 +288,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			objectAction.getObjectActionId());
 	}
 
-	private void _testSendNotification(List<String> expectedTo, String to)
+	private void _testSendNotification(
+			List<String> expectedToEmailAddress, String to)
 		throws Exception {
 
 		_executeNotificationObjectAction(
@@ -315,9 +316,11 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			notificationQueueEntries.size());
 
 		_assertNotificationQueueEntry(
-			true, expectedTo.get(0), notificationQueueEntries.get(0));
+			true, expectedToEmailAddress.get(0),
+			notificationQueueEntries.get(0));
 		_assertNotificationQueueEntry(
-			true, expectedTo.get(1), notificationQueueEntries.get(1));
+			true, expectedToEmailAddress.get(1),
+			notificationQueueEntries.get(1));
 
 		for (NotificationQueueEntry notificationQueueEntry :
 				notificationQueueEntries) {

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -58,25 +58,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 	@Test
 	public void testSendNotification() throws Exception {
-		NotificationTemplate notificationTemplate = _addNotificationTemplate(
-			false);
-
-		ObjectAction objectAction = objectActionLocalService.addObjectAction(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-			childObjectDefinition.getObjectDefinitionId(), true,
-			StringPool.BLANK, RandomTestUtil.randomString(),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			RandomTestUtil.randomString(),
-			ObjectActionExecutorConstants.KEY_NOTIFICATION,
-			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
-			UnicodePropertiesBuilder.put(
-				"notificationTemplateId",
-				notificationTemplate.getNotificationTemplateId()
-			).build(),
-			false);
-
-		_addObjectEntry();
+		_executeNotificationObjectAction(_addNotificationTemplate(false));
 
 		List<NotificationQueueEntry> notificationQueueEntries =
 			notificationQueueEntryLocalService.getNotificationEntries(
@@ -97,22 +79,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		notificationQueueEntryLocalService.deleteNotificationQueueEntry(
 			notificationQueueEntries.get(0));
 
-		notificationTemplate = _addNotificationTemplate(true);
-
-		objectActionLocalService.updateObjectAction(
-			RandomTestUtil.randomString(), objectAction.getObjectActionId(),
-			true, StringPool.BLANK, RandomTestUtil.randomString(),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			RandomTestUtil.randomString(),
-			ObjectActionExecutorConstants.KEY_NOTIFICATION,
-			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
-			UnicodePropertiesBuilder.put(
-				"notificationTemplateId",
-				notificationTemplate.getNotificationTemplateId()
-			).build());
-
-		_addObjectEntry();
+		_executeNotificationObjectAction(_addNotificationTemplate(true));
 
 		notificationQueueEntries = ListUtil.sort(
 			notificationQueueEntryLocalService.getNotificationEntries(
@@ -185,31 +152,6 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 				NotificationConstants.TYPE_EMAIL));
 	}
 
-	private void _addObjectEntry() throws Exception {
-		ObjectEntry objectEntry = objectEntryManager.addObjectEntry(
-			dtoConverterContext, parentObjectDefinition,
-			new ObjectEntry() {
-				{
-					properties = parentObjectEntryValues;
-				}
-			},
-			ObjectDefinitionConstants.SCOPE_COMPANY);
-
-		objectEntryManager.addObjectEntry(
-			dtoConverterContext, childObjectDefinition,
-			new ObjectEntry() {
-				{
-					properties = HashMapBuilder.putAll(
-						childObjectEntryValues
-					).put(
-						getObjectRelationshipObjectField2Name(),
-						objectEntry.getId()
-					).build();
-				}
-			},
-			ObjectDefinitionConstants.SCOPE_COMPANY);
-	}
-
 	private void _assertNotificationQueueEntry(
 		boolean expectedSingleRecipient, String expectedToEmailAddress,
 		NotificationQueueEntry notificationQueueEntry) {
@@ -258,6 +200,52 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		Assert.assertArrayEquals(
 			expectedToEmailAddressesArray, actualToEmailAddressesArray);
+	}
+
+	private void _executeNotificationObjectAction(
+			NotificationTemplate notificationTemplate)
+		throws Exception {
+
+		ObjectAction objectAction = objectActionLocalService.addObjectAction(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId(), true,
+			StringPool.BLANK, RandomTestUtil.randomString(),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_NOTIFICATION,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
+			UnicodePropertiesBuilder.put(
+				"notificationTemplateId",
+				notificationTemplate.getNotificationTemplateId()
+			).build(),
+			false);
+
+		ObjectEntry objectEntry = objectEntryManager.addObjectEntry(
+			dtoConverterContext, parentObjectDefinition,
+			new ObjectEntry() {
+				{
+					properties = parentObjectEntryValues;
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		objectEntryManager.addObjectEntry(
+			dtoConverterContext, childObjectDefinition,
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.putAll(
+						childObjectEntryValues
+					).put(
+						getObjectRelationshipObjectField2Name(),
+						objectEntry.getId()
+					).build();
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		objectActionLocalService.deleteObjectAction(
+			objectAction.getObjectActionId());
 	}
 
 }

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -64,6 +64,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// Multiples emails for each main recipient, comma separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
@@ -75,6 +76,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// Multiples emails for each main recipient, comma and space separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
@@ -86,6 +88,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// Multiples emails for each main recipient, semicolon separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
@@ -98,6 +101,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user2.getEmailAddress(),
@@ -111,6 +115,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// space separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user2.getEmailAddress(),
@@ -124,6 +129,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// separator
 
 		_testSendNotification(
+			2,
 			ListUtil.sort(
 				Arrays.asList(
 					user2.getEmailAddress(),
@@ -136,6 +142,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		// One email including all main recipients
 
 		_testSendNotification(
+			1,
 			ListUtil.sort(
 				Arrays.asList(
 					StringBundler.concat(
@@ -272,8 +279,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	}
 
 	private void _testSendNotification(
-			List<String> expectedToEmailAddress, boolean singleRecipient,
-			String to)
+			int expectedCount, List<String> expectedToEmailAddress,
+			boolean singleRecipient, String to)
 		throws Exception {
 
 		_executeNotificationObjectAction(
@@ -294,12 +301,6 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					return String.valueOf(
 						notificationRecipientSettingsMap.get("to"));
 				}));
-
-		int expectedCount = 1;
-
-		if (singleRecipient) {
-			expectedCount = 2;
-		}
 
 		Assert.assertEquals(
 			notificationQueueEntries.toString(), expectedCount,

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -85,43 +85,13 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		// Multiples emails for each main recipients, comma separator
 
-		_executeNotificationObjectAction(_addNotificationTemplate(true));
-
-		notificationQueueEntries = ListUtil.sort(
-			notificationQueueEntryLocalService.getNotificationEntries(
-				NotificationConstants.TYPE_EMAIL,
-				NotificationQueueEntryConstants.STATUS_SENT),
-			Comparator.comparing(
-				notificationQueueEntry -> {
-					Map<String, Object> notificationRecipientSettingsMap =
-						NotificationRecipientSettingUtil.
-							getNotificationRecipientSettingsMap(
-								notificationQueueEntry);
-
-					return String.valueOf(
-						notificationRecipientSettingsMap.get("to"));
-				}));
-
-		Assert.assertEquals(
-			notificationQueueEntries.toString(), 2,
-			notificationQueueEntries.size());
-
-		List<String> expectedToEmailAddresses = ListUtil.sort(
-			Arrays.asList(user1.getEmailAddress(), user2.getEmailAddress()));
-
-		_assertNotificationQueueEntry(
-			true, expectedToEmailAddresses.get(0),
-			notificationQueueEntries.get(0));
-		_assertNotificationQueueEntry(
-			true, expectedToEmailAddresses.get(1),
-			notificationQueueEntries.get(1));
-
-		for (NotificationQueueEntry notificationQueueEntry :
-				notificationQueueEntries) {
-
-			notificationQueueEntryLocalService.deleteNotificationQueueEntry(
-				notificationQueueEntry);
-		}
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.COMMA,
+				user2.getEmailAddress()));
 	}
 
 	private NotificationTemplate _addNotificationTemplate(
@@ -259,6 +229,45 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		objectActionLocalService.deleteObjectAction(
 			objectAction.getObjectActionId());
+	}
+
+	private void _testSendNotification(List<String> expectedTo, String to)
+		throws Exception {
+
+		_executeNotificationObjectAction(
+			_addNotificationTemplate(
+				true, Collections.singletonMap(LocaleUtil.US, to)));
+
+		List<NotificationQueueEntry> notificationQueueEntries = ListUtil.sort(
+			notificationQueueEntryLocalService.getNotificationEntries(
+				NotificationConstants.TYPE_EMAIL,
+				NotificationQueueEntryConstants.STATUS_SENT),
+			Comparator.comparing(
+				notificationQueueEntry -> {
+					Map<String, Object> notificationRecipientSettingsMap =
+						NotificationRecipientSettingUtil.
+							getNotificationRecipientSettingsMap(
+								notificationQueueEntry);
+
+					return String.valueOf(
+						notificationRecipientSettingsMap.get("to"));
+				}));
+
+		Assert.assertEquals(
+			notificationQueueEntries.toString(), 2,
+			notificationQueueEntries.size());
+
+		_assertNotificationQueueEntry(
+			true, expectedTo.get(0), notificationQueueEntries.get(0));
+		_assertNotificationQueueEntry(
+			true, expectedTo.get(1), notificationQueueEntries.get(1));
+
+		for (NotificationQueueEntry notificationQueueEntry :
+				notificationQueueEntries) {
+
+			notificationQueueEntryLocalService.deleteNotificationQueueEntry(
+				notificationQueueEntry);
+		}
 	}
 
 }

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -67,6 +67,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
+			true,
 			StringBundler.concat(
 				user1.getEmailAddress(), StringPool.COMMA,
 				user2.getEmailAddress()));
@@ -77,6 +78,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
+			true,
 			StringBundler.concat(
 				user1.getEmailAddress(), StringPool.COMMA_AND_SPACE,
 				user2.getEmailAddress()));
@@ -87,6 +89,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			ListUtil.sort(
 				Arrays.asList(
 					user1.getEmailAddress(), user2.getEmailAddress())),
+			true,
 			StringBundler.concat(
 				user1.getEmailAddress(), StringPool.SEMICOLON,
 				user2.getEmailAddress()));
@@ -100,6 +103,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					user2.getEmailAddress(),
 					GetterUtil.getString(
 						childObjectEntryValues.get("emailTextObjectField")))),
+			true,
 			"[%CURRENT_USER_EMAIL_ADDRESS%]," +
 				getTermName("emailTextObjectField"));
 
@@ -112,6 +116,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					user2.getEmailAddress(),
 					GetterUtil.getString(
 						childObjectEntryValues.get("emailTextObjectField")))),
+			true,
 			"[%CURRENT_USER_EMAIL_ADDRESS%], " +
 				getTermName("emailTextObjectField"));
 
@@ -124,6 +129,7 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					user2.getEmailAddress(),
 					GetterUtil.getString(
 						childObjectEntryValues.get("emailTextObjectField")))),
+			true,
 			"[%CURRENT_USER_EMAIL_ADDRESS%];" +
 				getTermName("emailTextObjectField"));
 
@@ -289,12 +295,13 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	}
 
 	private void _testSendNotification(
-			List<String> expectedToEmailAddress, String to)
+			List<String> expectedToEmailAddress, boolean singleRecipient,
+			String to)
 		throws Exception {
 
 		_executeNotificationObjectAction(
 			_addNotificationTemplate(
-				true, Collections.singletonMap(LocaleUtil.US, to)));
+				singleRecipient, Collections.singletonMap(LocaleUtil.US, to)));
 
 		List<NotificationQueueEntry> notificationQueueEntries = ListUtil.sort(
 			notificationQueueEntryLocalService.getNotificationEntries(
@@ -316,10 +323,10 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			notificationQueueEntries.size());
 
 		_assertNotificationQueueEntry(
-			true, expectedToEmailAddress.get(0),
+			singleRecipient, expectedToEmailAddress.get(0),
 			notificationQueueEntries.get(0));
 		_assertNotificationQueueEntry(
-			true, expectedToEmailAddress.get(1),
+			singleRecipient, expectedToEmailAddress.get(1),
 			notificationQueueEntries.get(1));
 
 		for (NotificationQueueEntry notificationQueueEntry :

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -58,6 +58,9 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 	@Test
 	public void testSendNotification() throws Exception {
+
+		// One email including all main recipients
+
 		_executeNotificationObjectAction(_addNotificationTemplate(false));
 
 		List<NotificationQueueEntry> notificationQueueEntries =
@@ -78,6 +81,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 
 		notificationQueueEntryLocalService.deleteNotificationQueueEntry(
 			notificationQueueEntries.get(0));
+
+		// Multiples emails for each main recipients, comma separator
 
 		_executeNotificationObjectAction(_addNotificationTemplate(true));
 

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -148,19 +148,6 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	}
 
 	private NotificationTemplate _addNotificationTemplate(
-			boolean singleRecipient)
-		throws Exception {
-
-		return _addNotificationTemplate(
-			singleRecipient,
-			Collections.singletonMap(
-				LocaleUtil.US,
-				StringBundler.concat(
-					user1.getEmailAddress(), StringPool.COMMA,
-					user2.getEmailAddress())));
-	}
-
-	private NotificationTemplate _addNotificationTemplate(
 			boolean singleRecipient, Map<Locale, String> to)
 		throws Exception {
 

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -22,6 +22,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -92,6 +93,62 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 			StringBundler.concat(
 				user1.getEmailAddress(), StringPool.COMMA,
 				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipients, comma and space separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.COMMA_AND_SPACE,
+				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipients, semicolon separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user1.getEmailAddress(), user2.getEmailAddress())),
+			StringBundler.concat(
+				user1.getEmailAddress(), StringPool.SEMICOLON,
+				user2.getEmailAddress()));
+
+		// Multiples emails for each main recipients, with terms and comma
+		// separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%]," +
+				getTermName("emailTextObjectField"));
+
+		// Multiples emails for each main recipients, with terms and comma and
+		// space separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%], " +
+				getTermName("emailTextObjectField"));
+
+		// Multiples emails for each main recipients, with terms and semicolon
+		// separator
+
+		_testSendNotification(
+			ListUtil.sort(
+				Arrays.asList(
+					user2.getEmailAddress(),
+					GetterUtil.getString(
+						childObjectEntryValues.get("emailTextObjectField")))),
+			"[%CURRENT_USER_EMAIL_ADDRESS%];" +
+				getTermName("emailTextObjectField"));
 	}
 
 	private NotificationTemplate _addNotificationTemplate(


### PR DESCRIPTION
Issue : https://liferay.atlassian.net/browse/LPS-192516