### PR TITLE
LPS-200494 MALFORMED_QUERY when try to filter by OR operator a Salesforce Proxy Object Account Restricted

### DIFF
--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -442,7 +442,7 @@ public class SalesforceObjectEntryManagerImpl
 				 Validator.isNotNull(filterSOSQLString)) {
 
 			sosqlString = StringBundler.concat(
-				" WHERE ", filterSOSQLString, " AND ",
+				" WHERE (", filterSOSQLString, ") AND ",
 				accountRestrictionSOSQLString);
 		}
 


### PR DESCRIPTION
it was only necessary to add parentheses to avoid confusing OR and AND.