### PR TITLE
LPD-26480 Create a test to ensure that the user cannot delete the object relationship that is the only custom object field from the published object definition

### DIFF
--- a/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
@@ -129,7 +129,7 @@ export class ObjectAdminApiHelper {
 				en_US: objectDefinitionExternalReferenceCode,
 			},
 			name: objectDefinitionExternalReferenceCode,
-			objectFields: objectFields || [
+			objectFields: objectFields ?? [
 				{
 					DBType: 'String',
 					businessType: 'Text',

--- a/modules/test/playwright/pages/object-web/ModelBuilderPage.ts
+++ b/modules/test/playwright/pages/object-web/ModelBuilderPage.ts
@@ -15,6 +15,7 @@ export class ModelBuilderPage {
 	readonly deleteObjectDefinitionOption: Locator;
 	readonly deleteObjectRelationshipButton: Locator;
 	readonly deleteTrashButton: Locator;
+	readonly deletionNotAllowed: Locator;
 	readonly diagramArea: Locator;
 	readonly editInPageViewOption: Locator;
 	readonly editObjectFolderDetailsButton: Locator;
@@ -52,7 +53,10 @@ export class ModelBuilderPage {
 		});
 		this.createNewObjectDefinitionButton =
 			page.getByText('Create New Object');
-		this.deleteButton = page.getByTitle('Delete');
+		this.deleteButton = page.getByRole('button', {
+			exact: true,
+			name: 'Delete',
+		});
 		this.deleteObjectDefinitionOption = page.getByRole('menuitem', {
 			name: 'Delete Object',
 		});
@@ -62,6 +66,9 @@ export class ModelBuilderPage {
 		this.deleteTrashButton = page
 			.getByRole('tabpanel')
 			.getByTitle('Delete');
+		this.deletionNotAllowed = page.getByRole('heading', {
+			name: 'Deletion Not Allowed',
+		});
 		this.diagramArea = page.locator('.react-flow');
 		this.editInPageViewOption = page.getByRole('menuitem', {
 			name: 'Edit in page view',

--- a/modules/test/playwright/tests/object-web/objectRelationships.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectRelationships.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {objectPagesTest} from '../../fixtures/objectPagesTest';
 import {getRandomInt} from '../../utils/getRandomInt';
+import {createObjectField} from './utils/mockObjectFields';
 
 export const test = mergeTests(apiHelpersTest, loginTest(), objectPagesTest);
 
@@ -257,5 +258,109 @@ test.describe('Manage object relationships through Model Builder', () => {
 				name: 'Accessing Accounts Data from Custom Object',
 			})
 		).toBeVisible();
+	});
+
+	test('cannot delete the object relationship that is the only custom object field from the published object definition', async ({
+		apiHelpers,
+		modelBuilderPage,
+		page,
+		viewObjectDefinitionsPage,
+	}) => {
+		const objectFolder =
+			await apiHelpers.objectAdmin.postRandomObjectFolder();
+
+		createdEntities.objectFolderIds.push(objectFolder.id);
+
+		const objectDefinition1 =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFolderExternalReferenceCode:
+					objectFolder.externalReferenceCode,
+				status: {code: 0},
+			});
+
+		const objectDefinition2 =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFields: [],
+				objectFolderExternalReferenceCode:
+					objectFolder.externalReferenceCode,
+				status: {code: 1},
+			});
+
+		createdEntities.objectDefinitionIds.push(
+			objectDefinition1.id,
+			objectDefinition2.id
+		);
+
+		const objectRelationshipLabel =
+			'objectRelationshipLabel' + getRandomInt();
+		const objectRelationshipName =
+			'objectRelationshipName' + Math.floor(Math.random() * 99);
+
+		const objectRelationshipData: Partial<ObjectRelationship> = {
+			label: {
+				en_US: objectRelationshipLabel,
+			},
+			name: objectRelationshipName,
+			objectDefinitionExternalReferenceCode1:
+				objectDefinition1.externalReferenceCode,
+			objectDefinitionExternalReferenceCode2:
+				objectDefinition2.externalReferenceCode,
+			objectDefinitionId1: objectDefinition1.id,
+			objectDefinitionId2: objectDefinition2.id,
+			objectDefinitionName2: objectDefinition2.name,
+			type: 'oneToMany' as ObjectRelationshipType,
+		};
+
+		const objectRelationship =
+			await apiHelpers.objectAdmin.postObjectRelationship(
+				objectRelationshipData
+			);
+
+		createdEntities.objectRelationshipIds.push(objectRelationship.id);
+
+		const publishedObjectDefinition2 =
+			await apiHelpers.objectAdmin.postObjectDefinitionPublish(
+				objectDefinition2.id
+			);
+
+		await viewObjectDefinitionsPage.goto();
+
+		await viewObjectDefinitionsPage.openObjectFolder(
+			objectFolder.label['en_US']
+		);
+
+		await viewObjectDefinitionsPage.viewInModelBuilderButton.click();
+
+		await modelBuilderPage.fitViewButton.click();
+
+		await modelBuilderPage.clickObjectRelationshipEdge(
+			objectRelationshipLabel
+		);
+
+		await modelBuilderPage.deleteObjectRelationship(
+			objectRelationshipData.name
+		);
+
+		await expect(modelBuilderPage.deletionNotAllowed).toBeVisible();
+
+		const objectFieldObjectRelationship =
+			publishedObjectDefinition2.objectFields.find(
+				(objectField: ObjectField) =>
+					objectField.businessType === 'Relationship'
+			);
+
+		await expect(
+			page.getByText(
+				`The object field "${objectFieldObjectRelationship.name}" cannot be deleted because it is the only custom object field of the published object definition "${objectDefinition2.name}". Add at least one object field to the object definition.`
+			)
+		).toBeVisible();
+
+		await apiHelpers.objectAdmin.postObjectFieldByExternalReferenceCode(
+			publishedObjectDefinition2.externalReferenceCode,
+			createObjectField('text', {
+				label: 'textField',
+				name: 'textField',
+			})
+		);
 	});
 });


### PR DESCRIPTION
Related [Ticket](https://liferay.atlassian.net/browse/LPD-26480)