### PR TITLE
COMMERCE-12980 Pass the dtoConverterContext with the correct userId when converting the related unmodifiable system Objects to DTO

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -603,7 +603,8 @@ public class ObjectEntryDTOConverter
 		if (entityExtensionHandler != null) {
 			nestedFieldsRelatedProperties =
 				entityExtensionHandler.getExtendedProperties(
-					objectDefinition.getCompanyId(), dto);
+					objectDefinition.getCompanyId(),
+					dtoConverterContext.getUserId(), dto);
 		}
 
 		return ExtendedEntity.extend(dto, nestedFieldsRelatedProperties, null);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -468,7 +468,8 @@ public class ObjectDefinitionGraphQLDTOContributor
 		if (entityExtensionHandler != null) {
 			nestedFieldsRelatedProperties =
 				entityExtensionHandler.getExtendedProperties(
-					objectDefinition.getCompanyId(), systemObjectEntry);
+					objectDefinition.getCompanyId(),
+					dtoConverterContext.getUserId(), systemObjectEntry);
 		}
 
 		return ExtendedEntity.extend(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectEntryExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectEntryExtensionProvider.java
@@ -43,7 +43,7 @@ public class ObjectEntryExtensionProvider extends BaseObjectExtensionProvider {
 
 	@Override
 	public Map<String, Serializable> getExtendedProperties(
-		long companyId, String className, Object entity) {
+		long companyId, long userId, String className, Object entity) {
 
 		try {
 			ObjectDefinition objectDefinition = fetchObjectDefinition(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -59,7 +59,7 @@ public class ObjectRelationshipExtensionProvider
 
 	@Override
 	public Map<String, Serializable> getExtendedProperties(
-			long companyId, String className, Object entity)
+			long companyId, long userId, String className, Object entity)
 		throws Exception {
 
 		ObjectDefinition objectDefinition = fetchObjectDefinition(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -104,7 +104,7 @@ public class ObjectRelationshipExtensionProvider
 					return defaultObjectEntryManager.
 						fetchRelatedManyToOneObjectEntry(
 							_getDefaultDTOConverterContext(
-								objectDefinition, primaryKey, null, null),
+								objectDefinition, primaryKey, null, userId),
 							objectDefinition, primaryKey,
 							objectRelationship.getName());
 				}
@@ -118,7 +118,7 @@ public class ObjectRelationshipExtensionProvider
 					defaultObjectEntryManager.
 						getObjectEntryRelatedObjectEntries(
 							_getDefaultDTOConverterContext(
-								objectDefinition, primaryKey, null, null),
+								objectDefinition, primaryKey, null, userId),
 							objectDefinition, primaryKey,
 							objectRelationship.getName(),
 							Pagination.of(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
@@ -247,8 +247,8 @@ public class ObjectEntryExtensionProviderTest {
 
 		Map<String, Serializable> extendedProperties =
 			_extensionProvider.getExtendedProperties(
-				TestPropsValues.getCompanyId(), UserAccount.class.getName(),
-				userAccount);
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				UserAccount.class.getName(), userAccount);
 
 		Assert.assertEquals(
 			values.get("boolean"), extendedProperties.get("boolean"));

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -133,8 +133,8 @@ public class ObjectRelationshipExtensionProviderTest {
 
 		Map<String, Serializable> extendedProperties =
 			_extensionProvider.getExtendedProperties(
-				TestPropsValues.getCompanyId(), UserAccount.class.getName(),
-				userAccount);
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				UserAccount.class.getName(), userAccount);
 
 		Assert.assertNull(extendedProperties);
 
@@ -142,8 +142,8 @@ public class ObjectRelationshipExtensionProviderTest {
 			_getNestedFieldsContext(RandomTestUtil.randomString()));
 
 		extendedProperties = _extensionProvider.getExtendedProperties(
-			TestPropsValues.getCompanyId(), UserAccount.class.getName(),
-			userAccount);
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			UserAccount.class.getName(), userAccount);
 
 		Assert.assertTrue(extendedProperties.isEmpty());
 
@@ -151,8 +151,8 @@ public class ObjectRelationshipExtensionProviderTest {
 			_getNestedFieldsContext(_objectRelationship.getName()));
 
 		extendedProperties = _extensionProvider.getExtendedProperties(
-			TestPropsValues.getCompanyId(), UserAccount.class.getName(),
-			userAccount);
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			UserAccount.class.getName(), userAccount);
 
 		Assert.assertEquals(
 			extendedProperties.toString(), 1, extendedProperties.size());

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 40.2.1
+Bundle-Version: 41.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/EntityExtensionHandler.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/EntityExtensionHandler.java
@@ -33,7 +33,7 @@ public class EntityExtensionHandler {
 	}
 
 	public Map<String, Serializable> getExtendedProperties(
-			long companyId, Object entity)
+			long companyId, long userId, Object entity)
 		throws Exception {
 
 		Map<String, Serializable> extendedProperties = new HashMap<>();
@@ -41,7 +41,7 @@ public class EntityExtensionHandler {
 		for (ExtensionProvider extensionProvider : _extensionProviders) {
 			Map<String, Serializable> extensionProviderExtendedProperties =
 				extensionProvider.getExtendedProperties(
-					companyId, _className, entity);
+					companyId, userId, _className, entity);
 
 			if (extensionProviderExtendedProperties != null) {
 				extendedProperties.putAll(extensionProviderExtendedProperties);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/ExtensionProvider.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/ExtensionProvider.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public interface ExtensionProvider {
 
 	public Map<String, Serializable> getExtendedProperties(
-			long companyId, String className, Object entity)
+			long companyId, long userId, String className, Object entity)
 		throws Exception;
 
 	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 5.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.vulcan.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.jaxrs.extension.ExtendedEntity;
 
@@ -53,7 +54,7 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 				ExtendedEntity.extend(
 					writerInterceptorContext.getEntity(),
 					entityExtensionHandler.getExtendedProperties(
-						_company.getCompanyId(),
+						_company.getCompanyId(), _user.getUserId(),
 						writerInterceptorContext.getEntity()),
 					entityExtensionHandler.getFilteredPropertyNames(
 						_company.getCompanyId(),
@@ -89,5 +90,8 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 
 	@Context
 	private Providers _providers;
+
+	@Context
+	private User _user;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptor.java
@@ -8,6 +8,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.jaxrs.extension.ExtendedEntity;
@@ -78,7 +79,7 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 					ExtendedEntity.extend(
 						item,
 						entityExtensionHandler.getExtendedProperties(
-							_company.getCompanyId(), item),
+							_company.getCompanyId(), _user.getUserId(), item),
 						entityExtensionHandler.getFilteredPropertyNames(
 							_company.getCompanyId(), item)));
 			}
@@ -125,5 +126,8 @@ public class PageEntityExtensionWriterInterceptor implements WriterInterceptor {
 
 	@Context
 	private Providers _providers;
+
+	@Context
+	private User _user;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -60,7 +60,8 @@ public class EntityExtensionHandlerTest {
 
 		Mockito.when(
 			_mockedExtensionProvider1.getExtendedProperties(
-				Mockito.anyLong(), Mockito.anyString(), Mockito.any())
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(),
+				Mockito.any())
 		).thenReturn(
 			testMap1
 		);
@@ -70,26 +71,28 @@ public class EntityExtensionHandlerTest {
 
 		Mockito.when(
 			_mockedExtensionProvider2.getExtendedProperties(
-				Mockito.anyLong(), Mockito.anyString(), Mockito.any())
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString(),
+				Mockito.any())
 		).thenReturn(
 			testMap2
 		);
 
 		Map<String, Serializable> extendedProperties =
-			_entityExtensionHandler.getExtendedProperties(_COMPANY_ID, _OBJECT);
+			_entityExtensionHandler.getExtendedProperties(
+				_COMPANY_ID, _USER_ID, _OBJECT);
 
 		Mockito.verify(
 			_mockedExtensionProvider1
 		).getExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_CLASS_NAME),
-			Mockito.eq(_OBJECT)
+			Mockito.eq(_COMPANY_ID), Mockito.eq(_USER_ID),
+			Mockito.eq(_CLASS_NAME), Mockito.eq(_OBJECT)
 		);
 
 		Mockito.verify(
 			_mockedExtensionProvider2
 		).getExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_CLASS_NAME),
-			Mockito.eq(_OBJECT)
+			Mockito.eq(_COMPANY_ID), Mockito.eq(_USER_ID),
+			Mockito.eq(_CLASS_NAME), Mockito.eq(_OBJECT)
 		);
 
 		Assert.assertEquals(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -45,6 +46,8 @@ public class EntityExtensionWriterInterceptorTest {
 			_entityExtensionWriterInterceptor, "_company", _company);
 		ReflectionTestUtil.setFieldValue(
 			_entityExtensionWriterInterceptor, "_providers", _providers);
+		ReflectionTestUtil.setFieldValue(
+			_entityExtensionWriterInterceptor, "_user", _user);
 	}
 
 	@Test
@@ -74,6 +77,12 @@ public class EntityExtensionWriterInterceptorTest {
 		);
 
 		Mockito.when(
+			_user.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		Mockito.when(
 			_writerInterceptorContext.getEntity()
 		).thenReturn(
 			_TEST_ENTITY
@@ -97,7 +106,8 @@ public class EntityExtensionWriterInterceptorTest {
 		Mockito.verify(
 			_entityExtensionHandler
 		).getExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_TEST_ENTITY)
+			Mockito.eq(_COMPANY_ID), Mockito.eq(_USER_ID),
+			Mockito.eq(_TEST_ENTITY)
 		);
 
 		Mockito.verify(
@@ -181,6 +191,12 @@ public class EntityExtensionWriterInterceptorTest {
 		);
 
 		Mockito.when(
+			_user.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		Mockito.when(
 			_providers.getContextResolver(
 				Mockito.eq(EntityExtensionHandler.class),
 				Mockito.any(MediaType.class))
@@ -211,7 +227,8 @@ public class EntityExtensionWriterInterceptorTest {
 		Mockito.verify(
 			_entityExtensionHandler
 		).getExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_TEST_ENTITY)
+			Mockito.eq(_COMPANY_ID), Mockito.eq(_USER_ID),
+			Mockito.eq(_TEST_ENTITY)
 		);
 
 		Mockito.verify(
@@ -254,6 +271,8 @@ public class EntityExtensionWriterInterceptorTest {
 
 	private static final TestEntity _TEST_ENTITY = new TestEntity();
 
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
 	private final Company _company = Mockito.mock(Company.class);
 	private final EntityExtensionHandler _entityExtensionHandler = Mockito.mock(
 		EntityExtensionHandler.class);
@@ -264,6 +283,7 @@ public class EntityExtensionWriterInterceptorTest {
 		_entityExtensionWriterInterceptor =
 			new EntityExtensionWriterInterceptor();
 	private final Providers _providers = Mockito.mock(Providers.class);
+	private final User _user = Mockito.mock(User.class);
 	private final WriterInterceptorContext _writerInterceptorContext =
 		Mockito.mock(WriterInterceptorContext.class);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
@@ -6,7 +6,9 @@
 package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.EntityExtensionHandlerContextResolver;
@@ -54,6 +56,8 @@ public class PageEntityExtensionWriterInterceptorTest {
 			_pageEntityExtensionWriterInterceptor, "_company", _company);
 		ReflectionTestUtil.setFieldValue(
 			_pageEntityExtensionWriterInterceptor, "_providers", _providers);
+		ReflectionTestUtil.setFieldValue(
+			_pageEntityExtensionWriterInterceptor, "_user", _user);
 	}
 
 	@Test
@@ -72,8 +76,14 @@ public class PageEntityExtensionWriterInterceptorTest {
 		);
 
 		Mockito.when(
+			_user.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		Mockito.when(
 			_entityExtensionHandler.getExtendedProperties(
-				Mockito.anyLong(), Mockito.any())
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.any())
 		).thenReturn(
 			extendedProperties
 		);
@@ -123,7 +133,8 @@ public class PageEntityExtensionWriterInterceptorTest {
 		Mockito.verify(
 			_entityExtensionHandler
 		).getExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_TEST_ENTITY)
+			Mockito.eq(_COMPANY_ID), Mockito.eq(_USER_ID),
+			Mockito.eq(_TEST_ENTITY)
 		);
 
 		Mockito.verify(
@@ -266,6 +277,8 @@ public class PageEntityExtensionWriterInterceptorTest {
 
 	private static final TestEntity _TEST_ENTITY = new TestEntity();
 
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
 	private final Company _company = Mockito.mock(Company.class);
 	private final EntityExtensionHandler _entityExtensionHandler = Mockito.mock(
 		EntityExtensionHandler.class);
@@ -275,6 +288,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 	private PageEntityExtensionWriterInterceptor
 		_pageEntityExtensionWriterInterceptor;
 	private final Providers _providers = Mockito.mock(Providers.class);
+	private final User _user = Mockito.mock(User.class);
 	private final WriterInterceptorContext _writerInterceptorContext =
 		Mockito.mock(WriterInterceptorContext.class);
 

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
@@ -223,7 +223,7 @@ public class EntityExtensionTest {
 
 		@Override
 		public Map<String, Serializable> getExtendedProperties(
-			long companyId, String className, Object entity) {
+			long companyId, long userId, String className, Object entity) {
 
 			return HashMapBuilder.<String, Serializable>put(
 				_propertyName, RandomTestUtil.randomString()

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/ExtensionProviderRegistryTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/ExtensionProviderRegistryTest.java
@@ -89,7 +89,7 @@ public class ExtensionProviderRegistryTest {
 
 		@Override
 		public Map<String, Serializable> getExtendedProperties(
-			long companyId, String className, Object entity) {
+			long companyId, long userId, String className, Object entity) {
 
 			return null;
 		}


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/COMMERCE-12980

Related thread: https://liferay.slack.com/archives/C034JL018TV/p1701360998379129