### PR TITLE
LPD-34182 Prevent try to access objectEntryLocalService when the object definition's storage type is different from Default

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/display/context/ObjectEntryDisplayContextImpl.java
@@ -175,8 +175,6 @@ public class ObjectEntryDisplayContextImpl
 
 	@Override
 	public String getBackURL() throws PortalException {
-		ObjectEntry objectEntry = _getObjectEntry();
-
 		String redirect = ParamUtil.getString(
 			_objectRequestHelper.getRequest(), "redirect");
 
@@ -190,20 +188,22 @@ public class ObjectEntryDisplayContextImpl
 			backURL = String.valueOf(liferayPortletResponse.createRenderURL());
 		}
 
+		ObjectDefinition objectDefinition = getObjectDefinition1();
+
+		if (!objectDefinition.isDefaultStorageType() ||
+			!objectDefinition.isRootDescendantNode()) {
+
+			return backURL;
+		}
+
+		ObjectEntry objectEntry = _getObjectEntry();
+
 		if (objectEntry == null) {
 			return backURL;
 		}
 
 		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
 			_objectEntryLocalService.getObjectEntry(objectEntry.getId());
-
-		ObjectDefinition objectDefinition =
-			_objectDefinitionLocalService.getObjectDefinition(
-				serviceBuilderObjectEntry.getObjectDefinitionId());
-
-		if (!objectDefinition.isRootDescendantNode()) {
-			return backURL;
-		}
 
 		Tree tree = _treeFactory.createObjectEntryTree(
 			serviceBuilderObjectEntry.getRootObjectEntryId());


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-34182

**NOTE:** Caught by the test: 
`LocalFile.ObjectSalesforce#AssertCRUDWithCreatedCustomObject`