### PR TITLE
LPS-202145 Unable to edit the Maximum Number of Characters for a Long Text field to a number greater than 280

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/MaxLengthProperties.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/MaxLengthProperties.tsx
@@ -131,7 +131,7 @@ export function MaxLengthProperties({
 							onSettingsChange({
 								name: 'maxLength',
 								value:
-									Number(value) <= 280
+									Number(value) <= defaultMaxLength
 										? Number(value)
 										: (settings.maxLength as number),
 							})


### PR DESCRIPTION
Related Issue: [LPS-202145](https://liferay.atlassian.net/browse/LPS-202145)