### PR TITLE
LPS-203976 Do not reload page after moving an object definition

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ModalMoveObjectDefinition.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ModalMoveObjectDefinition.tsx
@@ -103,9 +103,7 @@ export function ModalMoveObjectDefinition({
 				type: 'success',
 			});
 
-			if (onAfterMoveObjectDefinition) {
-				onAfterMoveObjectDefinition();
-			}
+			onAfterMoveObjectDefinition();
 		}
 		catch (error) {
 			setError((error as Error).message);
@@ -114,16 +112,18 @@ export function ModalMoveObjectDefinition({
 
 	useEffect(() => {
 		const makeFetch = async () => {
-			const objectDefinitionResponse = await API.getObjectDefinitionById(
-				objectDefinitionId
-			);
+			if (objectDefinitionId) {
+				const objectDefinitionResponse = await API.getObjectDefinitionById(
+					objectDefinitionId
+				);
 
-			const objectFolderResponse = await API.getObjectFolderByExternalReferenceCode(
-				objectDefinitionResponse.objectFolderExternalReferenceCode
-			);
+				const objectFolderResponse = await API.getObjectFolderByExternalReferenceCode(
+					objectDefinitionResponse.objectFolderExternalReferenceCode
+				);
 
-			setSelectedObjectFolder(objectFolderResponse);
-			setObjectDefinition(objectDefinitionResponse);
+				setSelectedObjectFolder(objectFolderResponse);
+				setObjectDefinition(objectDefinitionResponse);
+			}
 		};
 
 		makeFetch();

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.tsx
@@ -653,9 +653,7 @@ export default function ViewObjectDefinitions({
 					}}
 					objectDefinitionId={moveObjectDefinition?.id as number}
 					objectFolders={objectFoldersRequestInfo.items}
-					onAfterMoveObjectDefinition={() =>
-						setTimeout(() => window.location.reload(), 1000)
-					}
+					onAfterMoveObjectDefinition={() => setReloadFDS(true)}
 					setMoveObjectDefinition={setMoveObjectDefinition}
 				/>
 			)}


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-203976

obs: blocked because it can only be forwarded after https://github.com/liferay-objects/liferay-portal/pull/3043