### PR TITLE
LPD-61750 Fix MultiSelectBase filtering

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Select/MultipleSelectBase.tsx
@@ -71,8 +71,8 @@ const MultipleSelectBase = ({
 		<ClayMultiSelect
 			{...accessibleProps}
 			clearAllTitle={Liferay.Language.get('clear-all')}
-			disabled={readOnly}
 			defaultItems={isAsync ? undefined : items}
+			disabled={readOnly}
 			items={isAsync ? items : undefined}
 			messages={messages}
 			onItemsChange={(itemsChanged: MultiSelectItem[]) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61750

Hey BPM,

Clay MultiSelect doesn't support this use case of asynchronously loading items via promise. The `onLoadMore` property only supports loading more items on scroll. Using `onLoadMore` this way causes `handleAsyncOptions()` to repeatedly get called on scroll. Could you open a feature request for this MultiSelect use case?