### PR TITLE
LPD-29830 Adapt ThreadLocal to use the id of the object entry so that validations will run properly in a batch call

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
@@ -27,7 +27,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectValidationRuleLocalService;
 import com.liferay.object.validation.rule.ObjectValidationRuleResult;
-import com.liferay.object.validation.rule.util.ObjectValidationRuleThreadLocal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -56,7 +55,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -83,10 +81,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -232,12 +228,6 @@ public class AccountEntryLocalServiceTest {
 				"This name is invalid.",
 				objectValidationRuleResult.getErrorMessage());
 		}
-
-		ThreadLocal<Set<Long>> threadLocal = ReflectionTestUtil.getFieldValue(
-			ObjectValidationRuleThreadLocal.class,
-			"_executedObjectValidationRuleIds");
-
-		threadLocal.set(new HashSet<>());
 
 		try {
 			AccountEntryTestUtil.addAccountEntry(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/validation/rule/util/ObjectValidationRuleThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/validation/rule/util/ObjectValidationRuleThreadLocal.java
@@ -16,29 +16,21 @@ import java.util.Set;
  */
 public class ObjectValidationRuleThreadLocal {
 
-	public static void addExecutedObjectValidationRuleId(
-		long objectValidationRuleId) {
+	public static void addValidatedObjectEntryId(long objectEntryId) {
+		Set<Long> validatedObjectEntryIds = _validatedObjectEntryIds.get();
 
-		Set<Long> executedObjectValidationRuleIds =
-			_executedObjectValidationRuleIds.get();
-
-		executedObjectValidationRuleIds.add(objectValidationRuleId);
-
-		_executedObjectValidationRuleIds.set(executedObjectValidationRuleIds);
+		validatedObjectEntryIds.add(objectEntryId);
 	}
 
-	public static boolean isExecutedObjectValidationRuleId(
-		long objectValidationRuleId) {
+	public static boolean isValidatedObjectEntry(long objectEntryId) {
+		Set<Long> validatedObjectEntryIds = _validatedObjectEntryIds.get();
 
-		Set<Long> executedObjectValidationRuleIds =
-			_executedObjectValidationRuleIds.get();
-
-		return executedObjectValidationRuleIds.contains(objectValidationRuleId);
+		return validatedObjectEntryIds.contains(objectEntryId);
 	}
 
-	private static final ThreadLocal<Set<Long>>
-		_executedObjectValidationRuleIds = new CentralizedThreadLocal<>(
-			ObjectEntryThreadLocal.class + "._executedObjectValidationRuleIds",
+	private static final ThreadLocal<Set<Long>> _validatedObjectEntryIds =
+		new CentralizedThreadLocal<>(
+			ObjectEntryThreadLocal.class + "._validatedObjectEntryIds",
 			HashSet::new);
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectValidationRuleLocalServiceImpl.java
@@ -368,7 +368,10 @@ public class ObjectValidationRuleLocalServiceImpl
 			JSONObject payloadJSONObject, long userId)
 		throws PortalException {
 
-		if (baseModel == null) {
+		if ((baseModel == null) ||
+			ObjectValidationRuleThreadLocal.isValidatedObjectEntry(
+				(long)baseModel.getPrimaryKeyObj())) {
+
 			return;
 		}
 
@@ -392,13 +395,6 @@ public class ObjectValidationRuleLocalServiceImpl
 
 		for (ObjectValidationRule objectValidationRule :
 				objectValidationRules) {
-
-			if (ObjectValidationRuleThreadLocal.
-					isExecutedObjectValidationRuleId(
-						objectValidationRule.getObjectValidationRuleId())) {
-
-				continue;
-			}
 
 			Map<String, Object> results = new HashMap<>();
 
@@ -448,9 +444,6 @@ public class ObjectValidationRuleLocalServiceImpl
 				results = objectValidationRuleEngine.execute(
 					(Map<String, Object>)variables.get("entryDTO"), null);
 			}
-
-			ObjectValidationRuleThreadLocal.addExecutedObjectValidationRuleId(
-				objectValidationRule.getObjectValidationRuleId());
 
 			Locale locale = LocaleUtil.getMostRelevantLocale();
 
@@ -503,6 +496,9 @@ public class ObjectValidationRuleLocalServiceImpl
 					new ObjectValidationRuleResult(errorMessage));
 			}
 		}
+
+		ObjectValidationRuleThreadLocal.addValidatedObjectEntryId(
+			(long)baseModel.getPrimaryKeyObj());
 
 		if (ListUtil.isNotEmpty(objectValidationRuleResults)) {
 			throw new ObjectValidationRuleEngineException(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -456,6 +456,61 @@ public class ObjectEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddMultipleObjectEntriesWithObjectValidationRule()
+		throws Exception {
+
+		ObjectValidationRule objectValidationRule = _addObjectValidationRule(
+			ObjectValidationRuleConstants.ENGINE_TYPE_DDM,
+			LocalizedMapUtil.getLocalizedMap("Field must be an email address"),
+			"isEmailAddress(emailAddressRequired)");
+
+		_addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"emailAddressRequired", "bob@liferay.com"
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build());
+
+		_assertCount(1);
+
+		for (String invalidEmailAddress :
+				Arrays.asList(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString())) {
+
+			try {
+				_addObjectEntry(
+					HashMapBuilder.<String, Serializable>put(
+						"emailAddressRequired", invalidEmailAddress
+					).put(
+						"listTypeEntryKeyRequired", "listTypeEntryKey1"
+					).build());
+
+				Assert.fail();
+			}
+			catch (ModelListenerException modelListenerException) {
+				ObjectValidationRuleEngineException
+					objectValidationRuleEngineException =
+						(ObjectValidationRuleEngineException)
+							modelListenerException.getCause();
+
+				List<ObjectValidationRuleResult> objectValidationRuleResults =
+					objectValidationRuleEngineException.
+						getObjectValidationRuleResults();
+
+				Assert.assertEquals(
+					objectValidationRuleResults.toString(), 1,
+					objectValidationRuleResults.size());
+
+				_assertObjectValidationRuleResult(
+					objectValidationRule.getErrorLabel(LocaleUtil.getDefault()),
+					null, objectValidationRuleResults.get(0));
+			}
+		}
+	}
+
+	@Test
 	public void testAddObjectEntry() throws Exception {
 		_assertCount(0);
 
@@ -3486,7 +3541,12 @@ public class ObjectEntryLocalServiceTest {
 		try {
 			user.setEmailAddress(RandomTestUtil.randomString());
 
-			_clearExecutedObjectValidationIds();
+			ThreadLocal<Set<Long>> threadLocal =
+				ReflectionTestUtil.getFieldValue(
+					ObjectValidationRuleThreadLocal.class,
+					"_validatedObjectEntryIds");
+
+			threadLocal.set(new HashSet<>());
 
 			_userLocalService.updateUser(user);
 
@@ -3632,8 +3692,6 @@ public class ObjectEntryLocalServiceTest {
 			Map<String, Serializable> values)
 		throws Exception {
 
-		_clearExecutedObjectValidationIds();
-
 		return _objectEntryLocalService.addObjectEntry(
 			TestPropsValues.getUserId(), groupId, objectDefinitionId, values,
 			ServiceContextTestUtil.getServiceContext());
@@ -3759,14 +3817,6 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(
 			expectedObjectFieldName,
 			objectValidationRuleResult.getObjectFieldName());
-	}
-
-	private void _clearExecutedObjectValidationIds() throws Exception {
-		ThreadLocal<Set<Long>> threadLocal = ReflectionTestUtil.getFieldValue(
-			ObjectValidationRuleThreadLocal.class,
-			"_executedObjectValidationRuleIds");
-
-		threadLocal.set(new HashSet<>());
 	}
 
 	private boolean _containsObjectEntryValuesSQLQuery(LogCapture logCapture) {


### PR DESCRIPTION
Related ticket: [LPD-29830](https://liferay.atlassian.net/browse/LPD-29830)

[LPD-29830]: https://liferay.atlassian.net/browse/LPD-29830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ