### PR TITLE
LPD-85865 Inconsistent translation status when site's default language differs from the instance default language with non text fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldType.java
@@ -6,6 +6,7 @@
 package com.liferay.dynamic.data.mapping.form.field.type;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Marcellus Tavares
@@ -27,6 +28,10 @@ public interface DDMFormFieldType {
 
 	public default boolean isCustomDDMFormFieldType() {
 		return false;
+	}
+
+	public default boolean isPredefinedValueEmpty(String value) {
+		return Validator.isNull(value);
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/CheckboxDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/CheckboxDDMFormFieldType.java
@@ -9,6 +9,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.BaseDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -44,6 +45,17 @@ public class CheckboxDDMFormFieldType extends BaseDDMFormFieldType {
 	@Override
 	public String getName() {
 		return DDMFormFieldTypeConstants.CHECKBOX;
+	}
+
+	@Override
+	public boolean isPredefinedValueEmpty(String value) {
+		if (super.isPredefinedValueEmpty(value) ||
+			StringUtil.equals(value, "[\"false\"]")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldType.java
@@ -9,6 +9,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.BaseDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -45,6 +46,17 @@ public class CheckboxMultipleDDMFormFieldType extends BaseDDMFormFieldType {
 	@Override
 	public String getName() {
 		return DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE;
+	}
+
+	@Override
+	public boolean isPredefinedValueEmpty(String value) {
+		if (super.isPredefinedValueEmpty(value) ||
+			StringUtil.equals(value, "[]")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldType.java
@@ -9,6 +9,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.BaseDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -44,6 +45,17 @@ public class ImageDDMFormFieldType extends BaseDDMFormFieldType {
 	@Override
 	public String getName() {
 		return DDMFormFieldTypeConstants.IMAGE;
+	}
+
+	@Override
+	public boolean isPredefinedValueEmpty(String value) {
+		if (super.isPredefinedValueEmpty(value) ||
+			StringUtil.equals(value, "{}")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldType.java
@@ -9,6 +9,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.BaseDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -45,6 +46,17 @@ public class RadioDDMFormFieldType extends BaseDDMFormFieldType {
 	@Override
 	public String getName() {
 		return DDMFormFieldTypeConstants.RADIO;
+	}
+
+	@Override
+	public boolean isPredefinedValueEmpty(String value) {
+		if (super.isPredefinedValueEmpty(value) ||
+			StringUtil.equals(value, "[]")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldType.java
@@ -9,6 +9,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.BaseDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -44,6 +45,17 @@ public class SelectDDMFormFieldType extends BaseDDMFormFieldType {
 	@Override
 	public String getName() {
 		return DDMFormFieldTypeConstants.SELECT;
+	}
+
+	@Override
+	public boolean isPredefinedValueEmpty(String value) {
+		if (super.isPredefinedValueEmpty(value) ||
+			StringUtil.equals(value, "[]")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
@@ -5,6 +5,8 @@
 
 package com.liferay.dynamic.data.mapping.internal.util;
 
+import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
+import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeServicesRegistry;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
@@ -22,7 +24,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marcellus Tavares
@@ -167,7 +169,9 @@ public class DDMFormValuesToFieldsConverterImpl
 		if (MapUtil.isEmpty(value.getValues())) {
 			LocalizedValue predefinedValue = ddmFormField.getPredefinedValue();
 
-			if (_isEmpty(predefinedValue.getValues())) {
+			if (_isPredefinedValueEmpty(
+					ddmFormField, predefinedValue.getValues())) {
+
 				LocalizedValue localizedValue = new LocalizedValue(
 					defaultLocale);
 
@@ -251,18 +255,27 @@ public class DDMFormValuesToFieldsConverterImpl
 		return availableLocales;
 	}
 
-	private boolean _isEmpty(Map<Locale, String> valuesMap) {
+	private boolean _isPredefinedValueEmpty(
+		DDMFormField ddmFormField, Map<Locale, String> valuesMap) {
+
 		if (MapUtil.isEmpty(valuesMap)) {
 			return true;
 		}
 
-		for (String value : valuesMap.values()) {
-			if (Validator.isNotNull(value)) {
+		DDMFormFieldType ddmFormFieldType =
+			_ddmFormFieldTypeServicesRegistry.getDDMFormFieldType(
+				ddmFormField.getType());
+
+		for (String predefinedValue : valuesMap.values()) {
+			if (!ddmFormFieldType.isPredefinedValueEmpty(predefinedValue)) {
 				return false;
 			}
 		}
 
 		return true;
 	}
+
+	@Reference
+	private DDMFormFieldTypeServicesRegistry _ddmFormFieldTypeServicesRegistry;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/BaseDDMTestCase.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/BaseDDMTestCase.java
@@ -10,7 +10,10 @@ import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldRenderer;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeServicesRegistry;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeSettings;
+import com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.CheckboxDDMFormFieldType;
+import com.liferay.dynamic.data.mapping.form.field.type.internal.checkbox.multiple.CheckboxMultipleDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.fieldset.FieldSetDDMFormFieldType;
+import com.liferay.dynamic.data.mapping.form.field.type.internal.image.ImageDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.radio.RadioDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.select.SelectDDMFormFieldType;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.text.TextDDMFormFieldType;
@@ -472,9 +475,30 @@ public abstract class BaseDDMTestCase {
 
 		Mockito.when(
 			ddmFormFieldTypeServicesRegistry.getDDMFormFieldType(
+				Mockito.eq("checkbox"))
+		).thenReturn(
+			new CheckboxDDMFormFieldType()
+		);
+
+		Mockito.when(
+			ddmFormFieldTypeServicesRegistry.getDDMFormFieldType(
+				Mockito.eq("checkbox_multiple"))
+		).thenReturn(
+			new CheckboxMultipleDDMFormFieldType()
+		);
+
+		Mockito.when(
+			ddmFormFieldTypeServicesRegistry.getDDMFormFieldType(
 				Mockito.eq("fieldset"))
 		).thenReturn(
 			new FieldSetDDMFormFieldType()
+		);
+
+		Mockito.when(
+			ddmFormFieldTypeServicesRegistry.getDDMFormFieldType(
+				Mockito.eq("image"))
+		).thenReturn(
+			new ImageDDMFormFieldType()
 		);
 
 		Mockito.when(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesToFieldsConverterTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesToFieldsConverterTest.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -63,6 +64,11 @@ public class DDMFormValuesToFieldsConverterTest extends BaseDDMTestCase {
 		setUpJSONFactoryUtil();
 		setUpLanguageUtil();
 		setUpSAXReaderUtil();
+
+		ReflectionTestUtil.setFieldValue(
+			_ddmFormValuesToFieldsConverter,
+			"_ddmFormFieldTypeServicesRegistry",
+			getMockedDDMFormFieldTypeServicesRegistry());
 	}
 
 	@Test
@@ -168,28 +174,36 @@ public class DDMFormValuesToFieldsConverterTest extends BaseDDMTestCase {
 	public void testConversionWithEmptyPredefinedValueInNondefaultLocale()
 		throws Exception {
 
-		DDMForm ddmForm = createDDMForm(
-			createAvailableLocales(LocaleUtil.BRAZIL, LocaleUtil.US),
-			LocaleUtil.US);
-
-		DDMFormField ddmFormField = createTextDDMFormField("Text");
-
-		LocalizedValue predefinedValue = new LocalizedValue(LocaleUtil.BRAZIL);
-
-		predefinedValue.addString(LocaleUtil.BRAZIL, StringPool.BLANK);
-
-		ddmFormField.setPredefinedValue(predefinedValue);
-
-		addDDMFormFields(ddmForm, ddmFormField);
-
-		Fields fields = _ddmFormValuesToFieldsConverter.convert(
-			createStructure(RandomTestUtil.randomString(), ddmForm),
-			DDMFormValuesTestUtil.createDDMFormValues(ddmForm));
-
-		testField(
-			fields.get("Text"), createValuesList(StringPool.BLANK),
-			createValuesList(StringPool.BLANK),
-			createAvailableLocales(LocaleUtil.US), LocaleUtil.US);
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"string", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.CHECKBOX),
+			"[\"false\"]");
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"string", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE),
+			"[]");
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"json", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.IMAGE),
+			"{}");
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"string", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.RADIO),
+			"[]");
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"string", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.SELECT),
+			"[]");
+		_testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			_createDDMFormField(
+				"string", RandomTestUtil.randomString(),
+				DDMFormFieldTypeConstants.TEXT),
+			StringPool.BLANK);
 	}
 
 	@Test
@@ -662,6 +676,49 @@ public class DDMFormValuesToFieldsConverterTest extends BaseDDMTestCase {
 		Assert.assertTrue(clazz.isAssignableFrom(Boolean.class));
 
 		Assert.assertEquals(expectedValue, value);
+	}
+
+	private DDMFormField _createDDMFormField(
+		String dataType, String name, String type) {
+
+		DDMFormField ddmFormField = new DDMFormField(name, type);
+
+		ddmFormField.setDataType(dataType);
+		ddmFormField.setFieldReference(name);
+		ddmFormField.setLocalizable(true);
+
+		LocalizedValue label = ddmFormField.getLabel();
+
+		label.addString(LocaleUtil.US, name);
+
+		return ddmFormField;
+	}
+
+	private void _testConversionWithEmptyPredefinedValueInNondefaultLocale(
+			DDMFormField ddmFormField, String predefinedValue)
+		throws Exception {
+
+		DDMForm ddmForm = createDDMForm(
+			createAvailableLocales(LocaleUtil.BRAZIL, LocaleUtil.US),
+			LocaleUtil.US);
+
+		LocalizedValue localizedValue = new LocalizedValue(LocaleUtil.BRAZIL);
+
+		localizedValue.addString(LocaleUtil.BRAZIL, predefinedValue);
+
+		ddmFormField.setPredefinedValue(localizedValue);
+
+		addDDMFormFields(ddmForm, ddmFormField);
+
+		Fields fields = _ddmFormValuesToFieldsConverter.convert(
+			createStructure(RandomTestUtil.randomString(), ddmForm),
+			DDMFormValuesTestUtil.createDDMFormValues(ddmForm));
+
+		testField(
+			fields.get(ddmFormField.getName()),
+			createValuesList(StringPool.BLANK),
+			createValuesList(StringPool.BLANK),
+			createAvailableLocales(LocaleUtil.US), LocaleUtil.US);
 	}
 
 	private Set<Locale> _availableLocales;


### PR DESCRIPTION
[LPD-85865](https://liferay.atlassian.net/browse/LPD-85865)

[LPD-85865]: https://liferay.atlassian.net/browse/LPD-85865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ