### PR TITLE
[TS] LPS-195463 Added condition for hiding export menu based on storage type.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormAdminActionDropdownItemsProvider.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormAdminActionDropdownItemsProvider.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.RenderResponse;
 
@@ -92,7 +93,9 @@ public class DDMFormAdminActionDropdownItemsProvider {
 					).add(
 						() ->
 							_formInstancePermissionCheckerHelper.
-								isShowExportIcon(_ddmFormInstance),
+								isShowExportIcon(_ddmFormInstance) &&
+							!Objects.equals(
+								_ddmFormInstance.getStorageType(), "object"),
 						_getExportActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);


### PR DESCRIPTION
Hi Team,

May I ask to review my PR?

The issue is based on https://liferay.atlassian.net/browse/LPS-195463, when exporting form with object storage type, wont be supported (Already throws UnsupportedOperationException). Based on the decision of hiding the menu option
solution is:
by adding the condition !Objects.equals(_ddmFormInstance.getStorageType(), "object")." 

I am using hardcoded string because I could not find CONST for storage types and also found a similar solution on [DDMFormAdminDisplayContext.java#L1229](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java#L1229).

Thank you in advance!


