### PR TITLE
LPS-199095 Prevent modifiable system object definitions from being used in Form Container using permissions instead of providing an incomplete IF implementation

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemDetailsProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemDetailsProvider.java
@@ -29,10 +29,6 @@ public class ObjectEntryInfoItemDetailsProvider
 
 	@Override
 	public InfoItemClassDetails getInfoItemClassDetails() {
-		if (_objectDefinition.isModifiable() && _objectDefinition.isSystem()) {
-			return null;
-		}
-
 		return new InfoItemClassDetails(
 			_objectDefinition.getClassName(),
 			InfoLocalizedValue.<String>builder(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/permission/provider/ObjectEntryInfoPermissionProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/permission/provider/ObjectEntryInfoPermissionProvider.java
@@ -52,6 +52,10 @@ public class ObjectEntryInfoPermissionProvider
 
 	@Override
 	public boolean hasViewPermission(PermissionChecker permissionChecker) {
+		if (_objectDefinition.isModifiable() && _objectDefinition.isSystem()) {
+			return false;
+		}
+
 		Portlet portlet = _portletLocalService.getPortletById(
 			_objectDefinition.getCompanyId(), _objectDefinition.getPortletId());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-199095

Hi Team :hand: 
Yesterday we found [this bug](https://liferay.atlassian.net/browse/LPS-199081) caused by [this commit](https://github.com/liferay-echo/liferay-portal/commit/1e76b332bca37fe8fb9b4d17e1f5ec838d36edc7).
It has been solved from our components in a simple way ([related PR](https://github.com/liferay-echo/liferay-portal/pull/14003/files)), but we are worried that it will cause other problems.
That is why I come to propose an alternative implementation that I have verified achieves the same objective and is more secure and aligned with the Info Framework.
Please could you take it into consideration?
Thank you so much!
Regards
