### PR TITLE
LPD-28411 LPD-33634 object-service: remove duplicate externalReferenc…

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -251,10 +251,6 @@ public class ObjectEntryModelDocumentContributor
 			new Field(
 				Field.getSortableFieldName(Field.ENTRY_CLASS_PK),
 				document.get(Field.ENTRY_CLASS_PK)));
-		document.add(
-			new Field(
-				Field.getSortableFieldName("externalReferenceCode"),
-				objectEntry.getExternalReferenceCode()));
 
 		FieldArray fieldArray = (FieldArray)document.getField(
 			"nestedFieldArray");


### PR DESCRIPTION
…eCode_sortable field from search documents, this is now handled by [ExternalReferenceCodeModelDocumentContributor](https://github.com/liferay/liferay-portal/blob/0f6caee8d748c3090bb5e8da9b70c5b89bfd1ebe/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/spi/model/index/contributor/ExternalReferenceCodeModelDocumentContributor.java)

[LPD-28411](https://liferay.atlassian.net/browse/LPD-28411)

**Author:** @joshuacords 

From [LPD-28411](https://liferay.atlassian.net/browse/LPD-28411):
> Looks like ObjectsEntryModelDocumentContributor indexes a sortable variant of that field already ... a Task ticket should be created to remove the duplicates from the code base

Could this team confirm this change is fine and no other changes are needed?


[LPD-28411]: https://liferay.atlassian.net/browse/LPD-28411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-28411]: https://liferay.atlassian.net/browse/LPD-28411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ