### PR TITLE
LPD-26436 Remove the ignore annotation from the CannotCreateCustomObjectsEntriesWithNonexistentNestedFieldInManyToManyRelationships Poshi test

### DIFF
--- a/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
+++ b/modules/apps/object/object-rest-test/src/testFunctional/tests/OperateCustomObjectAndRelatedCustomObjectsWithinSingleRequest.testcase
@@ -363,7 +363,6 @@ definition {
 
 	@description = "Ignore tests unitl LPS-169348 fixed"
 	@disable-webdriver = "true"
-	@ignore = "true"
 	@priority = 3
 	test CannotCreateCustomObjectsEntriesWithNonexistentNestedFieldInManyToManyRelationships {
 		property portal.acceptance = "true";


### PR DESCRIPTION
[LPD-26436](https://liferay.atlassian.net/browse/LPD-26436)