### PR TITLE
LPD-35321 String values should be used to validate number conversion.

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -5028,12 +5028,10 @@ public class ObjectEntryLocalServiceImpl
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_INTEGER)) {
 
-			Serializable entryValue = entry.getValue();
-
-			String entryValueString = entryValue.toString();
+			String entryValueString = String.valueOf(entry.getValue());
 
 			if (!entryValueString.isEmpty()) {
-				int value = GetterUtil.getInteger(entryValue);
+				int value = GetterUtil.getInteger(entryValueString);
 
 				if ((value == 0) &&
 					!StringUtil.equals(
@@ -5048,16 +5046,14 @@ public class ObjectEntryLocalServiceImpl
 					objectField.getDBType(),
 					ObjectFieldConstants.DB_TYPE_LONG)) {
 
-			Serializable entryValue = entry.getValue();
-
-			String entryValueString = entryValue.toString();
+			String entryValueString = String.valueOf(entry.getValue());
 
 			if (!entryValueString.isEmpty()) {
-				long value = GetterUtil.getLong(entryValue);
+				long value = GetterUtil.getLong(entryValueString);
 
 				if ((value == 0) &&
 					!StringUtil.equals(
-						String.valueOf(value), entryValue.toString())) {
+						String.valueOf(value), entryValueString)) {
 
 					throw new ObjectEntryValuesException.ExceedsLongSize(
 						16, objectField.getName());


### PR DESCRIPTION
It solves testAddInfoItemInvalidIntegerTooSmall, testAddInfoItemInvalidIntegerTooBig on EditInfoItemStrutsActionTest.

https://liferay.atlassian.net/browse/LPD-35393

No need of an additional test, as we're solving two which already cover the behaviour, right?

The language itself it was not validating properly the value passed by the Content Management team (-2147483649, one value greater than the allowed to int variables), so I did this change to consider a String instead of an int value, which was causing the problem with the integer overflow. The value passed on the tests are now being converted to 0, which is the value expected to be returned if it is out of the var range.
