### PR TITLE
LPD-35068 add `themeId` field to `StyleBookEntry`

### DIFF
--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
@@ -444,7 +444,8 @@ public class LayoutStagedModelDataHandlerTest
 				false, StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK,
 				ServiceContextTestUtil.getServiceContext(
-					stagingGroup.getGroupId()));
+					stagingGroup.getGroupId()),
+				StringPool.BLANK);
 
 		Layout layout = LayoutTestUtil.addTypeContentLayout(stagingGroup);
 

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
@@ -442,10 +442,9 @@ public class LayoutStagedModelDataHandlerTest
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
 				false, StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK,
+				StringPool.BLANK, RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
-					stagingGroup.getGroupId()),
-				StringPool.BLANK);
+					stagingGroup.getGroupId()));
 
 		Layout layout = LayoutTestUtil.addTypeContentLayout(stagingGroup);
 

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
@@ -89,7 +89,8 @@ public class EditLayoutDesignMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				serviceContext);
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
@@ -89,7 +89,7 @@ public class EditLayoutDesignMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, serviceContext);
+				StringPool.BLANK, serviceContext, StringPool.BLANK);
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
@@ -154,9 +154,8 @@ public class CreateLayoutPageTemplateEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK,
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()),
-				StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		draftLayout = _layoutLocalService.updateStyleBookEntryId(
 			draftLayout.getGroupId(), draftLayout.isPrivateLayout(),

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
@@ -155,7 +155,8 @@ public class CreateLayoutPageTemplateEntryMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK,
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()),
+				StringPool.BLANK);
 
 		draftLayout = _layoutLocalService.updateStyleBookEntryId(
 			draftLayout.getGroupId(), draftLayout.isPrivateLayout(),

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
@@ -150,7 +150,8 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		Layout layout = _layoutLocalService.fetchLayout(
 			layoutPageTemplateEntry.getPlid());

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
@@ -150,7 +150,7 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		Layout layout = _layoutLocalService.fetchLayout(
 			layoutPageTemplateEntry.getPlid());

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 8.0.1
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryModel.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryModel.java
@@ -347,6 +347,21 @@ public interface StyleBookEntryModel
 	 */
 	public void setStyleBookEntryKey(String styleBookEntryKey);
 
+	/**
+	 * Returns the theme ID of this style book entry.
+	 *
+	 * @return the theme ID of this style book entry
+	 */
+	@AutoEscape
+	public String getThemeId();
+
+	/**
+	 * Sets the theme ID of this style book entry.
+	 *
+	 * @param themeId the theme ID of this style book entry
+	 */
+	public void setThemeId(String themeId);
+
 	@Override
 	public StyleBookEntry cloneWithOriginalValues();
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryTable.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryTable.java
@@ -73,6 +73,8 @@ public class StyleBookEntryTable extends BaseTable<StyleBookEntryTable> {
 		createColumn(
 			"styleBookEntryKey", String.class, Types.VARCHAR,
 			Column.FLAG_DEFAULT);
+	public final Column<StyleBookEntryTable, String> themeId = createColumn(
+		"themeId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 
 	private StyleBookEntryTable() {
 		super("StyleBookEntry", StyleBookEntryTable::new);

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionModel.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionModel.java
@@ -358,6 +358,21 @@ public interface StyleBookEntryVersionModel
 	 */
 	public void setStyleBookEntryKey(String styleBookEntryKey);
 
+	/**
+	 * Returns the theme ID of this style book entry version.
+	 *
+	 * @return the theme ID of this style book entry version
+	 */
+	@AutoEscape
+	public String getThemeId();
+
+	/**
+	 * Sets the theme ID of this style book entry version.
+	 *
+	 * @param themeId the theme ID of this style book entry version
+	 */
+	public void setThemeId(String themeId);
+
 	@Override
 	public StyleBookEntryVersion cloneWithOriginalValues();
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionTable.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionTable.java
@@ -82,6 +82,9 @@ public class StyleBookEntryVersionTable
 		createColumn(
 			"styleBookEntryKey", String.class, Types.VARCHAR,
 			Column.FLAG_DEFAULT);
+	public final Column<StyleBookEntryVersionTable, String> themeId =
+		createColumn(
+			"themeId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 
 	private StyleBookEntryVersionTable() {
 		super("StyleBookEntryVersion", StyleBookEntryVersionTable::new);

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionWrapper.java
@@ -55,6 +55,7 @@ public class StyleBookEntryVersionWrapper
 		attributes.put("name", getName());
 		attributes.put("previewFileEntryId", getPreviewFileEntryId());
 		attributes.put("styleBookEntryKey", getStyleBookEntryKey());
+		attributes.put("themeId", getThemeId());
 
 		return attributes;
 	}
@@ -171,6 +172,12 @@ public class StyleBookEntryVersionWrapper
 
 		if (styleBookEntryKey != null) {
 			setStyleBookEntryKey(styleBookEntryKey);
+		}
+
+		String themeId = (String)attributes.get("themeId");
+
+		if (themeId != null) {
+			setThemeId(themeId);
 		}
 	}
 
@@ -327,6 +334,16 @@ public class StyleBookEntryVersionWrapper
 	@Override
 	public long getStyleBookEntryVersionId() {
 		return model.getStyleBookEntryVersionId();
+	}
+
+	/**
+	 * Returns the theme ID of this style book entry version.
+	 *
+	 * @return the theme ID of this style book entry version
+	 */
+	@Override
+	public String getThemeId() {
+		return model.getThemeId();
 	}
 
 	/**
@@ -537,6 +554,16 @@ public class StyleBookEntryVersionWrapper
 	@Override
 	public void setStyleBookEntryVersionId(long styleBookEntryVersionId) {
 		model.setStyleBookEntryVersionId(styleBookEntryVersionId);
+	}
+
+	/**
+	 * Sets the theme ID of this style book entry version.
+	 *
+	 * @param themeId the theme ID of this style book entry version
+	 */
+	@Override
+	public void setThemeId(String themeId) {
+		model.setThemeId(themeId);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryWrapper.java
@@ -53,6 +53,7 @@ public class StyleBookEntryWrapper
 		attributes.put("name", getName());
 		attributes.put("previewFileEntryId", getPreviewFileEntryId());
 		attributes.put("styleBookEntryKey", getStyleBookEntryKey());
+		attributes.put("themeId", getThemeId());
 
 		return attributes;
 	}
@@ -162,6 +163,12 @@ public class StyleBookEntryWrapper
 
 		if (styleBookEntryKey != null) {
 			setStyleBookEntryKey(styleBookEntryKey);
+		}
+
+		String themeId = (String)attributes.get("themeId");
+
+		if (themeId != null) {
+			setThemeId(themeId);
 		}
 	}
 
@@ -325,6 +332,16 @@ public class StyleBookEntryWrapper
 	@Override
 	public String getStyleBookEntryKey() {
 		return model.getStyleBookEntryKey();
+	}
+
+	/**
+	 * Returns the theme ID of this style book entry.
+	 *
+	 * @return the theme ID of this style book entry
+	 */
+	@Override
+	public String getThemeId() {
+		return model.getThemeId();
 	}
 
 	/**
@@ -538,6 +555,16 @@ public class StyleBookEntryWrapper
 	@Override
 	public void setStyleBookEntryKey(String styleBookEntryKey) {
 		model.setStyleBookEntryKey(styleBookEntryKey);
+	}
+
+	/**
+	 * Sets the theme ID of this style book entry.
+	 *
+	 * @param themeId the theme ID of this style book entry
+	 */
+	@Override
+	public void setThemeId(String themeId) {
+		model.setThemeId(themeId);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -68,8 +68,8 @@ public interface StyleBookEntryLocalService
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
-			String name, String styleBookEntryKey,
-			ServiceContext serviceContext, String themeId)
+			String name, String styleBookEntryKey, String themeId,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -69,7 +69,7 @@ public interface StyleBookEntryLocalService
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey,
-			ServiceContext serviceContext)
+			ServiceContext serviceContext, String themeId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -39,15 +39,14 @@ public class StyleBookEntryLocalServiceUtil {
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
-			String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String name, String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext,
-			themeId);
+			frontendTokensValues, name, styleBookEntryKey, themeId,
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -40,12 +40,14 @@ public class StyleBookEntryLocalServiceUtil {
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext);
+			frontendTokensValues, name, styleBookEntryKey, serviceContext,
+			themeId);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -36,15 +36,14 @@ public class StyleBookEntryLocalServiceWrapper
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
-			String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String name, String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext,
-			themeId);
+			frontendTokensValues, name, styleBookEntryKey, themeId,
+			serviceContext);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -37,12 +37,14 @@ public class StyleBookEntryLocalServiceWrapper
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext);
+			frontendTokensValues, name, styleBookEntryKey, serviceContext,
+			themeId);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
@@ -45,7 +45,8 @@ public interface StyleBookEntryService extends BaseService {
 	 */
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, ServiceContext serviceContext)
+			String styleBookEntryKey, ServiceContext serviceContext,
+			String themeId)
 		throws PortalException;
 
 	public StyleBookEntry addStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
@@ -45,14 +45,14 @@ public interface StyleBookEntryService extends BaseService {
 	 */
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, ServiceContext serviceContext,
-			String themeId)
+			String styleBookEntryKey, String themeId,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			ServiceContext serviceContext, String themeId)
+			String themeId, ServiceContext serviceContext)
 		throws PortalException;
 
 	public StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
@@ -51,7 +51,7 @@ public interface StyleBookEntryService extends BaseService {
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			ServiceContext serviceContext)
+			ServiceContext serviceContext, String themeId)
 		throws PortalException;
 
 	public StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
@@ -31,12 +31,13 @@ public class StyleBookEntryServiceUtil {
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
 			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, groupId, name, styleBookEntryKey,
-			serviceContext);
+			serviceContext, themeId);
 	}
 
 	public static StyleBookEntry addStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
@@ -30,26 +30,25 @@ public class StyleBookEntryServiceUtil {
 	 */
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
-			externalReferenceCode, groupId, name, styleBookEntryKey,
-			serviceContext, themeId);
+			externalReferenceCode, groupId, name, styleBookEntryKey, themeId,
+			serviceContext);
 	}
 
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, serviceContext, themeId);
+			styleBookEntryKey, themeId, serviceContext);
 	}
 
 	public static StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
@@ -42,12 +42,13 @@ public class StyleBookEntryServiceUtil {
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, serviceContext);
+			styleBookEntryKey, serviceContext, themeId);
 	}
 
 	public static StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
@@ -32,12 +32,13 @@ public class StyleBookEntryServiceWrapper
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
 			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			externalReferenceCode, groupId, name, styleBookEntryKey,
-			serviceContext);
+			serviceContext, themeId);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
@@ -31,27 +31,26 @@ public class StyleBookEntryServiceWrapper
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
-			externalReferenceCode, groupId, name, styleBookEntryKey,
-			serviceContext, themeId);
+			externalReferenceCode, groupId, name, styleBookEntryKey, themeId,
+			serviceContext);
 	}
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, serviceContext, themeId);
+			styleBookEntryKey, themeId, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
@@ -44,12 +44,13 @@ public class StyleBookEntryServiceWrapper
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, serviceContext);
+			styleBookEntryKey, serviceContext, themeId);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/model/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/style-book/style-book-service/bnd.bnd
+++ b/modules/apps/style-book/style-book-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book Service
 Bundle-SymbolicName: com.liferay.style.book.service
 Bundle-Version: 2.0.51
-Liferay-Require-SchemaVersion: 1.5.0
+Liferay-Require-SchemaVersion: 1.7.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/style-book/style-book-service/service.xml
+++ b/modules/apps/style-book/style-book-service/service.xml
@@ -28,6 +28,7 @@
 		<column name="name" type="String" />
 		<column name="previewFileEntryId" type="long" />
 		<column name="styleBookEntryKey" type="String" />
+		<column name="themeId" type="String" />
 
 		<!-- Order -->
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
@@ -50,8 +50,8 @@ public class StylebookEntryStagedModelRepository
 			styleBookEntry.getGroupId(),
 			styleBookEntry.isDefaultStyleBookEntry(),
 			styleBookEntry.getFrontendTokensValues(), styleBookEntry.getName(),
-			styleBookEntry.getStyleBookEntryKey(), serviceContext,
-			styleBookEntry.getThemeId());
+			styleBookEntry.getStyleBookEntryKey(), styleBookEntry.getThemeId(),
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
@@ -50,7 +50,8 @@ public class StylebookEntryStagedModelRepository
 			styleBookEntry.getGroupId(),
 			styleBookEntry.isDefaultStyleBookEntry(),
 			styleBookEntry.getFrontendTokensValues(), styleBookEntry.getName(),
-			styleBookEntry.getStyleBookEntryKey(), serviceContext);
+			styleBookEntry.getStyleBookEntryKey(), serviceContext,
+			styleBookEntry.getThemeId());
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.MVCCVersionUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.style.book.internal.upgrade.v1_1_0.StyleBookEntryUpgradeProcess;
 import com.liferay.style.book.internal.upgrade.v1_2_0.StyleBookEntryVersionUpgradeProcess;
@@ -73,6 +74,16 @@ public class StyleBookServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"1.5.0", "1.6.0",
+			UpgradeProcessFactory.addColumns(
+				"StyleBookEntry", "themeId VARCHAR(255) null"));
+
+		registry.register(
+			"1.6.0", "1.7.0",
+			UpgradeProcessFactory.addColumns(
+				"StyleBookEntryVersion", "themeId VARCHAR(255) null"));
 	}
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryCacheModel.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryCacheModel.java
@@ -68,7 +68,7 @@ public class StyleBookEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(35);
+		StringBundler sb = new StringBundler(37);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -104,6 +104,8 @@ public class StyleBookEntryCacheModel
 		sb.append(previewFileEntryId);
 		sb.append(", styleBookEntryKey=");
 		sb.append(styleBookEntryKey);
+		sb.append(", themeId=");
+		sb.append(themeId);
 		sb.append("}");
 
 		return sb.toString();
@@ -183,6 +185,13 @@ public class StyleBookEntryCacheModel
 			styleBookEntryImpl.setStyleBookEntryKey(styleBookEntryKey);
 		}
 
+		if (themeId == null) {
+			styleBookEntryImpl.setThemeId("");
+		}
+		else {
+			styleBookEntryImpl.setThemeId(themeId);
+		}
+
 		styleBookEntryImpl.resetOriginalValues();
 
 		return styleBookEntryImpl;
@@ -219,6 +228,7 @@ public class StyleBookEntryCacheModel
 
 		previewFileEntryId = objectInput.readLong();
 		styleBookEntryKey = objectInput.readUTF();
+		themeId = objectInput.readUTF();
 	}
 
 	@Override
@@ -287,6 +297,13 @@ public class StyleBookEntryCacheModel
 		else {
 			objectOutput.writeUTF(styleBookEntryKey);
 		}
+
+		if (themeId == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(themeId);
+		}
 	}
 
 	public long mvccVersion;
@@ -307,5 +324,6 @@ public class StyleBookEntryCacheModel
 	public String name;
 	public long previewFileEntryId;
 	public String styleBookEntryKey;
+	public String themeId;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
@@ -105,7 +105,7 @@ public class StyleBookEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(75) null,primary key (styleBookEntryId, ctCollectionId))";
+		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,primary key (styleBookEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table StyleBookEntry";
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
@@ -76,7 +76,7 @@ public class StyleBookEntryModelImpl
 		{"defaultStyleBookEntry", Types.BOOLEAN},
 		{"frontendTokensValues", Types.CLOB}, {"name", Types.VARCHAR},
 		{"previewFileEntryId", Types.BIGINT},
-		{"styleBookEntryKey", Types.VARCHAR}
+		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -101,10 +101,11 @@ public class StyleBookEntryModelImpl
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("previewFileEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("styleBookEntryKey", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("themeId", Types.VARCHAR);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,primary key (styleBookEntryId, ctCollectionId))";
+		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(75) null,primary key (styleBookEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table StyleBookEntry";
 
@@ -323,6 +324,7 @@ public class StyleBookEntryModelImpl
 				"previewFileEntryId", StyleBookEntry::getPreviewFileEntryId);
 			attributeGetterFunctions.put(
 				"styleBookEntryKey", StyleBookEntry::getStyleBookEntryKey);
+			attributeGetterFunctions.put("themeId", StyleBookEntry::getThemeId);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -402,6 +404,9 @@ public class StyleBookEntryModelImpl
 				"styleBookEntryKey",
 				(BiConsumer<StyleBookEntry, String>)
 					StyleBookEntry::setStyleBookEntryKey);
+			attributeSetterBiConsumers.put(
+				"themeId",
+				(BiConsumer<StyleBookEntry, String>)StyleBookEntry::setThemeId);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -430,6 +435,7 @@ public class StyleBookEntryModelImpl
 		styleBookEntryVersion.setName(getName());
 		styleBookEntryVersion.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntryVersion.setStyleBookEntryKey(getStyleBookEntryKey());
+		styleBookEntryVersion.setThemeId(getThemeId());
 	}
 
 	@JSON
@@ -854,6 +860,26 @@ public class StyleBookEntryModelImpl
 		return getColumnOriginalValue("styleBookEntryKey");
 	}
 
+	@JSON
+	@Override
+	public String getThemeId() {
+		if (_themeId == null) {
+			return "";
+		}
+		else {
+			return _themeId;
+		}
+	}
+
+	@Override
+	public void setThemeId(String themeId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_themeId = themeId;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -933,6 +959,7 @@ public class StyleBookEntryModelImpl
 		styleBookEntryImpl.setName(getName());
 		styleBookEntryImpl.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntryImpl.setStyleBookEntryKey(getStyleBookEntryKey());
+		styleBookEntryImpl.setThemeId(getThemeId());
 
 		styleBookEntryImpl.resetOriginalValues();
 
@@ -976,6 +1003,8 @@ public class StyleBookEntryModelImpl
 			this.<Long>getColumnOriginalValue("previewFileEntryId"));
 		styleBookEntryImpl.setStyleBookEntryKey(
 			this.<String>getColumnOriginalValue("styleBookEntryKey"));
+		styleBookEntryImpl.setThemeId(
+			this.<String>getColumnOriginalValue("themeId"));
 
 		return styleBookEntryImpl;
 	}
@@ -1150,6 +1179,14 @@ public class StyleBookEntryModelImpl
 			styleBookEntryCacheModel.styleBookEntryKey = null;
 		}
 
+		styleBookEntryCacheModel.themeId = getThemeId();
+
+		String themeId = styleBookEntryCacheModel.themeId;
+
+		if ((themeId != null) && (themeId.length() == 0)) {
+			styleBookEntryCacheModel.themeId = null;
+		}
+
 		return styleBookEntryCacheModel;
 	}
 
@@ -1230,6 +1267,7 @@ public class StyleBookEntryModelImpl
 	private String _name;
 	private long _previewFileEntryId;
 	private String _styleBookEntryKey;
+	private String _themeId;
 
 	public <T> T getColumnValue(String columnName) {
 		if (columnName.equals("head")) {
@@ -1286,6 +1324,7 @@ public class StyleBookEntryModelImpl
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("previewFileEntryId", _previewFileEntryId);
 		_columnOriginalValues.put("styleBookEntryKey", _styleBookEntryKey);
+		_columnOriginalValues.put("themeId", _themeId);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1344,6 +1383,8 @@ public class StyleBookEntryModelImpl
 		columnBitmasks.put("previewFileEntryId", 65536L);
 
 		columnBitmasks.put("styleBookEntryKey", 131072L);
+
+		columnBitmasks.put("themeId", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionCacheModel.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionCacheModel.java
@@ -69,7 +69,7 @@ public class StyleBookEntryVersionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -107,6 +107,8 @@ public class StyleBookEntryVersionCacheModel
 		sb.append(previewFileEntryId);
 		sb.append(", styleBookEntryKey=");
 		sb.append(styleBookEntryKey);
+		sb.append(", themeId=");
+		sb.append(themeId);
 		sb.append("}");
 
 		return sb.toString();
@@ -191,6 +193,13 @@ public class StyleBookEntryVersionCacheModel
 			styleBookEntryVersionImpl.setStyleBookEntryKey(styleBookEntryKey);
 		}
 
+		if (themeId == null) {
+			styleBookEntryVersionImpl.setThemeId("");
+		}
+		else {
+			styleBookEntryVersionImpl.setThemeId(themeId);
+		}
+
 		styleBookEntryVersionImpl.resetOriginalValues();
 
 		return styleBookEntryVersionImpl;
@@ -227,6 +236,7 @@ public class StyleBookEntryVersionCacheModel
 
 		previewFileEntryId = objectInput.readLong();
 		styleBookEntryKey = objectInput.readUTF();
+		themeId = objectInput.readUTF();
 	}
 
 	@Override
@@ -295,6 +305,13 @@ public class StyleBookEntryVersionCacheModel
 		else {
 			objectOutput.writeUTF(styleBookEntryKey);
 		}
+
+		if (themeId == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(themeId);
+		}
 	}
 
 	public long mvccVersion;
@@ -315,5 +332,6 @@ public class StyleBookEntryVersionCacheModel
 	public String name;
 	public long previewFileEntryId;
 	public String styleBookEntryKey;
+	public String themeId;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
@@ -101,7 +101,7 @@ public class StyleBookEntryVersionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(75) null,primary key (styleBookEntryVersionId, ctCollectionId))";
+		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,primary key (styleBookEntryVersionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table StyleBookEntryVersion";

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
@@ -72,7 +72,7 @@ public class StyleBookEntryVersionModelImpl
 		{"defaultStyleBookEntry", Types.BOOLEAN},
 		{"frontendTokensValues", Types.CLOB}, {"name", Types.VARCHAR},
 		{"previewFileEntryId", Types.BIGINT},
-		{"styleBookEntryKey", Types.VARCHAR}
+		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -97,10 +97,11 @@ public class StyleBookEntryVersionModelImpl
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("previewFileEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("styleBookEntryKey", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("themeId", Types.VARCHAR);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,primary key (styleBookEntryVersionId, ctCollectionId))";
+		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(75) null,primary key (styleBookEntryVersionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table StyleBookEntryVersion";
@@ -319,6 +320,8 @@ public class StyleBookEntryVersionModelImpl
 			attributeGetterFunctions.put(
 				"styleBookEntryKey",
 				StyleBookEntryVersion::getStyleBookEntryKey);
+			attributeGetterFunctions.put(
+				"themeId", StyleBookEntryVersion::getThemeId);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -410,6 +413,10 @@ public class StyleBookEntryVersionModelImpl
 				"styleBookEntryKey",
 				(BiConsumer<StyleBookEntryVersion, String>)
 					StyleBookEntryVersion::setStyleBookEntryKey);
+			attributeSetterBiConsumers.put(
+				"themeId",
+				(BiConsumer<StyleBookEntryVersion, String>)
+					StyleBookEntryVersion::setThemeId);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -438,6 +445,7 @@ public class StyleBookEntryVersionModelImpl
 		styleBookEntry.setName(getName());
 		styleBookEntry.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntry.setStyleBookEntryKey(getStyleBookEntryKey());
+		styleBookEntry.setThemeId(getThemeId());
 	}
 
 	@Override
@@ -842,6 +850,25 @@ public class StyleBookEntryVersionModelImpl
 		return getColumnOriginalValue("styleBookEntryKey");
 	}
 
+	@Override
+	public String getThemeId() {
+		if (_themeId == null) {
+			return "";
+		}
+		else {
+			return _themeId;
+		}
+	}
+
+	@Override
+	public void setThemeId(String themeId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_themeId = themeId;
+	}
+
 	public long getColumnBitmask() {
 		if (_columnBitmask > 0) {
 			return _columnBitmask;
@@ -923,6 +950,7 @@ public class StyleBookEntryVersionModelImpl
 		styleBookEntryVersionImpl.setPreviewFileEntryId(
 			getPreviewFileEntryId());
 		styleBookEntryVersionImpl.setStyleBookEntryKey(getStyleBookEntryKey());
+		styleBookEntryVersionImpl.setThemeId(getThemeId());
 
 		styleBookEntryVersionImpl.resetOriginalValues();
 
@@ -970,6 +998,8 @@ public class StyleBookEntryVersionModelImpl
 			this.<Long>getColumnOriginalValue("previewFileEntryId"));
 		styleBookEntryVersionImpl.setStyleBookEntryKey(
 			this.<String>getColumnOriginalValue("styleBookEntryKey"));
+		styleBookEntryVersionImpl.setThemeId(
+			this.<String>getColumnOriginalValue("themeId"));
 
 		return styleBookEntryVersionImpl;
 	}
@@ -1158,6 +1188,14 @@ public class StyleBookEntryVersionModelImpl
 			styleBookEntryVersionCacheModel.styleBookEntryKey = null;
 		}
 
+		styleBookEntryVersionCacheModel.themeId = getThemeId();
+
+		String themeId = styleBookEntryVersionCacheModel.themeId;
+
+		if ((themeId != null) && (themeId.length() == 0)) {
+			styleBookEntryVersionCacheModel.themeId = null;
+		}
+
 		return styleBookEntryVersionCacheModel;
 	}
 
@@ -1239,6 +1277,7 @@ public class StyleBookEntryVersionModelImpl
 	private String _name;
 	private long _previewFileEntryId;
 	private String _styleBookEntryKey;
+	private String _themeId;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1292,6 +1331,7 @@ public class StyleBookEntryVersionModelImpl
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("previewFileEntryId", _previewFileEntryId);
 		_columnOriginalValues.put("styleBookEntryKey", _styleBookEntryKey);
+		_columnOriginalValues.put("themeId", _themeId);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1350,6 +1390,8 @@ public class StyleBookEntryVersionModelImpl
 		columnBitmasks.put("previewFileEntryId", 65536L);
 
 		columnBitmasks.put("styleBookEntryKey", 131072L);
+
+		columnBitmasks.put("themeId", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
@@ -896,6 +896,7 @@ public abstract class StyleBookEntryLocalServiceBaseImpl
 			publishedStyleBookEntry.getPreviewFileEntryId());
 		draftStyleBookEntry.setStyleBookEntryKey(
 			publishedStyleBookEntry.getStyleBookEntryKey());
+		draftStyleBookEntry.setThemeId(publishedStyleBookEntry.getThemeId());
 
 		draftStyleBookEntry.resetOriginalValues();
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
@@ -43,9 +43,8 @@ public class StyleBookEntryServiceHttp {
 
 	public static com.liferay.style.book.model.StyleBookEntry addStyleBookEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
-			long groupId, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			long groupId, String name, String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -55,7 +54,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, name,
-				styleBookEntryKey, serviceContext, themeId);
+				styleBookEntryKey, themeId, serviceContext);
 
 			Object returnObj = null;
 
@@ -88,9 +87,8 @@ public class StyleBookEntryServiceHttp {
 	public static com.liferay.style.book.model.StyleBookEntry addStyleBookEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long groupId, String frontendTokensValues, String name,
-			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext,
-			String themeId)
+			String styleBookEntryKey, String themeId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -100,7 +98,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, frontendTokensValues,
-				name, styleBookEntryKey, serviceContext, themeId);
+				name, styleBookEntryKey, themeId, serviceContext);
 
 			Object returnObj = null;
 
@@ -635,13 +633,13 @@ public class StyleBookEntryServiceHttp {
 
 	private static final Class<?>[] _addStyleBookEntryParameterTypes0 =
 		new Class[] {
-			String.class, long.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class, String.class
+			String.class, long.class, String.class, String.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addStyleBookEntryParameterTypes1 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class, String.class
+			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _copyStyleBookEntryParameterTypes2 =
 		new Class[] {

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
@@ -44,7 +44,8 @@ public class StyleBookEntryServiceHttp {
 	public static com.liferay.style.book.model.StyleBookEntry addStyleBookEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long groupId, String name, String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -54,7 +55,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, name,
-				styleBookEntryKey, serviceContext);
+				styleBookEntryKey, serviceContext, themeId);
 
 			Object returnObj = null;
 
@@ -635,7 +636,7 @@ public class StyleBookEntryServiceHttp {
 	private static final Class<?>[] _addStyleBookEntryParameterTypes0 =
 		new Class[] {
 			String.class, long.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
+			com.liferay.portal.kernel.service.ServiceContext.class, String.class
 		};
 	private static final Class<?>[] _addStyleBookEntryParameterTypes1 =
 		new Class[] {

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
@@ -88,7 +88,8 @@ public class StyleBookEntryServiceHttp {
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long groupId, String frontendTokensValues, String name,
 			String styleBookEntryKey,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			String themeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -98,7 +99,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, frontendTokensValues,
-				name, styleBookEntryKey, serviceContext);
+				name, styleBookEntryKey, serviceContext, themeId);
 
 			Object returnObj = null;
 
@@ -639,7 +640,7 @@ public class StyleBookEntryServiceHttp {
 	private static final Class<?>[] _addStyleBookEntryParameterTypes1 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
+			com.liferay.portal.kernel.service.ServiceContext.class, String.class
 		};
 	private static final Class<?>[] _copyStyleBookEntryParameterTypes2 =
 		new Class[] {

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -52,7 +52,7 @@ public class StyleBookEntryLocalServiceImpl
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey,
-			ServiceContext serviceContext)
+			ServiceContext serviceContext, String themeId)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -114,8 +114,8 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry targetStyleBookEntry = addStyleBookEntry(
 			null, userId, groupId, false,
 			sourceStyleBookEntry.getFrontendTokensValues(), name,
-			StringPool.BLANK, serviceContext,
-			sourceStyleBookEntry.getThemeId());
+			StringPool.BLANK, sourceStyleBookEntry.getThemeId(),
+			serviceContext);
 
 		long previewFileEntryId = _copyStyleBookEntryPreviewFileEntry(
 			userId, groupId, sourceStyleBookEntry, targetStyleBookEntry);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -51,8 +51,8 @@ public class StyleBookEntryLocalServiceImpl
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
-			String name, String styleBookEntryKey,
-			ServiceContext serviceContext, String themeId)
+			String name, String styleBookEntryKey, String themeId,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -95,6 +95,7 @@ public class StyleBookEntryLocalServiceImpl
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
 		styleBookEntry.setStyleBookEntryKey(styleBookEntryKey);
+		styleBookEntry.setThemeId(themeId);
 
 		return publishDraft(styleBookEntry);
 	}
@@ -113,7 +114,8 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry targetStyleBookEntry = addStyleBookEntry(
 			null, userId, groupId, false,
 			sourceStyleBookEntry.getFrontendTokensValues(), name,
-			StringPool.BLANK, serviceContext);
+			StringPool.BLANK, serviceContext,
+			sourceStyleBookEntry.getThemeId());
 
 		long previewFileEntryId = _copyStyleBookEntryPreviewFileEntry(
 			userId, groupId, sourceStyleBookEntry, targetStyleBookEntry);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
@@ -43,14 +43,15 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 
 		return styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, getUserId(), groupId, false,
-			StringPool.BLANK, name, styleBookEntryKey, serviceContext);
+			StringPool.BLANK, name, styleBookEntryKey, serviceContext,
+			StringPool.BLANK);
 	}
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			ServiceContext serviceContext)
+			ServiceContext serviceContext, String themeId)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -59,7 +60,8 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 
 		return styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, getUserId(), groupId, false,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext);
+			frontendTokensValues, name, styleBookEntryKey, serviceContext,
+			themeId);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
@@ -34,17 +34,13 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, ServiceContext serviceContext)
+			String styleBookEntryKey, ServiceContext serviceContext,
+			String themeId)
 		throws PortalException {
 
-		_portletResourcePermission.check(
-			getPermissionChecker(), groupId,
-			StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES);
-
-		return styleBookEntryLocalService.addStyleBookEntry(
-			externalReferenceCode, getUserId(), groupId, false,
-			StringPool.BLANK, name, styleBookEntryKey, serviceContext,
-			StringPool.BLANK);
+		return addStyleBookEntry(
+			externalReferenceCode, groupId, StringPool.BLANK, name,
+			styleBookEntryKey, serviceContext, themeId);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
@@ -40,7 +40,7 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 
 		return addStyleBookEntry(
 			externalReferenceCode, groupId, StringPool.BLANK, name,
-			styleBookEntryKey, serviceContext, themeId);
+			styleBookEntryKey, themeId, serviceContext);
 	}
 
 	@Override
@@ -56,8 +56,8 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 
 		return styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, getUserId(), groupId, false,
-			frontendTokensValues, name, styleBookEntryKey, serviceContext,
-			themeId);
+			frontendTokensValues, name, styleBookEntryKey, themeId,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
@@ -34,8 +34,8 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, ServiceContext serviceContext,
-			String themeId)
+			String styleBookEntryKey, String themeId,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		return addStyleBookEntry(
@@ -47,7 +47,7 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			ServiceContext serviceContext, String themeId)
+			String themeId, ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
@@ -9697,6 +9697,7 @@ public class StyleBookEntryPersistenceImpl
 		ctStrictColumnNames.add("name");
 		ctStrictColumnNames.add("previewFileEntryId");
 		ctStrictColumnNames.add("styleBookEntryKey");
+		ctStrictColumnNames.add("themeId");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
@@ -9451,6 +9451,7 @@ public class StyleBookEntryVersionPersistenceImpl
 		ctStrictColumnNames.add("name");
 		ctStrictColumnNames.add("previewFileEntryId");
 		ctStrictColumnNames.add("styleBookEntryKey");
+		ctStrictColumnNames.add("themeId");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/module-hbm.xml
@@ -25,6 +25,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="previewFileEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.style.book.model.impl.StyleBookEntryVersionImpl" table="StyleBookEntryVersion">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryVersionId" type="long">
@@ -47,5 +48,6 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="previewFileEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>
 </hibernate-mapping>

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -21,6 +21,7 @@
 		<field name="name" type="String" />
 		<field name="previewFileEntryId" type="long" />
 		<field name="styleBookEntryKey" type="String" />
+		<field name="themeId" type="String" />
 	</model>
 	<model name="com.liferay.style.book.model.StyleBookEntryVersion">
 		<field name="mvccVersion" type="long" />
@@ -43,5 +44,6 @@
 		<field name="name" type="String" />
 		<field name="previewFileEntryId" type="long" />
 		<field name="styleBookEntryKey" type="String" />
+		<field name="themeId" type="String" />
 	</model>
 </model-hints>

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -21,7 +21,9 @@
 		<field name="name" type="String" />
 		<field name="previewFileEntryId" type="long" />
 		<field name="styleBookEntryKey" type="String" />
-		<field name="themeId" type="String" />
+		<field name="themeId" type="String">
+			<hint name="max-length">255</hint>
+		</field>
 	</model>
 	<model name="com.liferay.style.book.model.StyleBookEntryVersion">
 		<field name="mvccVersion" type="long" />
@@ -44,6 +46,8 @@
 		<field name="name" type="String" />
 		<field name="previewFileEntryId" type="long" />
 		<field name="styleBookEntryKey" type="String" />
-		<field name="themeId" type="String" />
+		<field name="themeId" type="String">
+			<hint name="max-length">255</hint>
+		</field>
 	</model>
 </model-hints>

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
@@ -17,7 +17,7 @@ create table StyleBookEntry (
 	name VARCHAR(75) null,
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
-	themeId VARCHAR(75) null,
+	themeId VARCHAR(255) null,
 	primary key (styleBookEntryId, ctCollectionId)
 );
 
@@ -40,6 +40,6 @@ create table StyleBookEntryVersion (
 	name VARCHAR(75) null,
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
-	themeId VARCHAR(75) null,
+	themeId VARCHAR(255) null,
 	primary key (styleBookEntryVersionId, ctCollectionId)
 );

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
@@ -17,6 +17,7 @@ create table StyleBookEntry (
 	name VARCHAR(75) null,
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
+	themeId VARCHAR(75) null,
 	primary key (styleBookEntryId, ctCollectionId)
 );
 
@@ -39,5 +40,6 @@ create table StyleBookEntryVersion (
 	name VARCHAR(75) null,
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
+	themeId VARCHAR(75) null,
 	primary key (styleBookEntryVersionId, ctCollectionId)
 );

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
@@ -41,8 +41,8 @@ public class StyleBookEntryTableReferenceDefinitionTest
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
-			StringPool.BLANK, ServiceContextTestUtil.getServiceContext(),
-			StringPool.BLANK);
+			StringPool.BLANK, RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Inject

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
@@ -41,7 +41,8 @@ public class StyleBookEntryTableReferenceDefinitionTest
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
-			StringPool.BLANK, ServiceContextTestUtil.getServiceContext());
+			StringPool.BLANK, ServiceContextTestUtil.getServiceContext(),
+			StringPool.BLANK);
 	}
 
 	@Inject

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
@@ -46,8 +46,8 @@ public class StyleBookEntryVersionTableReferenceDefinitionTest
 		_styleBookEntry = _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext(), StringPool.BLANK);
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
@@ -47,7 +47,7 @@ public class StyleBookEntryVersionTableReferenceDefinitionTest
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
-			ServiceContextTestUtil.getServiceContext());
+			ServiceContextTestUtil.getServiceContext(), StringPool.BLANK);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -151,6 +151,8 @@ public class StyleBookEntryPersistenceTest {
 
 		newStyleBookEntry.setStyleBookEntryKey(RandomTestUtil.randomString());
 
+		newStyleBookEntry.setThemeId(RandomTestUtil.randomString());
+
 		_styleBookEntries.add(_persistence.update(newStyleBookEntry));
 
 		StyleBookEntry existingStyleBookEntry = _persistence.findByPrimaryKey(
@@ -203,6 +205,9 @@ public class StyleBookEntryPersistenceTest {
 		Assert.assertEquals(
 			existingStyleBookEntry.getStyleBookEntryKey(),
 			newStyleBookEntry.getStyleBookEntryKey());
+		Assert.assertEquals(
+			existingStyleBookEntry.getThemeId(),
+			newStyleBookEntry.getThemeId());
 	}
 
 	@Test
@@ -235,6 +240,7 @@ public class StyleBookEntryPersistenceTest {
 			styleBookEntry.getPreviewFileEntryId());
 		draftStyleBookEntry.setStyleBookEntryKey(
 			styleBookEntry.getStyleBookEntryKey());
+		draftStyleBookEntry.setThemeId(styleBookEntry.getThemeId());
 
 		_styleBookEntries.add(_persistence.update(draftStyleBookEntry));
 
@@ -279,6 +285,8 @@ public class StyleBookEntryPersistenceTest {
 		Assert.assertEquals(
 			styleBookEntry.getStyleBookEntryKey(),
 			draftStyleBookEntry.getStyleBookEntryKey());
+		Assert.assertEquals(
+			styleBookEntry.getThemeId(), draftStyleBookEntry.getThemeId());
 	}
 
 	@Test(
@@ -326,6 +334,8 @@ public class StyleBookEntryPersistenceTest {
 		styleBookEntry2.setPreviewFileEntryId(RandomTestUtil.nextLong());
 
 		styleBookEntry2.setStyleBookEntryKey(RandomTestUtil.randomString());
+
+		styleBookEntry2.setThemeId(RandomTestUtil.randomString());
 
 		_styleBookEntries.add(_persistence.update(styleBookEntry2));
 	}
@@ -546,7 +556,8 @@ public class StyleBookEntryPersistenceTest {
 			"styleBookEntryId", true, "groupId", true, "companyId", true,
 			"userId", true, "userName", true, "createDate", true,
 			"modifiedDate", true, "defaultStyleBookEntry", true, "name", true,
-			"previewFileEntryId", true, "styleBookEntryKey", true);
+			"previewFileEntryId", true, "styleBookEntryKey", true, "themeId",
+			true);
 	}
 
 	@Test
@@ -890,6 +901,8 @@ public class StyleBookEntryPersistenceTest {
 		styleBookEntry.setPreviewFileEntryId(RandomTestUtil.nextLong());
 
 		styleBookEntry.setStyleBookEntryKey(RandomTestUtil.randomString());
+
+		styleBookEntry.setThemeId(RandomTestUtil.randomString());
 
 		_styleBookEntries.add(_persistence.update(styleBookEntry));
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
@@ -155,6 +155,8 @@ public class StyleBookEntryVersionPersistenceTest {
 		newStyleBookEntryVersion.setStyleBookEntryKey(
 			RandomTestUtil.randomString());
 
+		newStyleBookEntryVersion.setThemeId(RandomTestUtil.randomString());
+
 		_styleBookEntryVersions.add(
 			_persistence.update(newStyleBookEntryVersion));
 
@@ -218,6 +220,9 @@ public class StyleBookEntryVersionPersistenceTest {
 		Assert.assertEquals(
 			existingStyleBookEntryVersion.getStyleBookEntryKey(),
 			newStyleBookEntryVersion.getStyleBookEntryKey());
+		Assert.assertEquals(
+			existingStyleBookEntryVersion.getThemeId(),
+			newStyleBookEntryVersion.getThemeId());
 	}
 
 	@Test
@@ -395,7 +400,7 @@ public class StyleBookEntryVersionPersistenceTest {
 			"groupId", true, "companyId", true, "userId", true, "userName",
 			true, "createDate", true, "modifiedDate", true,
 			"defaultStyleBookEntry", true, "name", true, "previewFileEntryId",
-			true, "styleBookEntryKey", true);
+			true, "styleBookEntryKey", true, "themeId", true);
 	}
 
 	@Test
@@ -752,6 +757,8 @@ public class StyleBookEntryVersionPersistenceTest {
 
 		styleBookEntryVersion.setStyleBookEntryKey(
 			RandomTestUtil.randomString());
+
+		styleBookEntryVersion.setThemeId(RandomTestUtil.randomString());
 
 		_styleBookEntryVersions.add(_persistence.update(styleBookEntryVersion));
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -56,7 +56,7 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, _serviceContext, null);
+				null, RandomTestUtil.randomString(), _serviceContext);
 
 		Assert.assertTrue(
 			Validator.isNotNull(styleBookEntry.getExternalReferenceCode()));
@@ -73,11 +73,11 @@ public class StyleBookEntryLocalServiceTest {
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, _serviceContext, null);
+			null, RandomTestUtil.randomString(), _serviceContext);
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, _serviceContext, null);
+			null, RandomTestUtil.randomString(), _serviceContext);
 	}
 
 	@Test
@@ -88,7 +88,7 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, _serviceContext, null);
+				null, RandomTestUtil.randomString(), _serviceContext);
 
 		_styleBookEntryLocalService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -56,7 +56,7 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, _serviceContext);
+				null, _serviceContext, null);
 
 		Assert.assertTrue(
 			Validator.isNotNull(styleBookEntry.getExternalReferenceCode()));
@@ -73,11 +73,11 @@ public class StyleBookEntryLocalServiceTest {
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, _serviceContext);
+			null, _serviceContext, null);
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, _serviceContext);
+			null, _serviceContext, null);
 	}
 
 	@Test
@@ -88,7 +88,7 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, _serviceContext);
+				null, _serviceContext, null);
 
 		_styleBookEntryLocalService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
@@ -63,8 +63,8 @@ public class StyleBookEntryServiceTest {
 
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext,
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomString(), _serviceContext);
 
 			Assert.fail();
 		}
@@ -82,8 +82,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext,
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		_styleBookEntryService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),
@@ -101,8 +101,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext,
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		try {
 			UserTestUtil.setUser(
@@ -128,8 +128,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext,
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		StyleBookEntry curStyleBookEntry =
 			_styleBookEntryService.getStyleBookEntryByExternalReferenceCode(
@@ -148,8 +148,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext,
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		RoleTestUtil.removeResourcePermission(
 			RoleConstants.GUEST, StyleBookEntry.class.getName(),

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
@@ -63,7 +63,8 @@ public class StyleBookEntryServiceTest {
 
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext);
+				RandomTestUtil.randomString(), null, _serviceContext,
+				RandomTestUtil.randomString());
 
 			Assert.fail();
 		}
@@ -81,7 +82,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext);
+				RandomTestUtil.randomString(), null, _serviceContext,
+				RandomTestUtil.randomString());
 
 		_styleBookEntryService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),
@@ -99,7 +101,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext);
+				RandomTestUtil.randomString(), null, _serviceContext,
+				RandomTestUtil.randomString());
 
 		try {
 			UserTestUtil.setUser(
@@ -125,7 +128,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext);
+				RandomTestUtil.randomString(), null, _serviceContext,
+				RandomTestUtil.randomString());
 
 		StyleBookEntry curStyleBookEntry =
 			_styleBookEntryService.getStyleBookEntryByExternalReferenceCode(
@@ -144,7 +148,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
-				RandomTestUtil.randomString(), null, _serviceContext);
+				RandomTestUtil.randomString(), null, _serviceContext,
+				RandomTestUtil.randomString());
 
 		RoleTestUtil.removeResourcePermission(
 			RoleConstants.GUEST, StyleBookEntry.class.getName(),

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
@@ -65,13 +65,15 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		StyleBookEntry styleBookEntry2 =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -99,8 +101,8 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, name, StringPool.BLANK, _serviceContext,
-				StringPool.BLANK);
+				StringPool.BLANK, name, StringPool.BLANK,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -130,7 +132,8 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
@@ -65,13 +65,13 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		StyleBookEntry styleBookEntry2 =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -99,7 +99,7 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, name, StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, name, StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -129,7 +129,7 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
@@ -99,7 +99,8 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, name, StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, name, StringPool.BLANK, _serviceContext,
+				StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
@@ -64,7 +64,8 @@ public class DeleteStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
@@ -64,7 +64,7 @@ public class DeleteStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -7,7 +7,6 @@ package com.liferay.style.book.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -78,13 +77,13 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY_1",
-				serviceContext, StringPool.BLANK);
+				RandomTestUtil.randomString(), serviceContext);
 		StyleBookEntry styleBookEntry2 =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY_2",
-				serviceContext, StringPool.BLANK);
+				RandomTestUtil.randomString(), serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -122,8 +121,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
-				StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
+				RandomTestUtil.randomString(), serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -174,8 +173,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
-				StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
+				RandomTestUtil.randomString(), serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -218,8 +217,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
-				StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
+				RandomTestUtil.randomString(), serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -284,7 +283,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY",
-				serviceContext, StringPool.BLANK);
+				RandomTestUtil.randomString(), serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -7,6 +7,7 @@ package com.liferay.style.book.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
@@ -77,13 +78,13 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY_1",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 		StyleBookEntry styleBookEntry2 =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY_2",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -122,7 +123,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -174,7 +175,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -218,7 +219,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -283,7 +284,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), "STYLE_BOOK_ENTRY_KEY",
-				serviceContext);
+				serviceContext, StringPool.BLANK);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -122,8 +122,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext, StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
+				StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -174,8 +174,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext, StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
+				StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -218,8 +218,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
-				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				serviceContext, StringPool.BLANK);
+				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY", serviceContext,
+				StringPool.BLANK);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
@@ -52,9 +52,8 @@ public class StyleBookEntryServiceTest {
 		StyleBookEntry sourceStyleBookEntry =
 			_styleBookEntryService.addStyleBookEntry(
 				null, _group.getGroupId(), RandomTestUtil.randomString(),
-				"STYLE_BOOK_ENTRY_KEY",
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()),
-				RandomTestUtil.randomString());
+				"STYLE_BOOK_ENTRY_KEY", RandomTestUtil.randomString(),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		StyleBookEntry targetStyleBookEntry =
 			_styleBookEntryService.copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
@@ -53,7 +53,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				null, _group.getGroupId(), RandomTestUtil.randomString(),
 				"STYLE_BOOK_ENTRY_KEY",
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()),
+				RandomTestUtil.randomString());
 
 		StyleBookEntry targetStyleBookEntry =
 			_styleBookEntryService.copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
@@ -77,7 +77,8 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -107,7 +108,8 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -134,7 +136,8 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		mockLiferayPortletActionRequest = new MockLiferayPortletActionRequest();
 
@@ -167,7 +170,8 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
@@ -77,7 +77,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -107,7 +107,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -134,7 +134,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		mockLiferayPortletActionRequest = new MockLiferayPortletActionRequest();
 
@@ -167,7 +167,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
@@ -92,8 +92,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, oldName, StringPool.BLANK, _serviceContext,
-				StringPool.BLANK);
+				StringPool.BLANK, oldName, StringPool.BLANK,
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -135,7 +135,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -161,7 +162,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -186,7 +188,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -211,7 +214,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
@@ -92,7 +92,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, oldName, StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, oldName, StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -134,7 +134,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -160,7 +160,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -185,7 +185,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -210,7 +210,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
@@ -92,7 +92,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
-				StringPool.BLANK, oldName, StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, oldName, StringPool.BLANK, _serviceContext,
+				StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
@@ -98,7 +98,8 @@ public class UpdateStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -184,7 +185,8 @@ public class UpdateStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext, StringPool.BLANK);
+				StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		FileEntry tempFileEntry = _addFileEntry(
 			"thumbnail.png", styleBookEntry);

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
@@ -98,7 +98,7 @@ public class UpdateStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -184,7 +184,7 @@ public class UpdateStyleBookEntryPreviewMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				StringPool.BLANK, _serviceContext);
+				StringPool.BLANK, _serviceContext, StringPool.BLANK);
 
 		FileEntry tempFileEntry = _addFileEntry(
 			"thumbnail.png", styleBookEntry);

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
@@ -82,7 +82,7 @@ public class AddStyleBookEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			null, serviceContext.getScopeGroupId(), name, StringPool.BLANK,
-			serviceContext, themeId);
+			themeId, serviceContext);
 	}
 
 	private String _getRedirectURL(

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
@@ -75,13 +75,14 @@ public class AddStyleBookEntryMVCActionCommand extends BaseMVCActionCommand {
 		throws PortalException {
 
 		String name = ParamUtil.getString(actionRequest, "name");
+		String themeId = ParamUtil.getString(actionRequest, "themeId");
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		return _styleBookEntryService.addStyleBookEntry(
 			null, serviceContext.getScopeGroupId(), name, StringPool.BLANK,
-			serviceContext);
+			serviceContext, themeId);
 	}
 
 	private String _getRedirectURL(

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
@@ -121,8 +121,8 @@ public class StyleBookEntryZipProcessorImpl
 			if (styleBookEntry == null) {
 				styleBookEntry = _styleBookEntryEntryService.addStyleBookEntry(
 					null, groupId, frontendTokensValues, name,
-					styleBookEntryKey,
-					ServiceContextThreadLocal.getServiceContext(), themeId);
+					styleBookEntryKey, themeId,
+					ServiceContextThreadLocal.getServiceContext());
 			}
 			else {
 				styleBookEntry =

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
@@ -106,7 +106,7 @@ public class StyleBookEntryZipProcessorImpl
 
 	private StyleBookEntry _addStyleBookEntry(
 			long groupId, String frontendTokensValues, String name,
-			boolean overwrite, String styleBookEntryKey)
+			boolean overwrite, String styleBookEntryKey, String themeId)
 		throws Exception {
 
 		StyleBookEntry styleBookEntry =
@@ -122,7 +122,7 @@ public class StyleBookEntryZipProcessorImpl
 				styleBookEntry = _styleBookEntryEntryService.addStyleBookEntry(
 					null, groupId, frontendTokensValues, name,
 					styleBookEntryKey,
-					ServiceContextThreadLocal.getServiceContext());
+					ServiceContextThreadLocal.getServiceContext(), themeId);
 			}
 			else {
 				styleBookEntry =
@@ -304,6 +304,8 @@ public class StyleBookEntryZipProcessorImpl
 
 		String styleBookEntryContent = _getContent(zipFile, fileName);
 
+		String themeId = StringPool.BLANK;
+
 		if (Validator.isNotNull(styleBookEntryContent)) {
 			JSONObject styleBookEntryJSONObject = _jsonFactory.createJSONObject(
 				styleBookEntryContent);
@@ -314,10 +316,12 @@ public class StyleBookEntryZipProcessorImpl
 				zipFile, fileName,
 				styleBookEntryJSONObject.getString("frontendTokensValuesPath"));
 			name = styleBookEntryJSONObject.getString("name");
+			themeId = styleBookEntryJSONObject.getString("themeId");
 		}
 
 		StyleBookEntry styleBookEntry = _addStyleBookEntry(
-			groupId, frontendTokensValues, name, overwrite, styleBookEntryKey);
+			groupId, frontendTokensValues, name, overwrite, styleBookEntryKey,
+			themeId);
 
 		if (styleBookEntry == null) {
 			return;


### PR DESCRIPTION
@gabrielwas 

Resent from https://github.com/liferay-platform-experience/liferay-portal/pull/730
Ticket: https://liferay.atlassian.net/browse/LPD-35068

# Goal
To add a new field to the `StyleBookEntry` entity to keep track of the theme in which the Style Book was based on.

# Approach

Modify style-book-service module and make sure previous versions of Liferay  get the required upgrade for the tables.

## Future tickets

In the future we will be using the `themeId` field to fetch the theme's name and the frontend token definition so that the Style Book can be created based on the provided tokens.

-----
### Original Description
https://liferay.atlassian.net/browse/LPD-35068
Modified based on https://github.com/liferay-platform-experience/liferay-portal/pull/712  

cc: @SelenaAungst