### PR TITLE
LPD-27490 It is not necessary since getMaxFileSize is already in MB

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -179,11 +179,9 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 				throw new InfoFormException();
 			}
 
-			long maxFileSize =
-				objectEntryValuesException.getMaxFileSize() / _FILE_LENGTH_MB;
-
 			throw new InfoFormValidationException.FileSize(
-				infoFieldUniqueId, maxFileSize + " MB");
+				infoFieldUniqueId,
+				objectEntryValuesException.getMaxFileSize() + " MB");
 		}
 
 		if (exception instanceof
@@ -326,8 +324,6 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 
 		return null;
 	}
-
-	private static final long _FILE_LENGTH_MB = 1024 * 1024;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryInfoItemExceptionRequestHandler.class);


### PR DESCRIPTION
Motivation
-----
Fix following test failure [LocalFile.FileUpload#ViewErrorMessageWhenSubmitFormWithAttachedFileSizeLargerThanAllowedMaximumUploadSize](https://testray.liferay.com/#/project/34754/routines/129511/build/8701497/case-result/8712519)

[Link to the issue](https://liferay.atlassian.net/browse/LPD-27490)

Proposed solution
-----
Removes conversion since the **objectEntryValuesException.getMaxFileSize()** is already in MB

This pr doesn't need a test since it is fixing a test failure.