### PR TITLE
LPD-35778 Extract the EditObjectRelationshipContent into your own component and reuse it in the Model Builder, removing unnecessary code repetitions

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
@@ -4,33 +4,26 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import ClayPanel from '@clayui/panel';
+import {API, openToast, stringUtils} from '@liferay/object-js-components-web';
 import {createResourceURL, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
-import {Edge, Elements, Node, isEdge, isNode} from 'react-flow-renderer';
+import {isEdge, isNode} from 'react-flow-renderer';
 
+import {defaultLanguageId} from '../../../utils/constants';
+import {EditObjectRelationshipContent} from '../../ObjectRelationship/EditObjectRelationshipContent';
+import {ModalDeleteObjectRelationship} from '../../ObjectRelationship/ModalDeleteObjectRelationship';
+import {useObjectRelationshipForm} from '../../ObjectRelationship/ObjectRelationshipFormBase';
+import {getUpdatedModelBuilderStructurePayload} from '../../ViewObjectDefinitions/objectDefinitionUtil';
+import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
 import {TYPES} from '../ModelBuilderContext/typesEnum';
 
 import './RightSidebarObjectRelationshipDetails.scss';
 
-import {
-	API,
-	Input,
-	SingleSelect,
-	openToast,
-	stringUtils,
-} from '@liferay/object-js-components-web';
-import {InputLocalized} from 'frontend-js-components-web';
+import type {Edge, Elements, Node} from 'react-flow-renderer';
 
-import {defaultLanguageId} from '../../../utils/constants';
-import {ModalDeleteObjectRelationship} from '../../ObjectRelationship/ModalDeleteObjectRelationship';
-import {
-	OBJECT_RELATIONSHIP_TYPES,
-	useObjectRelationshipForm,
-} from '../../ObjectRelationship/ObjectRelationshipFormBase';
-import SelectObjectRelationship from '../../ObjectRelationship/SelectObjectRelationship';
-import {getUpdatedModelBuilderStructurePayload} from '../../ViewObjectDefinitions/objectDefinitionUtil';
-import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
-import {ObjectRelationshipEdgeData} from '../types';
+import type {ObjectRelationshipEdgeData} from '../types';
 
 interface RightSidebarObjectRelationshipDetailsProps {
 	objectRelationshipDeletionTypes: LabelValueObject[];
@@ -48,10 +41,7 @@ export function RightSidebarObjectRelationshipDetails({
 		},
 		dispatch,
 	] = useObjectFolderContext();
-	const [objectDefinition1, setObjectDefinition1] =
-		useState<Partial<ObjectDefinition>>();
-	const [objectDefinition2, setObjectDefinition2] =
-		useState<Partial<ObjectDefinition>>();
+	const [loading, setLoading] = useState(false);
 	const [
 		objectRelationshipParameterRequired,
 		setObjectRelationshipParameterRequired,
@@ -66,7 +56,7 @@ export function RightSidebarObjectRelationshipDetails({
 		deleteObjectRelationship: false,
 	});
 
-	const {errors, handleValidate, setValues, values} =
+	const {errors, handleChange, handleValidate, setValues, values} =
 		useObjectRelationshipForm({
 			initialValues: {
 				id: 0,
@@ -80,6 +70,7 @@ export function RightSidebarObjectRelationshipDetails({
 	useEffect(() => {
 		const makeFetch = async () => {
 			if (selectedObjectRelationship) {
+				setLoading(true);
 				const selectedObjectRelationshipResponse =
 					(await API.getObjectRelationship(
 						selectedObjectRelationship.id
@@ -87,20 +78,9 @@ export function RightSidebarObjectRelationshipDetails({
 
 				setValues(selectedObjectRelationshipResponse);
 
-				const objectDefinition1 = await API.getObjectDefinitionById(
-					selectedObjectRelationshipResponse.objectDefinitionId1
-				);
-
-				const objectDefinition2 = await API.getObjectDefinitionById(
-					selectedObjectRelationshipResponse.objectDefinitionId2
-				);
-
-				setObjectDefinition1(objectDefinition1);
-
-				setObjectDefinition2(objectDefinition2);
-
 				const url = createResourceURL(baseResourceURL, {
-					objectDefinitionId: objectDefinition1.id,
+					objectDefinitionId:
+						selectedObjectRelationshipResponse.objectDefinitionId1,
 					p_p_resource_id:
 						'/object_definitions/get_object_relationship_info',
 				}).href;
@@ -130,6 +110,7 @@ export function RightSidebarObjectRelationshipDetails({
 
 					setReadOnly(readOnly);
 				}
+				setLoading(false);
 			}
 		};
 
@@ -247,110 +228,28 @@ export function RightSidebarObjectRelationshipDetails({
 			</div>
 
 			<div className="lfr-objects__model-builder-right-sidebar-object-relationship-content">
-				<InputLocalized
-					disabled={readOnly}
-					error={errors.label}
-					id="lfr-objects__object-relationship-form-base-label"
-					label={Liferay.Language.get('label')}
-					onBlur={(event) => {
-						event.stopPropagation();
-
-						onSubmit();
-					}}
-					onChange={(label) => setValues({label})}
-					required
-					translations={values.label as LocalizedValue<string>}
-				/>
-
-				<Input
-					disabled
-					id="lfr-objects__object-relationship-form-base-name"
-					label={Liferay.Language.get('name')}
-					required
-					value={values.name}
-				/>
-
-				<Input
-					disabled
-					id="lfr-objects__object-relationship-form-base-type"
-					label={Liferay.Language.get('type')}
-					required
-					value={
-						OBJECT_RELATIONSHIP_TYPES.find(
-							({value}) => value === values.type
-						)?.label
-					}
-				/>
-
-				<Input
-					disabled
-					id="lfr-objects__object-relationship-form-base-one-record-of"
-					label={
-						values.type === 'manyToMany'
-							? Liferay.Language.get('many-records-of')
-							: Liferay.Language.get('one-record-of')
-					}
-					required
-					value={objectDefinition1?.name}
-				/>
-
-				<Input
-					disabled
-					id="lfr-objects__object-relationship-form-base-many-records-of"
-					label={Liferay.Language.get('many-records-of')}
-					required
-					value={objectDefinition2?.name}
-				/>
-
-				<SingleSelect
-					className="lfr-objects__model-builder-left-sidebar-object-relationship-single-select"
-					disabled={
-						readOnly ||
-						(Liferay.FeatureFlags['LPS-187142'] && values.edge)
-					}
-					id="lfr-objects__object-relationship-form-base-deletion-type"
-					items={objectRelationshipDeletionTypes}
-					label={Liferay.Language.get('deletion-type')}
-					onSelectionChange={(value) => {
-						setValues({deletionType: value as string});
-
-						onSubmit({
-							...values,
-							deletionType: value as string,
-						});
-					}}
-					required
-					selectedKey={values.deletionType}
-				/>
-
-				{objectRelationshipParameterRequired &&
-					selectedObjectRelationship?.type === 'oneToMany' && (
-						<>
-							<Input
-								label={Liferay.Language.get('api-endpoint')}
-								readOnly
-								value={objectRelationshipRestContextPath}
-							/>
-
-							<SelectObjectRelationship
-								error={errors.parameterObjectFieldName}
-								objectDefinitionExternalReferenceCode1={
-									values.objectDefinitionExternalReferenceCode2 as string
-								}
-								onChange={(parameterObjectFieldName) => {
-									setValues({
-										parameterObjectFieldName,
-									});
-
-									onSubmit({
-										...values,
-										parameterObjectFieldName,
-									});
-								}}
-								value={values.parameterObjectFieldName}
-							/>
-						</>
-					)}
+				{!loading && values.objectDefinitionExternalReferenceCode1 ? (
+					<EditObjectRelationshipContent
+						baseResourceURL={baseResourceURL}
+						containerWrapper={ClayPanel}
+						errors={errors}
+						handleChange={handleChange}
+						objectDefinitionExternalReferenceCode={
+							values.objectDefinitionExternalReferenceCode1
+						}
+						objectRelationshipDeletionTypes={
+							objectRelationshipDeletionTypes
+						}
+						onSubmit={onSubmit}
+						parameterRequired={objectRelationshipParameterRequired}
+						readOnly={readOnly}
+						restContextPath={objectRelationshipRestContextPath}
+						setValues={setValues}
+						values={values}
+					/>
+				) : (
+					<ClayLoadingIndicator displayType="secondary" size="sm" />
+				)}
 			</div>
 
 			{showModal.deleteObjectRelationship && (

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
@@ -14,7 +14,7 @@ import {isEdge, isNode} from 'react-flow-renderer';
 import {defaultLanguageId} from '../../../utils/constants';
 import {EditObjectRelationshipContent} from '../../ObjectRelationship/EditObjectRelationshipContent';
 import {ModalDeleteObjectRelationship} from '../../ObjectRelationship/ModalDeleteObjectRelationship';
-import {useObjectRelationshipForm} from '../../ObjectRelationship/ObjectRelationshipFormBase';
+import {useObjectRelationshipForm} from '../../ObjectRelationship/useObjectRelationshipForm';
 import {getUpdatedModelBuilderStructurePayload} from '../../ViewObjectDefinitions/objectDefinitionUtil';
 import {useObjectFolderContext} from '../ModelBuilderContext/objectFolderContext';
 import {TYPES} from '../ModelBuilderContext/typesEnum';

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/CurrentObjectDefinition.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/CurrentObjectDefinition.tsx
@@ -33,6 +33,7 @@ export default function CurrentObjectDefinition({
 			<Input
 				disabled={disabled}
 				error={error}
+				id="lfr-objects__object-relationship-form-base-current-object-definition"
 				label={label}
 				name="currentObjectInput"
 				readOnly={readOnly}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
@@ -13,7 +13,7 @@ import {
 import React from 'react';
 
 import {EditObjectRelationshipContent} from './EditObjectRelationshipContent';
-import {useObjectRelationshipForm} from './ObjectRelationshipFormBase';
+import {useObjectRelationshipForm} from './useObjectRelationshipForm';
 
 interface EditObjectRelationshipProps {
 	baseResourceURL: string;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
@@ -3,24 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayAlert from '@clayui/alert';
 import {
 	API,
-	Card,
-	Input,
 	SidePanelForm,
-	SingleSelect,
 	openToast,
 	saveAndReload,
 } from '@liferay/object-js-components-web';
-import {InputLocalized} from 'frontend-js-components-web';
 import React from 'react';
 
-import {
-	ObjectRelationshipFormBase,
-	useObjectRelationshipForm,
-} from './ObjectRelationshipFormBase';
-import SelectObjectRelationship from './SelectObjectRelationship';
+import {EditObjectRelationshipContent} from './EditObjectRelationshipContent';
+import {useObjectRelationshipForm} from './ObjectRelationshipFormBase';
 
 interface EditObjectRelationshipProps {
 	baseResourceURL: string;
@@ -87,74 +79,22 @@ export default function EditObjectRelationship({
 			readOnly={readOnly}
 			title={Liferay.Language.get('relationship')}
 		>
-			<Card title={Liferay.Language.get('basic-info')}>
-				{values.reverse && (
-					<ClayAlert
-						displayType="warning"
-						title={`${Liferay.Language.get('warning')}:`}
-					>
-						{Liferay.Language.get(
-							'reverse-object-relationships-cannot-be-updated'
-						)}
-					</ClayAlert>
-				)}
-
-				<InputLocalized
-					disabled={readOnly}
-					error={errors.label}
-					label={Liferay.Language.get('label')}
-					onChange={(label) => setValues({label})}
-					required
-					translations={values.label as LocalizedValue<string>}
-				/>
-
-				<ObjectRelationshipFormBase
-					baseResourceURL={baseResourceURL}
-					errors={errors}
-					handleChange={handleChange}
-					objectDefinitionExternalReferenceCode1={
-						objectDefinitionExternalReferenceCode
-					}
-					readonly
-					setValues={setValues}
-					values={values}
-				/>
-
-				<SingleSelect
-					disabled={
-						readOnly ||
-						(Liferay.FeatureFlags['LPS-187142'] && values.edge)
-					}
-					items={objectRelationshipDeletionTypes}
-					label={Liferay.Language.get('deletion-type')}
-					onSelectionChange={(value) =>
-						setValues({deletionType: value as string})
-					}
-					required
-					selectedKey={values.deletionType}
-				/>
-			</Card>
-
-			{parameterRequired && values.type === 'oneToMany' && (
-				<Card title={Liferay.Language.get('parameters')}>
-					<Input
-						label={Liferay.Language.get('api-endpoint')}
-						readOnly
-						value={restContextPath}
-					/>
-
-					<SelectObjectRelationship
-						error={errors.parameterObjectFieldName}
-						objectDefinitionExternalReferenceCode1={
-							values.objectDefinitionExternalReferenceCode2 as string
-						}
-						onChange={(parameterObjectFieldName) =>
-							setValues({parameterObjectFieldName})
-						}
-						value={values.parameterObjectFieldName}
-					/>
-				</Card>
-			)}
+			<EditObjectRelationshipContent
+				baseResourceURL={baseResourceURL}
+				errors={errors}
+				handleChange={handleChange}
+				objectDefinitionExternalReferenceCode={
+					objectDefinitionExternalReferenceCode
+				}
+				objectRelationshipDeletionTypes={
+					objectRelationshipDeletionTypes
+				}
+				parameterRequired={parameterRequired}
+				readOnly={readOnly}
+				restContextPath={restContextPath}
+				setValues={setValues}
+				values={values}
+			/>
 		</SidePanelForm>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
@@ -5,6 +5,7 @@
 
 import {
 	API,
+	Card,
 	SidePanelForm,
 	openToast,
 	saveAndReload,
@@ -81,6 +82,7 @@ export default function EditObjectRelationship({
 		>
 			<EditObjectRelationshipContent
 				baseResourceURL={baseResourceURL}
+				containerWrapper={Card}
 				errors={errors}
 				handleChange={handleChange}
 				objectDefinitionExternalReferenceCode={

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
@@ -9,7 +9,7 @@ import {InputLocalized} from 'frontend-js-components-web';
 import React from 'react';
 
 import {ObjectRelationshipFormBase} from './ObjectRelationshipFormBase';
-import SelectObjectRelationship from './SelectObjectRelationship';
+import {SelectObjectRelationship} from './SelectObjectRelationship';
 
 import type {FormError} from '@liferay/object-js-components-web';
 import type {ChangeEventHandler} from 'react';

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import {Card, Input, SingleSelect} from '@liferay/object-js-components-web';
+import {Input, SingleSelect} from '@liferay/object-js-components-web';
 import {InputLocalized} from 'frontend-js-components-web';
 import React from 'react';
 
@@ -12,14 +12,16 @@ import {ObjectRelationshipFormBase} from './ObjectRelationshipFormBase';
 import {SelectObjectRelationship} from './SelectObjectRelationship';
 
 import type {FormError} from '@liferay/object-js-components-web';
-import type {ChangeEventHandler} from 'react';
+import type {ChangeEventHandler, ElementType} from 'react';
 
 interface EditObjectRelationshipContentProps {
 	baseResourceURL: string;
+	containerWrapper: ElementType;
 	errors: FormError<ObjectRelationship>;
 	handleChange: ChangeEventHandler<HTMLInputElement>;
 	objectDefinitionExternalReferenceCode: string;
 	objectRelationshipDeletionTypes: LabelValueObject[];
+	onSubmit?: (editedObjectRelationship?: Partial<ObjectRelationship>) => void;
 	parameterRequired: boolean;
 	readOnly?: boolean;
 	restContextPath: string;
@@ -29,10 +31,12 @@ interface EditObjectRelationshipContentProps {
 
 export function EditObjectRelationshipContent({
 	baseResourceURL,
+	containerWrapper: ContainerWrapper,
 	errors,
 	handleChange,
 	objectDefinitionExternalReferenceCode,
 	objectRelationshipDeletionTypes,
+	onSubmit,
 	parameterRequired,
 	readOnly,
 	restContextPath,
@@ -41,7 +45,7 @@ export function EditObjectRelationshipContent({
 }: EditObjectRelationshipContentProps) {
 	return (
 		<>
-			<Card title={Liferay.Language.get('basic-info')}>
+			<ContainerWrapper title={Liferay.Language.get('basic-info')}>
 				{values.reverse && (
 					<ClayAlert
 						displayType="warning"
@@ -58,6 +62,13 @@ export function EditObjectRelationshipContent({
 					error={errors.label}
 					id="lfr-objects__object-relationship-form-base-label"
 					label={Liferay.Language.get('label')}
+					onBlur={(event) => {
+						event.stopPropagation();
+
+						if (onSubmit) {
+							onSubmit();
+						}
+					}}
 					onChange={(label) => setValues({label})}
 					required
 					translations={values.label as LocalizedValue<string>}
@@ -83,16 +94,23 @@ export function EditObjectRelationshipContent({
 					id="lfr-objects__object-relationship-deletion-type"
 					items={objectRelationshipDeletionTypes}
 					label={Liferay.Language.get('deletion-type')}
-					onSelectionChange={(value) =>
-						setValues({deletionType: value as string})
-					}
+					onSelectionChange={(value) => {
+						setValues({deletionType: value as string});
+
+						if (onSubmit) {
+							onSubmit({
+								...values,
+								deletionType: value as string,
+							});
+						}
+					}}
 					required
 					selectedKey={values.deletionType}
 				/>
-			</Card>
+			</ContainerWrapper>
 
 			{parameterRequired && values.type === 'oneToMany' && (
-				<Card title={Liferay.Language.get('parameters')}>
+				<ContainerWrapper title={Liferay.Language.get('parameters')}>
 					<Input
 						id="lfr-objects__object-relationship-api-endpoint"
 						label={Liferay.Language.get('api-endpoint')}
@@ -105,12 +123,19 @@ export function EditObjectRelationshipContent({
 						objectDefinitionExternalReferenceCode1={
 							values.objectDefinitionExternalReferenceCode2 as string
 						}
-						onChange={(parameterObjectFieldName) =>
-							setValues({parameterObjectFieldName})
-						}
+						onChange={(parameterObjectFieldName) => {
+							setValues({parameterObjectFieldName});
+
+							if (onSubmit) {
+								onSubmit({
+									...values,
+									parameterObjectFieldName,
+								});
+							}
+						}}
 						value={values.parameterObjectFieldName}
 					/>
-				</Card>
+				</ContainerWrapper>
 			)}
 		</>
 	);

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationshipContent.tsx
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import {Card, Input, SingleSelect} from '@liferay/object-js-components-web';
+import {InputLocalized} from 'frontend-js-components-web';
+import React from 'react';
+
+import {ObjectRelationshipFormBase} from './ObjectRelationshipFormBase';
+import SelectObjectRelationship from './SelectObjectRelationship';
+
+import type {FormError} from '@liferay/object-js-components-web';
+import type {ChangeEventHandler} from 'react';
+
+interface EditObjectRelationshipContentProps {
+	baseResourceURL: string;
+	errors: FormError<ObjectRelationship>;
+	handleChange: ChangeEventHandler<HTMLInputElement>;
+	objectDefinitionExternalReferenceCode: string;
+	objectRelationshipDeletionTypes: LabelValueObject[];
+	parameterRequired: boolean;
+	readOnly?: boolean;
+	restContextPath: string;
+	setValues: (values: Partial<ObjectRelationship>) => void;
+	values: Partial<ObjectRelationship>;
+}
+
+export function EditObjectRelationshipContent({
+	baseResourceURL,
+	errors,
+	handleChange,
+	objectDefinitionExternalReferenceCode,
+	objectRelationshipDeletionTypes,
+	parameterRequired,
+	readOnly,
+	restContextPath,
+	setValues,
+	values,
+}: EditObjectRelationshipContentProps) {
+	return (
+		<>
+			<Card title={Liferay.Language.get('basic-info')}>
+				{values.reverse && (
+					<ClayAlert
+						displayType="warning"
+						title={`${Liferay.Language.get('warning')}:`}
+					>
+						{Liferay.Language.get(
+							'reverse-object-relationships-cannot-be-updated'
+						)}
+					</ClayAlert>
+				)}
+
+				<InputLocalized
+					disabled={readOnly}
+					error={errors.label}
+					id="lfr-objects__object-relationship-form-base-label"
+					label={Liferay.Language.get('label')}
+					onChange={(label) => setValues({label})}
+					required
+					translations={values.label as LocalizedValue<string>}
+				/>
+
+				<ObjectRelationshipFormBase
+					baseResourceURL={baseResourceURL}
+					errors={errors}
+					handleChange={handleChange}
+					objectDefinitionExternalReferenceCode1={
+						objectDefinitionExternalReferenceCode
+					}
+					readonly
+					setValues={setValues}
+					values={values}
+				/>
+
+				<SingleSelect
+					disabled={
+						readOnly ||
+						(Liferay.FeatureFlags['LPS-187142'] && values.edge)
+					}
+					id="lfr-objects__object-relationship-deletion-type"
+					items={objectRelationshipDeletionTypes}
+					label={Liferay.Language.get('deletion-type')}
+					onSelectionChange={(value) =>
+						setValues({deletionType: value as string})
+					}
+					required
+					selectedKey={values.deletionType}
+				/>
+			</Card>
+
+			{parameterRequired && values.type === 'oneToMany' && (
+				<Card title={Liferay.Language.get('parameters')}>
+					<Input
+						id="lfr-objects__object-relationship-api-endpoint"
+						label={Liferay.Language.get('api-endpoint')}
+						readOnly
+						value={restContextPath}
+					/>
+
+					<SelectObjectRelationship
+						error={errors.parameterObjectFieldName}
+						objectDefinitionExternalReferenceCode1={
+							values.objectDefinitionExternalReferenceCode2 as string
+						}
+						onChange={(parameterObjectFieldName) =>
+							setValues({parameterObjectFieldName})
+						}
+						value={values.parameterObjectFieldName}
+					/>
+				</Card>
+			)}
+		</>
+	);
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ModalAddObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ModalAddObjectRelationship.tsx
@@ -16,7 +16,7 @@ import {
 	ObjectRelationshipFormBase,
 	useObjectRelationshipForm,
 } from './ObjectRelationshipFormBase';
-import SelectObjectRelationship from './SelectObjectRelationship';
+import {SelectObjectRelationship} from './SelectObjectRelationship';
 
 import './ModalAddObjectRelationship.scss';
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ModalAddObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ModalAddObjectRelationship.tsx
@@ -12,11 +12,9 @@ import React, {useState} from 'react';
 
 import {defaultLanguageId} from '../../utils/constants';
 import {toCamelCase} from '../../utils/string';
-import {
-	ObjectRelationshipFormBase,
-	useObjectRelationshipForm,
-} from './ObjectRelationshipFormBase';
+import {ObjectRelationshipFormBase} from './ObjectRelationshipFormBase';
 import {SelectObjectRelationship} from './SelectObjectRelationship';
+import {useObjectRelationshipForm} from './useObjectRelationshipForm';
 
 import './ModalAddObjectRelationship.scss';
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -8,15 +8,11 @@ import {
 	FormError,
 	Input,
 	SingleSelect,
-	constantsUtils,
-	invalidateRequired,
 	stringUtils,
-	useForm,
 } from '@liferay/object-js-components-web';
 import {createResourceURL} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {defaultLanguageId} from '../../utils/constants';
 import CurrentObjectDefinition from './CurrentObjectDefinition';
 import SelectObjectDefinition from './SelectObjectDefinition';
 
@@ -31,12 +27,6 @@ interface ObjectRelationshipFormBaseProps {
 	readonly?: boolean;
 	setValues: (values: Partial<ObjectRelationship>) => void;
 	values: Partial<ObjectRelationship>;
-}
-
-interface UseObjectRelationshipFormProps {
-	initialValues: Partial<ObjectRelationship>;
-	onSubmit: (relationship: ObjectRelationship) => void;
-	parameterRequired: boolean;
 }
 
 export type ObjectRelationshipType = 'manyToMany' | 'oneToMany' | 'oneToOne';
@@ -84,70 +74,6 @@ export const OBJECT_RELATIONSHIP_TYPES = [
 	ONE_TO_MANY,
 	ONE_TO_ONE,
 ];
-
-export function useObjectRelationshipForm({
-	initialValues,
-	onSubmit,
-	parameterRequired,
-}: UseObjectRelationshipFormProps) {
-	const validate = (relationship: Partial<ObjectRelationship>) => {
-		const errors: FormError<ObjectRelationship> = {};
-
-		const label = relationship.label?.[defaultLanguageId];
-
-		if (invalidateRequired(label)) {
-			errors.label = constantsUtils.REQUIRED_MSG;
-		}
-
-		if (invalidateRequired(relationship.name ?? label)) {
-			errors.name = constantsUtils.REQUIRED_MSG;
-		}
-
-		if (invalidateRequired(relationship.type)) {
-			errors.type = constantsUtils.REQUIRED_MSG;
-		}
-
-		if (!relationship.objectDefinitionId1) {
-			errors.objectDefinitionId1 = constantsUtils.REQUIRED_MSG;
-		}
-
-		if (!relationship.objectDefinitionId2) {
-			errors.objectDefinitionId2 = constantsUtils.REQUIRED_MSG;
-		}
-
-		if (
-			parameterRequired &&
-			relationship.type === 'oneToMany' &&
-			!relationship.parameterObjectFieldName
-		) {
-			errors.parameterObjectFieldName = constantsUtils.REQUIRED_MSG;
-		}
-
-		return errors;
-	};
-
-	const {
-		errors,
-		handleChange,
-		handleSubmit,
-		handleValidate,
-		setValues,
-		values,
-	} = useForm({
-		initialValues,
-		onSubmit,
-		validate,
-	});
-
-	return {
-		errors,
-		handleChange,
-		handleSubmit,
-		handleValidate,
-		setValues,
-		values,
-	};
-}
 
 export function ObjectRelationshipFormBase({
 	baseResourceURL,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/ObjectRelationshipFormBase.tsx
@@ -337,6 +337,7 @@ export function ObjectRelationshipFormBase({
 			<Input
 				disabled={readonly}
 				error={errors.name}
+				id="lfr-objects__object-relationship-form-base-name"
 				label={Liferay.Language.get('name')}
 				name="name"
 				onChange={handleChange}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/SelectObjectRelationship.tsx
@@ -10,20 +10,19 @@ import {
 } from '@liferay/object-js-components-web';
 import React, {useEffect, useMemo, useState} from 'react';
 
-interface IProps {
+interface SelectObjectRelationshipProps {
 	error?: string;
 	objectDefinitionExternalReferenceCode1: string;
 	onChange: (objectFieldName: string) => void;
 	value?: string;
 }
 
-export default function SelectRelationship({
+export function SelectObjectRelationship({
 	error,
 	objectDefinitionExternalReferenceCode1,
 	onChange,
 	value,
-	...otherProps
-}: IProps) {
+}: SelectObjectRelationshipProps) {
 	const [creationLanguageId, setCreationLanguageId] =
 		useState<Liferay.Language.Locale>();
 	const [objectFields, setObjectFields] = useState<ObjectField[]>([]);
@@ -106,7 +105,6 @@ export default function SelectRelationship({
 			tooltip={Liferay.Language.get(
 				'choose-a-relationship-field-from-the-selected-object'
 			)}
-			{...otherProps}
 		/>
 	);
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/useObjectRelationshipForm.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/useObjectRelationshipForm.ts
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	FormError,
+	constantsUtils,
+	invalidateRequired,
+	useForm,
+} from '@liferay/object-js-components-web';
+
+import {defaultLanguageId} from '../../utils/constants';
+
+interface UseObjectRelationshipFormProps {
+	initialValues: Partial<ObjectRelationship>;
+	onSubmit: (relationship: ObjectRelationship) => void;
+	parameterRequired: boolean;
+}
+
+export function useObjectRelationshipForm({
+	initialValues,
+	onSubmit,
+	parameterRequired,
+}: UseObjectRelationshipFormProps) {
+	const validate = (relationship: Partial<ObjectRelationship>) => {
+		const errors: FormError<ObjectRelationship> = {};
+
+		const label = relationship.label?.[defaultLanguageId];
+
+		if (invalidateRequired(label)) {
+			errors.label = constantsUtils.REQUIRED_MSG;
+		}
+
+		if (invalidateRequired(relationship.name ?? label)) {
+			errors.name = constantsUtils.REQUIRED_MSG;
+		}
+
+		if (invalidateRequired(relationship.type)) {
+			errors.type = constantsUtils.REQUIRED_MSG;
+		}
+
+		if (!relationship.objectDefinitionId1) {
+			errors.objectDefinitionId1 = constantsUtils.REQUIRED_MSG;
+		}
+
+		if (!relationship.objectDefinitionId2) {
+			errors.objectDefinitionId2 = constantsUtils.REQUIRED_MSG;
+		}
+
+		if (
+			parameterRequired &&
+			relationship.type === 'oneToMany' &&
+			!relationship.parameterObjectFieldName
+		) {
+			errors.parameterObjectFieldName = constantsUtils.REQUIRED_MSG;
+		}
+
+		return errors;
+	};
+
+	const {
+		errors,
+		handleChange,
+		handleSubmit,
+		handleValidate,
+		setValues,
+		values,
+	} = useForm({
+		initialValues,
+		onSubmit,
+		validate,
+	});
+
+	return {
+		errors,
+		handleChange,
+		handleSubmit,
+		handleValidate,
+		setValues,
+		values,
+	};
+}


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-35778

Hi @rebsilva, This PR does not need unit or playwright tests since I extracted 1 component and 1 function to reuse them and avoid code repetition, our current tests are enough to see if this change will break anything :smile: 