### PR TITLE
LPD-65974 [Test Fix] calendarEvent.spec.ts > event ending at midnight does not render on the next day

### DIFF
--- a/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
+++ b/modules/test/playwright/tests/calendar-web/main/calendarEvent.spec.ts
@@ -497,7 +497,7 @@ test('event ending at midnight does not render on the next day', async ({
 		})
 	);
 
-	const title = getRandomInt().toString();
+	const title = 'midnightEvent' + getRandomInt();
 
 	await calendarWidgetPage.addEvent({
 		allDay: false,


### PR DESCRIPTION
Related Issue: [LPD-65974](https://liferay.atlassian.net/browse/LPD-65974)

[LPD-65974]: https://liferay.atlassian.net/browse/LPD-65974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ