### PR TITLE
LPD-58384 Remove low priority BPM tests from Acceptance

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldset.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/DEFieldset.testcase
@@ -79,7 +79,6 @@ definition {
 	@description = "LPS-165487 - Verify if the user can create structures with different Global language."
 	@priority = 3
 	test CanBeCreatedWithDifferentGlobalLanguage {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 
 		NavItem.gotoStructures();

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
@@ -163,8 +163,6 @@ definition {
 	@description = "This is a test for LPS-98077. Make sure data inserted on a Group Field persists"
 	@priority = 3
 	test CheckIfFieldGroupDataPersists {
-		property portal.acceptance = "true";
-
 		DataEngine.addField(
 			fieldFieldLabel = "Text",
 			fieldName = "Text");

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase
@@ -2617,7 +2617,6 @@ definition {
 	@description = "LPS-86652 - Verify that hovering the cursor on the process step, when it contains more than 1 option, the toolip will display a bullet list"
 	@priority = 3
 	test TooltipDisplaysStepsListWhenMultipleItems {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsListReassignTasks.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsListReassignTasks.testcase
@@ -571,7 +571,6 @@ definition {
 	@description = "LPS-106219 - Verify that the user can filter, by Process Step, instances with pending tasks in parallel"
 	@priority = 3
 	test UserCanFilterInstanceWithPendingTasksInParallelByStep {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsPerformanceByStep.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsPerformanceByStep.testcase
@@ -1284,7 +1284,6 @@ definition {
 	@description = "LPS-100677 - Verify that searching steps containing non-ascii chars is possible"
 	@priority = 3
 	test UserCanSearchNonAsciiChars {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormRules.testcase
@@ -95,7 +95,6 @@ definition {
 	@description = "LPS-73332 - Verify that when a Form is duplicated, the Rules in that Form are also duplicated"
 	@priority = 2
 	test AreDuplicatedWhenTheFormIsDuplicated {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -162,7 +161,6 @@ definition {
 	@description = "LPS-73332 - Verify that when creating a new Form, rules from a pre-existing Form are not copied into the new Form"
 	@priority = 2
 	test AreNotCopiedIntoANewForm {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 
 		FormsAdmin.addForm();
@@ -301,7 +299,6 @@ definition {
 	@description = "LPS-71466 - Verify that a Rule can be created using a Field with a Predefined Value"
 	@priority = 2
 	test CanBeCreatedUsingAFieldWithAPredefinedValue {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -131,7 +131,6 @@ definition {
 	@description = "This is a use case for LPS-68377."
 	@priority = 3
 	test AddFormToUserSiteAndViewNoDuplicates {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -239,7 +238,6 @@ definition {
 	@description = "LPS-68390 - Verify that a notification appears when a Form is autosaved."
 	@priority = 3
 	test AutosaveDisplaysANotification {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -264,7 +262,6 @@ definition {
 	@description = "LPS-68418 - Verify that a Form's autosave interval can be configured"
 	@priority = 3
 	test AutosaveIntervalCanBeConfigured {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -726,7 +723,6 @@ definition {
 	@description = "LPS-69334 - Verify that a Form can be edited after the default language is changed"
 	@priority = 3
 	test CanBeEditedAfterChangingLanguage {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -771,7 +767,6 @@ definition {
 	@description = "LPS-69100 - Verify that a Form can be edited after the Site's default locale is changed"
 	@priority = 3
 	test CanBeEditedAfterChangingLocale {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -1166,7 +1161,6 @@ definition {
 	@description = "LPS-69214 - Verify that a confirmation appears when attempting to leave a Form without saving."
 	@priority = 3
 	test ConfirmationAppearsWhenLeavingFormWithoutSaving {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsEntries.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsEntries.testcase
@@ -586,8 +586,6 @@ definition {
 	@description = "Verify that the correct number of Entries are displayed"
 	@priority = 3
 	test DisplayCorrectNumberOfEntries {
-		property portal.acceptance = "true";
-
 		task ("Given a published form") {
 			FormsAdmin.addForm();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsFields.testcase
@@ -35,7 +35,6 @@ definition {
 	@description = "LPS-68182 - Verify that the Field Label is blank when adding a new Field"
 	@priority = 3
 	test AddingANewFieldCreatesADefaultLabel {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsJumpToPage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsJumpToPage.testcase
@@ -594,7 +594,6 @@ definition {
 	@description = "This is a use case for LPS-68227."
 	@priority = 3
 	test ViewRuleAfterOptionValueEdit {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsSubmissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsSubmissions.testcase
@@ -1543,7 +1543,6 @@ definition {
 	@description = "Verify if that the See Partial results page displays graphs correctly."
 	@priority = 3
 	test CheckSeePartialResultsPageWithGraph {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 
 		FormsAdmin.addForm();
@@ -1611,8 +1610,6 @@ definition {
 	@description = "Verify if with 'Limit to one submit per user' enabled, the translation options are the same as those present in the Form Builder"
 	@priority = 3
 	test CheckTranslationOptionsOneSubmissionPerUserMessage {
-		property portal.acceptance = "true";
-
 		FormsAdmin.addForm();
 
 		Click(locator1 = "Form#LANGUAGE_ADD_BUTTON");
@@ -1898,8 +1895,6 @@ definition {
 	@description = "Verify that a Form's Submit button's text can be customized with numbers"
 	@priority = 3
 	test SubmitButtonTextCanBeCustomizedWithNumbers {
-		property portal.acceptance = "true";
-
 		FormsAdmin.addForm();
 
 		Form.editName(formName = "Form 1");
@@ -1928,8 +1923,6 @@ definition {
 	@description = "Verify that a Form's Submit button's text can be customized with special characters"
 	@priority = 3
 	test SubmitButtonTextCanBeCustomizedWithSpecialCharacters {
-		property portal.acceptance = "true";
-
 		FormsAdmin.addForm();
 
 		Form.editName(formName = "Form 1");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
@@ -682,7 +682,6 @@ definition {
 	@description = "LPS-68381 - Verify that options can be rearranged after one is removed"
 	@priority = 3
 	test OptionsCanBeReordered {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
@@ -429,7 +429,6 @@ definition {
 	@description = "Verify can that a Form create an empty option in the Select from List"
 	@priority = 3
 	test CanCreateEmptyOption {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 
 		FormsAdmin.addForm();
@@ -1147,7 +1146,6 @@ definition {
 	@description = "LPS-68362 - Verify that options can be removed"
 	@priority = 3
 	test OptionsCanBeDeleted {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
@@ -439,7 +439,6 @@ definition {
 	@description = "LPS-59997 - Verify that a Text Field can be set to Multiple Lines"
 	@priority = 3
 	test CanBeSetToMultipleLines {
-		property portal.acceptance = "true";
 		property portal.upstream = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsUploadField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsUploadField.testcase
@@ -35,8 +35,6 @@ definition {
 	@description = "Verify that a user can upload up to 5 files when the Repeatable option is enabled"
 	@priority = 3
 	test AllowsFiveUploadsWhenRepeatableIsEnabled {
-		property portal.acceptance = "true";
-
 		FormsAdmin.addForm();
 
 		Form.editName(formName = "Form 1");
@@ -637,7 +635,6 @@ definition {
 	@description = "This is a use case for LPS-125499."
 	@priority = 2
 	test GuestUserCannotUploadFileWithInvalidSize {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Hello,
The Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on the Acceptance Test Suite. 
If you believe any of these tests should not be removed, please let us know so we can update the priority and keep the test running on Acceptance. 
Thank you!

https://liferay.atlassian.net/browse/LPD-58384 
https://liferay.atlassian.net/browse/LPD-58065