### PR TITLE
LPS-197087 As we do elsewhere in the Objects portlet, we should default to the "ID" field if the titleObjectFieldId is orphaned.

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -226,6 +226,14 @@ public class ObjectEntryDTOConverter
 										objectDefinition.
 											getTitleObjectFieldId());
 
+								if (objectField == null) {
+									objectField =
+										_objectFieldLocalService.getObjectField(
+											objectDefinition.
+												getObjectDefinitionId(),
+											"id");
+								}
+
 								values.put(
 									objectField.getName(),
 									ObjectEntryValuesUtil.getTitleFieldValue(


### PR DESCRIPTION
Ticket: [LPS-197087](https://liferay.atlassian.net/browse/LPS-197087)