### PR TITLE
LPD-22652 Use locks to avoid updating the same object action concurrently

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 88.0.1
+Bundle-Version: 88.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/LockedObjectActionException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/LockedObjectActionException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+package com.liferay.object.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Marco Leo
+ */
+public class LockedObjectActionException extends PortalException {
+
+	public LockedObjectActionException() {
+	}
+
+	public LockedObjectActionException(String msg) {
+		super(msg);
+	}
+
+	public LockedObjectActionException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public LockedObjectActionException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/LockedObjectActionException.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/exception/LockedObjectActionException.java
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
 package com.liferay.object.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 27.1.0
+version 27.2.0

--- a/modules/apps/object/object-service/service.xml
+++ b/modules/apps/object/object-service/service.xml
@@ -1014,6 +1014,7 @@
 		<exception>DuplicateObjectFieldExternalReferenceCode</exception>
 		<exception>DuplicateObjectRelationship</exception>
 		<exception>DuplicateObjectRelationshipExternalReferenceCode</exception>
+		<exception>LockedObjectAction</exception>
 		<exception>ObjectActionConditionExpression</exception>
 		<exception>ObjectActionErrorMessage</exception>
 		<exception>ObjectActionExecutorKey</exception>

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/engine/ObjectActionEngineImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/engine/ObjectActionEngineImpl.java
@@ -16,6 +16,7 @@ import com.liferay.object.constants.ObjectActionConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.dynamic.data.mapping.expression.ObjectEntryDDMExpressionFieldAccessor;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
+import com.liferay.object.exception.LockedObjectActionException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
 import com.liferay.object.internal.action.util.ObjectEntryVariablesUtil;
 import com.liferay.object.internal.dynamic.data.mapping.expression.ObjectEntryDDMExpressionParameterAccessor;
@@ -28,6 +29,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -281,14 +283,12 @@ public class ObjectActionEngineImpl implements ObjectActionEngine {
 				objectAction.getParametersUnicodeProperties(),
 				payloadJSONObject, userId);
 
-			_objectActionLocalService.updateStatus(
-				objectAction.getObjectActionId(),
-				ObjectActionConstants.STATUS_SUCCESS);
+			_updateObjectActionStatus(
+				objectAction, ObjectActionConstants.STATUS_SUCCESS);
 		}
 		catch (Exception exception) {
-			_objectActionLocalService.updateStatus(
-				objectAction.getObjectActionId(),
-				ObjectActionConstants.STATUS_FAILED);
+			_updateObjectActionStatus(
+				objectAction, ObjectActionConstants.STATUS_FAILED);
 
 			throw exception;
 		}
@@ -310,6 +310,25 @@ public class ObjectActionEngineImpl implements ObjectActionEngine {
 
 		return GetterUtil.getLong(
 			map.get("id"), (long)map.get("objectEntryId"));
+	}
+
+	private void _updateObjectActionStatus(
+			ObjectAction objectAction, int status)
+		throws PortalException {
+
+		if (objectAction.getStatus() == status) {
+			return;
+		}
+
+		try {
+			_objectActionLocalService.updateStatus(
+				objectAction.getObjectActionId(), status);
+		}
+		catch (PortalException portalException) {
+			if (!(portalException instanceof LockedObjectActionException)) {
+				throw portalException;
+			}
+		}
 	}
 
 	private void _updatePayloadJSONObject(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.exception.DuplicateObjectActionExternalReferenceCodeException;
+import com.liferay.object.exception.LockedObjectActionException;
 import com.liferay.object.exception.ObjectActionConditionExpressionException;
 import com.liferay.object.exception.ObjectActionErrorMessageException;
 import com.liferay.object.exception.ObjectActionExecutorKeyException;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.lock.LockManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
@@ -65,6 +67,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.security.script.management.configuration.helper.ScriptManagementConfigurationHelper;
 
 import java.util.HashMap;
@@ -391,15 +394,37 @@ public class ObjectActionLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public ObjectAction updateStatus(long objectActionId, int status)
+	public synchronized ObjectAction updateStatus(
+			long objectActionId, int status)
 		throws PortalException {
 
-		ObjectAction objectAction = objectActionPersistence.findByPrimaryKey(
-			objectActionId);
+		boolean locked = LockManagerUtil.isLocked(
+			ObjectAction.class.getName(), objectActionId);
 
-		objectAction.setStatus(status);
+		if (locked) {
+			throw new LockedObjectActionException(
+				String.format(
+					"Unable to update the status of the object action %d " +
+						"because it is being updated by another thread",
+					objectActionId));
+		}
 
-		return objectActionPersistence.update(objectAction);
+		try {
+			LockManagerUtil.lock(
+				ObjectAction.class.getName(), String.valueOf(objectActionId),
+				PortalUUIDUtil.generate());
+
+			ObjectAction objectAction =
+				objectActionPersistence.findByPrimaryKey(objectActionId);
+
+			objectAction.setStatus(status);
+
+			return objectActionPersistence.update(objectAction);
+		}
+		finally {
+			LockManagerUtil.unlock(
+				ObjectAction.class.getName(), objectActionId);
+		}
 	}
 
 	private void _validateErrorMessage(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -93,6 +93,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -1713,6 +1714,94 @@ public class ObjectActionLocalServiceTest {
 		_objectFieldLocalService.deleteObjectField(objectField1);
 		_objectFieldLocalService.deleteObjectField(objectField2);
 		_objectFieldLocalService.deleteObjectField(objectField3);
+	}
+
+	@Test
+	public void testConcurrentObjectActions() throws Exception {
+		_addObjectAction(
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
+			UnicodePropertiesBuilder.put(
+				"script", "println \"Hello World\""
+			).build(),
+			false);
+
+		_objectDefinition = _publishCustomObjectDefinition();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		String originalName = PrincipalThreadLocal.getName();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(_user));
+			PrincipalThreadLocal.setName(_user.getUserId());
+
+			Thread thread1 = new Thread(
+				() -> {
+					try {
+						_objectEntryLocalService.addObjectEntry(
+							TestPropsValues.getUserId(), 0,
+							_objectDefinition.getObjectDefinitionId(),
+							HashMapBuilder.<String, Serializable>put(
+								"firstName", "John"
+							).build(),
+							ServiceContextTestUtil.getServiceContext());
+					}
+					catch (PortalException portalException) {
+					}
+				});
+
+			Thread thread2 = new Thread(
+				() -> {
+					try {
+						_objectEntryLocalService.addObjectEntry(
+							TestPropsValues.getUserId(), 0,
+							_objectDefinition.getObjectDefinitionId(),
+							HashMapBuilder.<String, Serializable>put(
+								"firstName", "Peter"
+							).build(),
+							ServiceContextTestUtil.getServiceContext());
+					}
+					catch (PortalException portalException) {
+					}
+				});
+
+			thread1.start();
+			thread2.start();
+
+			thread1.join();
+			thread2.join();
+
+			Assert.assertEquals(
+				2,
+				_objectEntryLocalService.getObjectEntriesCount(
+					0, _objectDefinition.getObjectDefinitionId()));
+
+			Assert.assertEquals(2, _argumentsList.size());
+
+			Object[] arguments = _argumentsList.poll();
+
+			Set<String> firstNames = SetUtil.fromArray(
+				new String[] {"John", "Peter"});
+
+			Map<String, Object> inputObjects =
+				(Map<String, Object>)arguments[0];
+
+			Assert.assertTrue(firstNames.remove(inputObjects.get("firstName")));
+
+			arguments = _argumentsList.poll();
+
+			inputObjects = (Map<String, Object>)arguments[0];
+
+			Assert.assertTrue(firstNames.remove(inputObjects.get("firstName")));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+			PrincipalThreadLocal.setName(originalName);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Related ticket: [LPD-22652](https://liferay.atlassian.net/browse/LPD-22652)