### PR TITLE
LPS-197185 Handle picklist fields on DTO parsing for external object entries

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
@@ -111,6 +112,62 @@ public class ObjectEntryDTOConverter
 	@Override
 	public String getContentType() {
 		return ObjectEntry.class.getSimpleName();
+	}
+
+	@Override
+	public ObjectEntry toDTO(DTOConverterContext dtoConverterContext)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			(ObjectDefinition)dtoConverterContext.getAttribute(
+				"objectDefinition");
+
+		ObjectEntry objectEntry = ObjectEntry.unsafeToDTO(
+			(String)dtoConverterContext.getAttribute("payload"));
+
+		User user = dtoConverterContext.getUser();
+
+		objectEntry.setActions(dtoConverterContext.getActions());
+
+		if (objectEntry.getStatus() == null) {
+			objectEntry.setStatus(
+				new Status() {
+					{
+						code = WorkflowConstants.STATUS_APPROVED;
+						label = WorkflowConstants.LABEL_APPROVED;
+						label_i18n = _language.get(
+							user.getLocale(), WorkflowConstants.LABEL_APPROVED);
+					}
+				});
+		}
+
+		List<ObjectField> objectFields =
+			_objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId());
+
+		for (ObjectField objectField : objectFields) {
+			if (!Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
+
+				continue;
+			}
+
+			Map<String, Object> properties = objectEntry.getProperties();
+
+			Map<String, String> listTypeEntryMap =
+				(Map<String, String>)properties.get(objectField.getName());
+
+			properties.put(
+				objectField.getName(),
+				_getListEntry(
+					dtoConverterContext, listTypeEntryMap.get("key"),
+					objectField.getListTypeDefinitionId()));
+
+			objectEntry.setProperties(properties);
+		}
+
+		return objectEntry;
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
@@ -85,7 +85,7 @@ public class FunctionObjectEntryManagerImpl
 						objectDefinition.getExternalReferenceCode())),
 				dtoConverterContext.getUserId()
 			).get(),
-			objectDefinition, scopeKey, dtoConverterContext.getUser());
+			dtoConverterContext, objectDefinition, scopeKey);
 	}
 
 	@Override
@@ -146,8 +146,7 @@ public class FunctionObjectEntryManagerImpl
 				Http.Method.GET, null, resourcePath,
 				dtoConverterContext.getUserId()
 			).get(),
-			objectDefinition, pagination, scopeKey,
-			dtoConverterContext.getUser());
+			dtoConverterContext, objectDefinition, pagination, scopeKey);
 	}
 
 	@Override
@@ -179,7 +178,7 @@ public class FunctionObjectEntryManagerImpl
 					dtoConverterContext, resourcePath, scopeKey),
 				dtoConverterContext.getUserId()
 			).get(),
-			objectDefinition, scopeKey, dtoConverterContext.getUser());
+			dtoConverterContext, objectDefinition, scopeKey);
 	}
 
 	@Override
@@ -219,7 +218,7 @@ public class FunctionObjectEntryManagerImpl
 					StringPool.SLASH, externalReferenceCode),
 				dtoConverterContext.getUserId()
 			).get(),
-			objectDefinition, scopeKey, dtoConverterContext.getUser());
+			dtoConverterContext, objectDefinition, scopeKey);
 	}
 
 	@Activate
@@ -357,8 +356,9 @@ public class FunctionObjectEntryManagerImpl
 	}
 
 	private Page<ObjectEntry> _toObjectEntries(
-			byte[] bytes, ObjectDefinition objectDefinition,
-			Pagination pagination, String scopeKey, User user)
+			byte[] bytes, DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, Pagination pagination,
+			String scopeKey)
 		throws Exception {
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
@@ -368,24 +368,26 @@ public class FunctionObjectEntryManagerImpl
 			JSONUtil.toList(
 				(JSONArray)jsonObject.get("items"),
 				itemJSONObject -> _toObjectEntry(
-					itemJSONObject.toString(), objectDefinition, scopeKey,
-					user)),
+					dtoConverterContext, itemJSONObject.toString(),
+					objectDefinition, scopeKey)),
 			pagination, (Integer)jsonObject.get("totalCount"));
 	}
 
 	private ObjectEntry _toObjectEntry(
-		byte[] bytes, ObjectDefinition objectDefinition, String scopeKey,
-		User user) {
+		byte[] bytes, DTOConverterContext dtoConverterContext,
+		ObjectDefinition objectDefinition, String scopeKey) {
 
 		return _toObjectEntry(
-			new String(bytes), objectDefinition, scopeKey, user);
+			dtoConverterContext, new String(bytes), objectDefinition, scopeKey);
 	}
 
 	private ObjectEntry _toObjectEntry(
-		String json, ObjectDefinition objectDefinition, String scopeKey,
-		User user) {
+		DTOConverterContext dtoConverterContext, String json,
+		ObjectDefinition objectDefinition, String scopeKey) {
 
 		ObjectEntry objectEntry = ObjectEntry.unsafeToDTO(json);
+
+		User user = dtoConverterContext.getUser();
 
 		objectEntry.setActions(
 			HashMapBuilder.put(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
@@ -5,14 +5,20 @@
 
 package com.liferay.object.rest.internal.manager.v1_0;
 
+import com.liferay.list.type.model.ListTypeEntry;
+import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.internal.configuration.FunctionObjectEntryManagerConfiguration;
 import com.liferay.object.rest.manager.v1_0.BaseObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.CompanyScoped;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -38,9 +44,12 @@ import com.liferay.portal.vulcan.aggregation.Aggregation;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.osgi.service.component.annotations.Activate;
@@ -374,16 +383,18 @@ public class FunctionObjectEntryManagerImpl
 	}
 
 	private ObjectEntry _toObjectEntry(
-		byte[] bytes, DTOConverterContext dtoConverterContext,
-		ObjectDefinition objectDefinition, String scopeKey) {
+			byte[] bytes, DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, String scopeKey)
+		throws Exception {
 
 		return _toObjectEntry(
 			dtoConverterContext, new String(bytes), objectDefinition, scopeKey);
 	}
 
 	private ObjectEntry _toObjectEntry(
-		DTOConverterContext dtoConverterContext, String json,
-		ObjectDefinition objectDefinition, String scopeKey) {
+			DTOConverterContext dtoConverterContext, String json,
+			ObjectDefinition objectDefinition, String scopeKey)
+		throws Exception {
 
 		ObjectEntry objectEntry = ObjectEntry.unsafeToDTO(json);
 
@@ -406,6 +417,44 @@ public class FunctionObjectEntryManagerImpl
 				});
 		}
 
+		List<ObjectField> objectFields =
+			_objectFieldLocalService.getObjectFields(
+				objectDefinition.getObjectDefinitionId());
+
+		for (ObjectField objectField : objectFields) {
+			if (!Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
+
+				continue;
+			}
+
+			Map<String, Object> properties = objectEntry.getProperties();
+
+			Map<String, String> listTypeEntryMap =
+				(Map<String, String>)properties.get(objectField.getName());
+
+			ListTypeEntry listTypeEntry =
+				_listTypeEntryLocalService.getListTypeEntry(
+					objectField.getListTypeDefinitionId(),
+					listTypeEntryMap.get("key"));
+
+			properties.put(
+				objectField.getName(),
+				new ListEntry() {
+					{
+						key = listTypeEntry.getKey();
+						name = listTypeEntry.getName(
+							dtoConverterContext.getLocale());
+						name_i18n = LocalizedMapUtil.getI18nMap(
+							dtoConverterContext.isAcceptAllLanguages(),
+							listTypeEntry.getNameMap());
+					}
+				});
+
+			objectEntry.setProperties(properties);
+		}
+
 		return objectEntry;
 	}
 
@@ -419,6 +468,12 @@ public class FunctionObjectEntryManagerImpl
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ListTypeEntryLocalService _listTypeEntryLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private PortalCatapult _portalCatapult;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/FunctionObjectEntryManagerImpl.java
@@ -5,20 +5,13 @@
 
 package com.liferay.object.rest.internal.manager.v1_0;
 
-import com.liferay.list.type.model.ListTypeEntry;
-import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectActionKeys;
-import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectField;
-import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
-import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.rest.internal.configuration.FunctionObjectEntryManagerConfiguration;
 import com.liferay.object.rest.manager.v1_0.BaseObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.CompanyScoped;
-import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -28,7 +21,6 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -39,17 +31,15 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.Future;
 
 import org.osgi.service.component.annotations.Activate;
@@ -396,66 +386,22 @@ public class FunctionObjectEntryManagerImpl
 			ObjectDefinition objectDefinition, String scopeKey)
 		throws Exception {
 
-		ObjectEntry objectEntry = ObjectEntry.unsafeToDTO(json);
-
-		User user = dtoConverterContext.getUser();
-
-		objectEntry.setActions(
+		dtoConverterContext = new DefaultDTOConverterContext(
+			dtoConverterContext.isAcceptAllLanguages(),
 			HashMapBuilder.put(
-				"delete", addDeleteAction(objectDefinition, scopeKey, user)
-			).build());
+				"delete",
+				addDeleteAction(
+					objectDefinition, scopeKey, dtoConverterContext.getUser())
+			).build(),
+			dtoConverterContext.getDTOConverterRegistry(),
+			dtoConverterContext.getHttpServletRequest(),
+			dtoConverterContext.getId(), dtoConverterContext.getLocale(),
+			dtoConverterContext.getUriInfo(), dtoConverterContext.getUser());
 
-		if (objectEntry.getStatus() == null) {
-			objectEntry.setStatus(
-				new Status() {
-					{
-						code = WorkflowConstants.STATUS_APPROVED;
-						label = WorkflowConstants.LABEL_APPROVED;
-						label_i18n = language.get(
-							user.getLocale(), WorkflowConstants.LABEL_APPROVED);
-					}
-				});
-		}
+		dtoConverterContext.setAttribute("objectDefinition", objectDefinition);
+		dtoConverterContext.setAttribute("payload", json);
 
-		List<ObjectField> objectFields =
-			_objectFieldLocalService.getObjectFields(
-				objectDefinition.getObjectDefinitionId());
-
-		for (ObjectField objectField : objectFields) {
-			if (!Objects.equals(
-					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_PICKLIST)) {
-
-				continue;
-			}
-
-			Map<String, Object> properties = objectEntry.getProperties();
-
-			Map<String, String> listTypeEntryMap =
-				(Map<String, String>)properties.get(objectField.getName());
-
-			ListTypeEntry listTypeEntry =
-				_listTypeEntryLocalService.getListTypeEntry(
-					objectField.getListTypeDefinitionId(),
-					listTypeEntryMap.get("key"));
-
-			properties.put(
-				objectField.getName(),
-				new ListEntry() {
-					{
-						key = listTypeEntry.getKey();
-						name = listTypeEntry.getName(
-							dtoConverterContext.getLocale());
-						name_i18n = LocalizedMapUtil.getI18nMap(
-							dtoConverterContext.isAcceptAllLanguages(),
-							listTypeEntry.getNameMap());
-					}
-				});
-
-			objectEntry.setProperties(properties);
-		}
-
-		return objectEntry;
+		return _objectEntryDTOConverter.toDTO(dtoConverterContext);
 	}
 
 	private long _companyId;
@@ -469,11 +415,11 @@ public class FunctionObjectEntryManagerImpl
 	@Reference
 	private JSONFactory _jsonFactory;
 
-	@Reference
-	private ListTypeEntryLocalService _listTypeEntryLocalService;
-
-	@Reference
-	private ObjectFieldLocalService _objectFieldLocalService;
+	@Reference(
+		target = "(component.name=com.liferay.object.rest.internal.dto.v1_0.converter.ObjectEntryDTOConverter)"
+	)
+	private DTOConverter<com.liferay.object.model.ObjectEntry, ObjectEntry>
+		_objectEntryDTOConverter;
 
 	@Reference
 	private PortalCatapult _portalCatapult;


### PR DESCRIPTION
Hey @guilhermedcamacho these changes are related to display the list entry label for external storage types (Client Extensions),

I'm getting this information from list type entry local service and converted to list entry dto after I fixing the issue I've moved the logic to parse the json provided by the customers to object entry dto converter this this way we can keep the responsibility there.

Please follow the commits.

Thank you!