### PR TITLE
LPD-54871 Remove unnecessary aria tag to avoid double label reference

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/MultipleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/MultipleSelectBase.tsx
@@ -97,7 +97,6 @@ const MultipleSelectBase = ({
 						>
 							<div className="auto autofit-row-center fit-row">
 								<ClayCheckbox
-									aria-label={item.label}
 									checked={values?.includes(item.value)!}
 									data-itemValue={item.value}
 									data-option-reference={item.reference}


### PR DESCRIPTION
### References:
- Parent Task: [LPP-58719 Accessibility - Screen Reader Reads Labels Twice in 'Select from List' Field with Multiple Selections Enabled](https://liferay.atlassian.net/browse/LPD-54896)

### What is the goal of this PR?
The purpose of this change is to avoid repeating the label announced by the screen reader. 
Technical notes inline.

### What did it look like before the changes?

https://github.com/user-attachments/assets/3ba8fd24-4625-48cf-8455-bbf2197961ec

### What does it look like after the changes?

https://github.com/user-attachments/assets/2e1b4f91-c17d-4caf-919d-ef1d1824ff3a