### PR TITLE
LPD-2294 [Upgrade process] Drop views of the object definition dynamic tables from partitioned DB

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.200
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 9.2.1
+Liferay-Require-SchemaVersion: 9.2.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -465,6 +465,11 @@ public class ObjectServiceUpgradeStepRegistrator
 			"9.2.0", "9.2.1",
 			new com.liferay.object.internal.upgrade.v9_2_1.
 				ObjectActionUpgradeProcess(_notificationTemplateLocalService));
+
+		registry.register(
+			"9.2.1", "9.2.2",
+			new com.liferay.object.internal.upgrade.v9_2_2.
+				SchemaUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v9_2_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Paulo Albuquerque
+ */
+public class SchemaUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long companyId = CompanyThreadLocal.getCompanyId();
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+		if ((defaultCompanyId == companyId) ||
+			!DBPartition.isPartitionEnabled()) {
+
+			return;
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+			SQLTransformer.transform(
+				StringBundler.concat("select table_name from ",
+					"information_schema.views where table_name like \"%",
+					defaultCompanyId, "%\" and (table_name like \"%\\_x\\_%\" ",
+					"or table_name like \"%\\_x\" or table_name like \"O\\_%\"",
+					")")));
+
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				runSQL(
+					StringBundler.concat(
+						"drop view if exists ",
+						DBPartitionUtil.getPartitionName(companyId),
+						StringPool.PERIOD, resultSet.getString("table_name")));
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-2294;

**NOTE:**
For upgrade process that perform DDL operations, integration tests aren't needed:
https://liferay.atlassian.net/wiki/spaces/ENGCOREUPGRADE/pages/1654719711/Upgrade+Development+Training#Testing