### PR TITLE
 LPD-25711 - Allow bound objects entries to be managed entirely if user can update Root entry

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java
@@ -154,20 +154,20 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			long objectDefinitionId, long objectEntryId, String actionId)
 		throws PortalException {
 
-		ModelResourcePermission<ObjectEntry> modelResourcePermission =
-			getModelResourcePermission(objectDefinitionId);
-
-		modelResourcePermission.check(
-			getPermissionChecker(), objectEntryId, actionId);
+		_checkPermission(
+			actionId, objectDefinitionId, getObjectEntry(objectEntryId));
 	}
 
 	@Override
 	public ObjectEntry deleteObjectEntry(long objectEntryId)
 		throws PortalException {
 
+		ObjectEntry objectEntry = objectEntryLocalService.getObjectEntry(
+			objectEntryId);
+
 		_checkPermission(
-			ActionKeys.DELETE,
-			objectEntryLocalService.getObjectEntry(objectEntryId));
+			ActionKeys.DELETE, objectEntry.getObjectDefinitionId(),
+			objectEntry);
 
 		return objectEntryLocalService.deleteObjectEntry(objectEntryId);
 	}
@@ -180,7 +180,9 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 		ObjectEntry objectEntry = objectEntryLocalService.getObjectEntry(
 			externalReferenceCode, companyId, groupId);
 
-		_checkPermission(ActionKeys.DELETE, objectEntry);
+		_checkPermission(
+			ActionKeys.DELETE, objectEntry.getObjectDefinitionId(),
+			objectEntry);
 
 		return objectEntryLocalService.deleteObjectEntry(objectEntry);
 	}
@@ -213,7 +215,9 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			objectEntryId);
 
 		if (objectEntry != null) {
-			_checkPermission(ActionKeys.VIEW, objectEntry);
+			_checkPermission(
+				ActionKeys.VIEW, objectEntry.getObjectDefinitionId(),
+				objectEntry);
 		}
 
 		return objectEntry;
@@ -277,7 +281,9 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			objectEntryId);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
-			_checkPermission(ActionKeys.VIEW, objectEntry);
+			_checkPermission(
+				ActionKeys.VIEW, objectEntry.getObjectDefinitionId(),
+				objectEntry);
 		}
 
 		return objectEntry;
@@ -292,7 +298,9 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			externalReferenceCode, companyId, groupId);
 
 		if (!ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission()) {
-			_checkPermission(ActionKeys.VIEW, objectEntry);
+			_checkPermission(
+				ActionKeys.VIEW, objectEntry.getObjectDefinitionId(),
+				objectEntry);
 		}
 
 		return objectEntry;
@@ -417,8 +425,29 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		portletResourcePermission.check(
-			permissionChecker, groupId, ObjectActionKeys.ADD_OBJECT_ENTRY);
+		ObjectDefinition objectDefinition =
+			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
+
+		try {
+			portletResourcePermission.check(
+				permissionChecker, groupId, ObjectActionKeys.ADD_OBJECT_ENTRY);
+		}
+		catch (PortalException portalException) {
+			if (objectDefinition.isRootDescendantNode()) {
+				ObjectEntry rootObjectEntry = _getRootObjectEntry(
+					objectDefinition, values);
+
+				ModelResourcePermission<ObjectEntry> modelResourcePermission =
+					getModelResourcePermission(objectDefinitionId);
+
+				modelResourcePermission.check(
+					permissionChecker, rootObjectEntry, ActionKeys.UPDATE);
+
+				return;
+			}
+
+			throw portalException;
+		}
 
 		if (permissionChecker.hasPermission(
 				groupId, portletResourcePermission.getResourceName(), 0,
@@ -428,9 +457,6 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 		}
 
 		long accountEntryId = 0;
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId);
 
 		if (objectDefinition.isRootDescendantNode()) {
 			accountEntryId = _getRootObjectEntryAccountEntryId(
@@ -520,8 +546,16 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 				continue;
 			}
 
-			if (resourcePermission.hasActionId(
+			if (!objectDefinition.isRootDescendantNode() &&
+				resourcePermission.hasActionId(
 					ObjectActionKeys.ADD_OBJECT_ENTRY)) {
+
+				return;
+			}
+
+			if (resourcePermission.hasActionId(
+					ObjectActionKeys.ADD_OBJECT_ENTRY) ||
+				resourcePermission.hasActionId(ActionKeys.UPDATE)) {
 
 				return;
 			}
@@ -532,14 +566,33 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			ObjectActionKeys.ADD_OBJECT_ENTRY);
 	}
 
-	private void _checkPermission(String actionId, ObjectEntry objectEntry)
+	private void _checkPermission(
+			String actionId, long objectDefinitionId, ObjectEntry objectEntry)
 		throws PortalException {
 
 		ModelResourcePermission<ObjectEntry> modelResourcePermission =
-			getModelResourcePermission(objectEntry.getObjectDefinitionId());
+			getModelResourcePermission(objectDefinitionId);
 
-		modelResourcePermission.check(
-			getPermissionChecker(), objectEntry, actionId);
+		try {
+			modelResourcePermission.check(
+				getPermissionChecker(), objectEntry, actionId);
+		}
+		catch (PortalException portalException) {
+			if ((objectEntry.getRootObjectEntryId() != 0) &&
+				(objectEntry.getRootObjectEntryId() !=
+					objectEntry.getObjectEntryId()) &&
+				(actionId.equals(ActionKeys.DELETE) ||
+				 actionId.equals(ActionKeys.UPDATE) ||
+				 actionId.equals(ActionKeys.VIEW))) {
+
+				modelResourcePermission.check(
+					getPermissionChecker(), objectEntry, ActionKeys.UPDATE);
+
+				return;
+			}
+
+			throw portalException;
+		}
 	}
 
 	private PortletResourcePermission _getPortletResourcePermission(
@@ -558,7 +611,7 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 			objectDefinition.getResourceName());
 	}
 
-	private long _getRootObjectEntryAccountEntryId(
+	private ObjectEntry _getRootObjectEntry(
 			ObjectDefinition objectDefinition, Map<String, Serializable> values)
 		throws PortalException {
 
@@ -579,8 +632,16 @@ public class ObjectEntryServiceImpl extends ObjectEntryServiceBaseImpl {
 		ObjectEntry parentObjectEntry = objectEntryLocalService.getObjectEntry(
 			MapUtil.getLong(values, objectField2.getName()));
 
-		ObjectEntry rootObjectEntry = objectEntryLocalService.getObjectEntry(
+		return objectEntryLocalService.getObjectEntry(
 			parentObjectEntry.getRootObjectEntryId());
+	}
+
+	private long _getRootObjectEntryAccountEntryId(
+			ObjectDefinition objectDefinition, Map<String, Serializable> values)
+		throws PortalException {
+
+		ObjectEntry rootObjectEntry = _getRootObjectEntry(
+			objectDefinition, values);
 
 		ObjectDefinition rootObjectDefinition =
 			_objectDefinitionPersistence.findByPrimaryKey(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryServiceTest.java
@@ -319,6 +319,82 @@ public class ObjectEntryServiceTest {
 						String.valueOf(TestPropsValues.getCompanyId()),
 						role.getRoleId(), ObjectActionKeys.ADD_OBJECT_ENTRY));
 			});
+
+		// User can add object entry to descendant object definitions
+		// with the update permission.
+
+		_setUser(_adminUser);
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			TestPropsValues.getCompanyId(),
+			_rootObjectDefinition.getResourceName(),
+			ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()), role.getRoleId(),
+			ObjectActionKeys.ADD_OBJECT_ENTRY);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(),
+			_rootObjectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_rootObjectDefinition.getObjectDefinitionId()),
+			role.getRoleId(), new String[] {ActionKeys.UPDATE});
+
+		_setUser(_user);
+
+		iterator = _tree.iterator();
+
+		while (iterator.hasNext()) {
+			Node node = iterator.next();
+
+			if (node.isRoot()) {
+				continue;
+			}
+
+			Assert.assertNotNull(
+				_objectEntryService.addObjectEntry(
+					0, node.getPrimaryKey(),
+					HashMapBuilder.<String, Serializable>put(
+						() -> {
+							Edge edge = node.getEdge();
+
+							ObjectRelationship objectRelationship =
+								_objectRelationshipLocalService.
+									getObjectRelationship(
+										edge.getObjectRelationshipId());
+
+							ObjectField objectField =
+								_objectFieldLocalService.getObjectField(
+									objectRelationship.getObjectFieldId2());
+
+							return objectField.getName();
+						},
+						() -> {
+							Node parentNode = node.getParentNode();
+
+							ObjectEntry objectEntry = objectEntries.get(
+								parentNode.getPrimaryKey());
+
+							return objectEntry.getObjectEntryId();
+						}
+					).build(),
+					ServiceContextTestUtil.getServiceContext(
+						TestPropsValues.getGroupId(), _user.getUserId())));
+		}
+
+		// User cannot add object entry to a root object definition
+		// with the update permission.
+
+		AssertUtils.assertFailure(
+			PortalException.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(),
+				" must have ADD_OBJECT_ENTRY permission for ",
+				_rootObjectDefinition.getResourceName(), " "),
+			() -> _objectEntryService.addObjectEntry(
+				0, _rootObjectDefinition.getObjectDefinitionId(),
+				Collections.emptyMap(),
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getGroupId(), _user.getUserId())));
 	}
 
 	@Test
@@ -423,6 +499,54 @@ public class ObjectEntryServiceTest {
 			objectEntry -> Assert.assertNotNull(
 				_objectEntryService.deleteObjectEntry(
 					objectEntry.getObjectEntryId())));
+
+		// User can delete an object entry of a descendant object definition
+		// with the update permission.
+
+		_setUser(_adminUser);
+
+		objectEntryTree = TreeTestUtil.createObjectEntryTree(
+			"1", _objectEntryLocalService, _objectFieldLocalService,
+			_rootObjectDefinition.getRootObjectDefinitionId(),
+			_objectRelationshipLocalService, _treeFactory);
+
+		objectEntryRootNode = objectEntryTree.getRootNode();
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(),
+			_rootObjectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntryRootNode.getPrimaryKey()),
+			role.getRoleId(), new String[] {ActionKeys.UPDATE});
+
+		_setUser(_user);
+
+		TreeTestUtil.forEachNodeObjectEntry(
+			objectEntryTree.iterator(TreeConstants.ITERATOR_TYPE_POST_ORDER),
+			_objectEntryLocalService,
+			objectEntry -> {
+				if (objectEntry.getRootObjectEntryId() ==
+						objectEntry.getObjectEntryId()) {
+
+					return;
+				}
+
+				Assert.assertNotNull(
+					_objectEntryService.deleteObjectEntry(
+						objectEntry.getObjectEntryId()));
+			});
+
+		long rootObjectEntryId = objectEntryRootNode.getPrimaryKey();
+
+		// User cannot delete an object entry to a root object definition
+		// with the update permission.
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have DELETE permission for ",
+				_rootObjectDefinition.getClassName(), " ", rootObjectEntryId),
+			() -> _objectEntryService.deleteObjectEntry(rootObjectEntryId));
 	}
 
 	@Test
@@ -563,6 +687,46 @@ public class ObjectEntryServiceTest {
 			objectEntry -> Assert.assertNotNull(
 				_objectEntryService.getObjectEntry(
 					objectEntry.getObjectEntryId())));
+
+		// User can view an object entry of a descendant object definition
+		// with the update permission.
+
+		_setUser(_adminUser);
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(),
+			_rootObjectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(objectEntryRootNode.getPrimaryKey()),
+			role.getRoleId(), new String[] {ActionKeys.UPDATE});
+
+		_setUser(_user);
+
+		TreeTestUtil.forEachNodeObjectEntry(
+			objectEntryTree.iterator(), _objectEntryLocalService,
+			objectEntry -> {
+				if (objectEntry.getRootObjectEntryId() ==
+						objectEntry.getObjectEntryId()) {
+
+					return;
+				}
+
+				Assert.assertNotNull(
+					_objectEntryService.getObjectEntry(
+						objectEntry.getObjectEntryId()));
+			});
+
+		long rootObjectEntryId = objectEntryRootNode.getPrimaryKey();
+
+		// User cannot view an object entry of a root object definition
+		// with the update permission.
+
+		AssertUtils.assertFailure(
+			PrincipalException.MustHavePermission.class,
+			StringBundler.concat(
+				"User ", _user.getUserId(), " must have VIEW permission for ",
+				_rootObjectDefinition.getClassName(), " ", rootObjectEntryId),
+			() -> _objectEntryService.getObjectEntry(rootObjectEntryId));
 	}
 
 	@Test

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -330,7 +330,10 @@ public class ObjectEntryDisplayContextImpl
 					objectScopeProvider.getGroupId(
 						_objectRequestHelper.getRequest()),
 					rootObjectDefinition.getObjectDefinitionId(),
-					ObjectActionKeys.ADD_OBJECT_ENTRY)) {
+					ObjectActionKeys.ADD_OBJECT_ENTRY) ||
+				ObjectEntryServiceUtil.hasModelResourcePermission(
+					rootObjectDefinition.getObjectDefinitionId(),
+					_objectEntry.getId(), ActionKeys.UPDATE)) {
 
 				creationMenu.addDropdownItem(
 					_getCreateNewRelatedModelDropdownItem(


### PR DESCRIPTION
Related to [LPD-27466](https://liferay.atlassian.net/browse/LPD-27466) and [LPD-27468](https://liferay.atlassian.net/browse/LPD-27468)