### PR TITLE
[CLDR] LPD-20669 Fix functional test ObjectFieldsDateAndTime#CanSeeDifferentTimeZone to work with CLDR locale provider

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFieldsDateAndTime.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFieldsDateAndTime.testcase
@@ -107,9 +107,7 @@ definition {
 
 			UserNavigator.gotoDisplaySettings();
 
-			Select(
-				locator1 = "Select#TIME_ZONE",
-				value1 = "(UTC -03:00) Brasilia Time");
+			Click.clickNoMouseOver(locator1 = "//option[@value='America/Sao_Paulo']");
 
 			PortletEntry.save();
 


### PR DESCRIPTION
Hi Team,
This is for issue: https://liferay.atlassian.net/browse/LPD-20669
This is the same issue as other testcase here: https://github.com/liferay-workflow/liferay-portal/pull/1086

--- Copied from the workflow PR ---
Our current java locale provider is JRE (jdk8 default)
In preparation to make the change to jdk21, we noticed that jdk21 default is CLDR. This made many functional tests fail because display name for timezone, country, format are slightly different.

In the case of this Object test:
The testcase is looking for an option where the label text matches exactly with the text `(UTC -03:00) Brasilia Time` both to select.
This failed test case with CLDR because the label text changed.

Solution:
We can use timezoneId to locate the option with xpath and assert that it is clicked instead.

This works both with JRE and CLDR locally
CI Testing CLDR here: https://github.com/julschong/liferay-portal/pull/1182
This PR will have results for CI Testing with JRE

Thanks!



