### PR TITLE
[TS] LPS-198535 Convert Multi-Select Picklists ListEntry type to ArrayList

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -735,8 +735,8 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		if (objectEntry.getProperties() != null) {
-			Map<String, Object> properties =
-				existingObjectEntry.getProperties();
+			Map<String, Object> properties = _toObjectProperties(
+				objectDefinition, existingObjectEntry);
 
 			properties.putAll(objectEntry.getProperties());
 
@@ -1567,6 +1567,49 @@ public class DefaultObjectEntryManagerImpl
 
 		return _objectEntryDTOConverter.toDTO(
 			defaultDTOConverterContext, serviceBuilderObjectEntry);
+	}
+
+	private Map<String, Object> _toObjectProperties(
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
+
+		Map<String, Object> values = new HashMap<>();
+		Map<String, Object> properties = objectEntry.getProperties();
+
+		for (ObjectField objectField :
+				objectFieldLocalService.getObjectFields(
+					objectDefinition.getObjectDefinitionId(), false)) {
+
+			Object fieldValue = properties.get(objectField.getName());
+
+			if (Validator.isNotNull(fieldValue)) {
+				if (objectField.compareBusinessType(
+						ObjectFieldConstants.
+							BUSINESS_TYPE_MULTISELECT_PICKLIST)) {
+
+					ArrayList<String> list = new ArrayList<>();
+
+					if (fieldValue instanceof List) {
+						List<String> listTypeFieldValue =
+							(List<String>)fieldValue;
+
+						for (Object value : listTypeFieldValue) {
+							if (value instanceof ListEntry) {
+								ListEntry listEntry = (ListEntry)value;
+
+								list.add(listEntry.getKey());
+							}
+						}
+					}
+
+					values.put(objectField.getName(), list);
+				}
+				else {
+					values.put(objectField.getName(), fieldValue);
+				}
+			}
+		}
+
+		return values;
 	}
 
 	private Map<String, Serializable> _toObjectValues(


### PR DESCRIPTION
Hi Team,

I would like to kindly ask you to review my PR.

Issue: https://liferay.atlassian.net/browse/LPS-198535. When an object has a multiselect picklist field with entries, it can not be edited through Headless Api Patch if we don't include the multiselect values in the request. If we don't add it fails.

Root cause: Multiselect values got new schemas in https://liferay.atlassian.net/browse/LPS-143671, and the validation can not handle that.

Solution: change back the ListEntry type to ArrayList<String> to be able to validate and update the object with an ArrayList.

I was considering creating a validation for ListEntry but it caused more issues, as the ObjectEntryLocalServiceImpl.java is not yet ready to handle ListEntry, and it needs a major change.

Thank you in advance! 
BR,
Gege 