### PR TITLE
LPD-33890 Avoid lost localized field values when unlink entries through relationship tab

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsProviderImpl.java
@@ -103,9 +103,14 @@ public class ObjectEntry1toMObjectRelatedModelsProviderImpl
 			long primaryKey2)
 		throws PortalException {
 
+		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(
+			primaryKey2);
+
 		_objectEntryService.updateObjectEntry(
 			primaryKey2,
-			HashMapBuilder.<String, Serializable>put(
+			HashMapBuilder.<String, Serializable>putAll(
+				objectEntry.getValues()
+			).put(
 				() -> {
 					ObjectRelationship objectRelationship =
 						_objectRelationshipLocalService.getObjectRelationship(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -329,14 +329,32 @@ public class ObjectRelatedModelsProviderTest {
 			_objectEntryLocalService.getValues(objectEntry5.getObjectEntryId());
 
 		Assert.assertEquals(
-			expectedLocalizedValues.get("longTextLocalized_i18n"),
-			actualLocalizedValues.get("longTextLocalized_i18n"));
+			expectedLocalizedValues.get("longText_i18n"),
+			actualLocalizedValues.get("longText_i18n"));
 		Assert.assertEquals(
-			expectedLocalizedValues.get("richTextLocalized_i18n"),
-			actualLocalizedValues.get("richTextLocalized_i18n"));
+			expectedLocalizedValues.get("richText_i18n"),
+			actualLocalizedValues.get("richText_i18n"));
 		Assert.assertEquals(
-			expectedLocalizedValues.get("textLocalized_i18n"),
-			actualLocalizedValues.get("textLocalized_i18n"));
+			expectedLocalizedValues.get("text_i18n"),
+			actualLocalizedValues.get("text_i18n"));
+
+		_objectRelatedModelsProvider.disassociateRelatedModels(
+			TestPropsValues.getUserId(),
+			_objectRelationship.getObjectRelationshipId(),
+			objectEntry1.getObjectEntryId(), objectEntry5.getObjectEntryId());
+
+		actualLocalizedValues = _objectEntryLocalService.getValues(
+			objectEntry5.getObjectEntryId());
+
+		Assert.assertEquals(
+			expectedLocalizedValues.get("longText_i18n"),
+			actualLocalizedValues.get("longText_i18n"));
+		Assert.assertEquals(
+			expectedLocalizedValues.get("richText_i18n"),
+			actualLocalizedValues.get("richText_i18n"));
+		Assert.assertEquals(
+			expectedLocalizedValues.get("text_i18n"),
+			actualLocalizedValues.get("text_i18n"));
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntry5);
 


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-33890