### PR TITLE
LPD-85904 | Remove FF from Comments API Site Scoped

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -107,6 +108,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -122,6 +124,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -1070,6 +1073,15 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), false, "LPD-43996");
+
+		Assert.assertFalse(
+			FeatureFlagManagerUtil.isEnabled(
+				TestPropsValues.getCompanyId(), "LPD-43996"));
 
 		_testExportImportObjectEntriesWithComments(
 			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -371,7 +371,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 
 										</ul>
 
-										<c:if test='<%= FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") || !stagingGroupHelper.isCompanyGroup(group) %>'>
+										<c:if test="<%= !stagingGroupHelper.isCompanyGroup(group) %>">
 											<aui:fieldset cssClass="content-options" label="for-each-of-the-selected-content-types,-import-their">
 												<span class="selected-labels" id="<portlet:namespace />selectedContentOptions"></span>
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -968,8 +968,11 @@ public class ObjectEntryDTOConverter
 		return NestedFieldsSupplier.supply(
 			"comments",
 			nestedFieldNames -> {
-				if (!FeatureFlagManagerUtil.isEnabled(
-						objectDefinition.getCompanyId(), "LPD-43996") ||
+				if ((!Objects.equals(
+						objectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_SITE) &&
+					 !FeatureFlagManagerUtil.isEnabled(
+						 objectDefinition.getCompanyId(), "LPD-43996")) ||
 					!objectDefinition.isEnableComments() ||
 					!_discussionPermission.hasViewPermission(
 						PermissionThreadLocal.getPermissionChecker(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -1997,8 +1997,11 @@ public class DefaultObjectEntryManagerImpl
 		List<ObjectEntryComment> objectEntryComments = null;
 
 		if ((objectEntry.getComments() != null) &&
-			FeatureFlagManagerUtil.isEnabled(
-				objectDefinition.getCompanyId(), "LPD-43996")) {
+			(Objects.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE) ||
+			 FeatureFlagManagerUtil.isEnabled(
+				 objectDefinition.getCompanyId(), "LPD-43996"))) {
 
 			objectEntryComments = TransformUtil.transformToList(
 				objectEntry.getComments(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CommentResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.util.CommentUtil;
 import com.liferay.headless.delivery.resource.v1_0.util.CommentResourceUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.provider.CommentEntityModel;
@@ -43,6 +44,7 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -71,10 +73,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String externalReferenceCode, String commentExternalReferenceCode)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -99,10 +98,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -197,10 +193,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -218,10 +211,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -248,10 +238,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey, String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -269,10 +256,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -300,10 +284,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -331,10 +312,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -441,10 +419,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -470,10 +445,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey, String search, Sort[] sorts)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -525,10 +497,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Pagination pagination, String scopeKey, String search, Sort[] sorts)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -623,6 +592,22 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		return defaultObjectEntryManager.getObjectEntry(
 			contextCompany.getCompanyId(), _getDTOConverterContext(null),
 			objectEntryExternalReferenceCode, _objectDefinition, scopeKey);
+	}
+
+	private boolean _isCommentsSupported() {
+		if (!_objectDefinition.isEnableComments()) {
+			return false;
+		}
+
+		if (Objects.equals(
+				_objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			return true;
+		}
+
+		return FeatureFlagManagerUtil.isEnabled(
+			_objectDefinition.getCompanyId(), "LPD-43996");
 	}
 
 	private Comment _updateComment(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
@@ -18,14 +18,17 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -46,7 +49,6 @@ import org.junit.runner.RunWith;
 /**
  * @author Guilherme Camacho
  */
-@FeatureFlag("LPD-43996")
 @RunWith(Arquillian.class)
 public class CommentResourceTest {
 
@@ -110,6 +112,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_testDeleteByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -124,6 +128,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		_disableCommentsFeatureFlag();
 
 		_testGetByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
@@ -141,6 +147,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_testGetByExternalReferenceCodeCommentChildCommentsPage(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -156,6 +164,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_testGetByExternalReferenceCodeCommentsPage(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -170,6 +180,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		_disableCommentsFeatureFlag();
 
 		_testPostByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
@@ -187,6 +199,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_testPostByExternalReferenceCodeCommentReplyComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -201,6 +215,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		_disableCommentsFeatureFlag();
 
 		_testPutByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
@@ -283,6 +299,17 @@ public class CommentResourceTest {
 		JSONArray jsonArray = jsonObject.getJSONArray("items");
 
 		Assert.assertEquals(expectedSize, jsonArray.length());
+	}
+
+	private void _disableCommentsFeatureFlag() throws Exception {
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), false, "LPD-43996");
+
+		Assert.assertFalse(
+			FeatureFlagManagerUtil.isEnabled(
+				TestPropsValues.getCompanyId(), "LPD-43996"));
 	}
 
 	private void _enableComments(ObjectDefinition objectDefinition) {

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -162,6 +162,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -188,6 +189,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -1350,6 +1352,8 @@ public class ObjectEntryResourceTest {
 		_testDeleteObjectEntryWithComments(0, _objectDefinition1);
 
 		// Site scope
+
+		_disableCommentsFeatureFlag();
 
 		_testDeleteObjectEntryWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);
@@ -6154,6 +6158,8 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_testGetObjectEntriesPageWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);
 	}
@@ -9504,6 +9510,8 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
+		_disableCommentsFeatureFlag();
+
 		_enableComments(_siteScopedObjectDefinition1);
 
 		_testPatchPutObjectEntryWithComments(
@@ -11043,6 +11051,8 @@ public class ObjectEntryResourceTest {
 		_testPostObjectEntriesWithComments(0, _objectDefinition1);
 
 		// Site scope
+
+		_disableCommentsFeatureFlag();
 
 		_testPostObjectEntriesWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);
@@ -16186,6 +16196,17 @@ public class ObjectEntryResourceTest {
 		}
 
 		return jsonArray;
+	}
+
+	private void _disableCommentsFeatureFlag() throws Exception {
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), false, "LPD-43996");
+
+		Assert.assertFalse(
+			FeatureFlagManagerUtil.isEnabled(
+				TestPropsValues.getCompanyId(), "LPD-43996"));
 	}
 
 	private void _enableComments(ObjectDefinition objectDefinition) {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
@@ -31,6 +31,9 @@ export function ConfigurationContainer({
 	setValues,
 	values,
 }: ConfigurationContainerProps) {
+	const isCommentsEnabled =
+		values.scope === 'site' || Liferay.FeatureFlags['LPD-43996'];
+
 	const isReadOnly = !values.modifiable && values.system;
 
 	const disabled =
@@ -89,7 +92,7 @@ export function ConfigurationContainer({
 					disabled={disabled}
 					label={sub(
 						Liferay.Language.get('enable-x'),
-						Liferay.FeatureFlags['LPD-43996']
+						isCommentsEnabled
 							? Liferay.Language.get('comments')
 							: Liferay.Language.get('comments-in-page-builder')
 					)}
@@ -109,7 +112,7 @@ export function ConfigurationContainer({
 					toggled={values.enableComments}
 				/>
 
-				{Liferay.FeatureFlags['LPD-43996'] && (
+				{isCommentsEnabled && (
 					<>
 						&nbsp;
 						<ClayTooltipProvider>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
@@ -235,19 +235,11 @@ html = html.trim();
 	<%= html %>
 </ul>
 
-<c:if test='<%= type.equals(Constants.EXPORT) && (FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") || !stagingGroupHelper.isCompanyGroup(group)) %>'>
+<c:if test="<%= type.equals(Constants.EXPORT) && !stagingGroupHelper.isCompanyGroup(group) %>">
 	<liferay-util:buffer
 		var="selectedContentOptionsLabel"
 	>
 		<liferay-ui:message key="for-each-of-the-selected-content-types,-export-their" />
-
-		<c:if test='<%= !FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") %>'>
-			<span aria-label="<%= LanguageUtil.get(request, "comments-associated-to-object-entries-are-currently-excluded-from-the-export") %>" class="lfr-portal-tooltip ml-1" title="<%= LanguageUtil.get(request, "comments-associated-to-object-entries-are-currently-excluded-from-the-export") %>">
-				<clay:icon
-					symbol="question-circle-full"
-				/>
-			</span>
-		</c:if>
 	</liferay-util:buffer>
 
 	<aui:fieldset cssClass="content-options" label="<%= selectedContentOptionsLabel %>">


### PR DESCRIPTION
related: [LPD-85904](https://liferay.atlassian.net/browse/LPD-85904)

[LPD-85904]: https://liferay.atlassian.net/browse/LPD-85904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Dear reviewer,
All related tests in CommentResourceTest, ObjectEntryResourceTest, and BatchEnginePortletDataHandlerTest are passing.

These changes ensure that the LPD-43996 feature flag behavior is preserved for Comments added to company-scoped Object Definitions, while enabling the feature when operating within a site-scoped Object Definition context.