### PR TITLE
LPD-86015 Implement structural CSS fix for Data Engine styles

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
@@ -1,4 +1,4 @@
-$c: '.sidebar-container';
+$c: '.lfr-de__form-report-sidebar';
 
 #{$c} {
 	bottom: 0;

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_control_menu.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_control_menu.scss
@@ -23,8 +23,4 @@
 
 .top-bar {
 	top: var(--control-menu-container-height);
-
-	@include media-breakpoint-down(sm) {
-		position: static;
-	}
 }

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_sidebar.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/components/_sidebar.scss
@@ -7,9 +7,7 @@
 	}
 
 	.lfr-layout-structure-item-sidebar & {
-		position: static;
-		transform: none;
-		width: unset;
+		position: fixed;
 	}
 }
 

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -1,14 +1,19 @@
 .sidebar-layout {
 	--sidebar-layout-height: calc(
-		100vh - var(--control-menu-container-height, 0)
+		100vh - var(--control-menu-container-height, 0) - var(--top-bar-height, 0rem)
 	);
 	--sidebar-layout-width: 280px;
 
+	column-gap: .05rem;
 	display: grid;
 	grid-template-areas: 'sidebar content';
 	grid-template-columns: 0px minmax(0, 1fr);
 	min-height: var(--sidebar-layout-height);
 	transition: 400ms ease-in-out;
+
+	.lfr-layout-structure-item-sidebar:has(.cms-control-menu) & {
+		--top-bar-height: 3.5rem;
+	}
 
 	.c-prefers-reduced-motion & {
 		transition: none;
@@ -23,9 +28,8 @@
 	}
 
 	.sidebar {
-		max-width: var(--sidebar-layout-width);
-		min-height: var(--sidebar-layout-height);
-		min-width: var(--sidebar-layout-width);
+		height: var(--sidebar-layout-height);
+		width: var(--sidebar-layout-width);
 		scroll-behavior: smooth;
 
 		.menubar-primary {
@@ -53,7 +57,7 @@
 	}
 
 	.content {
-		background: var(--body-bg);
+		background: var(--body-bg, #fff);
 		grid-area: content;
 	}
 
@@ -89,16 +93,9 @@
 		}
 
 		.sidebar-container {
-			height: 100%;
 			left: calc(-1 * var(--sidebar-layout-width));
-			position: absolute;
 			width: var(--sidebar-layout-width);
 			z-index: 989;
-		}
-
-		.sidebar {
-			height: 100%;
-			max-height: none;
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -29,8 +29,8 @@
 
 	.sidebar {
 		height: var(--sidebar-layout-height);
-		width: var(--sidebar-layout-width);
 		scroll-behavior: smooth;
+		width: var(--sidebar-layout-width);
 
 		.menubar-primary {
 			.nav-link {

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.html
@@ -15,7 +15,7 @@
 		</div>
 	</nav>
 
-	<div class="content">
+	<div class="content position-relative">
 		<lfr-drop-zone data-lfr-drop-zone-id="content"></lfr-drop-zone>
 	</div>
 </div>

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/productMenuLayout.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/productMenuLayout.spec.ts
@@ -22,8 +22,8 @@ test(
 		await expect(productMenu).toHaveCSS('transform', 'none');
 		await expect(productMenu).toHaveCSS('position', 'fixed');
 
-		await expect(
-			page.locator('.lfr-de__form-report-sidebar')
-		).toHaveCount(0);
+		await expect(page.locator('.lfr-de__form-report-sidebar')).toHaveCount(
+			0
+		);
 	}
 );

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/productMenuLayout.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/productMenuLayout.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect} from '@playwright/test';
+
+import {cmpPagesTest as test} from './fixtures/cmpPagesTest';
+
+test(
+	'CMS product menu layout is not clobbered by data-engine styles on CMP pages',
+	{tag: '@LPD-86015'},
+	async ({page, projectsPage}) => {
+		await projectsPage.goto();
+
+		const productMenu = page.getByRole('navigation', {
+			name: 'CMS Product Menu',
+		});
+
+		await expect(productMenu).toBeVisible();
+
+		await expect(productMenu).toHaveCSS('transform', 'none');
+		await expect(productMenu).toHaveCSS('position', 'fixed');
+
+		await expect(
+			page.locator('.lfr-de__form-report-sidebar')
+		).toHaveCount(0);
+	}
+);


### PR DESCRIPTION
## Ticket

https://liferay.atlassian.net/browse/LPD-86015

## Summary

Permanent fix for the CSS leak that caused PR #7940 (LPD-82884) to be reverted. The form-report sidebar in `data-engine-js-components-web` was targeting the bare `.sidebar-container` selector, applying `position: fixed; transform: translateX(100%); width: 422px;` to every `.sidebar-container` on any page that loads the data-engine bundle — including CMP, where it displaced the CMS product menu.