### PR TITLE
LPS-201757 Get the userId from the permission checker when principalName is not provided

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/trigger/messaging/ObjectActionTriggerMessageListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/trigger/messaging/ObjectActionTriggerMessageListener.java
@@ -9,6 +9,7 @@ import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 /**
@@ -31,7 +32,25 @@ public class ObjectActionTriggerMessageListener extends BaseMessageListener {
 		_objectActionEngine.executeObjectActions(
 			_className, GetterUtil.getLong(message.get("companyId")),
 			_objectActionTriggerKey, (JSONObject)message.getPayload(),
-			GetterUtil.getLong(message.get("principalName")));
+			_getUserId(message));
+	}
+
+	private long _getUserId(Message message) {
+		long userId = GetterUtil.getLong(message.get("principalName"));
+
+		if (userId != 0L) {
+			return userId;
+		}
+
+		Object object = message.get("permissionChecker");
+
+		if (!(object instanceof PermissionChecker)) {
+			return 0L;
+		}
+
+		PermissionChecker permissionChecker = (PermissionChecker)object;
+
+		return permissionChecker.getUserId();
 	}
 
 	private final String _className;


### PR DESCRIPTION
`principalName` (e.g.: "20122" userId) is not provided when a PaymentMethod like PayPal is used, I believe it could be solved from Commerce side by setting the `PrincipalThreadLocal.setName()` with the proper user id, but from Objects side we can get this used id from permission checker that is provided in the message. 