### PR TITLE
LPD-26339 - Add default language labels missing during import

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/dto/v1_0/util/ObjectFieldUtil.java
@@ -275,6 +275,8 @@ public class ObjectFieldUtil {
 			}
 		}
 
+		labelMap.computeIfAbsent(defaultLocale, key -> objectField.getName());
+
 		serviceBuilderObjectField.setLabelMap(labelMap);
 
 		serviceBuilderObjectField.setLocalized(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -341,7 +341,8 @@ public class ObjectDefinitionResourceImpl
 		}
 
 		_addObjectDefinitionResources(
-			Collections.emptySet(), objectDefinition.getObjectActions(),
+			Collections.emptySet(), objectDefinition.getDefaultLanguageId(),
+			objectDefinition.getObjectActions(),
 			serviceBuilderObjectDefinition.getObjectDefinitionId(),
 			objectDefinition.getObjectLayouts(),
 			objectDefinition.getObjectRelationships(),
@@ -785,6 +786,7 @@ public class ObjectDefinitionResourceImpl
 
 		_addObjectDefinitionResources(
 			accountEntryRestrictedObjectRelationshipsNames,
+			objectDefinition.getDefaultLanguageId(),
 			objectActions.toArray(new ObjectAction[0]), objectDefinitionId,
 			objectLayouts,
 			objectRelationships.toArray(new ObjectRelationship[0]),
@@ -843,8 +845,8 @@ public class ObjectDefinitionResourceImpl
 
 	private void _addObjectDefinitionResources(
 			Set<String> accountEntryRestrictedObjectRelationshipsNames,
-			ObjectAction[] objectActions, long objectDefinitionId,
-			ObjectLayout[] objectLayouts,
+			String defaultLanguageId, ObjectAction[] objectActions,
+			long objectDefinitionId, ObjectLayout[] objectLayouts,
 			ObjectRelationship[] objectRelationships,
 			ObjectValidationRule[] objectValidationRules,
 			ObjectView[] objectViews)
@@ -864,6 +866,13 @@ public class ObjectDefinitionResourceImpl
 						_objectActionLocalService.fetchObjectAction(
 							objectAction.getExternalReferenceCode(),
 							objectDefinitionId);
+
+				Map<String, String> labelMap = objectAction.getLabel();
+
+				labelMap.computeIfAbsent(
+					defaultLanguageId, key -> objectAction.getName());
+
+				objectAction.setLabel(() -> labelMap);
 
 				if (serviceBuilderObjectAction != null) {
 					objectActionResource.putObjectAction(
@@ -907,6 +916,16 @@ public class ObjectDefinitionResourceImpl
 								objectDefinitionId,
 								objectRelationship.getName());
 				}
+
+				Map<String, String> labelMap = objectRelationship.getLabel();
+
+				ObjectRelationship finalObjectRelationship = objectRelationship;
+
+				labelMap.computeIfAbsent(
+					defaultLanguageId,
+					key -> finalObjectRelationship.getName());
+
+				objectRelationship.setLabel(() -> labelMap);
 
 				boolean edge = GetterUtil.getBoolean(
 					objectRelationship.getEdge());

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/test-object-definition.portuguese-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/test-object-definition.portuguese-locale.json
@@ -3,6 +3,22 @@
 	"label": {
 		"pt_BR": "Definição de Objeto Teste"
 	},
+	"objectActions": [
+		{
+			"active": true,
+			"conditionExpression": "",
+			"description": "",
+			"label": {
+				"en_US": "Action"
+			},
+			"name": "Acao",
+			"objectActionExecutorKey": "notification",
+			"objectActionTriggerKey": "onAfterAdd",
+			"parameters": {
+				"notificationTemplateExternalReferenceCode": "TESTNOTIFICATIONTEMPLATE1"
+			}
+		}
+	],
 	"objectFields": [
 		{
 			"DBType": "String",
@@ -65,9 +81,30 @@
 			},
 			"name": "status",
 			"system": true
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Integer",
+			"label": {
+				"en_US": "Phone Number"
+			},
+			"name": "telefone",
+			"readOnly": "false",
+			"system": false
 		}
 	],
 	"objectFolderExternalReferenceCode": "default",
+	"objectRelationships": [
+		{
+			"label": {
+				"en_US": "Test Object Relationship"
+			},
+			"name": "relacionamento",
+			"objectDefinitionExternalReferenceCode2": "TESTOBJECTDEFINITION2",
+			"system": false,
+			"type": "oneToMany"
+		}
+	],
 	"pluralLabel": {
 		"pt_BR": "Definições de Objeto Teste"
 	},

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/test-object-definition.site-default-locale.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/test-object-definition.site-default-locale.json
@@ -4,6 +4,23 @@
 		"en_US": "Definição de Objeto Teste",
 		"pt_BR": "Definição de Objeto Teste"
 	},
+	"objectActions": [
+		{
+			"active": true,
+			"conditionExpression": "",
+			"description": "",
+			"label": {
+				"en_US": "Action",
+				"pt_BR": "Acao"
+			},
+			"name": "Acao",
+			"objectActionExecutorKey": "notification",
+			"objectActionTriggerKey": "onAfterAdd",
+			"parameters": {
+				"notificationTemplateExternalReferenceCode": "TESTNOTIFICATIONTEMPLATE1"
+			}
+		}
+	],
 	"objectFields": [
 		{
 			"DBType": "String",
@@ -73,9 +90,32 @@
 			},
 			"name": "status",
 			"system": true
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Integer",
+			"label": {
+				"en_US": "Phone Number",
+				"pt_BR": "telefone"
+			},
+			"name": "telefone",
+			"readOnly": "false",
+			"system": false
 		}
 	],
 	"objectFolderExternalReferenceCode": "default",
+	"objectRelationships": [
+		{
+			"label": {
+				"en_US": "Test Object Relationship",
+				"pt_BR": "relacionamento"
+			},
+			"name": "relacionamento",
+			"objectDefinitionExternalReferenceCode2": "TESTOBJECTDEFINITION2",
+			"system": false,
+			"type": "oneToMany"
+		}
+	],
 	"pluralLabel": {
 		"en_US": "Definições de Objeto Teste",
 		"pt_BR": "Definições de Objeto Teste"


### PR DESCRIPTION
[LPD-26339](https://liferay.atlassian.net/browse/LPD-26339)
Hi Guys,

I did the changes @marcelabc requested on this PR: https://github.com/liferay-objects/liferay-portal/pull/3367

1. I removed the _addDefaultLocaleLabel method and used computeIfAbsent()

CC @G-Sa 


