### PR TITLE
LPD-1901 Dyanmically pass the Alias javaType based on the output formula object field setting

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -42,6 +42,7 @@ import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.DateObjectFieldBuilder;
 import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.builder.DecimalObjectFieldBuilder;
+import com.liferay.object.field.builder.FormulaObjectFieldBuilder;
 import com.liferay.object.field.builder.IntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.LongIntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.LongTextObjectFieldBuilder;
@@ -348,6 +349,20 @@ public class DefaultObjectEntryManagerImplTest
 						RandomTestUtil.randomString())
 				).name(
 					"decimalObjectFieldName"
+				).build(),
+				new FormulaObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"formulaObjectFieldName"
+				).objectFieldSettings(
+					Arrays.asList(
+						_createObjectFieldSetting("output", "Decimal"),
+						_createObjectFieldSetting(
+							"script",
+							"integerObjectFieldName / " +
+								"longIntegerObjectFieldName"))
 				).build(),
 				new IntegerObjectFieldBuilder(
 				).labelMap(
@@ -1056,6 +1071,29 @@ public class DefaultObjectEntryManagerImplTest
 					"dateTimeUTCObjectFieldName eq null",
 				dateTimeString1),
 			_objectDefinition2, 2);
+
+		// Formula field
+
+		assertEquals(
+			_defaultObjectEntryManager.addObjectEntry(
+				dtoConverterContext, _objectDefinition2,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							"integerObjectFieldName", 3
+						).put(
+							"longIntegerObjectFieldName", 2
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY),
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"formulaObjectFieldName", 1.5
+					).build();
+				}
+			});
 
 		// Picklist by list entry
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3295,10 +3295,20 @@ public class ObjectEntryLocalServiceImpl
 
 				ddmExpression.setVariables(columns);
 
+				String output = GetterUtil.getString(
+					objectFieldSettingsValues.get("output"));
+
+				Class<?> javaType = Double.class;
+
+				if (Objects.equals(output, "Integer")) {
+					javaType = Integer.class;
+				}
+
 				try {
 					Expression<?> expression = ddmExpression.getDSLExpression();
 
-					selectExpressions.add(expression.as(objectField.getName()));
+					selectExpressions.add(
+						expression.as(javaType, objectField.getName()));
 				}
 				catch (Exception exception) {
 					_log.error(exception);

--- a/modules/core/petra/petra-sql-dsl-api/bnd.bnd
+++ b/modules/core/petra/petra-sql-dsl-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Petra SQL DSL API
 Bundle-SymbolicName: com.liferay.petra.sql.dsl.api
-Bundle-Version: 6.0.1
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.petra.sql.dsl,\
 	com.liferay.petra.sql.dsl.ast,\

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Alias.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Alias.java
@@ -12,6 +12,8 @@ public interface Alias<T> extends Expression<T> {
 
 	public Expression<T> getExpression();
 
+	public Class<?> getJavaType();
+
 	public String getName();
 
 }

--- a/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Expression.java
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/java/com/liferay/petra/sql/dsl/expression/Expression.java
@@ -14,6 +14,8 @@ import com.liferay.petra.sql.dsl.query.sort.OrderByExpression;
  */
 public interface Expression<T> extends ASTNode {
 
+	public Alias<T> as(Class<?> javaType, String name);
+
 	public Alias<T> as(String name);
 
 	public OrderByExpression ascending();

--- a/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/expression/packageinfo
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/expression/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/packageinfo
+++ b/modules/core/petra/petra-sql-dsl-api/src/main/resources/com/liferay/petra/sql/dsl/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 2.0.0

--- a/modules/core/petra/petra-sql-dsl-spi/bnd.bnd
+++ b/modules/core/petra/petra-sql-dsl-spi/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Petra SQL DSL SPI
 Bundle-SymbolicName: com.liferay.petra.sql.dsl.spi
-Bundle-Version: 4.0.1
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.petra.sql.dsl.spi,\
 	com.liferay.petra.sql.dsl.spi.ast,\

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultAlias.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultAlias.java
@@ -19,14 +19,26 @@ import java.util.function.Consumer;
 public class DefaultAlias<T>
 	extends BaseASTNode implements Alias<T>, DefaultExpression<T> {
 
-	public DefaultAlias(Expression<T> expression, String name) {
+	public DefaultAlias(
+		Expression<T> expression, Class<?> javaType, String name) {
+
 		_expression = Objects.requireNonNull(expression);
+		_javaType = javaType;
 		_name = Objects.requireNonNull(name);
+	}
+
+	public DefaultAlias(Expression<T> expression, String name) {
+		this(expression, null, name);
 	}
 
 	@Override
 	public Expression<T> getExpression() {
 		return _expression;
+	}
+
+	@Override
+	public Class<?> getJavaType() {
+		return _javaType;
 	}
 
 	@Override
@@ -42,6 +54,7 @@ public class DefaultAlias<T>
 	}
 
 	private final Expression<T> _expression;
+	private final Class<?> _javaType;
 	private final String _name;
 
 }

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultExpression.java
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/java/com/liferay/petra/sql/dsl/spi/expression/DefaultExpression.java
@@ -19,6 +19,11 @@ import com.liferay.petra.sql.dsl.spi.query.sort.DefaultOrderByExpression;
 public interface DefaultExpression<T> extends Expression<T> {
 
 	@Override
+	public default Alias<T> as(Class<?> javaType, String name) {
+		return new DefaultAlias<>(this, javaType, name);
+	}
+
+	@Override
 	public default Alias<T> as(String name) {
 		return new DefaultAlias<>(this, name);
 	}

--- a/modules/core/petra/petra-sql-dsl-spi/src/main/resources/com/liferay/petra/sql/dsl/spi/expression/packageinfo
+++ b/modules/core/petra/petra-sql-dsl-spi/src/main/resources/com/liferay/petra/sql/dsl/spi/expression/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/test/DSLQueryEntryPersistenceImplTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/test/DSLQueryEntryPersistenceImplTest.java
@@ -325,6 +325,22 @@ public class DSLQueryEntryPersistenceImplTest {
 	@Test
 	public void testDSLQueryWithDSLFunction() {
 		Assert.assertEquals(
+			Arrays.asList(0.5, 1.0, 1.5),
+			_dslQueryEntryPersistence.dslQuery(
+				DSLQueryFactoryUtil.select(
+					DSLFunctionFactoryUtil.divide(
+						DSLQueryStatusEntryTable.INSTANCE.dslQueryStatusEntryId,
+						new Scalar<>(2L)
+					).as(
+						Double.class, "alias"
+					)
+				).from(
+					DSLQueryStatusEntryTable.INSTANCE
+				).orderBy(
+					DSLQueryStatusEntryTable.INSTANCE.dslQueryStatusEntryId.
+						ascending()
+				)));
+		Assert.assertEquals(
 			Arrays.asList(0L, 1L, 2L),
 			_dslQueryEntryPersistence.dslQuery(
 				DSLQueryFactoryUtil.select(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -254,8 +254,16 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 					if (expression instanceof Alias) {
 						Alias<?> alias = (Alias<?>)expression;
 
-						sqlQuery.addScalar(
-							alias.getName(), _getType(alias.getExpression()));
+						Type type = null;
+
+						if (alias.getJavaType() != null) {
+							type = _types.get(alias.getJavaType());
+						}
+						else {
+							type = _getType(alias.getExpression());
+						}
+
+						sqlQuery.addScalar(alias.getName(), type);
 					}
 					else if (expression instanceof Column) {
 						Column<?, ?> column = (Column<?, ?>)expression;


### PR DESCRIPTION
## Related tickets

- https://liferay.atlassian.net/browse/LPD-1901

## Motivation

A decimal number is expected in the following use case but it always set the output type as the expression1 [here](https://github.com/liferay/liferay-portal/blob/bb9d7a1d3cecde95457c46f7c75c2d7d4090ecf6/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java#L1148),

**Given:** a division DSLFunction expression like this `expression1 / expression2` where the expression1 is a non-decimal column.

**When:** this expression is evaluated as an alias with the following operands 3 and 2 (e.g.: `3 / 2 as foo`)

**Then:** the result is 1 instead of 1.5 that is the expected due to [this](https://github.com/liferay/liferay-portal/blob/bb9d7a1d3cecde95457c46f7c75c2d7d4090ecf6/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java#L1148)

## Proposed Solution

Dynamically pass the Alias javaType based on the business rule needs (e.g.: formula output object field setting)