### PR TITLE
LPD-16074 Add default order in related models providers for consistency

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -54,10 +54,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -603,9 +601,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectEntry1.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_objectEntry2, _objectEntry3)),
-			objectRelationship);
+		_assertPagination(_objectEntry2, objectRelationship);
 
 		objectRelationship = _addObjectRelationship(
 			_objectDefinition2, _objectDefinition1,
@@ -616,9 +612,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectEntry3.getPrimaryKey(), _objectEntry1.getPrimaryKey(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_objectEntry2, _objectEntry3)),
-			objectRelationship);
+		_assertPagination(_objectEntry2, objectRelationship);
 
 		// One to many relationship
 
@@ -631,9 +625,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectEntry1.getPrimaryKey(), _objectEntry3.getPrimaryKey(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_objectEntry2, _objectEntry3)),
-			objectRelationship);
+		_assertPagination(_objectEntry2, objectRelationship);
 	}
 
 	@Test
@@ -715,8 +707,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectEntry1.getPrimaryKey(), _user2.getUserId(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_user1, _user2)), objectRelationship);
+		_assertPagination(_user1, objectRelationship);
 
 		objectRelationship = _addObjectRelationship(
 			relatedObjectDefinition, _objectDefinition1, _user1.getUserId(),
@@ -727,8 +718,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_user2.getUserId(), _objectEntry1.getPrimaryKey(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_user1, _user2)), objectRelationship);
+		_assertPagination(_user1, objectRelationship);
 
 		// One to many relationship
 
@@ -741,8 +731,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_objectEntry1.getPrimaryKey(), _user2.getUserId(),
 			objectRelationship, TestPropsValues.getUserId());
 
-		_assertPagination(
-			new ArrayList<>(Arrays.asList(_user1, _user2)), objectRelationship);
+		_assertPagination(_user1, objectRelationship);
 	}
 
 	@Test
@@ -1248,8 +1237,7 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	private void _assertPagination(
-			List<BaseModel<?>> baseModels,
-			ObjectRelationship objectRelationship)
+			BaseModel<?> baseModel, ObjectRelationship objectRelationship)
 		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
@@ -1257,48 +1245,19 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_getEndpoint(objectRelationship.getName()) + "?page=1&pageSize=1",
 			Http.Method.GET);
 
+		_assertEquals(baseModel, jsonObject.getJSONArray("items"));
+
 		Assert.assertEquals(2, jsonObject.getLong("lastPage"));
 		Assert.assertEquals(1, jsonObject.getLong("page"));
 		Assert.assertEquals(1, jsonObject.getLong("pageSize"));
 		Assert.assertEquals(2, jsonObject.getLong("totalCount"));
-
-		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject1 = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertTrue(
-			baseModels.removeIf(
-				baseModel -> Objects.equals(
-					baseModel.getPrimaryKeyObj(),
-					itemJSONObject1.getLong("id"))));
-
-		jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null,
-			_getEndpoint(objectRelationship.getName()) + "?page=2&pageSize=1",
-			Http.Method.GET);
-
-		itemsJSONArray = jsonObject.getJSONArray("items");
-
-		Assert.assertEquals(1, itemsJSONArray.length());
-
-		JSONObject itemJSONObject2 = itemsJSONArray.getJSONObject(0);
-
-		Assert.assertTrue(
-			baseModels.removeIf(
-				baseModel -> Objects.equals(
-					baseModel.getPrimaryKeyObj(),
-					itemJSONObject2.getLong("id"))));
-
-		Assert.assertTrue(baseModels.isEmpty());
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
 			_getEndpoint(objectRelationship.getName()) + "?page=0&pageSize=0",
 			Http.Method.GET);
 
-		itemsJSONArray = jsonObject.getJSONArray("items");
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(2, itemsJSONArray.length());
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObject1toMObjectRelatedModelsProviderImpl.java
@@ -259,6 +259,9 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 			_getDynamicObjectDefinitionTable(),
 			DSLQueryFactoryUtil.selectDistinct(_table), groupId,
 			objectRelationshipId, primaryKey, search
+		).orderBy(
+			_systemObjectDefinitionManager.getPrimaryKeyColumn(
+			).ascending()
 		).limit(
 			start, end
 		);
@@ -297,6 +300,9 @@ public class SystemObject1toMObjectRelatedModelsProviderImpl
 		DSLQuery dslQuery = _getUnrelatedModelsGroupByStep(
 			companyId, DSLQueryFactoryUtil.select(_table), groupId,
 			objectDefinition, objectRelationshipId
+		).orderBy(
+			_systemObjectDefinitionManager.getPrimaryKeyColumn(
+			).ascending()
 		).limit(
 			start, end
 		);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/SystemObjectMtoMObjectRelatedModelsProviderImpl.java
@@ -147,6 +147,9 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 			_getGroupByStep(
 				DSLQueryFactoryUtil.selectDistinct(_table), groupId,
 				objectRelationshipId, primaryKey, search
+			).orderBy(
+				_systemObjectDefinitionManager.getPrimaryKeyColumn(
+				).ascending()
 			).limit(
 				start, end
 			));
@@ -185,6 +188,9 @@ public class SystemObjectMtoMObjectRelatedModelsProviderImpl
 			_getUnrelatedModelsGroupByStep(
 				companyId, DSLQueryFactoryUtil.selectDistinct(_table), groupId,
 				objectDefinition, objectEntryId, objectRelationshipId
+			).orderBy(
+				_systemObjectDefinitionManager.getPrimaryKeyColumn(
+				).ascending()
 			).limit(
 				start, end
 			));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -771,6 +771,8 @@ public class ObjectEntryLocalServiceImpl
 		DSLQuery dslQuery = _getManyToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
 			groupId, objectRelationshipId, primaryKey, related, reverse, search
+		).orderBy(
+			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
 			start, end
 		);
@@ -904,6 +906,8 @@ public class ObjectEntryLocalServiceImpl
 		DSLQuery dslQuery = _getOneToManyObjectEntriesGroupByStep(
 			DSLQueryFactoryUtil.selectDistinct(ObjectEntryTable.INSTANCE),
 			groupId, objectRelationshipId, primaryKey, related, search
+		).orderBy(
+			ObjectEntryTable.INSTANCE.objectEntryId.ascending()
 		).limit(
 			start, end
 		);


### PR DESCRIPTION
Related: [LPD-16074](https://liferay.atlassian.net/browse/LPD-16074)

As requested, this PR takes a different approach to fixing the test, by adding a default sort when fetching related models.