### PR TITLE
LPS-193257 Hide Resource Permission manager and ObjectEntries portlet of root descendant ObjectDefinitions | LPS-193258 Make root descendant ObjectEntries follow the Resource Permissions set up in their Root Node ObjectEntry

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -246,9 +246,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					_accountEntryOrganizationRelLocalService,
 					_groupLocalService, objectDefinition.getClassName(),
 					_objectDefinitionLocalService, _objectEntryLocalService,
-					_objectFieldLocalService, portletResourcePermission,
-					_resourcePermissionLocalService,
-					_userGroupRoleLocalService),
+					_objectFieldLocalService, _objectRelationshipLocalService,
+					portletResourcePermission, _resourcePermissionLocalService,
+					_treeFactory, _userGroupRoleLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"com.liferay.object", "true"
 				).put(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -10,12 +10,18 @@ import com.liferay.account.model.AccountEntry;
 import com.liferay.account.model.AccountEntryOrganizationRel;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.object.definition.tree.Edge;
+import com.liferay.object.definition.tree.Node;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -58,8 +64,10 @@ public class ObjectEntryModelResourcePermission
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectFieldLocalService objectFieldLocalService,
+		ObjectRelationshipLocalService objectRelationshipLocalService,
 		PortletResourcePermission portletResourcePermission,
 		ResourcePermissionLocalService resourcePermissionLocalService,
+		TreeFactory treeFactory,
 		UserGroupRoleLocalService userGroupRoleLocalService) {
 
 		_accountEntryLocalService = accountEntryLocalService;
@@ -70,8 +78,10 @@ public class ObjectEntryModelResourcePermission
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectFieldLocalService = objectFieldLocalService;
+		_objectRelationshipLocalService = objectRelationshipLocalService;
 		_portletResourcePermission = portletResourcePermission;
 		_resourcePermissionLocalService = resourcePermissionLocalService;
+		_treeFactory = treeFactory;
 		_userGroupRoleLocalService = userGroupRoleLocalService;
 	}
 
@@ -82,8 +92,10 @@ public class ObjectEntryModelResourcePermission
 		throws PortalException {
 
 		if (!contains(permissionChecker, objectEntryId, actionId)) {
-			throw new PrincipalException.MustHavePermission(
-				permissionChecker, _modelName, objectEntryId, actionId);
+			_throwPrincipalException(
+				permissionChecker,
+				_objectEntryLocalService.getObjectEntry(objectEntryId),
+				actionId);
 		}
 	}
 
@@ -94,9 +106,7 @@ public class ObjectEntryModelResourcePermission
 		throws PortalException {
 
 		if (!contains(permissionChecker, objectEntry, actionId)) {
-			throw new PrincipalException.MustHavePermission(
-				permissionChecker, _modelName, objectEntry.getObjectEntryId(),
-				actionId);
+			_throwPrincipalException(permissionChecker, objectEntry, actionId);
 		}
 	}
 
@@ -119,26 +129,28 @@ public class ObjectEntryModelResourcePermission
 
 		User user = permissionChecker.getUser();
 
-		if (user.isGuestUser()) {
-			return permissionChecker.hasPermission(
-				objectEntry.getGroupId(), _modelName,
-				objectEntry.getObjectEntryId(), actionId);
-		}
-
-		if (permissionChecker.hasOwnerPermission(
-				permissionChecker.getCompanyId(), _modelName,
-				objectEntry.getObjectEntryId(), objectEntry.getUserId(),
-				actionId) ||
-			permissionChecker.hasPermission(
-				objectEntry.getGroupId(), _modelName,
-				objectEntry.getObjectEntryId(), actionId)) {
-
-			return true;
-		}
+		objectEntry = _getRootNodeObjectEntry(objectEntry);
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.getObjectDefinition(
 				objectEntry.getObjectDefinitionId());
+
+		if (user.isGuestUser()) {
+			return permissionChecker.hasPermission(
+				objectEntry.getGroupId(), objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId(), actionId);
+		}
+
+		if (permissionChecker.hasOwnerPermission(
+				permissionChecker.getCompanyId(),
+				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+				objectEntry.getUserId(), actionId) ||
+			permissionChecker.hasPermission(
+				objectEntry.getGroupId(), objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId(), actionId)) {
+
+			return true;
+		}
 
 		if (!objectDefinition.isAccountEntryRestricted()) {
 			return false;
@@ -246,6 +258,58 @@ public class ObjectEntryModelResourcePermission
 		return _portletResourcePermission;
 	}
 
+	private ObjectEntry _getRootNodeObjectEntry(ObjectEntry objectEntry)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		if (!objectDefinition.isRootDescendantNode()) {
+			return objectEntry;
+		}
+
+		Tree tree = _treeFactory.create(
+			objectDefinition.getRootObjectDefinitionId());
+
+		Node node = tree.getNode(objectDefinition.getObjectDefinitionId());
+
+		while (!node.isRoot()) {
+			Edge edge = node.getEdge();
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					edge.getObjectRelationshipId());
+
+			ObjectField objectField = _objectFieldLocalService.getObjectField(
+				objectRelationship.getObjectFieldId2());
+
+			objectEntry = _objectEntryLocalService.getObjectEntry(
+				MapUtil.getLong(
+					objectEntry.getValues(), objectField.getName()));
+
+			node = tree.getNode(objectEntry.getObjectDefinitionId());
+		}
+
+		return objectEntry;
+	}
+
+	private void _throwPrincipalException(
+			PermissionChecker permissionChecker, ObjectEntry objectEntry,
+			String actionId)
+		throws PortalException {
+
+		objectEntry = _getRootNodeObjectEntry(objectEntry);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		throw new PrincipalException.MustHavePermission(
+			permissionChecker, objectDefinition.getClassName(),
+			objectEntry.getObjectEntryId(), actionId);
+	}
+
 	private final AccountEntryLocalService _accountEntryLocalService;
 	private final AccountEntryOrganizationRelLocalService
 		_accountEntryOrganizationRelLocalService;
@@ -254,9 +318,12 @@ public class ObjectEntryModelResourcePermission
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectFieldLocalService _objectFieldLocalService;
+	private final ObjectRelationshipLocalService
+		_objectRelationshipLocalService;
 	private final PortletResourcePermission _portletResourcePermission;
 	private final ResourcePermissionLocalService
 		_resourcePermissionLocalService;
+	private final TreeFactory _treeFactory;
 	private final UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1158,9 +1158,7 @@ public class ObjectDefinitionLocalServiceImpl
 			objectDefinitionPersistence.findByPrimaryKey(
 				rootObjectDefinitionId);
 
-		if ((objectDefinitionId != rootObjectDefinitionId) &&
-			(rootObjectDefinition.getRootObjectDefinitionId() == 0)) {
-
+		if (rootObjectDefinition.isRootDescendantNode()) {
 			throw new ObjectDefinitionRootObjectDefinitionIdException(
 				"Object definition " + rootObjectDefinitionId +
 					" is not a root object definition");
@@ -1168,7 +1166,15 @@ public class ObjectDefinitionLocalServiceImpl
 
 		objectDefinition.setRootObjectDefinitionId(rootObjectDefinitionId);
 
-		return objectDefinitionPersistence.update(objectDefinition);
+		objectDefinition = objectDefinitionPersistence.update(objectDefinition);
+
+		if (objectDefinition.isRootDescendantNode() &&
+			objectDefinition.isApproved()) {
+
+			deployObjectDefinition(objectDefinition);
+		}
+
+		return objectDefinition;
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -556,6 +556,11 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 		ObjectDefinition objectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
+		if (objectDefinition.isRootDescendantNode()) {
+			objectDefinition = _objectDefinitionPersistence.findByPrimaryKey(
+				objectDefinition.getRootObjectDefinitionId());
+		}
+
 		return _portletResourcePermissionsServiceTrackerMap.getService(
 			objectDefinition.getResourceName());
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -11,7 +11,6 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
-import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.exception.NoSuchObjectFieldException;
@@ -87,7 +86,6 @@ import java.sql.Connection;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -290,8 +288,8 @@ public class ObjectDefinitionLocalServiceTest {
 			_objectDefinitionLocalService, _objectRelationshipLocalService,
 			_treeFactory);
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> {
 				Assert.assertFalse(
 					_hasTable(nodeObjectDefinition.getDBTableName()));
@@ -321,8 +319,8 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> {
 				Assert.assertEquals(
 					0,
@@ -351,8 +349,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_DRAFT, objectDefinition.getStatus());
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> Assert.assertEquals(
 				WorkflowConstants.STATUS_DRAFT,
 				nodeObjectDefinition.getStatus()));
@@ -378,8 +376,8 @@ public class ObjectDefinitionLocalServiceTest {
 				true
 			).build());
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> {
 				if (nodeObjectDefinition.isRootDescendantNode()) {
 					AssertUtils.assertFailure(
@@ -425,8 +423,8 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertTrue(
 			_hasTable(objectDefinition.getExtensionDBTableName()));
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> {
 				Assert.assertFalse(
 					_hasColumn(nodeObjectDefinition.getDBTableName(), "able"));
@@ -456,8 +454,8 @@ public class ObjectDefinitionLocalServiceTest {
 				ResourceConstants.SCOPE_INDIVIDUAL,
 				String.valueOf(objectDefinition.getObjectDefinitionId())));
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> {
 				Assert.assertEquals(
 					4,
@@ -486,15 +484,16 @@ public class ObjectDefinitionLocalServiceTest {
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectDefinition.getStatus());
 
-		_assertNodeObjectDefinitions(
-			tree,
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
 			nodeObjectDefinition -> Assert.assertEquals(
 				WorkflowConstants.STATUS_APPROVED,
 				nodeObjectDefinition.getStatus()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
 
-		_deleteObjectDefinitionHierarchy();
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -1254,7 +1253,8 @@ public class ObjectDefinitionLocalServiceTest {
 			_treeFactory.create(objectDefinitionA.getObjectDefinitionId()),
 			_objectDefinitionLocalService);
 
-		_deleteObjectDefinitionHierarchy();
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -1614,7 +1614,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertEquals(0, objectDefinition.getRootObjectDefinitionId());
 
-		_deleteObjectDefinitionHierarchy();
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -2078,22 +2079,6 @@ public class ObjectDefinitionLocalServiceTest {
 		}
 	}
 
-	private void _assertNodeObjectDefinitions(
-			Tree tree,
-			UnsafeConsumer<ObjectDefinition, Exception> unsafeConsumer)
-		throws Exception {
-
-		Iterator<Node> iterator = tree.iterator();
-
-		while (iterator.hasNext()) {
-			Node node = iterator.next();
-
-			unsafeConsumer.accept(
-				_objectDefinitionLocalService.getObjectDefinition(
-					node.getObjectDefinitionId()));
-		}
-	}
-
 	private void _assertObjectField(
 			ObjectDefinition objectDefinition, String dbColumnName,
 			String dbType, String name, boolean required)
@@ -2173,28 +2158,6 @@ public class ObjectDefinitionLocalServiceTest {
 			).buildString());
 
 		return objectAction;
-	}
-
-	private void _deleteObjectDefinitionHierarchy() throws Exception {
-		for (String objectDefinitionName :
-				new String[] {"C_A", "C_AA", "C_AAA", "C_AAB", "C_AB"}) {
-
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.fetchObjectDefinition(
-					TestPropsValues.getCompanyId(), objectDefinitionName);
-
-			if (objectDefinition == null) {
-				continue;
-			}
-
-			if (objectDefinition.getRootObjectDefinitionId() != 0) {
-				TreeTestUtil.unbind(
-					_objectDefinitionLocalService, objectDefinitionName);
-			}
-
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition.getObjectDefinitionId());
-		}
 	}
 
 	private boolean _hasColumn(String tableName, String columnName)

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -475,6 +475,119 @@ public class ObjectEntryServiceTest {
 		Assert.assertNotNull(
 			_objectEntryService.getObjectEntry(
 				adminObjectEntry.getObjectEntryId()));
+
+		Tree tree = TreeTestUtil.createTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_treeFactory);
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
+		rootObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				_adminUser.getUserId(),
+				rootObjectDefinition.getObjectDefinitionId());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+
+		_setUser(_user);
+
+		Map<String, ObjectEntry> objectEntries1 = _createBoundedObjectEntries(
+			tree);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				if (objectDefinition.isRootDescendantNode()) {
+					_resourcePermissionLocalService.addModelResourcePermissions(
+						TestPropsValues.getCompanyId(),
+						TestPropsValues.getGroupId(), _user.getUserId(),
+						objectDefinition.getClassName(),
+						String.valueOf(objectEntry.getObjectEntryId()),
+						ModelPermissionsFactory.create(
+							HashMapBuilder.put(
+								RoleConstants.USER,
+								new String[] {ActionKeys.VIEW}
+							).build(),
+							objectDefinition.getClassName()));
+				}
+
+				_assertPrincipalException(ActionKeys.VIEW, null, objectEntry);
+			});
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				if (objectDefinition.isRootDescendantNode()) {
+					_resourcePermissionLocalService.addResourcePermission(
+						TestPropsValues.getCompanyId(),
+						objectDefinition.getClassName(),
+						ResourceConstants.SCOPE_COMPANY,
+						String.valueOf(TestPropsValues.getCompanyId()),
+						role.getRoleId(), ActionKeys.VIEW);
+				}
+
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				_assertPrincipalException(ActionKeys.VIEW, null, objectEntry);
+			});
+
+		ObjectEntry rootObjectEntry = objectEntries1.get(
+			rootObjectDefinition.getName());
+
+		_resourcePermissionLocalService.addModelResourcePermissions(
+			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+			_user.getUserId(), rootObjectDefinition.getClassName(),
+			String.valueOf(rootObjectEntry.getObjectEntryId()),
+			ModelPermissionsFactory.create(
+				HashMapBuilder.put(
+					RoleConstants.USER, new String[] {ActionKeys.VIEW}
+				).build(),
+				rootObjectDefinition.getClassName()));
+
+		Map<String, ObjectEntry> objectEntries2 = _createBoundedObjectEntries(
+			tree);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				Assert.assertNotNull(
+					_objectEntryService.getObjectEntry(
+						objectEntry.getObjectEntryId()));
+
+				objectEntry = objectEntries2.get(objectDefinition.getName());
+
+				_assertPrincipalException(ActionKeys.VIEW, null, objectEntry);
+			});
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), rootObjectDefinition.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), role.getRoleId(),
+			ActionKeys.VIEW);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries2.get(
+					objectDefinition.getName());
+
+				Assert.assertNotNull(
+					_objectEntryService.getObjectEntry(
+						objectEntry.getObjectEntryId()));
+			});
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -13,15 +13,18 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Node;
 import com.liferay.object.definition.tree.Tree;
 import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.service.test.util.TreeTestUtil;
@@ -57,6 +60,9 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import java.io.Serializable;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -272,6 +278,161 @@ public class ObjectEntryServiceTest {
 
 		_testDeleteObjectEntry(_adminUser, _adminUser);
 		_testDeleteObjectEntry(_user, _user);
+
+		Tree tree = TreeTestUtil.createTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_treeFactory);
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
+		rootObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				_adminUser.getUserId(),
+				rootObjectDefinition.getObjectDefinitionId());
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.USER);
+
+		_setUser(_user);
+
+		Map<String, ObjectEntry> objectEntries1 = _createBoundedObjectEntries(
+			tree);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				if (objectDefinition.isRootDescendantNode()) {
+					_resourcePermissionLocalService.addModelResourcePermissions(
+						TestPropsValues.getCompanyId(),
+						TestPropsValues.getGroupId(), _user.getUserId(),
+						objectDefinition.getClassName(),
+						String.valueOf(objectEntry.getObjectEntryId()),
+						ModelPermissionsFactory.create(
+							HashMapBuilder.put(
+								RoleConstants.USER,
+								new String[] {ActionKeys.DELETE}
+							).build(),
+							objectDefinition.getClassName()));
+				}
+
+				_assertPrincipalException(ActionKeys.DELETE, null, objectEntry);
+			});
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				if (objectDefinition.isRootDescendantNode()) {
+					_resourcePermissionLocalService.addResourcePermission(
+						TestPropsValues.getCompanyId(),
+						objectDefinition.getClassName(),
+						ResourceConstants.SCOPE_COMPANY,
+						String.valueOf(TestPropsValues.getCompanyId()),
+						role.getRoleId(), ActionKeys.DELETE);
+				}
+
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				_assertPrincipalException(ActionKeys.DELETE, null, objectEntry);
+			});
+
+		ObjectEntry rootObjectEntry = objectEntries1.get(
+			rootObjectDefinition.getName());
+
+		_resourcePermissionLocalService.addModelResourcePermissions(
+			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+			_user.getUserId(), rootObjectDefinition.getClassName(),
+			String.valueOf(rootObjectEntry.getObjectEntryId()),
+			ModelPermissionsFactory.create(
+				HashMapBuilder.put(
+					RoleConstants.USER, new String[] {ActionKeys.DELETE}
+				).build(),
+				rootObjectDefinition.getClassName()));
+
+		Assert.assertNotNull(
+			_objectEntryService.deleteObjectEntry(
+				rootObjectEntry.getObjectEntryId()));
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries1.get(
+					objectDefinition.getName());
+
+				Assert.assertNull(
+					_objectEntryLocalService.fetchObjectEntry(
+						objectEntry.getObjectEntryId()));
+			});
+
+		Map<String, ObjectEntry> objectEntries2 = _createBoundedObjectEntries(
+			tree);
+
+		rootObjectEntry = objectEntries2.get(rootObjectDefinition.getName());
+
+		_resourcePermissionLocalService.addModelResourcePermissions(
+			TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+			_user.getUserId(), rootObjectDefinition.getClassName(),
+			String.valueOf(rootObjectEntry.getObjectEntryId()),
+			ModelPermissionsFactory.create(
+				HashMapBuilder.put(
+					RoleConstants.USER, new String[] {ActionKeys.DELETE}
+				).build(),
+				rootObjectDefinition.getClassName()));
+
+		_assertDeleteBoundedObjectEntriesByDepth(2, objectEntries2, tree);
+
+		_assertDeleteBoundedObjectEntriesByDepth(1, objectEntries2, tree);
+
+		Assert.assertNotNull(
+			_objectEntryService.deleteObjectEntry(
+				rootObjectEntry.getObjectEntryId()));
+
+		Map<String, ObjectEntry> objectEntries3 = _createBoundedObjectEntries(
+			tree);
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(), rootObjectDefinition.getClassName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), role.getRoleId(),
+			ActionKeys.DELETE);
+
+		rootObjectEntry = objectEntries3.get(rootObjectDefinition.getName());
+
+		Assert.assertNotNull(
+			_objectEntryService.deleteObjectEntry(
+				rootObjectEntry.getObjectEntryId()));
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				ObjectEntry objectEntry = objectEntries3.get(
+					objectDefinition.getName());
+
+				Assert.assertNull(
+					_objectEntryLocalService.fetchObjectEntry(
+						objectEntry.getObjectEntryId()));
+			});
+
+		Map<String, ObjectEntry> objectEntries4 = _createBoundedObjectEntries(
+			tree);
+
+		_assertDeleteBoundedObjectEntriesByDepth(2, objectEntries4, tree);
+
+		_assertDeleteBoundedObjectEntriesByDepth(1, objectEntries4, tree);
+
+		rootObjectEntry = objectEntries4.get(rootObjectDefinition.getName());
+
+		Assert.assertNotNull(
+			_objectEntryService.deleteObjectEntry(
+				rootObjectEntry.getObjectEntryId()));
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -417,6 +578,27 @@ public class ObjectEntryServiceTest {
 				TestPropsValues.getGroupId(), user.getUserId()));
 	}
 
+	private void _assertDeleteBoundedObjectEntriesByDepth(
+			int depth, Map<String, ObjectEntry> objectEntries, Tree tree)
+		throws Exception {
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				Node node = tree.getNode(
+					objectDefinition.getRootObjectDefinitionId());
+
+				if (node.getDepth() == depth) {
+					ObjectEntry objectEntry = objectEntries.get(
+						objectDefinition.getName());
+
+					Assert.assertNotNull(
+						_objectEntryService.deleteObjectEntry(
+							objectEntry.getObjectEntryId()));
+				}
+			});
+	}
+
 	private void _assertPrincipalException(
 			String action, ObjectDefinition objectDefinition,
 			ObjectEntry objectEntry)
@@ -428,6 +610,10 @@ public class ObjectEntryServiceTest {
 		try {
 			if (Objects.equals(action, ActionKeys.VIEW)) {
 				_objectEntryService.getObjectEntry(
+					objectEntry.getObjectEntryId());
+			}
+			else if (Objects.equals(action, ActionKeys.DELETE)) {
+				_objectEntryService.deleteObjectEntry(
 					objectEntry.getObjectEntryId());
 			}
 			else {
@@ -459,6 +645,68 @@ public class ObjectEntryServiceTest {
 		throws Exception {
 
 		_assertPrincipalException(action, _objectDefinition, objectEntry);
+	}
+
+	private Map<String, ObjectEntry> _createBoundedObjectEntries(Tree tree)
+		throws Exception {
+
+		Iterator<Node> iterator = tree.iterator();
+
+		Map<String, ObjectEntry> objectEntries = new HashMap<>();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId());
+
+			ObjectEntry objectEntry = null;
+
+			if (!objectDefinition.isRootDescendantNode()) {
+				objectEntry = _objectEntryLocalService.addObjectEntry(
+					_adminUser.getUserId(), 0,
+					objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"able", RandomStringUtils.randomAlphabetic(5)
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(), _adminUser.getUserId()));
+
+				objectEntries.put(objectDefinition.getName(), objectEntry);
+
+				continue;
+			}
+
+			ObjectRelationship objectRelationship =
+				_objectRelationshipLocalService.getObjectRelationship(
+					node.getEdge(
+					).getObjectRelationshipId());
+
+			ObjectDefinition parentObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectRelationship.getObjectDefinitionId1());
+
+			objectEntry = objectEntries.get(parentObjectDefinition.getName());
+
+			ObjectField objectField = _objectFieldLocalService.getObjectField(
+				objectRelationship.getObjectFieldId2());
+
+			objectEntries.put(
+				objectDefinition.getName(),
+				_objectEntryLocalService.addObjectEntry(
+					_adminUser.getUserId(), 0,
+					objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"able", RandomStringUtils.randomAlphabetic(5)
+					).put(
+						objectField.getName(), objectEntry.getObjectEntryId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(), _adminUser.getUserId())));
+		}
+
+		return objectEntries;
 	}
 
 	private void _setUser(User user) throws Exception {
@@ -509,6 +757,9 @@ public class ObjectEntryServiceTest {
 
 	@Inject
 	private ObjectEntryService _objectEntryService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -149,7 +149,8 @@ public class ObjectEntryServiceTest {
 
 		_setUser(_guestUser);
 
-		_assertPrincipalException(ObjectActionKeys.ADD_OBJECT_ENTRY, null);
+		_assertPrincipalException(
+			ObjectActionKeys.ADD_OBJECT_ENTRY, _objectDefinition, null);
 
 		TreeTestUtil.iterateNodeObjectDefinitions(
 			_objectDefinitionLocalService, tree,
@@ -158,7 +159,8 @@ public class ObjectEntryServiceTest {
 
 		_setUser(_user);
 
-		_assertPrincipalException(ObjectActionKeys.ADD_OBJECT_ENTRY, null);
+		_assertPrincipalException(
+			ObjectActionKeys.ADD_OBJECT_ENTRY, _objectDefinition, null);
 
 		TreeTestUtil.iterateNodeObjectDefinitions(
 			_objectDefinitionLocalService, tree,
@@ -370,9 +372,7 @@ public class ObjectEntryServiceTest {
 				).build(),
 				rootObjectDefinition.getClassName()));
 
-		_assertDeleteBoundedObjectEntriesByDepth(2, objectEntries2, tree);
-
-		_assertDeleteBoundedObjectEntriesByDepth(1, objectEntries2, tree);
+		_assertDeleteBoundedObjectEntries(objectEntries2, tree);
 
 		Assert.assertNotNull(
 			_objectEntryService.deleteObjectEntry(
@@ -407,9 +407,7 @@ public class ObjectEntryServiceTest {
 		Map<String, ObjectEntry> objectEntries4 = _createBoundedObjectEntries(
 			tree);
 
-		_assertDeleteBoundedObjectEntriesByDepth(2, objectEntries4, tree);
-
-		_assertDeleteBoundedObjectEntriesByDepth(1, objectEntries4, tree);
+		_assertDeleteBoundedObjectEntries(objectEntries4, tree);
 
 		rootObjectEntry = objectEntries4.get(rootObjectDefinition.getName());
 
@@ -439,15 +437,15 @@ public class ObjectEntryServiceTest {
 			_objectEntryService.getObjectEntry(
 				userObjectEntry.getObjectEntryId()));
 
-		_assertPrincipalException(ActionKeys.VIEW, adminObjectEntry);
+		_assertPrincipalException(ActionKeys.VIEW, null, adminObjectEntry);
 
 		_setUser(_guestUser);
 
-		_assertPrincipalException(ActionKeys.VIEW, adminObjectEntry);
+		_assertPrincipalException(ActionKeys.VIEW, null, adminObjectEntry);
 
 		ObjectEntry guestUserObjectEntry = _addObjectEntry(_guestUser);
 
-		_assertPrincipalException(ActionKeys.VIEW, guestUserObjectEntry);
+		_assertPrincipalException(ActionKeys.VIEW, null, guestUserObjectEntry);
 
 		Role guestRole = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.GUEST);
@@ -670,25 +668,29 @@ public class ObjectEntryServiceTest {
 				TestPropsValues.getGroupId(), user.getUserId()));
 	}
 
-	private void _assertDeleteBoundedObjectEntriesByDepth(
-			int depth, Map<String, ObjectEntry> objectEntries, Tree tree)
+	private void _assertDeleteBoundedObjectEntries(
+			Map<String, ObjectEntry> objectEntries, Tree tree)
 		throws Exception {
 
-		TreeTestUtil.iterateNodeObjectDefinitions(
-			_objectDefinitionLocalService, tree,
-			objectDefinition -> {
-				Node node = tree.getNode(
-					objectDefinition.getRootObjectDefinitionId());
+		for (int depth = 2; depth > 1; depth--) {
+			int finalDepth = depth;
 
-				if (node.getDepth() == depth) {
-					ObjectEntry objectEntry = objectEntries.get(
-						objectDefinition.getName());
+			TreeTestUtil.iterateNodeObjectDefinitions(
+				_objectDefinitionLocalService, tree,
+				objectDefinition -> {
+					Node node = tree.getNode(
+						objectDefinition.getRootObjectDefinitionId());
 
-					Assert.assertNotNull(
-						_objectEntryService.deleteObjectEntry(
-							objectEntry.getObjectEntryId()));
-				}
-			});
+					if (node.getDepth() == finalDepth) {
+						ObjectEntry objectEntry = objectEntries.get(
+							objectDefinition.getName());
+
+						Assert.assertNotNull(
+							_objectEntryService.deleteObjectEntry(
+								objectEntry.getObjectEntryId()));
+					}
+				});
+		}
 	}
 
 	private void _assertPrincipalException(
@@ -730,13 +732,6 @@ public class ObjectEntryServiceTest {
 						"User ", permissionChecker.getUserId(), " must have ",
 						action, " permission for")));
 		}
-	}
-
-	private void _assertPrincipalException(
-			String action, ObjectEntry objectEntry)
-		throws Exception {
-
-		_assertPrincipalException(action, _objectDefinition, objectEntry);
 	}
 
 	private Map<String, ObjectEntry> _createBoundedObjectEntries(Tree tree)

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -13,6 +13,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.Tree;
+import com.liferay.object.definition.tree.TreeFactory;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -22,6 +24,7 @@ import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -46,6 +49,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
@@ -68,6 +72,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Marco Leo
  */
+@FeatureFlags("LPS-187142")
 @RunWith(Arquillian.class)
 public class ObjectEntryServiceTest {
 
@@ -122,13 +127,48 @@ public class ObjectEntryServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId(), _adminUser.getUserId())));
 
+		Tree tree = TreeTestUtil.createTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_treeFactory);
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
+		rootObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				_adminUser.getUserId(),
+				rootObjectDefinition.getObjectDefinitionId());
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> Assert.assertNotNull(
+				_objectEntryService.addObjectEntry(
+					0, objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"able", RandomStringUtils.randomAlphabetic(5)
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(),
+						_adminUser.getUserId()))));
+
 		_setUser(_guestUser);
 
 		_assertPrincipalException(ObjectActionKeys.ADD_OBJECT_ENTRY, null);
 
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> _assertPrincipalException(
+				ObjectActionKeys.ADD_OBJECT_ENTRY, objectDefinition, null));
+
 		_setUser(_user);
 
 		_assertPrincipalException(ObjectActionKeys.ADD_OBJECT_ENTRY, null);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> _assertPrincipalException(
+				ObjectActionKeys.ADD_OBJECT_ENTRY, objectDefinition, null));
 
 		_setUser(_guestUser);
 
@@ -150,6 +190,43 @@ public class ObjectEntryServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId(), _guestUser.getUserId())));
 
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> {
+				if (objectDefinition.isRootDescendantNode()) {
+					_resourcePermissionLocalService.addResourcePermission(
+						TestPropsValues.getCompanyId(),
+						objectDefinition.getResourceName(),
+						ResourceConstants.SCOPE_COMPANY,
+						String.valueOf(TestPropsValues.getCompanyId()),
+						guestRole.getRoleId(),
+						ObjectActionKeys.ADD_OBJECT_ENTRY);
+
+					_assertPrincipalException(
+						ObjectActionKeys.ADD_OBJECT_ENTRY, objectDefinition,
+						null);
+				}
+			});
+
+		_resourcePermissionLocalService.addResourcePermission(
+			TestPropsValues.getCompanyId(),
+			rootObjectDefinition.getResourceName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			guestRole.getRoleId(), ObjectActionKeys.ADD_OBJECT_ENTRY);
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> Assert.assertNotNull(
+				_objectEntryService.addObjectEntry(
+					0, objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"able", RandomStringUtils.randomAlphabetic(5)
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(),
+						_guestUser.getUserId()))));
+
 		_setUser(_user);
 
 		Assert.assertNotNull(
@@ -160,6 +237,21 @@ public class ObjectEntryServiceTest {
 				).build(),
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId(), _guestUser.getUserId())));
+
+		TreeTestUtil.iterateNodeObjectDefinitions(
+			_objectDefinitionLocalService, tree,
+			objectDefinition -> Assert.assertNotNull(
+				_objectEntryService.addObjectEntry(
+					0, objectDefinition.getObjectDefinitionId(),
+					HashMapBuilder.<String, Serializable>put(
+						"able", RandomStringUtils.randomAlphabetic(5)
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(),
+						_guestUser.getUserId()))));
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService);
 	}
 
 	@Test
@@ -326,7 +418,8 @@ public class ObjectEntryServiceTest {
 	}
 
 	private void _assertPrincipalException(
-			String action, ObjectEntry objectEntry)
+			String action, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
 		throws Exception {
 
 		PermissionChecker permissionChecker =
@@ -339,7 +432,7 @@ public class ObjectEntryServiceTest {
 			}
 			else {
 				_objectEntryService.addObjectEntry(
-					0, _objectDefinition.getObjectDefinitionId(),
+					0, objectDefinition.getObjectDefinitionId(),
 					HashMapBuilder.<String, Serializable>put(
 						"firstName", RandomStringUtils.randomAlphabetic(5)
 					).build(),
@@ -359,6 +452,13 @@ public class ObjectEntryServiceTest {
 						"User ", permissionChecker.getUserId(), " must have ",
 						action, " permission for")));
 		}
+	}
+
+	private void _assertPrincipalException(
+			String action, ObjectEntry objectEntry)
+		throws Exception {
+
+		_assertPrincipalException(action, _objectDefinition, objectEntry);
 	}
 
 	private void _setUser(User user) throws Exception {
@@ -420,6 +520,9 @@ public class ObjectEntryServiceTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private TreeFactory _treeFactory;
 
 	private User _user;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -133,18 +133,7 @@ public class ObjectEntryServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					TestPropsValues.getGroupId(), _adminUser.getUserId())));
 
-		Tree tree = TreeTestUtil.createTree(
-			_objectDefinitionLocalService, _objectRelationshipLocalService,
-			_treeFactory);
-
-		ObjectDefinition rootObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				TestPropsValues.getCompanyId(), "C_A");
-
-		rootObjectDefinition =
-			_objectDefinitionLocalService.publishCustomObjectDefinition(
-				_adminUser.getUserId(),
-				rootObjectDefinition.getObjectDefinitionId());
+		Tree tree = _createTreeAndPublishObjectDefinitions();
 
 		TreeTestUtil.iterateNodeObjectDefinitions(
 			_objectDefinitionLocalService, tree,
@@ -214,6 +203,10 @@ public class ObjectEntryServiceTest {
 				}
 			});
 
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
 		_resourcePermissionLocalService.addResourcePermission(
 			TestPropsValues.getCompanyId(),
 			rootObjectDefinition.getResourceName(),
@@ -279,18 +272,7 @@ public class ObjectEntryServiceTest {
 		_testDeleteObjectEntry(_adminUser, _adminUser);
 		_testDeleteObjectEntry(_user, _user);
 
-		Tree tree = TreeTestUtil.createTree(
-			_objectDefinitionLocalService, _objectRelationshipLocalService,
-			_treeFactory);
-
-		ObjectDefinition rootObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				TestPropsValues.getCompanyId(), "C_A");
-
-		rootObjectDefinition =
-			_objectDefinitionLocalService.publishCustomObjectDefinition(
-				_adminUser.getUserId(),
-				rootObjectDefinition.getObjectDefinitionId());
+		Tree tree = _createTreeAndPublishObjectDefinitions();
 
 		Role role = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.USER);
@@ -340,6 +322,10 @@ public class ObjectEntryServiceTest {
 
 				_assertPrincipalException(ActionKeys.DELETE, null, objectEntry);
 			});
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
 
 		ObjectEntry rootObjectEntry = objectEntries1.get(
 			rootObjectDefinition.getName());
@@ -476,18 +462,7 @@ public class ObjectEntryServiceTest {
 			_objectEntryService.getObjectEntry(
 				adminObjectEntry.getObjectEntryId()));
 
-		Tree tree = TreeTestUtil.createTree(
-			_objectDefinitionLocalService, _objectRelationshipLocalService,
-			_treeFactory);
-
-		ObjectDefinition rootObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				TestPropsValues.getCompanyId(), "C_A");
-
-		rootObjectDefinition =
-			_objectDefinitionLocalService.publishCustomObjectDefinition(
-				_adminUser.getUserId(),
-				rootObjectDefinition.getObjectDefinitionId());
+		Tree tree = _createTreeAndPublishObjectDefinitions();
 
 		Role role = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), RoleConstants.USER);
@@ -537,6 +512,10 @@ public class ObjectEntryServiceTest {
 
 				_assertPrincipalException(ActionKeys.VIEW, null, objectEntry);
 			});
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
 
 		ObjectEntry rootObjectEntry = objectEntries1.get(
 			rootObjectDefinition.getName());
@@ -820,6 +799,22 @@ public class ObjectEntryServiceTest {
 		}
 
 		return objectEntries;
+	}
+
+	private Tree _createTreeAndPublishObjectDefinitions() throws Exception {
+		Tree tree = TreeTestUtil.createTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			_treeFactory);
+
+		ObjectDefinition rootObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), "C_A");
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			_adminUser.getUserId(),
+			rootObjectDefinition.getObjectDefinitionId());
+
+		return tree;
 	}
 
 	private void _setUser(User user) throws Exception {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/util/TreeTestUtil.java
@@ -13,6 +13,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.AssertUtils;
@@ -100,6 +101,30 @@ public class TreeTestUtil {
 		return treeFactory.create(objectDefinitionA.getObjectDefinitionId());
 	}
 
+	public static void deleteObjectDefinitionHierarchy(
+			ObjectDefinitionLocalService objectDefinitionLocalService)
+		throws Exception {
+
+		for (String objectDefinitionName :
+				new String[] {"C_A", "C_AA", "C_AAA", "C_AAB", "C_AB"}) {
+
+			ObjectDefinition objectDefinition =
+				objectDefinitionLocalService.fetchObjectDefinition(
+					TestPropsValues.getCompanyId(), objectDefinitionName);
+
+			if (objectDefinition == null) {
+				continue;
+			}
+
+			if (objectDefinition.getRootObjectDefinitionId() != 0) {
+				unbind(objectDefinitionLocalService, objectDefinitionName);
+			}
+
+			objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+		}
+	}
+
 	public static ObjectRelationship getEdgeObjectRelationship(
 			ObjectDefinition objectDefinition,
 			ObjectRelationshipLocalService objectRelationshipLocalService,
@@ -112,6 +137,23 @@ public class TreeTestUtil {
 
 		return objectRelationshipLocalService.getObjectRelationship(
 			edge.getObjectRelationshipId());
+	}
+
+	public static void iterateNodeObjectDefinitions(
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			Tree tree,
+			UnsafeConsumer<ObjectDefinition, Exception> unsafeConsumer)
+		throws Exception {
+
+		Iterator<Node> iterator = tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			unsafeConsumer.accept(
+				objectDefinitionLocalService.getObjectDefinition(
+					node.getObjectDefinitionId()));
+		}
 	}
 
 	public static void unbind(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -481,19 +481,22 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		// Register ObjectEntriesPanelApp after ObjectEntriesPortlet. See
 		// LPS-140379.
 
-		serviceRegistrations.add(
-			_bundleContext.registerService(
-				PanelApp.class,
-				new ObjectEntriesPanelApp(
-					objectDefinition,
-					() -> _portletLocalService.getPortletById(
-						objectDefinition.getPortletId())),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"panel.app.order:Integer",
-					objectDefinition.getPanelAppOrder()
-				).put(
-					"panel.category.key", objectDefinition.getPanelCategoryKey()
-				).build()));
+		if (!objectDefinition.isRootDescendantNode()) {
+			serviceRegistrations.add(
+				_bundleContext.registerService(
+					PanelApp.class,
+					new ObjectEntriesPanelApp(
+						objectDefinition,
+						() -> _portletLocalService.getPortletById(
+							objectDefinition.getPortletId())),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"panel.app.order:Integer",
+						objectDefinition.getPanelAppOrder()
+					).put(
+						"panel.category.key",
+						objectDefinition.getPanelCategoryKey()
+					).build()));
+		}
 
 		return serviceRegistrations;
 	}


### PR DESCRIPTION
Related issue: 
https://issues.liferay.com/browse/LPS-193257
https://issues.liferay.com/browse/LPS-193258