### PR TITLE
LPD-69619 PLOEntryValueException triggered when object definition labels lack current instance locale

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectDefinitionResourceImpl.java
@@ -100,6 +100,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -564,6 +565,27 @@ public class ObjectDefinitionResourceImpl
 							objectDefinition.getWorkflowDefinitionLinks()));
 			}
 			else {
+				Map<Locale, String> labelMap =
+					LocalizedMapUtil.populateLocalizedMap(
+						objectDefinition.getDefaultLanguageId(),
+						objectDefinition.getLabel());
+				Map<Locale, String> pluralLabelMap =
+					LocalizedMapUtil.populateLocalizedMap(
+						objectDefinition.getDefaultLanguageId(),
+						objectDefinition.getPluralLabel());
+
+				if (serviceBuilderObjectDefinition.isModifiableAndSystem()) {
+					labelMap.putIfAbsent(
+						serviceBuilderObjectDefinition.getDefaultLocale(),
+						serviceBuilderObjectDefinition.getLabel(
+							serviceBuilderObjectDefinition.getDefaultLocale()));
+
+					pluralLabelMap.putIfAbsent(
+						serviceBuilderObjectDefinition.getDefaultLocale(),
+						serviceBuilderObjectDefinition.getPluralLabel(
+							serviceBuilderObjectDefinition.getDefaultLocale()));
+				}
+
 				serviceBuilderObjectDefinition =
 					_objectDefinitionService.updateCustomObjectDefinition(
 						objectDefinition.getExternalReferenceCode(),
@@ -611,17 +633,11 @@ public class ObjectDefinitionResourceImpl
 							objectDefinition.getFriendlyURLSeparator(),
 							serviceBuilderObjectDefinition.
 								getFriendlyURLSeparator()),
-						LocalizedMapUtil.populateLocalizedMap(
-							objectDefinition.getDefaultLanguageId(),
-							objectDefinition.getLabel()),
-						objectDefinition.getName(),
+						labelMap, objectDefinition.getName(),
 						objectDefinition.getPanelAppOrder(),
 						objectDefinition.getPanelCategoryKey(),
 						GetterUtil.getBoolean(objectDefinition.getPortlet()),
-						LocalizedMapUtil.populateLocalizedMap(
-							objectDefinition.getDefaultLanguageId(),
-							objectDefinition.getPluralLabel()),
-						objectDefinition.getScope(), statusInt,
+						pluralLabelMap, objectDefinition.getScope(), statusInt,
 						ObjectDefinitionSettingUtil.toObjectDefinitionSettings(
 							contextUser.getCompanyId(), _groupLocalService,
 							objectDefinition.getObjectDefinitionSettings(),

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -903,6 +904,9 @@ public class ObjectDefinitionResourceTest
 		randomModifiableSystemObjectDefinition.
 			setObjectFolderExternalReferenceCode(StringPool.BLANK);
 
+		String finalObjectDefinitionExternalReferenceCode =
+			randomModifiableSystemObjectDefinition.getExternalReferenceCode();
+
 		ObjectValidationRule updatedCustomObjectValidationRule =
 			new ObjectValidationRule() {
 				{
@@ -915,8 +919,7 @@ public class ObjectDefinitionResourceTest
 					name = Collections.singletonMap(
 						"en_US", RandomTestUtil.randomString());
 					objectDefinitionExternalReferenceCode =
-						randomModifiableSystemObjectDefinition.
-							getExternalReferenceCode();
+						finalObjectDefinitionExternalReferenceCode;
 					objectValidationRuleSettings =
 						new ObjectValidationRuleSetting[] {
 							new ObjectValidationRuleSetting() {
@@ -945,8 +948,7 @@ public class ObjectDefinitionResourceTest
 					name = Collections.singletonMap(
 						"en_US", RandomTestUtil.randomString());
 					objectDefinitionExternalReferenceCode =
-						randomModifiableSystemObjectDefinition.
-							getExternalReferenceCode();
+						finalObjectDefinitionExternalReferenceCode;
 					objectValidationRuleSettings =
 						new ObjectValidationRuleSetting[] {
 							new ObjectValidationRuleSetting() {
@@ -1025,6 +1027,46 @@ public class ObjectDefinitionResourceTest
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			randomModifiableSystemObjectDefinition.getId());
+
+		// Modifiable system object definition with a different language ID
+
+		randomModifiableSystemObjectDefinition =
+			objectDefinitionResource.postObjectDefinition(
+				_randomModifiableSystemObjectDefinition());
+
+		randomModifiableSystemObjectDefinition.setDefaultLanguageId(
+			objectDefinitionDefaultLanguageId);
+		randomModifiableSystemObjectDefinition.setLabel(
+			MapUtil.fromArray(
+				objectDefinitionDefaultLanguageId,
+				RandomTestUtil.randomString()));
+
+		try {
+			CompanyTestUtil.resetCompanyLocales(
+				TestPropsValues.getCompanyId(),
+				LanguageUtil.getAvailableLocales(
+					TestPropsValues.getCompanyId()),
+				LocaleUtil.fromLanguageId("es_ES"));
+
+			randomModifiableSystemObjectDefinition =
+				objectDefinitionResource.putObjectDefinition(
+					randomModifiableSystemObjectDefinition.getId(),
+					randomModifiableSystemObjectDefinition);
+
+			labelMap = randomModifiableSystemObjectDefinition.getLabel();
+
+			Assert.assertTrue(
+				labelMap.containsKey(objectDefinitionDefaultLanguageId));
+			Assert.assertTrue(labelMap.containsKey(siteDefaultLanguageId));
+			Assert.assertTrue(labelMap.containsKey("es_ES"));
+		}
+		finally {
+			CompanyTestUtil.resetCompanyLocales(
+				TestPropsValues.getCompanyId(),
+				LanguageUtil.getAvailableLocales(
+					TestPropsValues.getCompanyId()),
+				LocaleUtil.fromLanguageId(siteDefaultLanguageId));
+		}
 
 		// Object definition settings
 


### PR DESCRIPTION
Related issue: [https://liferay.atlassian.net/browse/LPD-69619](https://liferay.atlassian.net/browse/LPD-69619)