### PR TITLE
LPD-22756 Cache proxy objects during the duration of the request

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
@@ -24,6 +24,11 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @author Guilherme Camacho
  */
@@ -67,17 +72,24 @@ public class ObjectEntryInfoItemObjectProvider
 			return objectEntry;
 		}
 
-		ObjectEntryManager objectEntryManager =
-			_objectEntryManagerRegistry.getObjectEntryManager(
-				_objectDefinition.getStorageType());
-
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
 		ERCInfoItemIdentifier ercInfoItemIdentifier =
 			(ERCInfoItemIdentifier)infoItemIdentifier;
+
+		Map<InfoItemIdentifier, ObjectEntry> objectEntries = _getObjectEntries(
+			serviceContext.getRequest());
+
+		if (objectEntries.containsKey(ercInfoItemIdentifier)) {
+			return objectEntries.get(ercInfoItemIdentifier);
+		}
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getStorageType());
 
 		try {
 			Group group = themeDisplay.getScopeGroup();
@@ -92,8 +104,12 @@ public class ObjectEntryInfoItemObjectProvider
 					_objectDefinition, group.getGroupKey());
 
 			if (objectEntry != null) {
-				return ObjectEntryUtil.toObjectEntry(
+				ObjectEntry nextObjectEntry = ObjectEntryUtil.toObjectEntry(
 					_objectDefinition.getObjectDefinitionId(), objectEntry);
+
+				objectEntries.put(ercInfoItemIdentifier, nextObjectEntry);
+
+				return nextObjectEntry;
 			}
 		}
 		catch (Exception exception) {
@@ -106,6 +122,28 @@ public class ObjectEntryInfoItemObjectProvider
 			"Unable to get object entry " +
 				ercInfoItemIdentifier.getExternalReferenceCode());
 	}
+
+	private Map<InfoItemIdentifier, ObjectEntry> _getObjectEntries(
+		HttpServletRequest httpServletRequest) {
+
+		if (httpServletRequest == null) {
+			return new HashMap<>();
+		}
+
+		Map<InfoItemIdentifier, ObjectEntry> objectEntries =
+			(Map<InfoItemIdentifier, ObjectEntry>)
+				httpServletRequest.getAttribute(_OBJECT_ENTRIES);
+
+		if (objectEntries == null) {
+			objectEntries = new HashMap<>();
+
+			httpServletRequest.setAttribute(_OBJECT_ENTRIES, objectEntries);
+		}
+
+		return objectEntries;
+	}
+
+	private static final String _OBJECT_ENTRIES = "OBJECT_ENTRIES";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryInfoItemObjectProvider.class);

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
@@ -21,8 +21,15 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -32,6 +39,8 @@ import org.junit.Test;
 
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Lourdes Fernández Besada
@@ -116,6 +125,45 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	}
 
 	@Test
+	public void testGetInfoItemProxyObjectEntryInfoItemIdentifierCachedInObjectEntriesAttribute()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
+			externalReferenceCode);
+
+		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
+
+		_assertGetInfoItemProxyObjectEntryCached(
+			ercInfoItemIdentifier,
+			_getHttpServletRequest(
+				HashMapBuilder.<String, Object>put(
+					_OBJECT_ENTRIES_KEY,
+					HashMapBuilder.<InfoItemIdentifier, ObjectEntry>put(
+						ercInfoItemIdentifier, objectEntry
+					).build()
+				).build()),
+			objectEntry);
+	}
+
+	@Test
+	public void testGetInfoItemProxyObjectEntryInfoItemIdentifierNotCachedInObjectEntriesAttribute()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Map<String, Object> attributes = new HashMap<>();
+
+		_assertGetInfoItemProxyObjectEntry(
+			attributes, new ERCInfoItemIdentifier(externalReferenceCode),
+			_getHttpServletRequest(attributes), objectEntry,
+			_setUpProxyObjectEntry(externalReferenceCode, objectEntry));
+	}
+
+	@Test
 	public void testGetInfoItemProxyObjectEntryNoSuchInfoItemException()
 		throws Exception {
 
@@ -133,6 +181,35 @@ public class ObjectEntryInfoItemObjectProviderTest {
 			Mockito.eq(externalReferenceCode), Mockito.eq(_objectDefinition),
 			Mockito.eq(null)
 		);
+	}
+
+	@Test
+	public void testGetInfoItemProxyObjectEntryNullHttpServletRequest()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
+			externalReferenceCode);
+
+		com.liferay.object.rest.dto.v1_0.ObjectEntry proxyObjectEntry =
+			_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
+
+		Assert.assertEquals(
+			objectEntry, _assertGetInfoItem(ercInfoItemIdentifier));
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+		Mockito.verify(
+			_objectEntryManager
+		).getObjectEntry(
+			Mockito.eq(0L), Mockito.any(DefaultDTOConverterContext.class),
+			Mockito.eq(ercInfoItemIdentifier.getExternalReferenceCode()),
+			Mockito.eq(_objectDefinition), Mockito.eq(null)
+		);
+
+		_objectEntryUtilMockedStatic.verify(
+			() -> ObjectEntryUtil.toObjectEntry(0L, proxyObjectEntry));
 	}
 
 	@Test
@@ -167,13 +244,21 @@ public class ObjectEntryInfoItemObjectProviderTest {
 			InfoItemIdentifier infoItemIdentifier)
 		throws NoSuchInfoItemException {
 
+		return _assertGetInfoItem(infoItemIdentifier, null);
+	}
+
+	private ObjectEntry _assertGetInfoItem(
+			InfoItemIdentifier infoItemIdentifier,
+			HttpServletRequest httpServletRequest)
+		throws NoSuchInfoItemException {
+
 		ObjectEntryInfoItemObjectProvider objectEntryInfoItemObjectProvider =
 			new ObjectEntryInfoItemObjectProvider(
 				_objectDefinition, _objectEntryLocalService,
 				_objectEntryManagerRegistry);
 
 		try {
-			_pushServiceContext();
+			_pushServiceContext(httpServletRequest);
 
 			return objectEntryInfoItemObjectProvider.getInfoItem(
 				infoItemIdentifier);
@@ -200,8 +285,128 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		Assert.assertTrue(noSuchInfoItemExceptionThrown);
 	}
 
-	private void _pushServiceContext() {
+	private void _assertGetInfoItemProxyObjectEntry(
+			Map<String, Object> attributes,
+			ERCInfoItemIdentifier ercInfoItemIdentifier,
+			HttpServletRequest httpServletRequest, ObjectEntry objectEntry,
+			com.liferay.object.rest.dto.v1_0.ObjectEntry proxyObjectEntry)
+		throws Exception {
+
+		Assert.assertEquals(
+			objectEntry,
+			_assertGetInfoItem(ercInfoItemIdentifier, httpServletRequest));
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+		Mockito.verify(
+			_objectEntryManager
+		).getObjectEntry(
+			Mockito.eq(0L), Mockito.any(DefaultDTOConverterContext.class),
+			Mockito.eq(ercInfoItemIdentifier.getExternalReferenceCode()),
+			Mockito.eq(_objectDefinition), Mockito.eq(null)
+		);
+
+		Mockito.verify(
+			httpServletRequest
+		).getAttribute(
+			_OBJECT_ENTRIES_KEY
+		);
+
+		_objectEntryUtilMockedStatic.verify(
+			() -> ObjectEntryUtil.toObjectEntry(0L, proxyObjectEntry));
+
+		_assertObjectEntriesAttribute(
+			attributes, ercInfoItemIdentifier, objectEntry);
+	}
+
+	private void _assertGetInfoItemProxyObjectEntryCached(
+			ERCInfoItemIdentifier ercInfoItemIdentifier,
+			HttpServletRequest httpServletRequest, ObjectEntry objectEntry)
+		throws Exception {
+
+		Assert.assertEquals(
+			objectEntry,
+			_assertGetInfoItem(ercInfoItemIdentifier, httpServletRequest));
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+		Mockito.verifyNoInteractions(_objectEntryManager);
+
+		_objectEntryUtilMockedStatic.verifyNoInteractions();
+
+		Mockito.verify(
+			httpServletRequest
+		).getAttribute(
+			_OBJECT_ENTRIES_KEY
+		);
+	}
+
+	private void _assertObjectEntriesAttribute(
+		Map<String, Object> attributes,
+		ERCInfoItemIdentifier infoItemIdentifier, ObjectEntry objectEntry) {
+
+		Object object = attributes.get(_OBJECT_ENTRIES_KEY);
+
+		Assert.assertNotNull(object);
+		Assert.assertTrue(object instanceof Map);
+
+		Map<InfoItemIdentifier, ObjectEntry> objectEntries =
+			(Map<InfoItemIdentifier, ObjectEntry>)object;
+
+		Assert.assertEquals(
+			MapUtil.toString(objectEntries), 1, objectEntries.size());
+
+		ObjectEntry chachedObjectEntry = objectEntries.get(infoItemIdentifier);
+
+		Assert.assertNotNull(chachedObjectEntry);
+		Assert.assertEquals(objectEntry, chachedObjectEntry);
+	}
+
+	private HttpServletRequest _getHttpServletRequest(
+		Map<String, Object> attributes) {
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(Mockito.anyString())
+		).thenAnswer(
+			new Answer<Object>() {
+
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock)
+					throws Throwable {
+
+					return attributes.get(
+						invocationOnMock.getArgument(0, String.class));
+				}
+
+			}
+		);
+
+		Mockito.doAnswer(
+			invocation -> {
+				attributes.put(
+					invocation.getArgument(0, String.class),
+					invocation.getArgument(1));
+
+				return null;
+			}
+		).when(
+			httpServletRequest
+		).setAttribute(
+			Mockito.anyString(), Mockito.any(Object.class)
+		);
+
+		return httpServletRequest;
+	}
+
+	private void _pushServiceContext(HttpServletRequest httpServletRequest) {
 		ServiceContext serviceContext = Mockito.mock(ServiceContext.class);
+
+		Mockito.when(
+			serviceContext.getRequest()
+		).thenReturn(
+			httpServletRequest
+		);
 
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
@@ -220,7 +425,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 	}
 
-	private void _setUpProxyObjectEntry(
+	private com.liferay.object.rest.dto.v1_0.ObjectEntry _setUpProxyObjectEntry(
 			String externalReferenceCode, ObjectEntry objectEntry)
 		throws Exception {
 
@@ -241,7 +446,11 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		).thenReturn(
 			objectEntry
 		);
+
+		return proxyObjectEntry;
 	}
+
+	private static final String _OBJECT_ENTRIES_KEY = "OBJECT_ENTRIES";
 
 	private static final MockedStatic<ObjectEntryUtil>
 		_objectEntryUtilMockedStatic = Mockito.mockStatic(

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
@@ -1,0 +1,255 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.provider;
+
+import com.liferay.info.exception.NoSuchInfoItemException;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.ERCInfoItemIdentifier;
+import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.provider.filter.InfoItemServiceFilter;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.web.internal.util.ObjectEntryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class ObjectEntryInfoItemObjectProviderTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_objectEntryUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		_objectDefinition = Mockito.mock(ObjectDefinition.class);
+		_objectEntryLocalService = Mockito.mock(ObjectEntryLocalService.class);
+		_objectEntryManagerRegistry = Mockito.mock(
+			ObjectEntryManagerRegistry.class);
+
+		_objectEntryManager = Mockito.mock(ObjectEntryManager.class);
+
+		Mockito.when(
+			_objectEntryManagerRegistry.getObjectEntryManager(null)
+		).thenReturn(
+			_objectEntryManager
+		);
+
+		_objectEntryUtilMockedStatic.reset();
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntry() throws Exception {
+		long classPK = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(classPK)
+		).thenReturn(
+			objectEntry
+		);
+
+		Assert.assertEquals(
+			objectEntry,
+			_assertGetInfoItem(new ClassPKInfoItemIdentifier(classPK)));
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntryNoSuchInfoItemException() {
+		long classPK = RandomTestUtil.randomLong();
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ClassPKInfoItemIdentifier(classPK),
+			"Unable to get object entry " + classPK);
+
+		Mockito.verify(
+			_objectEntryLocalService
+		).fetchObjectEntry(
+			classPK
+		);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemProxyObjectEntry() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
+
+		Assert.assertEquals(
+			objectEntry,
+			_assertGetInfoItem(
+				new ERCInfoItemIdentifier(externalReferenceCode)));
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+	}
+
+	@Test
+	public void testGetInfoItemProxyObjectEntryNoSuchInfoItemException()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ERCInfoItemIdentifier(externalReferenceCode),
+			"Unable to get object entry " + externalReferenceCode);
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+		Mockito.verify(
+			_objectEntryManager
+		).getObjectEntry(
+			Mockito.eq(0L), Mockito.any(DefaultDTOConverterContext.class),
+			Mockito.eq(externalReferenceCode), Mockito.eq(_objectDefinition),
+			Mockito.eq(null)
+		);
+	}
+
+	@Test
+	public void testGetInfoItemUnsoportedInfoItemIdentifierNoSuchInfoItemException() {
+		InfoItemIdentifier infoItemIdentifier = new InfoItemIdentifier() {
+
+			@Override
+			public InfoItemServiceFilter getInfoItemServiceFilter() {
+				return null;
+			}
+
+			@Override
+			public String getVersion() {
+				return null;
+			}
+
+			@Override
+			public void setVersion(String version) {
+			}
+
+		};
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			infoItemIdentifier,
+			"Unsupported info item identifier type " + infoItemIdentifier);
+
+		Mockito.verifyNoInteractions(_objectEntryLocalService);
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	private ObjectEntry _assertGetInfoItem(
+			InfoItemIdentifier infoItemIdentifier)
+		throws NoSuchInfoItemException {
+
+		ObjectEntryInfoItemObjectProvider objectEntryInfoItemObjectProvider =
+			new ObjectEntryInfoItemObjectProvider(
+				_objectDefinition, _objectEntryLocalService,
+				_objectEntryManagerRegistry);
+
+		try {
+			_pushServiceContext();
+
+			return objectEntryInfoItemObjectProvider.getInfoItem(
+				infoItemIdentifier);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	private void _assertGetInfoItemNoSuchInfoItemException(
+		InfoItemIdentifier infoItemIdentifier, String message) {
+
+		boolean noSuchInfoItemExceptionThrown = false;
+
+		try {
+			_assertGetInfoItem(infoItemIdentifier);
+		}
+		catch (NoSuchInfoItemException noSuchInfoItemException) {
+			noSuchInfoItemExceptionThrown = true;
+
+			Assert.assertEquals(message, noSuchInfoItemException.getMessage());
+		}
+
+		Assert.assertTrue(noSuchInfoItemExceptionThrown);
+	}
+
+	private void _pushServiceContext() {
+		ServiceContext serviceContext = Mockito.mock(ServiceContext.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			Mockito.mock(Group.class)
+		);
+
+		Mockito.when(
+			serviceContext.getThemeDisplay()
+		).thenReturn(
+			themeDisplay
+		);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+	}
+
+	private void _setUpProxyObjectEntry(
+			String externalReferenceCode, ObjectEntry objectEntry)
+		throws Exception {
+
+		com.liferay.object.rest.dto.v1_0.ObjectEntry proxyObjectEntry =
+			Mockito.mock(com.liferay.object.rest.dto.v1_0.ObjectEntry.class);
+
+		Mockito.when(
+			_objectEntryManager.getObjectEntry(
+				Mockito.eq(0L), Mockito.any(DefaultDTOConverterContext.class),
+				Mockito.eq(externalReferenceCode),
+				Mockito.eq(_objectDefinition), Mockito.eq(null))
+		).thenReturn(
+			proxyObjectEntry
+		);
+
+		_objectEntryUtilMockedStatic.when(
+			() -> ObjectEntryUtil.toObjectEntry(0L, proxyObjectEntry)
+		).thenReturn(
+			objectEntry
+		);
+	}
+
+	private static final MockedStatic<ObjectEntryUtil>
+		_objectEntryUtilMockedStatic = Mockito.mockStatic(
+			ObjectEntryUtil.class);
+
+	private ObjectDefinition _objectDefinition;
+	private ObjectEntryLocalService _objectEntryLocalService;
+	private ObjectEntryManager _objectEntryManager;
+	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+}


### PR DESCRIPTION
Hey!

This is fairly simply PR to cache proxy objects during the duration of the request. We have covered it with a test written by super @lfbesada :D 

During the rendering of a page, we may end up retrieving the proxy objects multiple time, which leads to several calls to the external services. We have made some test to cache it in our side, but we found out that it was more beneficial to just do it here.

Let me know what do you think

Thanks!