### PR TITLE
LPD-85904 | Remove FF from Comments API Site Scoped

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -1072,10 +1072,17 @@ public class BatchEnginePortletDataHandlerTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testExportImportObjectEntriesWithComments(
-			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testExportImportObjectEntriesWithComments(
+				GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@Test

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/data/handler/test/BatchEnginePortletDataHandlerTest.java
@@ -122,6 +122,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -1070,6 +1071,8 @@ public class BatchEnginePortletDataHandlerTest {
 			ObjectDefinitionConstants.SCOPE_COMPANY);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testExportImportObjectEntriesWithComments(
 			GroupTestUtil.addGroup(), ObjectDefinitionConstants.SCOPE_SITE);

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -371,7 +371,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 
 										</ul>
 
-										<c:if test='<%= FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") || !stagingGroupHelper.isCompanyGroup(group) %>'>
+										<c:if test='<%= !stagingGroupHelper.isCompanyGroup(group) || FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") %>'>
 											<aui:fieldset cssClass="content-options" label="for-each-of-the-selected-content-types,-import-their">
 												<span class="selected-labels" id="<portlet:namespace />selectedContentOptions"></span>
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -968,8 +968,11 @@ public class ObjectEntryDTOConverter
 		return NestedFieldsSupplier.supply(
 			"comments",
 			nestedFieldNames -> {
-				if (!FeatureFlagManagerUtil.isEnabled(
-						objectDefinition.getCompanyId(), "LPD-43996") ||
+				if ((!Objects.equals(
+						objectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_SITE) &&
+					 !FeatureFlagManagerUtil.isEnabled(
+						 objectDefinition.getCompanyId(), "LPD-43996")) ||
 					!objectDefinition.isEnableComments() ||
 					!_discussionPermission.hasViewPermission(
 						PermissionThreadLocal.getPermissionChecker(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2036,8 +2036,11 @@ public class DefaultObjectEntryManagerImpl
 		List<ObjectEntryComment> objectEntryComments = null;
 
 		if ((objectEntry.getComments() != null) &&
-			FeatureFlagManagerUtil.isEnabled(
-				objectDefinition.getCompanyId(), "LPD-43996")) {
+			(Objects.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE) ||
+			 FeatureFlagManagerUtil.isEnabled(
+				 objectDefinition.getCompanyId(), "LPD-43996"))) {
 
 			objectEntryComments = TransformUtil.transformToList(
 				objectEntry.getComments(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/CommentResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.headless.delivery.dto.v1_0.util.CommentUtil;
 import com.liferay.headless.delivery.resource.v1_0.util.CommentResourceUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.internal.odata.entity.v1_0.provider.CommentEntityModel;
@@ -43,6 +44,7 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -71,10 +73,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String externalReferenceCode, String commentExternalReferenceCode)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -99,10 +98,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -197,10 +193,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -218,10 +211,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -248,10 +238,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey, String externalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -269,10 +256,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -300,10 +284,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -331,10 +312,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String commentExternalReferenceCode, Comment comment)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -441,10 +419,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -470,10 +445,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			String scopeKey, String search, Sort[] sorts)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -525,10 +497,7 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 			Pagination pagination, String scopeKey, String search, Sort[] sorts)
 		throws Exception {
 
-		if (!_objectDefinition.isEnableComments() ||
-			!FeatureFlagManagerUtil.isEnabled(
-				_objectDefinition.getCompanyId(), "LPD-43996")) {
-
+		if (!_isCommentsSupported()) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -623,6 +592,22 @@ public class CommentResourceImpl extends BaseCommentResourceImpl {
 		return defaultObjectEntryManager.getObjectEntry(
 			contextCompany.getCompanyId(), _getDTOConverterContext(null),
 			objectEntryExternalReferenceCode, _objectDefinition, scopeKey);
+	}
+
+	private boolean _isCommentsSupported() {
+		if (!_objectDefinition.isEnableComments()) {
+			return false;
+		}
+
+		if (Objects.equals(
+				_objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_SITE)) {
+
+			return true;
+		}
+
+		return FeatureFlagManagerUtil.isEnabled(
+			_objectDefinition.getCompanyId(), "LPD-43996");
 	}
 
 	private Comment _updateComment(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -46,7 +47,6 @@ import org.junit.runner.RunWith;
 /**
  * @author Guilherme Camacho
  */
-@FeatureFlag("LPD-43996")
 @RunWith(Arquillian.class)
 public class CommentResourceTest {
 
@@ -110,6 +110,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_testDeleteByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -124,6 +126,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testGetByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
@@ -141,6 +145,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_testGetByExternalReferenceCodeCommentChildCommentsPage(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -156,6 +162,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_testGetByExternalReferenceCodeCommentsPage(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -170,6 +178,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testPostByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
@@ -187,6 +197,8 @@ public class CommentResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_testPostByExternalReferenceCodeCommentReplyComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
 	}
@@ -201,6 +213,8 @@ public class CommentResourceTest {
 			0, _objectDefinition, _objectEntry);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testPutByExternalReferenceCodeComment(
 			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/CommentResourceTest.java
@@ -110,10 +110,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testDeleteByExternalReferenceCodeComment(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testDeleteByExternalReferenceCodeComment(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -127,10 +134,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testGetByExternalReferenceCodeComment(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testGetByExternalReferenceCodeComment(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -145,10 +159,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testGetByExternalReferenceCodeCommentChildCommentsPage(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testGetByExternalReferenceCodeCommentChildCommentsPage(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -162,10 +183,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testGetByExternalReferenceCodeCommentsPage(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testGetByExternalReferenceCodeCommentsPage(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -179,10 +207,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testPostByExternalReferenceCodeComment(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testPostByExternalReferenceCodeComment(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -197,10 +232,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testPostByExternalReferenceCodeCommentReplyComment(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testPostByExternalReferenceCodeCommentReplyComment(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -214,10 +256,17 @@ public class CommentResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testPutByExternalReferenceCodeComment(
-			_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testPutByExternalReferenceCodeComment(
+				_testGroupId, _siteScopedObjectDefinition, _siteObjectEntry);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	private void _assertCommentsPageWithAggregation(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -188,6 +188,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -1350,6 +1351,8 @@ public class ObjectEntryResourceTest {
 		_testDeleteObjectEntryWithComments(0, _objectDefinition1);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testDeleteObjectEntryWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);
@@ -6154,6 +6157,8 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_testGetObjectEntriesPageWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);
 	}
@@ -9504,6 +9509,8 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+
 		_enableComments(_siteScopedObjectDefinition1);
 
 		_testPatchPutObjectEntryWithComments(
@@ -11043,6 +11050,8 @@ public class ObjectEntryResourceTest {
 		_testPostObjectEntriesWithComments(0, _objectDefinition1);
 
 		// Site scope
+
+		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
 
 		_testPostObjectEntriesWithComments(
 			_testGroupId, _siteScopedObjectDefinition1);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -1352,10 +1352,17 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testDeleteObjectEntryWithComments(
-			_testGroupId, _siteScopedObjectDefinition1);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testDeleteObjectEntryWithComments(
+				_testGroupId, _siteScopedObjectDefinition1);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@Test
@@ -6157,10 +6164,17 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testGetObjectEntriesPageWithComments(
-			_testGroupId, _siteScopedObjectDefinition1);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testGetObjectEntriesPageWithComments(
+				_testGroupId, _siteScopedObjectDefinition1);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@Test
@@ -9509,14 +9523,21 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_enableComments(_siteScopedObjectDefinition1);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
 
-		_testPatchPutObjectEntryWithComments(
-			_testGroupId, Http.Method.PATCH, _siteScopedObjectDefinition1);
-		_testPatchPutObjectEntryWithComments(
-			_testGroupId, Http.Method.PUT, _siteScopedObjectDefinition1);
+		try {
+			_enableComments(_siteScopedObjectDefinition1);
+
+			_testPatchPutObjectEntryWithComments(
+				_testGroupId, Http.Method.PATCH, _siteScopedObjectDefinition1);
+			_testPatchPutObjectEntryWithComments(
+				_testGroupId, Http.Method.PUT, _siteScopedObjectDefinition1);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")
@@ -11051,10 +11072,17 @@ public class ObjectEntryResourceTest {
 
 		// Site scope
 
-		PropsUtil.set("feature.flag.LPD-43996", Boolean.FALSE.toString());
+		String originalValue = PropsUtil.get("feature.flag.LPD-43996");
 
-		_testPostObjectEntriesWithComments(
-			_testGroupId, _siteScopedObjectDefinition1);
+		PropsUtil.set("feature.flag.LPD-43996", "false");
+
+		try {
+			_testPostObjectEntriesWithComments(
+				_testGroupId, _siteScopedObjectDefinition1);
+		}
+		finally {
+			PropsUtil.set("feature.flag.LPD-43996", originalValue);
+		}
 	}
 
 	@FeatureFlag("LPD-43996")

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.tsx
@@ -31,6 +31,9 @@ export function ConfigurationContainer({
 	setValues,
 	values,
 }: ConfigurationContainerProps) {
+	const isCommentsEnabled =
+		values.scope === 'site' || Liferay.FeatureFlags['LPD-43996'];
+
 	const isReadOnly = !values.modifiable && values.system;
 
 	const disabled =
@@ -89,7 +92,7 @@ export function ConfigurationContainer({
 					disabled={disabled}
 					label={sub(
 						Liferay.Language.get('enable-x'),
-						Liferay.FeatureFlags['LPD-43996']
+						isCommentsEnabled
 							? Liferay.Language.get('comments')
 							: Liferay.Language.get('comments-in-page-builder')
 					)}
@@ -109,7 +112,7 @@ export function ConfigurationContainer({
 					toggled={values.enableComments}
 				/>
 
-				{Liferay.FeatureFlags['LPD-43996'] && (
+				{isCommentsEnabled && (
 					<>
 						&nbsp;
 						<ClayTooltipProvider>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/portlet_list/page.jsp
@@ -235,13 +235,13 @@ html = html.trim();
 	<%= html %>
 </ul>
 
-<c:if test='<%= type.equals(Constants.EXPORT) && (FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") || !stagingGroupHelper.isCompanyGroup(group)) %>'>
+<c:if test='<%= type.equals(Constants.EXPORT) && (!stagingGroupHelper.isCompanyGroup(group) || FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996")) %>'>
 	<liferay-util:buffer
 		var="selectedContentOptionsLabel"
 	>
 		<liferay-ui:message key="for-each-of-the-selected-content-types,-export-their" />
 
-		<c:if test='<%= !FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") %>'>
+		<c:if test='<%= stagingGroupHelper.isCompanyGroup(group) && !FeatureFlagManagerUtil.isEnabled(company.getCompanyId(), "LPD-43996") %>'>
 			<span aria-label="<%= LanguageUtil.get(request, "comments-associated-to-object-entries-are-currently-excluded-from-the-export") %>" class="lfr-portal-tooltip ml-1" title="<%= LanguageUtil.get(request, "comments-associated-to-object-entries-are-currently-excluded-from-the-export") %>">
 				<clay:icon
 					symbol="question-circle-full"


### PR DESCRIPTION
related: [LPD-85904](https://liferay.atlassian.net/browse/LPD-85904)

Dear reviewer,
All related tests in CommentResourceTest, ObjectEntryResourceTest, and BatchEnginePortletDataHandlerTest are passing.

These changes ensure that the LPD-43996 feature flag behavior is preserved for Comments added to company-scoped Object Definitions, while enabling the feature when operating within a site-scoped Object Definition context.

[LPD-85904]: https://liferay.atlassian.net/browse/LPD-85904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

resent from https://github.com/brianchandotcom/liferay-portal/pull/173107