### PR TITLE
LPD-23786 Adapt Object Validation to support a new custom object validation engine

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectValidationRuleConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectValidationRuleConstants.java
@@ -16,6 +16,9 @@ public class ObjectValidationRuleConstants {
 
 	public static final String ENGINE_TYPE_GROOVY = "groovy";
 
+	public static final String ENGINE_TYPE_JAVA_DELEGATE_PREFIX =
+		"javaDelegate#";
+
 	public static final String OUTPUT_TYPE_FULL_VALIDATION = "fullValidation";
 
 	public static final String OUTPUT_TYPE_PARTIAL_VALIDATION =

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/util/ObjectEntryVariablesUtil.java
@@ -118,6 +118,10 @@ public class ObjectEntryVariablesUtil {
 					objectDefinition,
 					Collections.unmodifiableSet(currentVariables.keySet()));
 			}
+		).put(
+			"originalEntryDTO",
+			payloadJSONObject.get(
+				"originalObjectEntryDTO" + objectDefinition.getShortName())
 		).build();
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -420,6 +421,19 @@ public class ObjectValidationRuleLocalServiceImpl
 				results = objectValidationRuleEngine.execute(
 					(Map<String, Object>)variables.get("baseModel"),
 					objectValidationRule.getScript());
+			}
+			else if (StringUtil.startsWith(
+						objectValidationRuleEngine.getKey(),
+						ObjectValidationRuleConstants.
+							ENGINE_TYPE_JAVA_DELEGATE_PREFIX)) {
+
+				results = objectValidationRuleEngine.execute(
+					HashMapBuilder.put(
+						"entryDTO", variables.get("entryDTO")
+					).put(
+						"originalEntryDTO", variables.get("originalEntryDTO")
+					).build(),
+					null);
 			}
 			else {
 				results = objectValidationRuleEngine.execute(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -646,7 +646,11 @@ public class ObjectValidationRuleLocalServiceImpl
 			!(objectValidationRuleEngine instanceof
 				FunctionObjectValidationRuleEngineImpl ||
 			  objectValidationRuleEngine instanceof
-				  UniqueCompositeKeyObjectValidationRuleEngineImpl)) {
+				  UniqueCompositeKeyObjectValidationRuleEngineImpl ||
+			  StringUtil.startsWith(
+				  engine,
+				  ObjectValidationRuleConstants.
+					  ENGINE_TYPE_JAVA_DELEGATE_PREFIX))) {
 
 			throw new ObjectValidationRuleScriptException(
 				"The script is required", "required");

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -55,6 +55,8 @@ import com.liferay.object.model.ObjectStateFlow;
 import com.liferay.object.model.ObjectStateTransition;
 import com.liferay.object.model.ObjectValidationRule;
 import com.liferay.object.model.ObjectValidationRuleSetting;
+import com.liferay.object.scope.CompanyScoped;
+import com.liferay.object.scope.ObjectDefinitionScoped;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -70,6 +72,7 @@ import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.object.tree.Node;
 import com.liferay.object.tree.Tree;
 import com.liferay.object.tree.TreeFactory;
+import com.liferay.object.validation.rule.ObjectValidationRuleEngine;
 import com.liferay.object.validation.rule.ObjectValidationRuleResult;
 import com.liferay.object.validation.rule.setting.builder.ObjectValidationRuleSettingBuilder;
 import com.liferay.petra.sql.dsl.Column;
@@ -121,6 +124,7 @@ import com.liferay.portal.kernel.util.BigDecimalUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -130,6 +134,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
@@ -181,6 +186,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -3229,6 +3239,55 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdateObjectEntryWithJavaDelegateObjectValidationRule()
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectEntryLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		String key =
+			ObjectValidationRuleConstants.ENGINE_TYPE_JAVA_DELEGATE_PREFIX +
+				RandomTestUtil.randomString();
+
+		ServiceRegistration<ObjectValidationRuleEngine> serviceRegistration =
+			bundleContext.registerService(
+				ObjectValidationRuleEngine.class,
+				new TestObjectValidationRuleEngine(
+					TestPropsValues.getCompanyId(),
+					Collections.singletonList(_objectDefinition.getName()),
+					key),
+				null);
+
+		try {
+			ObjectEntry objectEntry = _addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddressRequired", "bob@liferay.com"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).build());
+
+			_addObjectValidationRule(
+				key,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"");
+
+			_objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddressRequired", "john@liferay.com"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Test
 	public void testUpdateStatus() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -3985,5 +4044,86 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private WorkflowTaskManager _workflowTaskManager;
+
+	private static class TestObjectValidationRuleEngine
+		implements CompanyScoped, ObjectDefinitionScoped,
+				   ObjectValidationRuleEngine {
+
+		@Override
+		public Map<String, Object> execute(
+			Map<String, Object> inputObjects, String script) {
+
+			String emailAddressRequired = "";
+
+			if (inputObjects.containsKey("entryDTO") &&
+				Validator.isNotNull(inputObjects.get("entryDTO"))) {
+
+				Map<String, Object> entryDTO =
+					(Map<String, Object>)inputObjects.get("entryDTO");
+
+				Map<String, Object> entryValues =
+					(Map<String, Object>)entryDTO.get("properties");
+
+				emailAddressRequired = GetterUtil.getString(
+					entryValues.get("emailAddressRequired"));
+			}
+
+			String oldEmailAddressRequired = "";
+
+			if (inputObjects.containsKey("originalEntryDTO") &&
+				Validator.isNotNull(inputObjects.get("originalEntryDTO"))) {
+
+				Map<String, Object> originalEntryDTO =
+					(Map<String, Object>)inputObjects.get("originalEntryDTO");
+
+				Map<String, Object> originalEntryValues =
+					(Map<String, Object>)originalEntryDTO.get("properties");
+
+				oldEmailAddressRequired = GetterUtil.getString(
+					originalEntryValues.get("emailAddressRequired"));
+			}
+
+			Assert.assertEquals("john@liferay.com", emailAddressRequired);
+			Assert.assertEquals("bob@liferay.com", oldEmailAddressRequired);
+
+			return HashMapBuilder.<String, Object>put(
+				"validationCriteriaMet", true
+			).build();
+		}
+
+		@Override
+		public long getAllowedCompanyId() {
+			return _allowedCompanyId;
+		}
+
+		@Override
+		public List<String> getAllowedObjectDefinitionNames() {
+			return _allowedObjectDefinitionNames;
+		}
+
+		@Override
+		public String getKey() {
+			return _key;
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return RandomTestUtil.randomString();
+		}
+
+		private TestObjectValidationRuleEngine(
+			long allowedCompanyId, List<String> allowedObjectDefinitionNames,
+			String key) {
+
+			_allowedCompanyId = allowedCompanyId;
+			_allowedObjectDefinitionNames = allowedObjectDefinitionNames;
+			_key = key;
+		}
+
+		private final long _allowedCompanyId;
+		private final List<String> _allowedObjectDefinitionNames;
+		private final String _key;
+
+	}
 
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/BasicInfo.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/BasicInfo.tsx
@@ -114,7 +114,8 @@ export function BasicInfo({
 				/>
 			</Card>
 
-			{values.engine?.startsWith('function#') && (
+			{(values.engine?.startsWith('function#') ||
+				values.engine?.startsWith('javaDelegate#')) && (
 				<Card title={Liferay.Language.get('error-message')}>
 					<InputLocalized
 						disabled={disabled}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/EditObjectValidation.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/EditObjectValidation.tsx
@@ -238,7 +238,9 @@ export default function EditObjectValidation({
 		>
 			<ClayTabs className="side-panel-iframe__tabs">
 				{TABS.map(({label}, index) =>
-					values.engine?.startsWith('function#') && index === 1 ? (
+					(values.engine?.startsWith('function#') ||
+						values.engine?.startsWith('javaDelegate#')) &&
+					index === 1 ? (
 						<React.Fragment key={index} />
 					) : (
 						<ClayTabs.Item

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/useObjectValidationForm.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectValidation/useObjectValidationForm.ts
@@ -51,6 +51,7 @@ export function useObjectValidationForm({
 		if (
 			validation.engine !== 'compositeKey' &&
 			!validation.engine?.startsWith('function#') &&
+			!validation.engine?.startsWith('javaDelegate#') &&
 			invalidateRequired(script)
 		) {
 			errors.script = constantsUtils.REQUIRED_MSG;


### PR DESCRIPTION
[LPD-23786](https://liferay.atlassian.net/browse/LPD-23786)


In this PR, I've introduced a new type of key called 'javaDelegate#'. All custom validations that utilize this name as a prefix in the key will now receive both the originalEntryDTO and the entryDTO. To validate this enhancement, I've implemented a new engine for Bookmarks object definition. Here is the commit https://github.com/pedro-oliveira446/liferay-portal/pull/76/commits/2daf7c2953bb3103704f7fc26893c8af4b969630