### PR TITLE
LPS-199937 - Restrict Autoincrement field where it could not be used and allow it to be used in Unique composite key validation

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutField.tsx
@@ -194,7 +194,7 @@ export default function ModalAddObjectLayoutField({
 						required
 						value={selectedObjectField?.label[defaultLanguageId]}
 					>
-						{({label, readOnly, required}) => (
+						{({businessType, label, readOnly, required}) => (
 							<div className="d-flex justify-content-between">
 								<div className="lfr__object-web-layout-modal-add-field-label">
 									{label[defaultLanguageId]}
@@ -212,7 +212,8 @@ export default function ModalAddObjectLayoutField({
 											: Liferay.Language.get('optional')}
 									</ClayLabel>
 
-									{(readOnly === 'conditional' ||
+									{(businessType === 'AutoIncrement' ||
+										readOnly === 'conditional' ||
 										readOnly === 'true') && (
 										<ClayLabel
 											className="label-inside-custom-select"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ObjectLayoutField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ObjectLayoutField.tsx
@@ -83,7 +83,8 @@ export function ObjectLayoutField({
 							: Liferay.Language.get('optional')}
 					</ClayLabel>
 
-					{(objectField.readOnly === 'true' ||
+					{(objectField.businessType === 'AutoIncrement' ||
+						objectField.readOnly === 'true' ||
 						objectField.readOnly === 'conditional') && (
 						<ClayLabel
 							className="label-inside-custom-select"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/ActionContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/ActionContainer.tsx
@@ -76,6 +76,7 @@ export function ActionContainer({
 
 		return isObjectActionSystem
 			? businessType !== 'Aggregation' &&
+					businessType !== 'AutoIncrement' &&
 					businessType !== 'Formula' &&
 					businessType !== 'Relationship' &&
 					name !== 'creator' &&
@@ -84,6 +85,7 @@ export function ActionContainer({
 					name !== 'modifiedDate' &&
 					name !== 'status'
 			: businessType !== 'Aggregation' &&
+					businessType !== 'AutoIncrement' &&
 					businessType !== 'Formula' &&
 					businessType !== 'Relationship' &&
 					!system;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/UniqueCompositeKey.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/UniqueCompositeKey.tsx
@@ -86,11 +86,12 @@ export function UniqueCompositeKey({
 	>();
 
 	const allowedObjectFieldBusinessTypes = [
+		'AutoIncrement',
 		'Integer',
 		'Picklist',
 		'Relationship',
 		'Text',
-	];
+	] as ObjectFieldBusinessType[];
 
 	const filteredCustomObjectFields = customObjectFields.filter(
 		(customObjectField) =>


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPS-199937