### PR TITLE
LPD-30425 User Interface not showing BCC/CC recipient fields when creating an Email Notification Template via API

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
@@ -267,6 +267,20 @@ export default function EditNotificationTemplate({
 					notificationTemplateId
 				);
 
+				let newRecipients = recipients;
+
+				if (type === 'email') {
+					newRecipients = [
+						{
+							...recipients[0],
+							bcc: recipients[0].bcc ?? '',
+							bccType: recipients[0].bccType ?? 'email',
+							cc: recipients[0].cc ?? '',
+							ccType: recipients[0].ccType ?? 'email',
+						},
+					];
+				}
+
 				setValues({
 					...values,
 					attachmentObjectFieldIds,
@@ -278,7 +292,7 @@ export default function EditNotificationTemplate({
 					objectDefinitionExternalReferenceCode,
 					objectDefinitionId,
 					recipientType,
-					recipients,
+					recipients: newRecipients,
 					subject,
 					system,
 					type,

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/utils/api.ts
@@ -51,7 +51,9 @@ type RecipientType = 'role' | 'term' | 'user';
 
 type Recipient = {
 	bcc: string;
+	bccType: string;
 	cc: string;
+	ccType: string;
 	from: string;
 	fromName: LocalizedValue<string>;
 	to: LocalizedValue<string>;

--- a/modules/test/playwright/helpers/NotificationApiHelper.ts
+++ b/modules/test/playwright/helpers/NotificationApiHelper.ts
@@ -23,9 +23,12 @@ type TRecipient = {
 	fromName: {
 		[key: string]: string;
 	};
-	to: {
-		[key: string]: string;
-	};
+	to: LocalizedValue<string> | EmailNotificationRecipients[];
+	toType: string;
+};
+
+type EmailNotificationRecipients = {
+	[key in 'roleName']?: string;
 };
 
 export class NotificationApiHelper {
@@ -82,6 +85,7 @@ export class NotificationApiHelper {
 					to: {
 						en_US: toEmail,
 					},
+					toType: 'email',
 				},
 			],
 			subject: {

--- a/modules/test/playwright/pages/notification-web/NotificationTemplatesPage.ts
+++ b/modules/test/playwright/pages/notification-web/NotificationTemplatesPage.ts
@@ -37,4 +37,8 @@ export class NotificationTemplatesPage {
 			`/group${siteUrl || '/guest'}${PORTLET_URLS.notificationTemplates}`
 		);
 	}
+
+	async openNotificationTemplate(notificationName: string) {
+		await this.page.getByRole('link', {name: notificationName}).click();
+	}
 }

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/pendingOrder.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/pendingOrder.spec.ts
@@ -245,6 +245,7 @@ test('LPD-4174 Sales agent can receive email notifications for new orders placed
 					to: {
 						en_US: '[%SALES_AGENT%]',
 					},
+					toType: 'email',
 				},
 			],
 			subject: {

--- a/modules/test/playwright/tests/notification-web/emailNotificationTemplate.spec.ts
+++ b/modules/test/playwright/tests/notification-web/emailNotificationTemplate.spec.ts
@@ -271,3 +271,43 @@ test('can see all roles groups in email notification template recipients', async
 		emailNotificationTemplatePage.organizationRolesGroupTitle
 	).toBeVisible();
 });
+
+test('can see cc/bcc fields in UI when creating notification via API without passing them', async ({
+	apiHelpers,
+	notificationTemplatesPage,
+	page,
+}) => {
+	const notificationTemplate =
+		await apiHelpers.notification.postNotificationTemplate({
+			editorType: 'richText',
+			name: 'Test Email',
+			recipientType: 'email',
+			recipients: [
+				{
+					from: 'test@liferay.com',
+					fromName: {
+						en_US: 'Test',
+					},
+					to: [
+						{
+							roleName: 'Account Administrator',
+						},
+					],
+					toType: 'role',
+				},
+			],
+			subject: {
+				en_US: 'Subject',
+			},
+			type: 'email',
+		});
+
+	await notificationTemplatesPage.goto();
+
+	await notificationTemplatesPage.openNotificationTemplate(
+		notificationTemplate.name
+	);
+
+	await expect(page.locator('#secondaryRecipientsCC')).toBeVisible();
+	await expect(page.locator('#secondaryRecipientsBCC')).toBeVisible();
+});


### PR DESCRIPTION
Related Issue: [LPD-30425](https://liferay.atlassian.net/browse/LPD-30425)

[LPD-30425]: https://liferay.atlassian.net/browse/LPD-30425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ