### PR TITLE
LPD-25300 Using the role key to fetch roles on BaseNotificationType

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/SettingsContainer/UserNotificationSettings.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/SettingsContainer/UserNotificationSettings.tsx
@@ -14,6 +14,7 @@ import React, {useEffect, useState} from 'react';
 
 interface Role {
 	description: string;
+	externalReferenceCode: string;
 	id: number;
 	name: string;
 	roleType: string;
@@ -70,7 +71,7 @@ export function UserNotificationSettings({
 		const roles = {
 			children: items
 				.filter(({name}) => name !== 'Guest')
-				.map(({name}) => {
+				.map(({externalReferenceCode, name}) => {
 					const selectedRole = !!(values.recipients as Partial<
 						UserNotificationRecipients
 					>[]).find((recipient) => recipient.roleName === name);
@@ -78,7 +79,7 @@ export function UserNotificationSettings({
 					return {
 						checked: selectedRole,
 						label: name,
-						value: name,
+						value: externalReferenceCode,
 					};
 				}),
 			label: '',


### PR DESCRIPTION
Hi team, I'm solving this problem https://liferay.atlassian.net/browse/LPD-25300 but I'm wondering if we should create a test only for this case and how it would be. I'm changing the validation we're doing here with the roles as we need the key in the backend and not the title/name, as in custom roles we can make them different. Any inputs?