### PR TITLE
LPS-196423 Persistance layer of Data Set Manager is not generated

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:batch-engine:batch-engine-api")
 	compileOnly project(":apps:client-extension:client-extension-api")
 	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.data.set.views.web.internal.portlet;
 
+import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
 import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsWebKeys;
@@ -153,6 +154,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 		if (fdsEntryObjectDefinition != null) {
 			return;
 		}
+
+		BatchEngineUnitThreadLocal.setFileName(
+			"com.liferay.frontend.data.set.views");
 
 		fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -6,7 +6,6 @@
 package com.liferay.object.definition.util;
 
 import com.liferay.batch.engine.unit.BatchEngineUnitThreadLocal;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -61,7 +60,9 @@ public class ObjectDefinitionUtil {
 
 		if (StringUtil.startsWith(
 				fileName, "com.liferay.headless.builder.impl") ||
-			StringUtil.startsWith(fileName, "com.liferay.object.service")) {
+			StringUtil.startsWith(fileName, "com.liferay.object.service") ||
+			StringUtil.startsWith(
+				fileName, "com.liferay.frontend.data.set.views")) {
 
 			return true;
 		}


### PR DESCRIPTION
### References

- [LPS-196423 Persistance layer of Data Set Manager is not generated](https://issues.liferay.com/browse/LPS-196423)
- caused by https://github.com/liferay-objects/liferay-portal/pull/2570

### What is the goal of this PR?

This is a critical bug, as it completely breaks Data Set Manager UI.

In this PR is a workaround to add `frontend-data-set-views` to the whitelist for generation of system objects. To achieve this, we are using Batch Engine API. **This is probably not a good solution**, DSM should not be coupled with Batch Engine. The PR proves the root cause of the issue. Could we add `frontend-data-set-views` to whitelist in some other way? Could you maybe extend `ObjectDefinitionUtil.isInvokerBundleAllowed` to include a whitelist of modules?

### Steps to reproduce

See steps in JIRA.
