### PR TITLE
LPD-22968 Do not sanitize Text fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -365,6 +365,13 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 						).build()));
 			}
 
+			if (Objects.equals(
+					ddmFormFieldValue.getType(),
+					DDMFormFieldTypeConstants.TEXT)) {
+
+				return valueString;
+			}
+
 			return SanitizerUtil.sanitize(
 				groupedModel.getCompanyId(), groupedModel.getGroupId(),
 				groupedModel.getUserId(), groupedModel.getModelClassName(),


### PR DESCRIPTION
Motivation
-----
Fix a problem where we are escaping & to &amp in text fields.

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-22968)

Proposed Solution
-----
Do not sanitize fields of type "text", since we should only sanitize HTML fields.