### PR TITLE
LPD-24914 Prevent company-scoped object definitions from being selected when creating manual and dynamic collections.

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -169,15 +169,30 @@ public class DefaultObjectEntryManagerImpl
 			long primaryKey2)
 		throws Exception {
 
+		ServiceContext serviceContext = new ServiceContext();
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId2());
+
+		if (!objectDefinition.isUnmodifiableSystemObject()) {
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+				_objectEntryService.getObjectEntry(primaryKey2);
+
+			if (serviceBuilderObjectEntry.getStatus() ==
+					WorkflowConstants.STATUS_DRAFT) {
+
+				serviceContext.setWorkflowAction(
+					WorkflowConstants.ACTION_SAVE_DRAFT);
+			}
+		}
+
 		_objectRelationshipService.addObjectRelationshipMappingTableValues(
 			objectRelationship.getObjectRelationshipId(), primaryKey1,
-			primaryKey2, new ServiceContext());
+			primaryKey2, serviceContext);
 
 		return getObjectEntry(
-			dtoConverterContext,
-			_objectDefinitionLocalService.getObjectDefinition(
-				objectRelationship.getObjectDefinitionId2()),
-			primaryKey2);
+			dtoConverterContext, objectDefinition, primaryKey2);
 	}
 
 	@Override

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -12,12 +12,14 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.rest.test.util.ObjectFieldTestUtil;
 import com.liferay.object.rest.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.rest.test.util.UserAccountTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.JaxRsApplicationDescriptor;
 import com.liferay.object.system.SystemObjectDefinitionManager;
@@ -47,6 +49,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -1241,6 +1244,44 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testPutObjectEntryRelatedObjectEntryWithDraftStatus()
+		throws Exception {
+
+		_enableObjectEntryDraft(_objectDefinition1);
+		_enableObjectEntryDraft(_objectDefinition2);
+
+		long objectEntryId1 = _addObjectEntryDraft(
+			_objectDefinition1, _OBJECT_FIELD_NAME_1);
+		long objectEntryId2 = _addObjectEntryDraft(
+			_objectDefinition2, _OBJECT_FIELD_NAME_2);
+
+		ObjectRelationship objectRelationship = _addObjectRelationship(
+			_objectDefinition1, _objectDefinition2,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
+				objectEntryId1, StringPool.SLASH, objectRelationship.getName(),
+				StringPool.SLASH, objectEntryId2),
+			Http.Method.PUT);
+
+		Assert.assertEquals(objectEntryId2, jsonObject.getLong("id"));
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		Assert.assertEquals(
+			objectEntryId1, jsonObject.getLong(objectField.getName()));
+
+		JSONObject statusJSONObject = jsonObject.getJSONObject("status");
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, statusJSONObject.getInt("code"));
+	}
+
+	@Test
 	public void testPutObjectEntryRelatedSystemObject() throws Exception {
 		_userSystemObjectDefinitionManager =
 			_systemObjectDefinitionManagerRegistry.
@@ -1303,6 +1344,21 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		jsonArray = jsonObject.getJSONArray("items");
 
 		_assertEquals(_user1, jsonArray);
+	}
+
+	private long _addObjectEntryDraft(
+			ObjectDefinition objectDefinition, String objectFieldName)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				objectFieldName, RandomTestUtil.randomString()
+			).put(
+				"status", JSONUtil.put("code", WorkflowConstants.STATUS_DRAFT)
+			).toString(),
+			objectDefinition.getRESTContextPath(), Http.Method.POST);
+
+		return jsonObject.getLong("id");
 	}
 
 	private ObjectRelationship _addObjectRelationship(
@@ -1399,6 +1455,12 @@ public class ObjectEntryRelatedObjectsResourceTest {
 
 		return userAccountJSONObject.put(
 			systemObjectFieldName, systemObjectFieldValue);
+	}
+
+	private void _enableObjectEntryDraft(ObjectDefinition objectDefinition) {
+		objectDefinition.setEnableObjectEntryDraft(true);
+
+		_objectDefinitionLocalService.updateObjectDefinition(objectDefinition);
 	}
 
 	private String _getEndpoint(
@@ -1988,6 +2050,10 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	private ObjectEntry _objectEntry2;
 	private ObjectEntry _objectEntry3;
 	private ObjectEntry _objectEntry4;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
 	private ObjectRelationship _objectRelationship;
 
 	@Inject

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactory.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.asset.model;
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectEntryLocalService;
@@ -18,6 +19,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import javax.servlet.ServletContext;
 
@@ -97,6 +99,18 @@ public class ObjectEntryAssetRendererFactory
 		}
 
 		return false;
+	}
+
+	@Override
+	public boolean isSelectable() {
+		if (StringUtil.equals(
+				_objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRendererFactoryTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.asset.model;
+
+import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.web.internal.object.entries.display.context.ObjectEntryDisplayContextFactory;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.servlet.ServletContext;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Carolina Barbosa
+ */
+public class ObjectEntryAssetRendererFactoryTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_objectEntryAssetRendererFactory = new ObjectEntryAssetRendererFactory(
+			_assetDisplayPageFriendlyURLProvider, _objectDefinition,
+			_objectEntryDisplayContextFactory, _objectEntryLocalService,
+			_objectEntryService, _servletContext);
+	}
+
+	@Test
+	public void testIsActive() throws Exception {
+		Mockito.when(
+			_objectDefinition.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Assert.assertFalse(
+			_objectEntryAssetRendererFactory.isActive(
+				RandomTestUtil.randomLong()));
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_objectDefinition.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Assert.assertTrue(_objectEntryAssetRendererFactory.isActive(companyId));
+	}
+
+	@Test
+	public void testIsSelectable() throws Exception {
+		Mockito.when(
+			_objectDefinition.getScope()
+		).thenReturn(
+			ObjectDefinitionConstants.SCOPE_COMPANY
+		);
+
+		Assert.assertFalse(_objectEntryAssetRendererFactory.isSelectable());
+
+		Mockito.when(
+			_objectDefinition.getScope()
+		).thenReturn(
+			ObjectDefinitionConstants.SCOPE_SITE
+		);
+
+		Assert.assertTrue(_objectEntryAssetRendererFactory.isSelectable());
+	}
+
+	private final AssetDisplayPageFriendlyURLProvider
+		_assetDisplayPageFriendlyURLProvider = Mockito.mock(
+			AssetDisplayPageFriendlyURLProvider.class);
+	private final ObjectDefinition _objectDefinition = Mockito.mock(
+		ObjectDefinition.class);
+	private ObjectEntryAssetRendererFactory _objectEntryAssetRendererFactory;
+	private final ObjectEntryDisplayContextFactory
+		_objectEntryDisplayContextFactory = Mockito.mock(
+			ObjectEntryDisplayContextFactory.class);
+	private final ObjectEntryLocalService _objectEntryLocalService =
+		Mockito.mock(ObjectEntryLocalService.class);
+	private final ObjectEntryService _objectEntryService = Mockito.mock(
+		ObjectEntryService.class);
+	private final ServletContext _servletContext = Mockito.mock(
+		ServletContext.class);
+
+}


### PR DESCRIPTION
- **LPD-32174 Shorten table name to less than 30 characters. This should be done to prevent the error "ORA-00972: identifier is too long" in case Oracle with the 'compatible' parameter set to a version lower than '19.0.0.0'.**
- **LPD-26438 Add singleton to module journal-api**
- **LPD-26438 Apply to usages from singleton**
- **LPD-26438 Update tests that uses to classes from module journal-api**
- **LPD-26438 baseline**
- **LPD-26438 Add Upgrade case and test**
- **LPD-26438 prep next**
- **LPD-26438 prep next**
- **LPD-30298 Add missing test.properties file**
- **LPD-31858 setDisabled to true after the first click**
- **LPD-28950 Fix concurrency problems**
- **LPD-28950 Fix field mapping**
- **LPD-28950 Fix Adyen**
- **LPD-28950 DRY**
- **LPD-31980 Auto SF**
- **LPD-28950 SF**
- **LPD-30312 Update object definitions nodes selected value after dragging**
- **LPD-30312 Create test to assert selected node style consistency**
- **LRCI-4360 Do not include extra properties in the job summary for the rule engine**
- **LRCI-4360 prep next**
- **LPD-20530 Add integration test to expose issue**
- **LPD-20530 Create the service context taking into account the object's entry status**
- **LPD-24914 Add unit test to expose issue**
- **LPD-24914 Prevent company-scoped object definitions from being selected when creating manual and dynamic collections.**
