### PR TITLE
LPS-196027 - Fixing binding within unpublished object definitions

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinition.java
@@ -74,6 +74,8 @@ public interface ObjectDefinition
 
 	public boolean isLinkedToObjectFolder(long objectFolderId);
 
+	public boolean isNodeCandidate();
+
 	public boolean isRootDescendantNode();
 
 	public boolean isRootNode();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectDefinitionWrapper.java
@@ -998,6 +998,11 @@ public class ObjectDefinitionWrapper
 		return model.isModifiable();
 	}
 
+	@Override
+	public boolean isNodeCandidate() {
+		return model.isNodeCandidate();
+	}
+
 	/**
 	 * Returns <code>true</code> if this object definition is portlet.
 	 *

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -181,7 +181,11 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 
 	@Override
 	public boolean isNodeCandidate() {
-		return !isApproved() && !isUnmodifiableSystemObject();
+		if (!isApproved() && !isUnmodifiableSystemObject()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectDefinitionImpl.java
@@ -180,6 +180,11 @@ public class ObjectDefinitionImpl extends ObjectDefinitionBaseImpl {
 	}
 
 	@Override
+	public boolean isNodeCandidate() {
+		return !isApproved() && !isUnmodifiableSystemObject();
+	}
+
+	@Override
 	public boolean isRootDescendantNode() {
 		if (!FeatureFlagManagerUtil.isEnabled("LPS-187142")) {
 			return false;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -10,7 +10,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Objects;
 import java.util.Set;
@@ -35,7 +34,6 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 
 	@Override
 	public boolean isEdgeCandidate() throws PortalException {
-
 		if (isSelf() ||
 			!Objects.equals(
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, getType())) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -35,13 +35,6 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 
 	@Override
 	public boolean isEdgeCandidate() throws PortalException {
-		ObjectDefinition objectDefinition1 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId1());
-
-		ObjectDefinition objectDefinition2 =
-			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
-				getObjectDefinitionId2());
 
 		if (isSelf() ||
 			!Objects.equals(
@@ -49,6 +42,14 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 
 			return false;
 		}
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
+				getObjectDefinitionId1());
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
+				getObjectDefinitionId2());
 
 		if (!objectDefinition1.isNodeCandidate() ||
 			!objectDefinition2.isNodeCandidate()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -43,18 +43,15 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
 				getObjectDefinitionId2());
 
-		if (Objects.equals(
-			objectDefinition1.getStatus(), WorkflowConstants.STATUS_APPROVED) ||
-			Objects.equals(
-				objectDefinition2.getStatus(),
-				WorkflowConstants.STATUS_APPROVED)) {
+		if (isSelf() ||
+			!Objects.equals(
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, getType())) {
+
 			return false;
 		}
 
-		if (isSelf() ||
-			!Objects.equals(
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, getType()) ||
-			objectDefinition1.isUnmodifiableSystemObject()) {
+		if (!objectDefinition1.isNodeCandidate() ||
+			!objectDefinition2.isNodeCandidate()) {
 
 			return false;
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectRelationshipImpl.java
@@ -10,6 +10,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Objects;
 import java.util.Set;
@@ -37,6 +38,18 @@ public class ObjectRelationshipImpl extends ObjectRelationshipBaseImpl {
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
 				getObjectDefinitionId1());
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionLocalServiceUtil.getObjectDefinition(
+				getObjectDefinitionId2());
+
+		if (Objects.equals(
+			objectDefinition1.getStatus(), WorkflowConstants.STATUS_APPROVED) ||
+			Objects.equals(
+				objectDefinition2.getStatus(),
+				WorkflowConstants.STATUS_APPROVED)) {
+			return false;
+		}
 
 		if (isSelf() ||
 			!Objects.equals(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -220,6 +220,37 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 			objectRelationshipBBB_AAAA.getObjectRelationshipId());
 	}
 
+	@Test
+	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
+		ObjectDefinition objectDefinitionPublished =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"PUB", _objectDefinitionLocalService);
+
+		ObjectDefinition objectDefinitionA =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"A", _objectDefinitionLocalService);
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			TestPropsValues.getUserId(),
+			objectDefinitionPublished.getObjectDefinitionId(),
+			objectDefinitionA.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(),
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinitionPublished.getObjectDefinitionId());
+
+		Assert.assertEquals(
+			_jsonFactory.createJSONArray(
+			).toString(),
+			_getObjectRelationshipEdgeCandidatesJSONArray(
+				2, objectDefinitionA.getObjectDefinitionId()
+			).toString());
+	}
+
 	private String _getEdgeLabel(
 		ObjectDefinition objectDefinition,
 		ObjectRelationship objectRelationship) {
@@ -258,39 +289,6 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		return JSONFactoryUtil.createJSONArray(
 			byteArrayOutputStream.toString());
-	}
-
-	@Test
-	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
-
-		ObjectDefinition objectDefinitionPublished =
-			ObjectDefinitionTestUtil.addObjectDefinition(
-				"PUB", _objectDefinitionLocalService);
-
-		ObjectDefinition objectDefinitionA =
-			ObjectDefinitionTestUtil.addObjectDefinition(
-				"A", _objectDefinitionLocalService);
-
-		ObjectRelationship objectRelationshipPUB_A =
-			_objectRelationshipLocalService.addObjectRelationship(
-				TestPropsValues.getUserId(),
-				objectDefinitionPublished.getObjectDefinitionId(),
-				objectDefinitionA.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
-			TestPropsValues.getUserId(),
-			objectDefinitionPublished.getObjectDefinitionId());
-
-		Assert.assertEquals(
-			_jsonFactory.createJSONArray(
-			).toString(),
-			_getObjectRelationshipEdgeCandidatesJSONArray(
-				2, objectDefinitionA.getObjectDefinitionId()
-			).toString());
 	}
 
 	@Inject

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -15,6 +15,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.service.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.service.test.util.TreeTestUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -221,34 +222,115 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 	}
 
 	@Test
-	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
-		ObjectDefinition objectDefinition1 =
-			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(), _objectDefinitionLocalService);
+	public void testIsEdgeCandidate() throws Exception {
+		// Child object definition published
 
-		ObjectDefinition objectDefinition2 =
+		ObjectDefinition childObjectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(), _objectDefinitionLocalService);
-
-		_objectRelationshipLocalService.addObjectRelationship(
-			TestPropsValues.getUserId(),
-			objectDefinition1.getObjectDefinitionId(),
-			objectDefinition2.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			StringUtil.randomId(),
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+				_objectDefinitionLocalService);
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
-			objectDefinition1.getObjectDefinitionId());
+			childObjectDefinition1.getObjectDefinitionId());
+
+		ObjectDefinition parentObjectDefinition1 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition1,
+				childObjectDefinition1);
 
 		Assert.assertEquals(
 			_jsonFactory.createJSONArray(
 			).toString(),
 			_getObjectRelationshipEdgeCandidatesJSONArray(
-				2, objectDefinition2.getObjectDefinitionId()
+				0, childObjectDefinition1.getObjectDefinitionId()
 			).toString());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship1.getObjectRelationshipId());
+
+		// Many to Many object relationship
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		ObjectRelationship objectRelationship2 =
+			_objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				objectDefinition1.getObjectDefinitionId(),
+				objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		Assert.assertEquals(
+			_jsonFactory.createJSONArray(
+			).toString(),
+			_getObjectRelationshipEdgeCandidatesJSONArray(
+				0, objectDefinition2.getObjectDefinitionId()
+			).toString());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship2.getObjectRelationshipId());
+
+		// Parent object definition published
+
+		ObjectDefinition childObjectDefinition2 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		ObjectDefinition parentObjectDefinition2 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			parentObjectDefinition2.getObjectDefinitionId());
+
+		ObjectRelationship objectRelationship3 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition2,
+				childObjectDefinition2);
+
+		Assert.assertEquals(
+			_jsonFactory.createJSONArray(
+			).toString(),
+			_getObjectRelationshipEdgeCandidatesJSONArray(
+				0, childObjectDefinition2.getObjectDefinitionId()
+			).toString());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship3.getObjectRelationshipId());
+
+		// Self object relationship
+
+		ObjectDefinition objectDefinition3 =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				_objectDefinitionLocalService);
+
+		ObjectRelationship objectRelationship4 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, objectDefinition3,
+				objectDefinition3);
+
+		Assert.assertEquals(
+			_jsonFactory.createJSONArray(
+			).toString(),
+			_getObjectRelationshipEdgeCandidatesJSONArray(
+				0, childObjectDefinition1.getObjectDefinitionId()
+			).toString());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship4.getObjectRelationshipId());
 	}
 
 	private String _getEdgeLabel(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -227,6 +227,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition childObjectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
@@ -235,6 +236,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition parentObjectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship1 =
@@ -256,10 +258,12 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship2 =
@@ -286,10 +290,12 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition childObjectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectDefinition parentObjectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
@@ -315,6 +321,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition objectDefinition3 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship4 =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -274,7 +274,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 				objectDefinition2.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(),
+				StringUtil.randomId(), false,
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
 
 		Assert.assertEquals(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -222,18 +222,18 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 	@Test
 	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
-		ObjectDefinition objectDefinitionPublished =
+		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				"PUB", _objectDefinitionLocalService);
+				RandomTestUtil.randomString(), _objectDefinitionLocalService);
 
-		ObjectDefinition objectDefinitionA =
+		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				"A", _objectDefinitionLocalService);
+				RandomTestUtil.randomString(), _objectDefinitionLocalService);
 
 		_objectRelationshipLocalService.addObjectRelationship(
 			TestPropsValues.getUserId(),
-			objectDefinitionPublished.getObjectDefinitionId(),
-			objectDefinitionA.getObjectDefinitionId(), 0,
+			objectDefinition1.getObjectDefinitionId(),
+			objectDefinition2.getObjectDefinitionId(), 0,
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			StringUtil.randomId(),
@@ -241,13 +241,13 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
-			objectDefinitionPublished.getObjectDefinitionId());
+			objectDefinition1.getObjectDefinitionId());
 
 		Assert.assertEquals(
 			_jsonFactory.createJSONArray(
 			).toString(),
 			_getObjectRelationshipEdgeCandidatesJSONArray(
-				2, objectDefinitionA.getObjectDefinitionId()
+				2, objectDefinition2.getObjectDefinitionId()
 			).toString());
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -223,6 +223,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 	@Test
 	public void testIsEdgeCandidate() throws Exception {
+
 		// Child object definition published
 
 		ObjectDefinition childObjectDefinition1 =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -223,11 +223,11 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 	@Test
 	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
 		ObjectDefinition objectDefinitionPublished =
-			ObjectDefinitionTestUtil.addObjectDefinition(
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
 				"PUB", _objectDefinitionLocalService);
 
 		ObjectDefinition objectDefinitionA =
-			ObjectDefinitionTestUtil.addObjectDefinition(
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
 				"A", _objectDefinitionLocalService);
 
 		_objectRelationshipLocalService.addObjectRelationship(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -260,6 +260,39 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 			byteArrayOutputStream.toString());
 	}
 
+	@Test
+	public void testPreventBidingWithinPublishedDefinitions() throws Exception {
+
+		ObjectDefinition objectDefinitionPublished =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"PUB", _objectDefinitionLocalService);
+
+		ObjectDefinition objectDefinitionA =
+			ObjectDefinitionTestUtil.addObjectDefinition(
+				"A", _objectDefinitionLocalService);
+
+		ObjectRelationship objectRelationshipPUB_A =
+			_objectRelationshipLocalService.addObjectRelationship(
+				TestPropsValues.getUserId(),
+				objectDefinitionPublished.getObjectDefinitionId(),
+				objectDefinitionA.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinitionPublished.getObjectDefinitionId());
+
+		Assert.assertEquals(
+			_jsonFactory.createJSONArray(
+			).toString(),
+			_getObjectRelationshipEdgeCandidatesJSONArray(
+				2, objectDefinitionA.getObjectDefinitionId()
+			).toString());
+	}
+
 	@Inject
 	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest.java
@@ -227,7 +227,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition childObjectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"A" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
@@ -236,7 +236,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition parentObjectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"B" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship1 =
@@ -258,12 +258,12 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition objectDefinition1 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"A" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectDefinition objectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"B" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship2 =
@@ -290,12 +290,12 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition childObjectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"A" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectDefinition parentObjectDefinition2 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"B" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
@@ -321,7 +321,7 @@ public class GetObjectRelationshipEdgeCandidatesMVCResourceCommandTest {
 
 		ObjectDefinition objectDefinition3 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				RandomTestUtil.randomString(),
+				"A" + RandomTestUtil.randomString(),
 				_objectDefinitionLocalService);
 
 		ObjectRelationship objectRelationship4 =


### PR DESCRIPTION
Adding some validation (and tests) to prevent unpublished objects to be binded to already published objects.