### PR TITLE
LPD-2294 Upgrade process: Drop views of the dynamic object definition tables from partitioned DB

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.201
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 9.2.1
+Liferay-Require-SchemaVersion: 9.2.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -465,6 +465,11 @@ public class ObjectServiceUpgradeStepRegistrator
 			"9.2.0", "9.2.1",
 			new com.liferay.object.internal.upgrade.v9_2_1.
 				ObjectActionUpgradeProcess(_notificationTemplateLocalService));
+
+		registry.register(
+			"9.2.1", "9.2.2",
+			new com.liferay.object.internal.upgrade.v9_2_2.
+				SchemaUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v9_2_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+/**
+ * @author Paulo Albuquerque
+ */
+public class SchemaUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long companyId = CompanyThreadLocal.getCompanyId();
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+		if (!DBPartition.isPartitionEnabled() ||
+			(companyId == defaultCompanyId)) {
+
+			return;
+		}
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+		DBInspector dbInspector = new DBInspector(connection);
+
+		try (ResultSet resultSet = databaseMetaData.getTables(
+				dbInspector.getCatalog(), dbInspector.getSchema(), null,
+				new String[] {"VIEW"})) {
+
+			while (resultSet.next()) {
+				String tableName = resultSet.getString("TABLE_NAME");
+
+				String tableNameLowerCase = StringUtil.toLowerCase(tableName);
+
+				if (tableName.contains(String.valueOf(defaultCompanyId)) &&
+					(tableNameLowerCase.contains("_x_") ||
+					 tableNameLowerCase.startsWith("o_"))) {
+
+					runSQL(
+						StringBundler.concat(
+							"drop view if exists ",
+							DBPartitionUtil.getPartitionName(companyId),
+							StringPool.PERIOD, tableName));
+				}
+			}
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_2/test/SchemaUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v9_2_2/test/SchemaUpgradeProcessTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v9_2_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Paulo Albuquerque
+ */
+@RunWith(Arquillian.class)
+public class SchemaUpgradeProcessTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		BaseDBPartitionTestCase.setUpClass();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		Company company = CompanyLocalServiceUtil.addCompany(
+			null, _VIRTUAL_HOSTNAME, _VIRTUAL_HOSTNAME, _VIRTUAL_HOSTNAME, 0,
+			true, true, null, null, null, null, null, null);
+
+		_partitionName = DBPartitionUtil.getPartitionName(
+			company.getCompanyId());
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				TestPropsValues.getCompanyId(), User.class.getSimpleName());
+
+		String dbTableName = StringBundler.concat(
+			objectDefinition.getDBTableName(), "x_",
+			PortalInstancePool.getDefaultCompanyId());
+
+		_createView(dbTableName);
+
+		objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"a" + RandomTestUtil.randomString()
+				).build()));
+
+		_createView(objectDefinition.getDBTableName());
+		_createView(objectDefinition.getExtensionDBTableName());
+
+		List<String> viewNames = _getViewNames();
+
+		Assert.assertTrue(
+			viewNames.contains(StringUtil.toLowerCase(dbTableName)));
+		Assert.assertTrue(
+			viewNames.contains(
+				StringUtil.toLowerCase(objectDefinition.getDBTableName())));
+		Assert.assertTrue(
+			viewNames.contains(
+				StringUtil.toLowerCase(
+					objectDefinition.getExtensionDBTableName())));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		viewNames = _getViewNames();
+
+		Assert.assertFalse(
+			viewNames.contains(StringUtil.toLowerCase(dbTableName)));
+		Assert.assertFalse(
+			viewNames.contains(
+				StringUtil.toLowerCase(objectDefinition.getDBTableName())));
+		Assert.assertFalse(
+			viewNames.contains(
+				StringUtil.toLowerCase(
+					objectDefinition.getExtensionDBTableName())));
+	}
+
+	private void _createView(String tableName) throws Exception {
+		String defaultPartitionName = DBPartitionUtil.getPartitionName(
+			PortalInstancePool.getDefaultCompanyId());
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(
+				StringBundler.concat(
+					"create or replace view ", _partitionName,
+					StringPool.PERIOD, tableName, " as select * from ",
+					defaultPartitionName, StringPool.PERIOD, tableName));
+		}
+	}
+
+	private List<String> _getViewNames() throws Exception {
+		List<String> viewNames = new ArrayList<>();
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		ResultSet resultSet = databaseMetaData.getTables(
+			_partitionName, null, null, new String[] {"VIEW"});
+
+		while (resultSet.next()) {
+			viewNames.add(
+				StringUtil.toLowerCase(resultSet.getString("TABLE_NAME")));
+		}
+
+		return viewNames;
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.internal.upgrade.v9_2_2.SchemaUpgradeProcess";
+
+	private static final String _VIRTUAL_HOSTNAME =
+		RandomTestUtil.randomString() + ".localtest.me";
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private String _partitionName;
+
+}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-2294