### PR TITLE
LPS-198115 Distance between the toggles is bigger than the distance between the inputs at the right side bar

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.scss
@@ -39,6 +39,3 @@
 		padding: 1rem 1rem 0;
 	}
 }
-.toggle-switch {
-	margin-bottom: 1.5rem;
-}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AccountRestrictionContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AccountRestrictionContainer.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayForm from '@clayui/form';
 import {
 	FormError,
 	SingleSelect,
@@ -116,36 +117,38 @@ export function AccountRestrictionContainer({
 
 	return (
 		<>
-			<Toggle
-				disabled={
-					!accountRelationshipFields.length ||
-					disableAccountToggle ||
-					isLinkedObjectDefinition ||
-					isRootDescendantNode
-				}
-				label={sub(
-					Liferay.Language.get('enable-x'),
-					Liferay.Language.get('account-restriction')
-				)}
-				name="accountEntryRestricted"
-				onBlur={(event) => {
-					event.stopPropagation();
-
-					if (onSubmit) {
-						onSubmit();
+			<ClayForm.Group>
+				<Toggle
+					disabled={
+						!accountRelationshipFields.length ||
+						disableAccountToggle ||
+						isLinkedObjectDefinition ||
+						isRootDescendantNode
 					}
-				}}
-				onToggle={() =>
-					setValues({
-						accountEntryRestricted: !values.accountEntryRestricted,
-						accountEntryRestrictedObjectFieldName:
-							!values.accountEntryRestricted === false
-								? ''
-								: values.accountEntryRestrictedObjectFieldName,
-					})
-				}
-				toggled={values.accountEntryRestricted}
-			/>
+					label={sub(
+						Liferay.Language.get('enable-x'),
+						Liferay.Language.get('account-restriction')
+					)}
+					name="accountEntryRestricted"
+					onBlur={(event) => {
+						event.stopPropagation();
+
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() =>
+						setValues({
+							accountEntryRestricted: !values.accountEntryRestricted,
+							accountEntryRestrictedObjectFieldName:
+								!values.accountEntryRestricted === false
+									? ''
+									: values.accountEntryRestrictedObjectFieldName,
+						})
+					}
+					toggled={values.accountEntryRestricted}
+				/>
+			</ClayForm.Group>
 
 			<SingleSelect<LabelValueObject>
 				disabled={

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayForm from '@clayui/form';
 import {Toggle} from '@liferay/object-js-components-web';
 import {sub} from 'frontend-js-web';
 import React from 'react';
@@ -33,99 +34,34 @@ export function ConfigurationContainer({
 
 	return (
 		<div className="lfr-objects__object-definition-details-configuration">
-			<Toggle
-				disabled={disabled || isRootDescendantNode}
-				label={sub(
-					Liferay.Language.get('show-widget-in-x'),
-					Liferay.Language.get('page-builder')
-				)}
-				name="showWidget"
-				onBlur={(event) => {
-					event.stopPropagation();
-
-					if (onSubmit) {
-						onSubmit();
-					}
-				}}
-				onToggle={() => setValues({portlet: !values.portlet})}
-				toggled={values.portlet}
-			/>
-
-			<Toggle
-				disabled={disabled}
-				label={sub(
-					Liferay.Language.get('enable-x'),
-					Liferay.Language.get('categorization-of-object-entries')
-				)}
-				name="enableCategorization"
-				onBlur={(event) => {
-					event.stopPropagation();
-
-					if (onSubmit) {
-						onSubmit();
-					}
-				}}
-				onToggle={() =>
-					setValues({
-						enableCategorization: !values.enableCategorization,
-					})
-				}
-				toggled={values.enableCategorization}
-			/>
-
-			<Toggle
-				disabled={disabled}
-				label={sub(
-					Liferay.Language.get('enable-x'),
-					Liferay.Language.get('comments-in-page-builder')
-				)}
-				name="enableComments"
-				onBlur={(event) => {
-					event.stopPropagation();
-
-					if (onSubmit) {
-						onSubmit();
-					}
-				}}
-				onToggle={() =>
-					setValues({
-						enableComments: !values.enableComments,
-					})
-				}
-				toggled={values.enableComments}
-			/>
-
-			<Toggle
-				disabled={isLinkedObjectDefinition || isReadOnly}
-				label={sub(
-					Liferay.Language.get('enable-x'),
-					Liferay.Language.get('entry-history-in-audit-framework')
-				)}
-				name="enableEntryHistory"
-				onBlur={(event) => {
-					event.stopPropagation();
-
-					if (onSubmit) {
-						onSubmit();
-					}
-				}}
-				onToggle={() =>
-					setValues({
-						enableObjectEntryHistory: !values.enableObjectEntryHistory,
-					})
-				}
-				toggled={values.enableObjectEntryHistory}
-			/>
-
-			{Liferay.FeatureFlags['LPS-181663'] && (
+			<ClayForm.Group>
 				<Toggle
-					disabled={
-						isReadOnly || !hasUpdateObjectDefinitionPermission
-					}
-					label={Liferay.Language.get(
-						'allow-users-to-save-entries-as-draft'
+					disabled={disabled || isRootDescendantNode}
+					label={sub(
+						Liferay.Language.get('show-widget-in-x'),
+						Liferay.Language.get('page-builder')
 					)}
-					name="enableObjectEntryDraft"
+					name="showWidget"
+					onBlur={(event) => {
+						event.stopPropagation();
+
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() => setValues({portlet: !values.portlet})}
+					toggled={values.portlet}
+				/>
+			</ClayForm.Group>
+
+			<ClayForm.Group>
+				<Toggle
+					disabled={disabled}
+					label={sub(
+						Liferay.Language.get('enable-x'),
+						Liferay.Language.get('categorization-of-object-entries')
+					)}
+					name="enableCategorization"
 					onBlur={(event) => {
 						event.stopPropagation();
 
@@ -135,11 +71,86 @@ export function ConfigurationContainer({
 					}}
 					onToggle={() =>
 						setValues({
-							enableObjectEntryDraft: !values.enableObjectEntryDraft,
+							enableCategorization: !values.enableCategorization,
 						})
 					}
-					toggled={values.enableObjectEntryDraft}
+					toggled={values.enableCategorization}
 				/>
+			</ClayForm.Group>
+
+			<ClayForm.Group>
+				<Toggle
+					disabled={disabled}
+					label={sub(
+						Liferay.Language.get('enable-x'),
+						Liferay.Language.get('comments-in-page-builder')
+					)}
+					name="enableComments"
+					onBlur={(event) => {
+						event.stopPropagation();
+
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() =>
+						setValues({
+							enableComments: !values.enableComments,
+						})
+					}
+					toggled={values.enableComments}
+				/>
+			</ClayForm.Group>
+
+			<ClayForm.Group>
+				<Toggle
+					disabled={isLinkedObjectDefinition || isReadOnly}
+					label={sub(
+						Liferay.Language.get('enable-x'),
+						Liferay.Language.get('entry-history-in-audit-framework')
+					)}
+					name="enableEntryHistory"
+					onBlur={(event) => {
+						event.stopPropagation();
+
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() =>
+						setValues({
+							enableObjectEntryHistory: !values.enableObjectEntryHistory,
+						})
+					}
+					toggled={values.enableObjectEntryHistory}
+				/>
+			</ClayForm.Group>
+
+			{Liferay.FeatureFlags['LPS-181663'] && (
+				<ClayForm.Group>
+					<Toggle
+						disabled={
+							isReadOnly || !hasUpdateObjectDefinitionPermission
+						}
+						label={Liferay.Language.get(
+							'allow-users-to-save-entries-as-draft'
+						)}
+						name="enableObjectEntryDraft"
+						onBlur={(event) => {
+							event.stopPropagation();
+
+							if (onSubmit) {
+								onSubmit();
+							}
+						}}
+						onToggle={() =>
+							setValues({
+								enableObjectEntryDraft: !values.enableObjectEntryDraft,
+							})
+						}
+						toggled={values.enableObjectEntryDraft}
+					/>
+				</ClayForm.Group>
 			)}
 		</div>
 	);

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDataContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDataContainer.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayForm from '@clayui/form';
 import {FormError, Input, Toggle} from '@liferay/object-js-components-web';
 import {InputLocalized} from 'frontend-js-components-web';
 import {sub} from 'frontend-js-web';
@@ -104,23 +105,25 @@ export function ObjectDataContainer({
 				value={dbTableName}
 			/>
 
-			<Toggle
-				disabled={!isApproved || isReadOnly || noPermissionOrLinked}
-				label={sub(
-					Liferay.Language.get('activate-x'),
-					Liferay.Language.get('object')
-				)}
-				name="active"
-				onBlur={(event) => {
-					event.stopPropagation();
+			<ClayForm.Group>
+				<Toggle
+					disabled={!isApproved || isReadOnly || noPermissionOrLinked}
+					label={sub(
+						Liferay.Language.get('activate-x'),
+						Liferay.Language.get('object')
+					)}
+					name="active"
+					onBlur={(event) => {
+						event.stopPropagation();
 
-					if (onSubmit) {
-						onSubmit();
-					}
-				}}
-				onToggle={() => setValues({active: !values.active})}
-				toggled={values.active}
-			/>
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() => setValues({active: !values.active})}
+					toggled={values.active}
+				/>
+			</ClayForm.Group>
 		</>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDetails.scss
@@ -5,7 +5,6 @@
 	&-configuration {
 		display: flex;
 		flex-direction: column;
-		gap: 0.8rem;
 	}
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/TranslationsContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/TranslationsContainer.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayForm from '@clayui/form';
 import {Toggle} from '@liferay/object-js-components-web';
 import React from 'react';
 
@@ -21,26 +22,28 @@ export function TranslationsContainer({
 }: TranslationsContainerProps) {
 	return (
 		<div className="lfr-objects-translations-container">
-			<Toggle
-				disabled={values.active}
-				label={Liferay.Language.get('enable-entry-translations')}
-				onBlur={(event) => {
-					event.stopPropagation();
+			<ClayForm.Group>
+				<Toggle
+					disabled={values.active}
+					label={Liferay.Language.get('enable-entry-translations')}
+					onBlur={(event) => {
+						event.stopPropagation();
 
-					if (onSubmit) {
-						onSubmit();
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
+					onToggle={() =>
+						setValues({
+							enableLocalization: !values.enableLocalization,
+						})
 					}
-				}}
-				onToggle={() =>
-					setValues({
-						enableLocalization: !values.enableLocalization,
-					})
-				}
-				toggled={values.enableLocalization}
-				tooltip={Liferay.Language.get(
-					'enable-entry-translations-in-all-fields'
-				)}
-			/>
+					toggled={values.enableLocalization}
+					tooltip={Liferay.Language.get(
+						'enable-entry-translations-in-all-fields'
+					)}
+				/>
+			</ClayForm.Group>
 		</div>
 	);
 }


### PR DESCRIPTION
Related Issue: [LPS-198115](https://liferay.atlassian.net/browse/LPS-198115)

Hello reviewer! 
I saw that the toggles presented in the ticket are all wrapped in `<ClayForm.Groups>` which already have the margin-bottom set as `1.5rem`, so that was adding up with the .toggle-swtich margin-bottom set in RightSidebarObjectDefinitionDetails.scss, also `1.5rem`, causing it to be so distant.
So wrapping the other toggles in form groups as well, will allow all of the toggles to present the same behavior and aesthetic of a form-group, and remove unnecessary styling.