### PR TITLE
LPD-74086 _objectEntry.getGroupId() returns 0 in ObjectEntryItemDescriptor.getPayload for Objects that are SiteScoped

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/item/selector/web/internal/test/ObjectEntryItemSelectorViewDescriptorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/item/selector/web/internal/test/ObjectEntryItemSelectorViewDescriptorTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -82,7 +83,8 @@ public class ObjectEntryItemSelectorViewDescriptorTest {
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING, "text", "text",
-					false)));
+					false)),
+			ObjectDefinitionConstants.SCOPE_SITE);
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -111,6 +113,8 @@ public class ObjectEntryItemSelectorViewDescriptorTest {
 
 		ObjectEntry objectEntry = (ObjectEntry)objectEntries.get(0);
 
+		Assert.assertEquals(
+			TestPropsValues.getGroupId(), objectEntry.getGroupId());
 		Assert.assertEquals(
 			WorkflowConstants.STATUS_APPROVED, objectEntry.getStatus());
 	}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -160,6 +160,8 @@ public class ObjectEntryUtil {
 			objectEntry.getExternalReferenceCode());
 		serviceBuilderObjectEntry.setObjectEntryId(
 			GetterUtil.getLong(objectEntry.getId()));
+		serviceBuilderObjectEntry.setGroupId(
+			GetterUtil.getLong(objectEntry.getScopeId()));
 		serviceBuilderObjectEntry.setObjectDefinitionId(
 			objectDefinition.getObjectDefinitionId());
 		serviceBuilderObjectEntry.setDefaultLanguageId(


### PR DESCRIPTION
Related issues: 

- https://liferay.atlassian.net/browse/LPD-74086
- https://liferay.atlassian.net/browse/LPD-74360