### PR TITLE
LPS-202203 Avoid using targetHandle and sourceHandle when not necessary

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
@@ -319,6 +319,19 @@ export async function getObjectValidationRuleById<T>(
 	);
 }
 
+export async function patchObjectDefinitionById(
+	objectDefinition: Partial<ObjectDefinition>
+) {
+	return await fetch(
+		`/o/object-admin/v1.0/object-definitions/${objectDefinition.id}`,
+		{
+			body: JSON.stringify(objectDefinition),
+			headers,
+			method: 'PATCH',
+		}
+	);
+}
+
 export async function postListTypeEntry({
 	key,
 	listTypeDefinitionId,

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/utils/api.d.ts
@@ -163,6 +163,9 @@ export declare function getObjectRelationship<T>(
 export declare function getObjectValidationRuleById<T>(
 	objectValidationRuleId: number
 ): Promise<T>;
+export declare function patchObjectDefinitionById(
+	objectDefinition: Partial<ObjectDefinition>
+): Promise<Response>;
 export declare function postListTypeEntry({
 	key,
 	listTypeDefinitionId,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Diagram/Diagram.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Diagram/Diagram.tsx
@@ -169,6 +169,13 @@ function DiagramBuilder() {
 			},
 			type: TYPES.UPDATE_MODEL_BUILDER_STRUCTURE,
 		});
+
+		dispatch({
+			payload: {
+				selectedObjectRelationshipId: newObjectRelationshipId,
+			},
+			type: TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
+		});
 	};
 
 	return (

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
@@ -518,11 +518,11 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 											source: `${objectDefinition.id}`,
 											sourceHandle: isSelfObjectRelationship
 												? 'fixedLeftHandle'
-												: `${objectDefinition.id}`,
+												: null,
 											target: `${objectRelationship.objectDefinitionId2}`,
 											targetHandle: isSelfObjectRelationship
 												? 'fixedRightHandle'
-												: `${objectRelationship.objectDefinitionId2}`,
+												: null,
 											type: isSelfObjectRelationship
 												? 'selfObjectRelationshipEdge'
 												: 'defaultObjectRelationshipEdge',

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
@@ -593,6 +593,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 					...selectedObjectFolder,
 					objectFolderItems: updatedObjectFolderItems,
 				},
+				selectedObjectRelationship: null,
 			};
 
 			if (rightSidebarType) {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
@@ -166,7 +166,7 @@ export function RightSidebarObjectDefinitionDetails({
 			}
 
 			try {
-				const updatedObjectDefinitionResponse = await API.putObjectDefinitionByExternalReferenceCode(
+				const updatedObjectDefinitionResponse = await API.patchObjectDefinitionById(
 					objectDefinition
 				);
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.tsx
@@ -142,7 +142,7 @@ export function RightSidebarObjectDefinitionDetails({
 
 		makeFetch();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [selectedObjectDefinitionNode?.id]);
 
 	const onSubmit = async (
 		editedObjectDefinition?: Partial<ObjectDefinition>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
@@ -142,7 +142,7 @@ export function RightSidebarObjectRelationshipDetails({
 
 		makeFetch();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [selectedObjectRelationship?.id]);
 
 	const onSubmit = async (
 		editedObjectRelationship?: Partial<ObjectRelationship>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
@@ -203,7 +203,7 @@ export type TState = {
 	selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData> | null;
 	selectedObjectField?: ObjectFieldNodeRow;
 	selectedObjectFolder: ObjectFolder;
-	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData>;
+	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData> | null;
 	showChangesSaved: boolean;
 	showSidebars: boolean;
 	workflowStatuses: LabelValueObject[];

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
@@ -200,7 +200,7 @@ export declare type TState = {
 	selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData> | null;
 	selectedObjectField?: ObjectFieldNodeRow;
 	selectedObjectFolder: ObjectFolder;
-	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData>;
+	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData> | null;
 	showChangesSaved: boolean;
 	showSidebars: boolean;
 	workflowStatuses: LabelValueObject[];


### PR DESCRIPTION
Related [ticket](https://liferay.atlassian.net/browse/LPS-202203)

When we do not want to point out exactly the source and target handles, it is not necessary to use this property. As in Model Builder, relationships use floating edge logic, and are not connected to specific handles. Using the sourceHandle and targetHandle properties are not necessary. It only remains necessary for selfRelationship cases.

React Flow Doc Exemple:
https://v9.reactflow.dev/examples/custom-node/