### PR TITLE
LPD-86442 Remove apiHelpers.headlessSite calls for BPM

### DIFF
--- a/modules/test/playwright/tests/portal-workflow-task-web/main/accessibility.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/main/accessibility.spec.ts
@@ -49,7 +49,7 @@ test('Workflow task view page is accessible', async ({
 		'Blogs Entry'
 	);
 
-	const site = await apiHelpers.headlessSite.getSiteByERC('L_GUEST');
+	const site = await apiHelpers.headlessAdminSite.getSite('L_GUEST');
 
 	const blogPost = await apiHelpers.headlessDelivery.postBlog(site.id);
 

--- a/modules/test/playwright/tests/portal-workflow-task-web/main/workload.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/main/workload.spec.ts
@@ -86,7 +86,7 @@ test('view workload distribution for all assignees', async ({
 		.getRoles('"Portal Content Reviewer"')
 		.then(({items}) => items[0]);
 
-	const site = await apiHelpers.headlessSite.getSiteByERC('L_GUEST');
+	const site = await apiHelpers.headlessAdminSite.getSite('L_GUEST');
 
 	for (let index = 0; index < NUMBER_OF_USERS_AND_TASKS; index++) {
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86442

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

If you encounter any failures or flakiness related to these changes, please let me know.