### PR TITLE
LPD-38542 Fix Issue in DDMServiceUpgradeStepRegistrator Due to Incorrect Upgrade Backport

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -40,6 +40,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.5.2
+Liferay-Require-SchemaVersion: 5.6.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -570,8 +570,16 @@ public class DDMServiceUpgradeStepRegistrator
 			"5.4.4", "5.4.5",
 			new DDMTemplateLinkUpgradeProcess(_classNameLocalService));
 
+		registry.register("5.4.5", "5.5.0", new DummyUpgradeStep());
+
 		registry.register(
-			"5.4.5", "5.5.0",
+			"5.5.0", "5.5.1",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.
+				DDMFieldUpgradeProcess(),
+			new DDMFieldAttributeUpgradeProcess());
+
+		registry.register(
+			"5.5.1", "5.6.0",
 			new BaseExternalReferenceCodeUpgradeProcess() {
 
 				@Override
@@ -582,14 +590,8 @@ public class DDMServiceUpgradeStepRegistrator
 			});
 
 		registry.register(
-			"5.5.0", "5.5.1",
-			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_1.
-				DDMFieldUpgradeProcess(),
-			new DDMFieldAttributeUpgradeProcess());
-
-		registry.register(
-			"5.5.1", "5.5.2",
-			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2.
+			"5.6.0", "5.6.1",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_6_1.
 				DDMFieldAttributeUpgradeProcess(
 					_classNameLocalService, _dlFileEntryLocalService,
 					_fileEntryFriendlyURLResolver, _groupLocalService,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2;
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_6_1;
 
 import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/test/DDMFieldAttributeUpgradeProcessTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/test/DDMFieldAttributeUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2.test;
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_6_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -121,7 +121,7 @@ public class DDMFieldAttributeUpgradeProcessTest {
 	}
 
 	private static final String _CLASS_NAME =
-		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_5_2." +
+		"com.liferay.dynamic.data.mapping.internal.upgrade.v5_6_1." +
 			"DDMFieldAttributeUpgradeProcess";
 
 	@Inject(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -58,9 +58,7 @@ journalEditArticleDisplayContext.setViewAttributes();
 				<li class="tbar-item tbar-item-expand">
 					<div class="autofit-row sidebar-section">
 						<div class="autofit-col d-flex flex-row">
-							<div class="inline-item px-6 py-2">
-								<span aria-hidden="true" class="loading-animation"></span>
-							</div>
+							<span aria-hidden="true" class="loading-animation mx-4 my-2"></span>
 
 							<react:component
 								module="{TranslationManager} from journal-web"
@@ -82,10 +80,6 @@ journalEditArticleDisplayContext.setViewAttributes();
 
 						<c:if test="<%= !JournalUtil.isEditDefaultValues(article) %>">
 							<div class="c-ml-2">
-								<div class="inline-item my-5 p-5 w-100">
-									<span aria-hidden="true" class="loading-animation"></span>
-								</div>
-
 								<react:component
 									module="{TranslationOptions} from journal-web"
 									props='<%=


### PR DESCRIPTION
[LPD-38542](https://liferay.atlassian.net/browse/LPD-38542)

This issue was caused by a [backport](https://liferay.atlassian.net/browse/BPR-77967) where a dummy [upgrade](https://github.com/liferay/liferay-portal-ee/blob/2024.q2.12/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java#L568) was added.  As a result, anyone upgrading from this tag to a later release will skip the necessary [upgrade](https://github.com/liferay/liferay-portal-ee/blob/2024.q3.3/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java#L570-L579).

[LPD-38542]: https://liferay.atlassian.net/browse/LPD-38542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ