### PR TITLE
[TS] LPD-18823 Change method to get objectDefinition by externalReferenceCode because we don't have objectDefinitionId at this point

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -923,9 +923,25 @@ public class ObjectDefinitionResourceImpl
 				continue;
 			}
 
-			com.liferay.object.model.ObjectDefinition objectDefinition2 =
-				_objectDefinitionLocalService.fetchObjectDefinition(
-					objectRelationship.getObjectDefinitionId2());
+			com.liferay.object.model.ObjectDefinition objectDefinition2 = null;
+
+			long objectDefinitionId2 = GetterUtil.getLong(
+				objectRelationship.getObjectDefinitionId2());
+
+			if (objectDefinitionId2 > 0) {
+				objectDefinition2 =
+					_objectDefinitionLocalService.fetchObjectDefinition(
+						objectRelationship.getObjectDefinitionId2());
+			}
+
+			if (objectDefinition2 == null) {
+				objectDefinition2 =
+					_objectDefinitionLocalService.
+						fetchObjectDefinitionByExternalReferenceCode(
+							objectRelationship.
+								getObjectDefinitionExternalReferenceCode2(),
+							contextCompany.getCompanyId());
+			}
 
 			if ((objectDefinition2 == null) ||
 				!objectDefinition2.isAccountEntryRestricted()) {


### PR DESCRIPTION
Hi Team,

https://liferay.atlassian.net/browse/LPD-18823

Issue:
The Account Object definition import process fails with NullPointerException when the definition has Relationships where the parent is the Account. It happens, because the objectDefinitionId2 is Null here:

			com.liferay.object.model.ObjectDefinition objectDefinition2 =
				_objectDefinitionLocalService.fetchObjectDefinition(
					objectRelationship.getObjectDefinitionId2());

In the import process the objectDefinitionId2 is always Null here (for all the other Objects too), but they don't reach this point in code, because of this validation and they return with an empty set:

		if ((objectDefinition1 == null) ||
			!objectDefinition1.isUnmodifiableSystemObject() ||
			(objectRelationships == null) ||
			!StringUtil.equals(
				objectDefinition1.getClassName(),
				AccountEntry.class.getName())) {

			return Collections.emptySet();
		}

Solution:
Following our discussion with @marcelabc I changed the method to fetchObjectDefinitionByExternalReferenceCode(). 

I tested in my local environment and following the fix, the Account Object definition import process was successful.

Please review my PR!

Thank you and best regards,
Évi