### PR TITLE
LPS-197482 Grouping Multiple Edges between Objects in Dropdowns

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Diagram/Diagram.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Diagram/Diagram.tsx
@@ -73,13 +73,13 @@ function DiagramBuilder() {
 		};
 	}>();
 
-	const edges: Edge<ObjectRelationshipEdgeData>[] = [];
+	const edges: Edge<ObjectRelationshipEdgeData[]>[] = [];
 
 	const nodes: Node<ObjectDefinitionNodeData>[] = [];
 
 	elements.forEach((element) => {
 		if (isEdge(element)) {
-			edges.push(element as Edge<ObjectRelationshipEdgeData>);
+			edges.push(element as Edge<ObjectRelationshipEdgeData[]>);
 		}
 		else {
 			nodes.push(element as Node<ObjectDefinitionNodeData>);

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.tsx
@@ -49,8 +49,6 @@ export default function DefaultObjectRelationshipEdge({
 		markerStartId,
 		objectRelationshipId,
 		selected,
-		sourceY: currentSourceY,
-		targetY: currentTargetY,
 	} = data!;
 
 	const [_, dispatch] = useObjectFolderContext();
@@ -111,36 +109,31 @@ export default function DefaultObjectRelationshipEdge({
 		targetPos,
 		targetX,
 		targetY,
-	} = getEdgeParams(
-		sourceNode,
-		currentSourceY as number,
-		targetNode,
-		currentTargetY as number
-	);
+	} = getEdgeParams(sourceNode, targetNode);
 
 	const edgePath = getSmoothStepPath({
 		sourcePosition: sourcePos,
 		sourceX,
-		sourceY: sourceY + currentSourceY,
+		sourceY,
 		targetPosition: targetPos,
 		targetX,
-		targetY: targetY + currentTargetY,
+		targetY,
 	});
 
 	const reverseEdgePath = getSmoothStepPath({
 		sourcePosition: targetPos,
 		sourceX: targetX,
-		sourceY: targetY + currentTargetY,
+		sourceY: targetY,
 		targetPosition: sourcePos,
 		targetX: sourceX,
-		targetY: sourceY + currentSourceY,
+		targetY: sourceY,
 	});
 
 	const [edgeCenterX, edgeCenterY] = getEdgeCenter({
 		sourceX,
-		sourceY: sourceY + currentSourceY,
+		sourceY,
 		targetX,
-		targetY: targetY + currentTargetY,
+		targetY,
 	});
 
 	return (

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.tsx
@@ -3,104 +3,36 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useMemo} from 'react';
 import {
 	EdgeProps,
-	EdgeText,
+	Node,
 	getEdgeCenter,
 	getSmoothStepPath,
 	useStoreState,
 } from 'react-flow-renderer';
 
-import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
-import {TYPES} from '../ModelBuilderContext/typesEnum';
 import {ObjectRelationshipEdgeData} from '../types';
 import {getEdgeParams} from '../utils';
-import ManyMarker from './ManyMarker';
-import OneMarker from './OneMarker';
-
-const DEFAULT_COLOR = '#80ACFF';
-const HIGHLIGHT_COLOR = '#0B5FFF';
-
-export function getInitialObjectRelationshipEdgeStyle(edgeSelected: boolean) {
-	return {
-		stroke: edgeSelected ? HIGHLIGHT_COLOR : DEFAULT_COLOR,
-		strokeWidth: '2px',
-	};
-}
-
-export function getInitialLabelBgStyle(edgeSelected: boolean) {
-	return {
-		fill: edgeSelected ? HIGHLIGHT_COLOR : DEFAULT_COLOR,
-		height: '24px',
-	};
-}
+import ObjectRelationshipEdge from './ObjectRelationshipEdge';
 
 export default function DefaultObjectRelationshipEdge({
 	data,
-	id,
+	id: edgeId,
 	source,
-	style = {},
 	target,
-}: EdgeProps<ObjectRelationshipEdgeData>) {
-	const {
-		label,
-		markerEndId,
-		markerStartId,
-		objectRelationshipId,
-		selected,
-	} = data!;
-
-	const [_, dispatch] = useObjectFolderContext();
-	const [
-		objectRelationshipEdgeStyle,
-		setObjectRelationshipEdgeStyle,
-	] = useState({
-		...style,
-		...getInitialObjectRelationshipEdgeStyle(selected),
-	});
-	const [labelBgStyle, setLabelBgStyle] = useState(
-		getInitialLabelBgStyle(selected)
-	);
+}: EdgeProps<ObjectRelationshipEdgeData[]>) {
 	const {nodes} = useStoreState((state) => state);
 
 	const sourceNode = useMemo(() => nodes.find((node) => node.id === source), [
 		source,
 		nodes,
-	]);
+	]) as Node<ObjectDefinitionNodeData>;
+
 	const targetNode = useMemo(() => nodes.find((node) => node.id === target), [
 		target,
 		nodes,
-	]);
-
-	useEffect(() => {
-		if (selected) {
-			setObjectRelationshipEdgeStyle((style) => {
-				return {...style, stroke: HIGHLIGHT_COLOR};
-			});
-			setLabelBgStyle((style) => {
-				return {
-					...style,
-					fill: HIGHLIGHT_COLOR,
-				};
-			});
-		}
-		else {
-			setObjectRelationshipEdgeStyle((style) => {
-				return {...style, stroke: DEFAULT_COLOR};
-			});
-			setLabelBgStyle((style) => {
-				return {
-					...style,
-					fill: DEFAULT_COLOR,
-				};
-			});
-		}
-	}, [selected]);
-
-	if (!sourceNode || !targetNode) {
-		return null;
-	}
+	]) as Node<ObjectDefinitionNodeData>;
 
 	const {
 		sourcePos,
@@ -137,49 +69,17 @@ export default function DefaultObjectRelationshipEdge({
 	});
 
 	return (
-		<g className="react-flow__connection">
-			<OneMarker />
-
-			<ManyMarker />
-
-			<path
-				className="react-flow__edge-path"
-				d={edgePath}
-				id={id}
-				markerEnd={`url(#${markerEndId})`}
-				style={objectRelationshipEdgeStyle}
-			/>
-
-			<path
-				className="react-flow__edge-path"
-				d={reverseEdgePath}
-				id={id + 'reverse'}
-				markerEnd={`url(#${markerStartId})`}
-				style={objectRelationshipEdgeStyle}
-			/>
-
-			<EdgeText
-				label={label}
-				labelBgBorderRadius={4}
-				labelBgPadding={[8, 5]}
-				labelBgStyle={labelBgStyle}
-				labelShowBg
-				labelStyle={{
-					fill: '#FFF',
-					fontSize: '12px',
-					fontWeight: 600,
-				}}
-				onClick={() => {
-					dispatch({
-						payload: {
-							selectedObjectRelationshipId: objectRelationshipId,
-						},
-						type: TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
-					});
-				}}
-				x={edgeCenterX}
-				y={edgeCenterY}
-			/>
-		</g>
+		<ObjectRelationshipEdge
+			data={data}
+			edgeCenterX={edgeCenterX}
+			edgeCenterY={edgeCenterY}
+			edgePath={edgePath}
+			id={edgeId}
+			reverseEdgePath={reverseEdgePath}
+			sourceX={sourceX}
+			sourceY={sourceY}
+			targetX={targetX}
+			targetY={targetY}
+		/>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ManyMarker.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ManyMarker.tsx
@@ -7,11 +7,15 @@ import React from 'react';
 
 export const manyMarkerId = 'manyMarker';
 
-export default function ManyMarker() {
+interface ManyMarkerProps {
+	objectRelationshipId: string;
+}
+
+export default function ManyMarker({objectRelationshipId}: ManyMarkerProps) {
 	return (
 		<defs>
 			<marker
-				id={manyMarkerId}
+				id={`${manyMarkerId}#${objectRelationshipId}`}
 				markerHeight="10"
 				markerWidth="22"
 				orient="auto"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipEdge.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipEdge.tsx
@@ -1,0 +1,213 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import React, {useEffect, useRef, useState} from 'react';
+import {EdgeProps, EdgeText} from 'react-flow-renderer';
+
+import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
+import {TYPES} from '../ModelBuilderContext/typesEnum';
+import {ObjectRelationshipEdgeData} from '../types';
+import ManyMarker from './ManyMarker';
+import OneMarker from './OneMarker';
+
+import './Edge.scss';
+
+const labelStyle = {
+	cursor: 'pointer',
+	fill: '#FFF',
+	fontSize: '12px',
+	fontWeight: 600,
+};
+
+const DEFAULT_COLOR = '#80ACFF';
+const HIGHLIGHT_COLOR = '#0B5FFF';
+
+function getInitialObjectRelationshipEdgeStyle(edgeSelected: boolean) {
+	return {
+		stroke: edgeSelected ? HIGHLIGHT_COLOR : DEFAULT_COLOR,
+		strokeWidth: '2px',
+	};
+}
+
+function getInitialLabelBgStyle(edgeSelected: boolean) {
+	return {
+		fill: edgeSelected ? HIGHLIGHT_COLOR : DEFAULT_COLOR,
+		height: '24px',
+	};
+}
+
+interface ObjectRelationshipEdge
+	extends Partial<EdgeProps<ObjectRelationshipEdgeData[]>> {
+	edgeCenterX: number;
+	edgeCenterY: number;
+	edgePath: string;
+	reverseEdgePath?: string;
+}
+
+export default function ObjectRelationshipEdge({
+	edgePath,
+	edgeCenterX,
+	edgeCenterY,
+	data,
+	id: edgeId,
+	reverseEdgePath,
+	style = {},
+}: ObjectRelationshipEdge) {
+	const [{id, label, markerEndId, markerStartId, selected}] = data!;
+
+	const [_, dispatch] = useObjectFolderContext();
+	const [activePopover, setActivePopover] = useState(false);
+	const [
+		objectRelationshipEdgeStyle,
+		setObjectRelationshipEdgeStyle,
+	] = useState({
+		...style,
+		...getInitialObjectRelationshipEdgeStyle(selected),
+	});
+	const [labelBgStyle, setLabelBgStyle] = useState(
+		getInitialLabelBgStyle(selected)
+	);
+
+	const hasManyObjectRelationships = data && data.length > 1;
+
+	const menuElementRef = useRef(null);
+	const triggerElementRef = useRef<HTMLElement | null>(null);
+
+	useEffect(() => {
+		if (activePopover || selected) {
+			setObjectRelationshipEdgeStyle((style) => {
+				return {...style, stroke: HIGHLIGHT_COLOR};
+			});
+			setLabelBgStyle((style) => {
+				return {
+					...style,
+					fill: HIGHLIGHT_COLOR,
+				};
+			});
+		}
+		else {
+			setObjectRelationshipEdgeStyle((style) => {
+				return {...style, stroke: DEFAULT_COLOR};
+			});
+			setLabelBgStyle((style) => {
+				return {
+					...style,
+					fill: DEFAULT_COLOR,
+				};
+			});
+		}
+	}, [activePopover, selected]);
+
+	return hasManyObjectRelationships ? (
+		<g className="react-flow__connection">
+			<path
+				className="react-flow__edge-path"
+				d={edgePath}
+				id={edgeId}
+				style={objectRelationshipEdgeStyle}
+			/>
+
+			<EdgeText
+				label={data.length}
+				labelBgBorderRadius={4}
+				labelBgPadding={[8, 5]}
+				labelBgStyle={labelBgStyle}
+				labelShowBg
+				labelStyle={labelStyle}
+				onClick={(event) => {
+					triggerElementRef.current = event.target as HTMLElement;
+
+					setActivePopover(!activePopover);
+				}}
+				x={edgeCenterX}
+				y={edgeCenterY}
+			/>
+
+			<ClayDropDown.Menu
+				active={activePopover}
+				alignElementRef={triggerElementRef}
+				onActiveChange={() => {
+					setActivePopover(!activePopover);
+				}}
+				ref={menuElementRef}
+			>
+				<ClayDropDown.ItemList>
+					{data.map((objectRelationshipEdgeData, index) => (
+						<ClayDropDown.Item
+							key={index}
+							onClick={() => {
+								dispatch({
+									payload: {
+										selectedObjectRelationshipId:
+											objectRelationshipEdgeData.id,
+									},
+									type:
+										TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
+								});
+							}}
+						>
+							<div className="lfr-objects__model-builder-self-edge-dropdown-item">
+								<div>
+									<div>
+										{objectRelationshipEdgeData.label}
+									</div>
+
+									<span className="text-small">
+										{objectRelationshipEdgeData.type}
+									</span>
+								</div>
+
+								<ClayIcon symbol="angle-right" />
+							</div>
+						</ClayDropDown.Item>
+					))}
+				</ClayDropDown.ItemList>
+			</ClayDropDown.Menu>
+		</g>
+	) : (
+		<g className="react-flow__connection">
+			<OneMarker objectRelationshipId={id.toString()} />
+
+			<ManyMarker objectRelationshipId={id.toString()} />
+
+			<path
+				className="react-flow__edge-path"
+				d={edgePath}
+				id={edgeId}
+				markerEnd={`url(#${markerEndId})`}
+				style={objectRelationshipEdgeStyle}
+			/>
+
+			<path
+				className="react-flow__edge-path"
+				d={reverseEdgePath}
+				id={edgeId + 'reverse'}
+				markerEnd={`url(#${markerStartId})`}
+				style={objectRelationshipEdgeStyle}
+			/>
+
+			<EdgeText
+				label={label}
+				labelBgBorderRadius={4}
+				labelBgPadding={[8, 5]}
+				labelBgStyle={labelBgStyle}
+				labelShowBg
+				labelStyle={labelStyle}
+				onClick={() => {
+					dispatch({
+						payload: {
+							selectedObjectRelationshipId: id,
+						},
+						type: TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
+					});
+				}}
+				x={edgeCenterX}
+				y={edgeCenterY}
+			/>
+		</g>
+	);
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipMap.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipMap.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export class ObjectRelationshipMap extends Map<string, ObjectRelationship[]> {
+	private _delete(key: string) {
+		return this.delete(key);
+	}
+
+	private _getValue(key: string): ObjectRelationship[] | undefined {
+		return this.get(key);
+	}
+
+	private _setValue(key: string, objectRelationship: ObjectRelationship[]) {
+		return this.set(key, objectRelationship);
+	}
+
+	public deleteByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	) {
+		const key = this.getKey(
+			objectDefinitionExternalReferenceCode1,
+			objectDefinitionExternalReferenceCode2
+		);
+
+		return this._delete(key);
+	}
+
+	public getKey(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	): string {
+		return `${objectDefinitionExternalReferenceCode1}#${objectDefinitionExternalReferenceCode2}`;
+	}
+
+	public getValueByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	): ObjectRelationship[] | undefined {
+		const key = this.getKey(
+			objectDefinitionExternalReferenceCode1,
+			objectDefinitionExternalReferenceCode2
+		);
+
+		return this._getValue(key);
+	}
+
+	public getValueByKey(key: string): ObjectRelationship[] | undefined {
+		return this._getValue(key);
+	}
+
+	public setValue(objectRelationship: ObjectRelationship) {
+		const key = this.getKey(
+			objectRelationship.objectDefinitionExternalReferenceCode1,
+			objectRelationship.objectDefinitionExternalReferenceCode2
+		);
+		const value = this.getValueByKey(key);
+
+		if (value) {
+			return this._setValue(key, [...value, objectRelationship]);
+		}
+		else {
+			return this._setValue(key, [objectRelationship]);
+		}
+	}
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/OneMarker.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/OneMarker.tsx
@@ -7,11 +7,15 @@ import React from 'react';
 
 export const oneMarkerId = 'oneMarker';
 
-export default function OneMarker() {
+interface OneMarkerProps {
+	objectRelationshipId: string;
+}
+
+export default function OneMarker({objectRelationshipId}: OneMarkerProps) {
 	return (
 		<defs>
 			<marker
-				id={oneMarkerId}
+				id={`${oneMarkerId}#${objectRelationshipId}`}
 				markerHeight="10"
 				markerWidth="22"
 				orient="auto"

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/SelfObjectRelationshipEdge.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/SelfObjectRelationshipEdge.tsx
@@ -3,230 +3,58 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayDropDown from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
-import {getLocalizableLabel} from '@liferay/object-js-components-web';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
-import {
-	EdgeProps,
-	EdgeText,
-	getEdgeCenter,
-	useStoreState,
-} from 'react-flow-renderer';
+import React from 'react';
+import {EdgeProps, getEdgeCenter} from 'react-flow-renderer';
 
-import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
-import {TYPES} from '../ModelBuilderContext/typesEnum';
 import {ObjectRelationshipEdgeData} from '../types';
-import {
-	getInitialLabelBgStyle,
-	getInitialObjectRelationshipEdgeStyle,
-} from './DefaultObjectRelationshipEdge';
-
-import './Edge.scss';
-
-const labelStyle = {
-	cursor: 'pointer',
-	fill: '#FFF',
-	fontSize: '12px',
-	fontWeight: 600,
-};
+import ObjectRelationshipEdge from './ObjectRelationshipEdge';
 
 export default function SelfObjectRelationshipEdge({
 	data,
-	id,
-	source,
+	id: edgeId,
 	sourceX,
 	sourceY,
-	style = {},
 	targetX,
 	targetY,
-}: EdgeProps<ObjectRelationshipEdgeData>) {
-	const {
-		defaultLanguageId,
-		label,
-		markerEndId,
-		markerStartId,
-		objectRelationshipId,
-		selected,
-		selfObjectRelationships,
-	} = data!;
-
-	const [_, dispatch] = useObjectFolderContext();
-	const [activePopover, setActivePopover] = useState(false);
-	const [
-		objectRelationshipEdgeStyle,
-		setObjectRelationshipEdgeStyle,
-	] = useState({
-		...style,
-		...getInitialObjectRelationshipEdgeStyle(selected),
-	});
-	const [labelBgStyle, setLabelBgStyle] = useState(
-		getInitialLabelBgStyle(selected)
-	);
-	const {nodes} = useStoreState((state) => state);
-
-	const sourceTargetNode = useMemo(
-		() => nodes.find((node) => node.id === source),
-		[source, nodes]
-	);
-
-	const menuElementRef = useRef(null);
-	const triggerElementRef = useRef<HTMLElement | null>(null);
-
-	useEffect(() => {
-		if (activePopover || selected) {
-			setObjectRelationshipEdgeStyle((style) => {
-				return {...style, stroke: '#0B5FFF'};
-			});
-			setLabelBgStyle((style) => {
-				return {
-					...style,
-					fill: '#0B5FFF',
-				};
-			});
-		}
-		else {
-			setObjectRelationshipEdgeStyle((style) => {
-				return {...style, stroke: '#80ACFF'};
-			});
-			setLabelBgStyle((style) => {
-				return {
-					...style,
-					fill: '#80ACFF',
-				};
-			});
-		}
-	}, [activePopover, selected]);
-
-	if (!sourceTargetNode) {
-		return null;
-	}
-
-	const hasManySelfObjectRelationships =
-		selfObjectRelationships && selfObjectRelationships.length > 1;
+}: EdgeProps<ObjectRelationshipEdgeData[]>) {
+	const hasManyObjectRelationships = data && data.length > 1;
 
 	const radiusX = (sourceX - targetX) * 0.6;
 	const radiusY = 150;
 
 	const edgePath = `M ${
-		sourceX - (hasManySelfObjectRelationships ? 5 : 20)
+		sourceX - (hasManyObjectRelationships ? 11 : 17)
 	} ${sourceY} A ${radiusX} ${radiusY} 0 1 0 ${
-		targetX + (hasManySelfObjectRelationships ? 2 : 8)
+		targetX + (hasManyObjectRelationships ? 5 : 11)
 	} ${targetY}`;
+
+	const reverseEdgePath = `M ${
+		targetX + (hasManyObjectRelationships ? 5 : 11)
+	} ${targetY} A ${radiusX} ${radiusY} 0 1 1 ${
+		sourceX - (hasManyObjectRelationships ? 11 : 17)
+	} ${sourceY}`;
 
 	const [edgeCenterX, edgeCenterY] = getEdgeCenter({
 		sourceX,
-		sourceY: sourceY - (hasManySelfObjectRelationships ? 0 : 45),
+		sourceY: sourceY - (hasManyObjectRelationships ? 0 : 40),
 		targetX,
 		targetY,
 	});
 
+	const INCREMENT_EDGE_CENTER_Y = 230;
+
 	return (
-		<g className="react-flow__connection">
-			<path
-				className="react-flow__edge-path"
-				d={edgePath}
-				id={id}
-				markerEnd={
-					!hasManySelfObjectRelationships
-						? `url(#${markerEndId})`
-						: ''
-				}
-				markerStart={
-					!hasManySelfObjectRelationships
-						? `url(#${markerStartId})`
-						: ''
-				}
-				style={objectRelationshipEdgeStyle}
-			/>
-
-			{hasManySelfObjectRelationships ? (
-				<>
-					<EdgeText
-						label={label}
-						labelBgBorderRadius={4}
-						labelBgPadding={[8, 5]}
-						labelBgStyle={labelBgStyle}
-						labelShowBg
-						labelStyle={labelStyle}
-						onClick={(event) => {
-							triggerElementRef.current = event.target as HTMLElement;
-
-							setActivePopover(!activePopover);
-						}}
-						x={edgeCenterX}
-						y={edgeCenterY + 230}
-					/>
-
-					<ClayDropDown.Menu
-						active={activePopover}
-						alignElementRef={triggerElementRef}
-						onActiveChange={() => {
-							setActivePopover(!activePopover);
-						}}
-						ref={menuElementRef}
-					>
-						<ClayDropDown.ItemList>
-							{selfObjectRelationships.map(
-								(selfObjectRelationship, index) => (
-									<ClayDropDown.Item
-										key={index}
-										onClick={() => {
-											dispatch({
-												payload: {
-													selectedObjectRelationshipId:
-														selfObjectRelationship.id,
-												},
-												type:
-													TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
-											});
-										}}
-									>
-										<div className="lfr-objects__model-builder-self-edge-dropdown-item">
-											<div>
-												<div>
-													{getLocalizableLabel(
-														defaultLanguageId!,
-														selfObjectRelationship.label,
-														selfObjectRelationship.name
-													)}
-												</div>
-
-												<span className="text-small">
-													{
-														selfObjectRelationship.type
-													}
-												</span>
-											</div>
-
-											<ClayIcon symbol="angle-right" />
-										</div>
-									</ClayDropDown.Item>
-								)
-							)}
-						</ClayDropDown.ItemList>
-					</ClayDropDown.Menu>
-				</>
-			) : (
-				<EdgeText
-					label={label}
-					labelBgBorderRadius={4}
-					labelBgPadding={[8, 5]}
-					labelBgStyle={labelBgStyle}
-					labelShowBg
-					labelStyle={labelStyle}
-					onClick={() => {
-						dispatch({
-							payload: {
-								selectedObjectRelationshipId: objectRelationshipId,
-							},
-							type: TYPES.SET_SELECTED_OBJECT_RELATIONSHIP_EDGE,
-						});
-					}}
-					x={edgeCenterX}
-					y={edgeCenterY + 230}
-				/>
-			)}
-		</g>
+		<ObjectRelationshipEdge
+			data={data}
+			edgeCenterX={edgeCenterX}
+			edgeCenterY={edgeCenterY + INCREMENT_EDGE_CENTER_Y}
+			edgePath={edgePath}
+			id={edgeId}
+			reverseEdgePath={reverseEdgePath}
+			sourceX={sourceX}
+			sourceY={sourceY}
+			targetX={targetX}
+			targetY={targetY}
+		/>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/objectRelationshipEdgeFactory.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/objectRelationshipEdgeFactory.ts
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getLocalizableLabel} from '@liferay/object-js-components-web';
+
+import {ObjectRelationshipEdgeData} from '../types';
+import {manyMarkerId} from './ManyMarker';
+import {ObjectRelationshipMap} from './ObjectRelationshipMap';
+import {oneMarkerId} from './OneMarker';
+
+interface GetObjectRelationships {
+	objectDefinitionExternalReferenceCode1: string;
+	objectDefinitionExternalReferenceCode2: string;
+	objectRelationshipMap: ObjectRelationshipMap;
+}
+
+function getObjectRelationships({
+	objectDefinitionExternalReferenceCode1,
+	objectDefinitionExternalReferenceCode2,
+	objectRelationshipMap,
+}: GetObjectRelationships) {
+	const objectRelationships = objectRelationshipMap.getValueByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1,
+		objectDefinitionExternalReferenceCode2
+	);
+
+	if (!objectRelationships) {
+		return [];
+	}
+
+	objectRelationshipMap.deleteByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1,
+		objectDefinitionExternalReferenceCode2
+	);
+
+	return objectRelationships;
+}
+
+interface ObjectRelationshipEdgeFactory {
+	objectDefinition: ObjectDefinitionNodeData;
+	objectRelationship: ObjectRelationship;
+	objectRelationshipMap: ObjectRelationshipMap;
+	selectedObjectRelationshipId: number | undefined;
+}
+
+export function objectRelationshipEdgeFactory({
+	objectDefinition,
+	objectRelationship,
+	objectRelationshipMap,
+	selectedObjectRelationshipId,
+}: ObjectRelationshipEdgeFactory) {
+	const objectRelationships: ObjectRelationship[] = [];
+
+	const isSelfObjectRelationship =
+		objectRelationship.objectDefinitionExternalReferenceCode1 ===
+		objectRelationship.objectDefinitionExternalReferenceCode2;
+
+	objectRelationships.push(
+		...getObjectRelationships({
+			objectDefinitionExternalReferenceCode1:
+				objectRelationship.objectDefinitionExternalReferenceCode1,
+			objectDefinitionExternalReferenceCode2:
+				objectRelationship.objectDefinitionExternalReferenceCode2,
+			objectRelationshipMap,
+		})
+	);
+
+	objectRelationships.push(
+		...getObjectRelationships({
+			objectDefinitionExternalReferenceCode1:
+				objectRelationship.objectDefinitionExternalReferenceCode2,
+			objectDefinitionExternalReferenceCode2:
+				objectRelationship.objectDefinitionExternalReferenceCode1,
+			objectRelationshipMap,
+		})
+	);
+
+	if (objectRelationships.length !== 0) {
+		return {
+			data: objectRelationships.map((objectRelationship) => {
+				return {
+					defaultLanguageId: objectDefinition.defaultLanguageId,
+					id: objectRelationship.id,
+					label: getLocalizableLabel(
+						objectDefinition.defaultLanguageId,
+						objectRelationship.label,
+						objectRelationship.name
+					),
+					markerEndId: `${manyMarkerId}#${objectRelationship.id}`,
+					markerStartId:
+						objectRelationship.type === 'manyToMany'
+							? `${manyMarkerId}#${objectRelationship.id}`
+							: `${oneMarkerId}#${objectRelationship.id}`,
+					name: objectRelationship.name,
+					selected:
+						selectedObjectRelationshipId === objectRelationship.id,
+					type: objectRelationship.type,
+				};
+			}) as ObjectRelationshipEdgeData[],
+			id: `reactflow__edge-object-relationship-parent-${objectRelationship.objectDefinitionId1}-child-${objectRelationship.objectDefinitionId2}`,
+			source: `${objectDefinition.id}`,
+			sourceHandle: isSelfObjectRelationship ? 'fixedLeftHandle' : null,
+			target: `${objectRelationship.objectDefinitionId2}`,
+			targetHandle: isSelfObjectRelationship ? 'fixedRightHandle' : null,
+			type: isSelfObjectRelationship
+				? 'selfObjectRelationshipEdge'
+				: 'defaultObjectRelationshipEdge',
+		};
+	}
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolder.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolder.tsx
@@ -84,7 +84,7 @@ export default function EditObjectFolder({
 	] = useState(false);
 
 	const edges = elements.filter((element) => isEdge(element)) as Edge<
-		ObjectRelationshipEdgeData
+		ObjectRelationshipEdgeData[]
 	>[];
 
 	const nodes = elements.filter((element) => isNode(element)) as Node<

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.tsx
@@ -31,7 +31,7 @@ enum STATUS {
 interface ModalPublishObjectDefinitionsProps {
 	disableAutoClose: boolean;
 	dispatch: React.Dispatch<TAction>;
-	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData>;
+	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]>;
 	handleOnClose: () => void;
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderContext.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderContext.tsx
@@ -31,7 +31,7 @@ const ObjectFolderContext = createContext({} as ObjectFolderContextProps);
 const initialState = {
 	deletedObjectDefinition: {} as DeletedObjectDefinition,
 	elements: [] as Elements<
-		ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+		ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 	>,
 	isLoadingObjectFolder: false,
 	leftSidebarItems: [] as LeftSidebarItem[],

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
@@ -26,7 +26,6 @@ import {
 } from '../utils';
 import {
 	convertAllObjectFieldsToUnselected,
-	getNonOverlappingEdges,
 	objectFieldsCustomSort,
 } from './objectFolderReducerUtil';
 import {TYPES} from './typesEnum';
@@ -576,8 +575,6 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 													selectedObjectRelationshipId ===
 													objectRelationship.id,
 												selfObjectRelationships,
-												sourceY: 0,
-												targetY: 0,
 												type: objectRelationship.type,
 											},
 											id: `reactflow__edge-object-relationship-${objectRelationship.name}-parent-${objectRelationship.objectDefinitionId1}-child-${objectRelationship.objectDefinitionId2}`,
@@ -636,8 +633,6 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 
 				selectedObjectFolder.objectFolderItems = updatedObjectFolderItems;
 			}
-
-			const newObjectRelationshipEdges = getNonOverlappingEdges(allEdges);
 
 			let newModelBuilderState = {
 				...state,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducer.ts
@@ -8,8 +8,8 @@ import {Edge, Node, isEdge, isNode} from 'react-flow-renderer';
 
 import {defaultLanguageId} from '../../../utils/constants';
 import {getObjectDefinitionNodeActions} from '../../ViewObjectDefinitions/objectDefinitionUtil';
-import {manyMarkerId} from '../Edges/ManyMarker';
-import {oneMarkerId} from '../Edges/OneMarker';
+import {ObjectRelationshipMap} from '../Edges/ObjectRelationshipMap';
+import {objectRelationshipEdgeFactory} from '../Edges/objectRelationshipEdgeFactory';
 import {
 	LeftSidebarItem,
 	LeftSidebarObjectDefinitionItem,
@@ -166,6 +166,18 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			updatedObjectFolders.push(selectedObjectFolder);
 
 			const updatedElements = elements.map((element) => {
+				if (Array.isArray(element.data)) {
+					return {
+						...element,
+						data: element.data.map((objectRelationshipEdgeData) => {
+							return {
+								...objectRelationshipEdgeData,
+								selected: false,
+							};
+						}),
+					};
+				}
+
 				return {
 					...element,
 					data: {
@@ -199,7 +211,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			return {
 				...state,
 				elements: [...updatedElements, newObjectDefinitionNode] as Node<
-					ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+					ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 				>[],
 				leftSidebarItems: newLeftSidebarItems,
 				objectFolders: updatedObjectFolders,
@@ -307,13 +319,15 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			) as Node<ObjectDefinitionNodeData>[];
 
 			const updatedObjectRelationshipEdges = objectRelationshipEdges.map(
-				(objectRelationshipEdge: Edge<ObjectRelationshipEdgeData>) => {
+				(
+					objectRelationshipEdge: Edge<ObjectRelationshipEdgeData[]>
+				) => {
 					return {
 						...objectRelationshipEdge,
 						isHidden: !hiddenObjectFolderObjectDefinitionNodes,
 					};
 				}
-			) as Edge<ObjectRelationshipEdgeData>[];
+			) as Edge<ObjectRelationshipEdgeData[]>[];
 
 			const updatedLeftSidebarItems = leftSidebarItems.map(
 				(leftSidebarItem: LeftSidebarItem) => {
@@ -365,7 +379,9 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			let isObjectDefinitionNodeSelected = false;
 
 			const updatedObjectRelationshipEdges = objectRelationshipEdges.map(
-				(objectRelationshipEdge: Edge<ObjectRelationshipEdgeData>) => {
+				(
+					objectRelationshipEdge: Edge<ObjectRelationshipEdgeData[]>
+				) => {
 					if (
 						objectRelationshipEdge.source ===
 							objectDefinitionId.toString() ||
@@ -457,10 +473,24 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 				selectedObjectRelationshipId,
 			} = action.payload;
 			const {baseResourceURL, objectDefinitionPermissionsURL} = state;
+			const objectRelationshipMap = new ObjectRelationshipMap();
 
 			const newLeftSidebarItems = objectFolders.map((objectFolder) => {
 				const leftSidebarObjectDefinitionItems = objectFolder.objectDefinitions?.map(
 					(objectDefinition) => {
+						objectDefinition.objectRelationships.forEach(
+							(objectRelationship) => {
+								if (
+									!objectDefinition.linkedObjectDefinition &&
+									!objectRelationship.reverse
+								) {
+									objectRelationshipMap.setValue(
+										objectRelationship
+									);
+								}
+							}
+						);
+
 						const kebabOptions = getObjectDefinitionNodeActions({
 							baseResourceURL,
 							dispatch,
@@ -519,81 +549,34 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 
 			const updatedObjectFolderItems: ObjectFolderItem[] = [];
 
-			let newObjectDefinitionNodes: Node<ObjectDefinitionNodeData>[] = [];
-			const allEdges: Edge<ObjectRelationshipEdgeData>[] = [];
+			let objectDefinitionNodes: Node<ObjectDefinitionNodeData>[] = [];
+			const objectRelationshipEdges: Edge<
+				ObjectRelationshipEdgeData[]
+			>[] = [];
 
 			if (selectedObjectFolder) {
 				const positionColumn = {x: 0, y: 0};
 
-				newObjectDefinitionNodes = selectedObjectFolder.objectDefinitions!.map(
+				objectDefinitionNodes = selectedObjectFolder.objectDefinitions!.map(
 					(objectDefinition, index) => {
-						let selfObjectRelationships: ObjectRelationship[] = objectDefinition.objectRelationships.filter(
-							(objectRelationship) =>
-								objectRelationship.objectDefinitionName2 ===
-								objectDefinition.name
-						);
-
-						selfObjectRelationships = selfObjectRelationships.filter(
-							(selfObjectRelationship) =>
-								!selfObjectRelationship.reverse
-						);
-
-						const hasOneSelfObjectRelationship =
-							selfObjectRelationships?.length === 1;
-
-						if (objectDefinition.objectRelationships.length) {
-							objectDefinition.objectRelationships.forEach(
-								(objectRelationship) => {
-									if (!objectRelationship.reverse) {
-										const isSelfObjectRelationship =
-											objectDefinition.name ===
-											objectRelationship.objectDefinitionName2;
-
-										allEdges.push({
-											data: {
-												defaultLanguageId:
-													objectDefinition.defaultLanguageId,
-												label:
-													!isSelfObjectRelationship ||
-													(isSelfObjectRelationship &&
-														hasOneSelfObjectRelationship)
-														? getLocalizableLabel(
-																objectDefinition.defaultLanguageId,
-																objectRelationship.label,
-																objectRelationship.name
-														  )
-														: selfObjectRelationships.length.toString(),
-												markerEndId: manyMarkerId,
-												markerStartId:
-													objectRelationship.type ===
-													'manyToMany'
-														? manyMarkerId
-														: oneMarkerId,
-												objectRelationshipId:
-													objectRelationship.id,
-												selected:
-													selectedObjectRelationshipId ===
-													objectRelationship.id,
-												selfObjectRelationships,
-												type: objectRelationship.type,
-											},
-											id: `reactflow__edge-object-relationship-${objectRelationship.name}-parent-${objectRelationship.objectDefinitionId1}-child-${objectRelationship.objectDefinitionId2}`,
-											source: `${objectDefinition.id}`,
-											sourceHandle: isSelfObjectRelationship
-												? 'fixedLeftHandle'
-												: null,
-											target: `${objectRelationship.objectDefinitionId2}`,
-											targetHandle: isSelfObjectRelationship
-												? 'fixedRightHandle'
-												: null,
-											type: isSelfObjectRelationship
-												? 'selfObjectRelationshipEdge'
-												: 'defaultObjectRelationshipEdge',
-										});
+						objectDefinition.objectRelationships.forEach(
+							(objectRelationship) => {
+								const objectRelationshipEdge = objectRelationshipEdgeFactory(
+									{
+										objectDefinition,
+										objectRelationship,
+										objectRelationshipMap,
+										selectedObjectRelationshipId,
 									}
+								);
+
+								if (objectRelationshipEdge) {
+									objectRelationshipEdges.push(
+										objectRelationshipEdge
+									);
 								}
-							);
-						}
+							}
+						);
 
 						const {x, y} = getObjectDefinitionNodePosition({
 							index,
@@ -637,8 +620,8 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			let newModelBuilderState = {
 				...state,
 				elements: [
-					...newObjectDefinitionNodes,
-					...newObjectRelationshipEdges,
+					...objectDefinitionNodes,
+					...objectRelationshipEdges,
 				],
 				leftSidebarItems: newLeftSidebarItems,
 				objectFolders,
@@ -671,7 +654,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 					selectedObjectField.externalReferenceCode
 			);
 
-			const newObjectDefinitionNodes = objectDefinitionNodes.map(
+			const updatedObjectDefinitionNodes = objectDefinitionNodes.map(
 				(objectDefinitionNode) => {
 					if (
 						objectDefinitionNode.data?.externalReferenceCode ===
@@ -695,7 +678,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			return {
 				...state,
 				elements: [
-					...newObjectDefinitionNodes,
+					...updatedObjectDefinitionNodes,
 					...objectRelationshipEdges,
 				],
 				rightSidebarType: 'empty',
@@ -809,9 +792,16 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			const newObjectRelationshipEdges = objectRelationshipEdges.map(
 				(objectRelationshipEdge) => ({
 					...objectRelationshipEdge,
-					data: {...objectRelationshipEdge.data, selected: false},
+					data: objectRelationshipEdge.data?.map(
+						(objectRelationshipEdgeData) => {
+							return {
+								...objectRelationshipEdgeData,
+								selected: false,
+							};
+						}
+					),
 				})
-			) as Edge<ObjectRelationshipEdgeData>[];
+			) as Edge<ObjectRelationshipEdgeData[]>[];
 
 			return {
 				...state,
@@ -891,21 +881,34 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 
 			const selectedObjectRelationshipEdge = objectRelationshipEdges.find(
 				(objectRelationshipEdge) =>
-					objectRelationshipEdge.data?.selected
+					objectRelationshipEdge.data?.some(
+						(objectRelationshipEdgeData) =>
+							objectRelationshipEdgeData.selected
+					)
 			);
 
 			const newObjectRelationshipEdges = objectRelationshipEdges;
 
 			if (selectedObjectRelationshipEdge?.data) {
-				const selectedEdgeIndex = objectDefinitionNodes.findIndex(
-					(objectDefinitionNode) =>
-						objectDefinitionNode.data?.selected
+				const selectedObjectRelationshipEdgeIndex = objectRelationshipEdges.findIndex(
+					(objectRelationshipEdge) =>
+						objectRelationshipEdge.data?.some(
+							(objectRelationshipEdgeData) =>
+								objectRelationshipEdgeData.selected
+						)
 				);
 
-				selectedObjectRelationshipEdge.data.selected = false;
+				selectedObjectRelationshipEdge.data = selectedObjectRelationshipEdge.data.map(
+					(objectRelationshipEdgeData) => {
+						return {
+							...objectRelationshipEdgeData,
+							selected: false,
+						};
+					}
+				);
 
 				newObjectRelationshipEdges[
-					selectedEdgeIndex
+					selectedObjectRelationshipEdgeIndex
 				] = selectedObjectRelationshipEdge;
 			}
 
@@ -963,31 +966,56 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 			const {elements} = state;
 
 			const edges = elements.filter((element) => isEdge(element)) as Edge<
-				ObjectRelationshipEdgeData
+				ObjectRelationshipEdgeData[]
 			>[];
 
 			const nodes = elements.filter((element) => isNode(element)) as Node<
 				ObjectDefinitionNodeData
 			>[];
 
-			const selectedObjectRelationshipEdge = edges.find(
-				(objectRelationshipEdge) =>
-					objectRelationshipEdge.data?.objectRelationshipId ===
-					selectedObjectRelationshipId
-			);
+			let selectedObjectRelationship:
+				| ObjectRelationshipEdgeData
+				| undefined;
+
+			edges.find((edge) => {
+				const selectedObjectRelationshipEdgeData = edge?.data?.find(
+					(objectRelationshipEdgeData) => {
+						return (
+							objectRelationshipEdgeData.id ===
+							selectedObjectRelationshipId
+						);
+					}
+				);
+
+				if (selectedObjectRelationshipEdgeData) {
+					selectedObjectRelationship = {
+						...selectedObjectRelationshipEdgeData,
+						selected: true,
+					};
+
+					return true;
+				}
+
+				return false;
+			});
 
 			const newObjectRelationshipEdges = edges.map(
-				(objectRelationshipEdge) => ({
-					...objectRelationshipEdge,
-					data: {
-						...objectRelationshipEdge.data,
-						selected:
-							objectRelationshipEdge.data
-								?.objectRelationshipId ===
-							selectedObjectRelationshipId,
-					},
-				})
-			) as Edge<ObjectRelationshipEdgeData>[];
+				(objectRelationshipEdge) => {
+					return {
+						...objectRelationshipEdge,
+						data: objectRelationshipEdge.data?.map(
+							(objectRelationshipEdgeData) => {
+								return {
+									...objectRelationshipEdgeData,
+									selected:
+										objectRelationshipEdgeData.id ===
+										selectedObjectRelationshipId,
+								};
+							}
+						),
+					};
+				}
+			) as Edge<ObjectRelationshipEdgeData[]>[];
 
 			const selectedObjectDefinitionNode = nodes.find(
 				(objectDefinitionNode) => objectDefinitionNode.data?.selected
@@ -1023,7 +1051,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 				],
 				rightSidebarType: 'objectRelationshipDetails',
 				selectedObjectField: undefined,
-				selectedObjectRelationship: selectedObjectRelationshipEdge,
+				selectedObjectRelationship,
 			};
 		}
 
@@ -1041,7 +1069,7 @@ export function ObjectFolderReducer(state: TState, action: TAction): TState {
 
 			const objectRelationshipEdges = elements.filter((element) =>
 				isEdge(element)
-			) as Edge<ObjectRelationshipEdgeData>[];
+			) as Edge<ObjectRelationshipEdgeData[]>[];
 
 			const newObjectDefinitionNodes = objectDefinitionNodes.map(
 				(objectDefinitionNode) => {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducerUtil.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducerUtil.ts
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Edge} from 'react-flow-renderer';
-
-import {ObjectRelationshipEdgeData} from '../types';
-
 export function convertAllObjectFieldsToUnselected(
 	objectFields: ObjectFieldNodeRow[]
 ) {
@@ -14,72 +10,6 @@ export function convertAllObjectFieldsToUnselected(
 		...objectField,
 		selected: false,
 	})) as ObjectFieldNodeRow[];
-}
-
-export function getNonOverlappingEdges(
-	allEdges: Edge<ObjectRelationshipEdgeData>[]
-) {
-	const groupedEdges = separateEdgesBySourceAndTarget(allEdges);
-
-	const newEdges: Edge<ObjectRelationshipEdgeData>[] = [];
-
-	function addIncrementedEdges(
-		edges: Edge<ObjectRelationshipEdgeData>[],
-		initialYPosition: number,
-		yIncrement: number
-	) {
-		const incrementedEdges = incrementEdgesYPosition(
-			edges,
-			initialYPosition,
-			yIncrement
-		);
-		newEdges.push(...incrementedEdges);
-	}
-
-	groupedEdges.forEach((edges) => {
-		const edgeCount = edges.length;
-
-		if (edgeCount <= 1) {
-			addIncrementedEdges(edges, 0, 0);
-		}
-		else if (edgeCount <= 3) {
-			addIncrementedEdges(edges, 0, 50);
-		}
-		else if (edgeCount <= 4) {
-			addIncrementedEdges(edges, -50, 50);
-		}
-		else if (edgeCount <= 6) {
-			addIncrementedEdges(edges, -100, 50);
-		}
-		else {
-			addIncrementedEdges(edges, -100, 30);
-		}
-	});
-
-	return newEdges;
-}
-
-export function incrementEdgesYPosition(
-	edges: Edge<ObjectRelationshipEdgeData>[],
-	initialYPosition: number,
-	yIncrement: number
-) {
-	let sourceTargetYIncrement = initialYPosition;
-
-	return edges.map((edge) => {
-		const newEdge = {
-			...edge,
-			data: {
-				...edge.data,
-				sourceY: sourceTargetYIncrement,
-				targetY: sourceTargetYIncrement,
-			},
-		} as Edge<ObjectRelationshipEdgeData>;
-
-		sourceTargetYIncrement += yIncrement;
-
-		return newEdge;
-	});
 }
 
 export function objectFieldsCustomSort(objectFields: ObjectFieldNodeRow[]) {
@@ -113,27 +43,4 @@ export function objectFieldsCustomSort(objectFields: ObjectFieldNodeRow[]) {
 	};
 
 	return objectFields.sort(compareFields);
-}
-
-function separateEdgesBySourceAndTarget(
-	edges: Edge<ObjectRelationshipEdgeData>[]
-) {
-	const edgeGroups: {[key: string]: Edge<ObjectRelationshipEdgeData>[]} = {};
-
-	edges.forEach((edge) => {
-		const key =
-			edge.source <= edge.target
-				? `${edge.source}-${edge.target}`
-				: `${edge.target}-${edge.source}`;
-
-		if (!edgeGroups[key]) {
-			edgeGroups[key] = [];
-		}
-
-		edgeGroups[key].push(edge);
-	});
-
-	const groupedEdges = Object.values(edgeGroups);
-
-	return groupedEdges;
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
@@ -87,7 +87,7 @@ export function RightSidebarObjectRelationshipDetails({
 		const makeFetch = async () => {
 			if (selectedObjectRelationship) {
 				const selectedObjectRelationshipResponse = (await API.getObjectRelationship(
-					selectedObjectRelationship.data!.objectRelationshipId
+					selectedObjectRelationship.id
 				)) as ObjectRelationship;
 
 				setValues(selectedObjectRelationshipResponse);
@@ -172,70 +172,36 @@ export function RightSidebarObjectRelationshipDetails({
 				return;
 			}
 
-			let newObjectRelationship = {};
-
-			const isSelfObjectRelationship =
-				objectRelationship.objectDefinitionId1 ===
-				objectRelationship.objectDefinitionId2;
-
-			const updatedElements = elements.map((element) => {
-				if (isEdge(element)) {
-					const edgeData = (element as Edge<
-						ObjectRelationshipEdgeData
-					>).data;
-
-					const objectRelationshipId = edgeData?.objectRelationshipId;
-					const selfObjectRelationships =
-						edgeData?.selfObjectRelationships;
-
-					const newSelfObjectRelationships = selfObjectRelationships?.map(
-						(selfObjectRelationship) => {
+			const updatedElements = elements.map((currentElement) => {
+				if (isEdge(currentElement)) {
+					return {
+						...currentElement,
+						data: (currentElement as Edge<
+							ObjectRelationshipEdgeData[]
+						>).data?.map((objectRelationshipEdgeData) => {
 							if (
-								objectRelationship?.id ===
-								selfObjectRelationship.id
+								objectRelationshipEdgeData.id ===
+								objectRelationship?.id
 							) {
 								return {
-									...selfObjectRelationship,
-									label: objectRelationship.label,
+									...objectRelationshipEdgeData,
+									label: getLocalizableLabel(
+										defaultLanguageId,
+										objectRelationship.label,
+										objectRelationship.name
+									),
 								};
 							}
 
-							return selfObjectRelationship;
-						}
-					);
-
-					if (objectRelationshipId === objectRelationship?.id) {
-						newObjectRelationship = {
-							...edgeData,
-							deletionType: objectRelationship.deletionType,
-							label:
-								isSelfObjectRelationship &&
-								selfObjectRelationships &&
-								selfObjectRelationships.length > 1
-									? selfObjectRelationships.length.toString()
-									: getLocalizableLabel(
-											defaultLanguageId,
-											objectRelationship.label,
-											objectRelationship.name
-									  ),
-							selfObjectRelationships: newSelfObjectRelationships,
-						};
-					}
-					else {
-						newObjectRelationship = {
-							...edgeData,
-							selfObjectRelationships: newSelfObjectRelationships,
-						};
-					}
-
-					return {
-						...element,
-						data: newObjectRelationship,
+							return objectRelationshipEdgeData;
+						}),
 					};
 				}
 
-				return element;
-			}) as Elements<ObjectDefinitionNodeData>;
+				return currentElement;
+			}) as Elements<
+				ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
+			>;
 
 			dispatch({
 				payload: {
@@ -359,7 +325,7 @@ export function RightSidebarObjectRelationshipDetails({
 				/>
 
 				{objectRelationshipParameterRequired &&
-					selectedObjectRelationship?.data?.type === 'oneToMany' && (
+					selectedObjectRelationship?.type === 'oneToMany' && (
 						<>
 							<Input
 								label={Liferay.Language.get('api-endpoint')}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
@@ -299,8 +299,6 @@ export interface ObjectRelationshipEdgeData {
 	objectRelationshipId: number;
 	selected: boolean;
 	selfObjectRelationships?: ObjectRelationship[];
-	sourceY: number;
-	targetY: number;
 	type: string;
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.ts
@@ -39,7 +39,7 @@ export type TAction =
 				dbTableName: string;
 				dispatch: React.Dispatch<TAction>;
 				elements: Elements<
-					ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+					ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 				>;
 				leftSidebarItems: LeftSidebarItem[];
 				newObjectDefinition: ObjectDefinition;
@@ -53,7 +53,7 @@ export type TAction =
 				newObjectField: ObjectField;
 				objectDefinitionExternalReferenceCode: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData>;
 			};
 			type: TYPES.ADD_OBJECT_FIELD;
@@ -63,7 +63,7 @@ export type TAction =
 				hiddenObjectFolderObjectDefinitionNodes: boolean;
 				leftSidebarItem: LeftSidebarItem;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 			};
 			type: TYPES.BULK_CHANGE_NODE_VIEW;
 	  }
@@ -73,7 +73,7 @@ export type TAction =
 				objectDefinitionId: number;
 				objectDefinitionName: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedSidebarItem: LeftSidebarItem;
 			};
 			type: TYPES.CHANGE_NODE_VIEW;
@@ -81,7 +81,7 @@ export type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<
 					ObjectDefinitionNodeData
 				> | null;
@@ -108,7 +108,7 @@ export type TAction =
 	| {
 			payload: {
 				newElements: Elements<
-					ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+					ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 				>;
 			};
 			type: TYPES.SET_ELEMENTS;
@@ -140,7 +140,7 @@ export type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionId: string;
 			};
 			type: TYPES.SET_SELECTED_OBJECT_DEFINITION_NODE;
@@ -152,7 +152,7 @@ export type TAction =
 					y: number;
 				};
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				updatedObjectDefinitionNodeId: number;
 				updatedObjectFolder: ObjectFolder;
 			};
@@ -161,7 +161,7 @@ export type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionId: number;
 				selectedObjectField: ObjectFieldNodeRow;
 				selectedObjectFieldName: string;
@@ -198,7 +198,7 @@ export type TAction =
 				currentObjectFolderName: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
 				objectDefinitionRelationshipEdges: Edge<
-					ObjectRelationshipEdgeData
+					ObjectRelationshipEdgeData[]
 				>[];
 				updatedObjectDefinition: Partial<ObjectDefinition>;
 			};
@@ -207,7 +207,7 @@ export type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<
 					ObjectDefinitionNodeData
 				> | null;
@@ -226,7 +226,7 @@ export type TState = {
 	baseResourceURL: string;
 	deletedObjectDefinition: DeletedObjectDefinition | null;
 	editObjectDefinitionURL: string;
-	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData>;
+	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]>;
 	filterOperators: TFilterOperators;
 	forbiddenChars: string[];
 	forbiddenLastChars: string[];
@@ -246,7 +246,7 @@ export type TState = {
 	selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData> | null;
 	selectedObjectField?: ObjectFieldNodeRow;
 	selectedObjectFolder: ObjectFolder;
-	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData> | null;
+	selectedObjectRelationship?: ObjectRelationshipEdgeData | null;
 	showChangesSaved: boolean;
 	showSidebars: boolean;
 	workflowStatuses: LabelValueObject[];
@@ -293,12 +293,12 @@ export interface LeftSidebarObjectDefinitionItem {
 
 export interface ObjectRelationshipEdgeData {
 	defaultLanguageId?: Liferay.Language.Locale;
+	id: number;
 	label: string;
 	markerEndId: string;
 	markerStartId: string;
-	objectRelationshipId: number;
+	name: string;
 	selected: boolean;
-	selfObjectRelationships?: ObjectRelationship[];
 	type: string;
 }
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/utils.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/utils.ts
@@ -76,37 +76,14 @@ export function createElements() {
 	return elements;
 }
 
-export function getEdgeParams(
-	source: Node,
-	sourceIncrementY: number,
-	target: Node,
-	targetIncrementY: number
-) {
-	const sourceIntersectionPoint = getNodeIntersection(
-		source,
-		sourceIncrementY,
-		targetIncrementY,
-		target
-	);
+export function getEdgeParams(source: Node, target: Node) {
+	const sourceIntersectionPoint = getNodeIntersection(source, target);
 
-	const targetIntersectionPoint = getNodeIntersection(
-		target,
-		sourceIncrementY,
-		targetIncrementY,
-		source
-	);
+	const targetIntersectionPoint = getNodeIntersection(target, source);
 
-	const sourcePos = getEdgePosition(
-		sourceIntersectionPoint,
-		source,
-		sourceIncrementY
-	);
+	const sourcePos = getEdgePosition(sourceIntersectionPoint, source);
 
-	const targetPos = getEdgePosition(
-		targetIntersectionPoint,
-		target,
-		targetIncrementY
-	);
+	const targetPos = getEdgePosition(targetIntersectionPoint, target);
 
 	return {
 		sourcePos,
@@ -118,14 +95,10 @@ export function getEdgeParams(
 	};
 }
 
-function getEdgePosition(
-	intersectionPoint: XYPosition,
-	node: Node,
-	nodeIncrementY: number
-) {
+function getEdgePosition(intersectionPoint: XYPosition, node: Node) {
 	const nodeProperties = {...node.__rf.position, ...node.__rf};
 	const nodePositionX = Math.round(nodeProperties.x);
-	const nodePositionY = Math.round(nodeProperties.y + nodeIncrementY);
+	const nodePositionY = Math.round(nodeProperties.y);
 	const intersectionPointX = Math.round(intersectionPoint.x);
 	const intersectionPointY = Math.round(intersectionPoint.y);
 
@@ -147,8 +120,6 @@ function getEdgePosition(
 
 function getNodeIntersection(
 	intersectionNode: Node,
-	sourceIncrementY: number,
-	targetIncrementY: number,
 	targetNode: Node
 ): XYPosition {
 
@@ -165,11 +136,9 @@ function getNodeIntersection(
 	const nodeHalfHeight = intersectionNodeHeight / 2;
 
 	const sourceCoordinateX = intersectionNodePosition.x + nodeHalfWidth;
-	const sourceCoordinateY =
-		intersectionNodePosition.y + sourceIncrementY + nodeHalfHeight;
+	const sourceCoordinateY = intersectionNodePosition.y + nodeHalfHeight;
 	const targetCoordinateX = targetPosition.x + nodeHalfWidth;
-	const targetCoordinateY =
-		targetPosition.y + targetIncrementY + nodeHalfHeight;
+	const targetCoordinateY = targetPosition.y + nodeHalfHeight;
 
 	const sourceToTargetXDifference =
 		(targetCoordinateX - sourceCoordinateX) / (2 * nodeHalfWidth) -

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.d.ts
@@ -25,4 +25,4 @@ export default function DefaultObjectRelationshipEdge({
 	source,
 	style,
 	target,
-}: EdgeProps<ObjectRelationshipEdgeData>): JSX.Element | null;
+}: EdgeProps<ObjectRelationshipEdgeData[]>): JSX.Element | null;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/DefaultObjectRelationshipEdge.d.ts
@@ -7,22 +7,9 @@
 
 import {EdgeProps} from 'react-flow-renderer';
 import {ObjectRelationshipEdgeData} from '../types';
-export declare function getInitialObjectRelationshipEdgeStyle(
-	edgeSelected: boolean
-): {
-	stroke: string;
-	strokeWidth: string;
-};
-export declare function getInitialLabelBgStyle(
-	edgeSelected: boolean
-): {
-	fill: string;
-	height: string;
-};
 export default function DefaultObjectRelationshipEdge({
 	data,
-	id,
+	id: edgeId,
 	source,
-	style,
 	target,
-}: EdgeProps<ObjectRelationshipEdgeData[]>): JSX.Element | null;
+}: EdgeProps<ObjectRelationshipEdgeData[]>): JSX.Element;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ManyMarker.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ManyMarker.d.ts
@@ -6,4 +6,10 @@
 /// <reference types="react" />
 
 export declare const manyMarkerId = 'manyMarker';
-export default function ManyMarker(): JSX.Element;
+interface ManyMarkerProps {
+	objectRelationshipId: string;
+}
+export default function ManyMarker({
+	objectRelationshipId,
+}: ManyMarkerProps): JSX.Element;
+export {};

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipEdge.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipEdge.d.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+import {EdgeProps} from 'react-flow-renderer';
+import {ObjectRelationshipEdgeData} from '../types';
+import './Edge.scss';
+interface ObjectRelationshipEdge
+	extends Partial<EdgeProps<ObjectRelationshipEdgeData[]>> {
+	edgeCenterX: number;
+	edgeCenterY: number;
+	edgePath: string;
+	reverseEdgePath?: string;
+}
+export default function ObjectRelationshipEdge({
+	edgePath,
+	edgeCenterX,
+	edgeCenterY,
+	data,
+	id: edgeId,
+	reverseEdgePath,
+	style,
+}: ObjectRelationshipEdge): JSX.Element;
+export {};

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipMap.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/ObjectRelationshipMap.d.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export declare class ObjectRelationshipMap extends Map<
+	string,
+	ObjectRelationship[]
+> {
+	private _delete;
+	private _getValue;
+	private _setValue;
+	deleteByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	): boolean;
+	getKey(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	): string;
+	getValueByExternalReferenceCodes(
+		objectDefinitionExternalReferenceCode1: string,
+		objectDefinitionExternalReferenceCode2: string
+	): ObjectRelationship[] | undefined;
+	getValueByKey(key: string): ObjectRelationship[] | undefined;
+	setValue(objectRelationship: ObjectRelationship): this;
+}

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/OneMarker.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/OneMarker.d.ts
@@ -6,4 +6,10 @@
 /// <reference types="react" />
 
 export declare const oneMarkerId = 'oneMarker';
-export default function OneMarker(): JSX.Element;
+interface OneMarkerProps {
+	objectRelationshipId: string;
+}
+export default function OneMarker({
+	objectRelationshipId,
+}: OneMarkerProps): JSX.Element;
+export {};

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/SelfObjectRelationshipEdge.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/SelfObjectRelationshipEdge.d.ts
@@ -7,14 +7,11 @@
 
 import {EdgeProps} from 'react-flow-renderer';
 import {ObjectRelationshipEdgeData} from '../types';
-import './Edge.scss';
 export default function SelfObjectRelationshipEdge({
 	data,
-	id,
-	source,
+	id: edgeId,
 	sourceX,
 	sourceY,
-	style,
 	targetX,
 	targetY,
-}: EdgeProps<ObjectRelationshipEdgeData>): JSX.Element | null;
+}: EdgeProps<ObjectRelationshipEdgeData[]>): JSX.Element;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/objectRelationshipEdgeFactory.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/objectRelationshipEdgeFactory.d.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ObjectRelationshipEdgeData} from '../types';
+import {ObjectRelationshipMap} from './ObjectRelationshipMap';
+interface ObjectRelationshipEdgeFactory {
+	objectDefinition: ObjectDefinitionNodeData;
+	objectRelationship: ObjectRelationship;
+	objectRelationshipMap: ObjectRelationshipMap;
+	selectedObjectRelationshipId: number | undefined;
+}
+export declare function objectRelationshipEdgeFactory({
+	objectDefinition,
+	objectRelationship,
+	objectRelationshipMap,
+	selectedObjectRelationshipId,
+}: ObjectRelationshipEdgeFactory):
+	| {
+			data: ObjectRelationshipEdgeData[];
+			id: string;
+			source: string;
+			sourceHandle: string | null;
+			target: string;
+			targetHandle: string | null;
+			type: string;
+	  }
+	| undefined;
+export {};

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.d.ts
@@ -10,7 +10,7 @@ import './ModalPublishObjectDefinitions.scss';
 interface ModalPublishObjectDefinitionsProps {
 	disableAutoClose: boolean;
 	dispatch: React.Dispatch<TAction>;
-	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData>;
+	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]>;
 	handleOnClose: () => void;
 }
 export declare function ModalPublishObjectDefinitions({

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducerUtil.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/ModelBuilderContext/objectFolderReducerUtil.d.ts
@@ -3,19 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Edge} from 'react-flow-renderer';
-import {ObjectRelationshipEdgeData} from '../types';
 export declare function convertAllObjectFieldsToUnselected(
 	objectFields: ObjectFieldNodeRow[]
 ): ObjectFieldNodeRow[];
-export declare function getNonOverlappingEdges(
-	allEdges: Edge<ObjectRelationshipEdgeData>[]
-): Edge<ObjectRelationshipEdgeData>[];
-export declare function incrementEdgesYPosition(
-	edges: Edge<ObjectRelationshipEdgeData>[],
-	initialYPosition: number,
-	yIncrement: number
-): Edge<ObjectRelationshipEdgeData>[];
 export declare function objectFieldsCustomSort(
 	objectFields: ObjectFieldNodeRow[]
 ): ObjectFieldNodeRow[];

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
@@ -292,8 +292,6 @@ export interface ObjectRelationshipEdgeData {
 	objectRelationshipId: number;
 	selected: boolean;
 	selfObjectRelationships?: ObjectRelationship[];
-	sourceY: number;
-	targetY: number;
 	type: string;
 }
 export declare type nonRelationshipObjectFieldsInfo = {

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/types.d.ts
@@ -37,7 +37,7 @@ export declare type TAction =
 				dbTableName: string;
 				dispatch: React.Dispatch<TAction>;
 				elements: Elements<
-					ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+					ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 				>;
 				leftSidebarItems: LeftSidebarItem[];
 				newObjectDefinition: ObjectDefinition;
@@ -51,7 +51,7 @@ export declare type TAction =
 				newObjectField: ObjectField;
 				objectDefinitionExternalReferenceCode: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData>;
 			};
 			type: TYPES.ADD_OBJECT_FIELD;
@@ -61,7 +61,7 @@ export declare type TAction =
 				hiddenObjectFolderObjectDefinitionNodes: boolean;
 				leftSidebarItem: LeftSidebarItem;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 			};
 			type: TYPES.BULK_CHANGE_NODE_VIEW;
 	  }
@@ -71,7 +71,7 @@ export declare type TAction =
 				objectDefinitionId: number;
 				objectDefinitionName: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedSidebarItem: LeftSidebarItem;
 			};
 			type: TYPES.CHANGE_NODE_VIEW;
@@ -79,7 +79,7 @@ export declare type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<
 					ObjectDefinitionNodeData
 				> | null;
@@ -106,7 +106,7 @@ export declare type TAction =
 	| {
 			payload: {
 				newElements: Elements<
-					ObjectDefinitionNodeData | ObjectRelationshipEdgeData
+					ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]
 				>;
 			};
 			type: TYPES.SET_ELEMENTS;
@@ -138,7 +138,7 @@ export declare type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionId: string;
 			};
 			type: TYPES.SET_SELECTED_OBJECT_DEFINITION_NODE;
@@ -150,7 +150,7 @@ export declare type TAction =
 					y: number;
 				};
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				updatedObjectDefinitionNodeId: number;
 				updatedObjectFolder: ObjectFolder;
 			};
@@ -159,7 +159,7 @@ export declare type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionId: number;
 				selectedObjectField: ObjectFieldNodeRow;
 				selectedObjectFieldName: string;
@@ -196,7 +196,7 @@ export declare type TAction =
 				currentObjectFolderName: string;
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
 				objectDefinitionRelationshipEdges: Edge<
-					ObjectRelationshipEdgeData
+					ObjectRelationshipEdgeData[]
 				>[];
 				updatedObjectDefinition: Partial<ObjectDefinition>;
 			};
@@ -205,7 +205,7 @@ export declare type TAction =
 	| {
 			payload: {
 				objectDefinitionNodes: Node<ObjectDefinitionNodeData>[];
-				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData>[];
+				objectRelationshipEdges: Edge<ObjectRelationshipEdgeData[]>[];
 				selectedObjectDefinitionNode: Node<
 					ObjectDefinitionNodeData
 				> | null;
@@ -223,7 +223,7 @@ export declare type TState = {
 	baseResourceURL: string;
 	deletedObjectDefinition: DeletedObjectDefinition | null;
 	editObjectDefinitionURL: string;
-	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData>;
+	elements: Elements<ObjectDefinitionNodeData | ObjectRelationshipEdgeData[]>;
 	filterOperators: TFilterOperators;
 	forbiddenChars: string[];
 	forbiddenLastChars: string[];
@@ -243,7 +243,7 @@ export declare type TState = {
 	selectedObjectDefinitionNode: Node<ObjectDefinitionNodeData> | null;
 	selectedObjectField?: ObjectFieldNodeRow;
 	selectedObjectFolder: ObjectFolder;
-	selectedObjectRelationship?: Edge<ObjectRelationshipEdgeData> | null;
+	selectedObjectRelationship?: ObjectRelationshipEdgeData | null;
 	showChangesSaved: boolean;
 	showSidebars: boolean;
 	workflowStatuses: LabelValueObject[];
@@ -286,12 +286,12 @@ export interface LeftSidebarObjectDefinitionItem {
 }
 export interface ObjectRelationshipEdgeData {
 	defaultLanguageId?: Liferay.Language.Locale;
+	id: number;
 	label: string;
 	markerEndId: string;
 	markerStartId: string;
-	objectRelationshipId: number;
+	name: string;
 	selected: boolean;
-	selfObjectRelationships?: ObjectRelationship[];
 	type: string;
 }
 export declare type nonRelationshipObjectFieldsInfo = {

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/utils.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModelBuilder/utils.d.ts
@@ -31,9 +31,7 @@ export declare function createElements(): (
 )[];
 export declare function getEdgeParams(
 	source: Node,
-	sourceIncrementY: number,
-	target: Node,
-	targetIncrementY: number
+	target: Node
 ): {
 	sourcePos: Position;
 	sourceX: number;


### PR DESCRIPTION
Related [Ticket](https://liferay.atlassian.net/browse/LPS-197482)

Motivation:

When dealing with lots of connections between two objects, we ended up with too many edges. Keeping them organized became a challenge as their number grew.

To make things easier, we've tweaked the way edges are handled. Now, the system can handle a bunch of connections all at once, making it simpler to manage and maintain consistency.

![screenshot-1705686220](https://github.com/liferay-objects/liferay-portal/assets/61854510/cd75e418-2d8e-4719-85b2-f2ab0a1178a1)


