### PR TITLE
LPS-202304 Use ID instead of name because the self many-to-many relationship has the same name for both child and parent

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
@@ -146,12 +146,12 @@ export function ModalAddObjectLayoutTab({
 	const objectRelationshipItems = useMemo(() => {
 		const availableObjectRelationships: ObjectRelationshipItem[] = [];
 
-		objectRelationships.forEach(({inLayout, label, name, reverse}) => {
+		objectRelationships.forEach(({id, inLayout, label, name, reverse}) => {
 			if (!inLayout) {
 				availableObjectRelationships.push({
 					label: getLocalizableLabel(creationLanguageId, label, name),
 					reverse,
-					value: name,
+					value: id.toString(),
 				});
 			}
 		});
@@ -258,7 +258,7 @@ export function ModalAddObjectLayoutTab({
 							label={Liferay.Language.get('relationship')}
 							onSelectionChange={(value) => {
 								const selectedObjectRelationship = objectRelationships.find(
-									({name}) => name === value
+									({id}) => id.toString() === value
 								);
 
 								setSelectedRelationship(
@@ -270,7 +270,7 @@ export function ModalAddObjectLayoutTab({
 								});
 							}}
 							required
-							selectedKey={selectedRelationship?.name}
+							selectedKey={selectedRelationship?.id.toString()}
 						>
 							{({label, reverse, value}) => {
 								const relationshipInfo = getRelationshipInfo(


### PR DESCRIPTION
**Related Issue**: https://liferay.atlassian.net/browse/LPS-202304