### PR TITLE
LPD-75148 Update scope key param converter

### DIFF
--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/constants/CommerceOrderConstants.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/constants/CommerceOrderConstants.java
@@ -19,6 +19,8 @@ public class CommerceOrderConstants {
 
 	public static final String DECIMAL_FORMAT_PATTERN = "###,##0.00";
 
+	public static final String OBJECT_DEFINITION_SCOPE = "commerceOrder";
+
 	public static final String ORDER_NOTIFICATION_AWAITING_SHIPMENT =
 		"order-awaiting-shipment";
 

--- a/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/constants/packageinfo
+++ b/modules/apps/commerce/commerce-api/src/main/resources/com/liferay/commerce/constants/packageinfo
@@ -1,1 +1,1 @@
-version 18.0.0
+version 18.1.0

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -69,8 +69,10 @@ public class CommerceOrderObjectScopeProviderImpl
 		GroupLocalService groupLocalService, ObjectEntry objectEntry) {
 
 		long commerceOrderId = GetterUtil.getLong(
-			objectEntry.getValues().get(
-				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId"));
+			objectEntry.getValues(
+			).get(
+				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId"
+			));
 
 		if (commerceOrderId > 0) {
 			return String.valueOf(commerceOrderId);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
@@ -1,0 +1,162 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.internal.object.scope;
+
+import com.liferay.commerce.constants.CommerceOrderConstants;
+import com.liferay.commerce.model.CommerceOrder;
+import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Stefano Motta
+ */
+@Component(
+	property = "object.scope.provider.key=" + CommerceOrderConstants.OBJECT_DEFINITION_SCOPE,
+	service = ObjectScopeProvider.class
+)
+public class CommerceOrderObjectScopeProviderImpl
+	implements ObjectScopeProvider {
+
+	@Override
+	public long getGroupId(HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		CommerceOrder commerceOrder =
+			_commerceOrderLocalService.fetchCommerceOrder(
+				_getCommerceOrderId(httpServletRequest));
+
+		if (commerceOrder == null) {
+			return 0;
+		}
+
+		return commerceOrder.getGroupId();
+	}
+
+	@Override
+	public String getKey() {
+		return CommerceOrderConstants.OBJECT_DEFINITION_SCOPE;
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "commerce-order");
+	}
+
+	@Override
+	public String[] getRootPanelCategoryKeys() {
+		return new String[0];
+	}
+
+	@Override
+	public boolean isGroupAware() {
+		return true;
+	}
+
+	@Override
+	public boolean isValidGroupId(long groupId) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return false;
+		}
+
+		long commerceOrderId = GetterUtil.getLong(
+			serviceContext.getAttribute("commerceOrderId"));
+
+		if (commerceOrderId <= 0) {
+			commerceOrderId = GetterUtil.getLong(
+				serviceContext.getAttribute("scopeKey"));
+		}
+
+		if (commerceOrderId <= 0) {
+			return false;
+		}
+
+		CommerceOrder commerceOrder =
+			_commerceOrderLocalService.fetchCommerceOrder(commerceOrderId);
+
+		if ((commerceOrder == null) ||
+			(commerceOrder.getGroupId() != groupId)) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public String resolveScopeKey(
+			long companyId, String scopeKey,
+			GroupLocalService groupLocalService)
+		throws PortalException {
+
+		CommerceOrder commerceOrder =
+			_commerceOrderLocalService.fetchCommerceOrder(
+				GetterUtil.getLong(scopeKey));
+
+		if ((commerceOrder == null) ||
+			(commerceOrder.getCompanyId() != companyId)) {
+
+			return null;
+		}
+
+		return String.valueOf(commerceOrder.getGroupId());
+	}
+
+	private long _getCommerceOrderId(HttpServletRequest httpServletRequest) {
+		long commerceOrderId = GetterUtil.getLong(
+			httpServletRequest.getAttribute("commerceOrderId"));
+
+		if (commerceOrderId > 0) {
+			return commerceOrderId;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return GetterUtil.getLong(
+				httpServletRequest.getParameter("commerceOrderId"));
+		}
+
+		commerceOrderId = GetterUtil.getLong(
+			serviceContext.getAttribute("commerceOrderId"));
+
+		if (commerceOrderId > 0) {
+			return commerceOrderId;
+		}
+
+		commerceOrderId = GetterUtil.getLong(
+			serviceContext.getAttribute("scopeKey"));
+
+		if (commerceOrderId > 0) {
+			return commerceOrderId;
+		}
+
+		return 0;
+	}
+
+	@Reference
+	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
@@ -8,6 +8,7 @@ package com.liferay.commerce.internal.object.scope;
 import com.liferay.commerce.constants.CommerceOrderConstants;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -61,6 +62,22 @@ public class CommerceOrderObjectScopeProviderImpl
 	@Override
 	public String[] getRootPanelCategoryKeys() {
 		return new String[0];
+	}
+
+	@Override
+	public String getScopeKey(
+		GroupLocalService groupLocalService, ObjectEntry objectEntry) {
+
+		long commerceOrderId = GetterUtil.getLong(
+			objectEntry.getValues().get(
+				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId"));
+
+		if (commerceOrderId > 0) {
+			return String.valueOf(commerceOrderId);
+		}
+
+		return ObjectScopeProvider.super.getScopeKey(
+			groupLocalService, objectEntry);
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -68,11 +69,9 @@ public class CommerceOrderObjectScopeProviderImpl
 	public String getScopeKey(
 		GroupLocalService groupLocalService, ObjectEntry objectEntry) {
 
-		long commerceOrderId = GetterUtil.getLong(
-			objectEntry.getValues(
-			).get(
-				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId"
-			));
+		long commerceOrderId = MapUtil.getLong(
+			objectEntry.getValues(),
+			"r_commerceOrderToCommerceOrderAttachments_commerceOrderId");
 
 		if (commerceOrderId > 0) {
 			return String.valueOf(commerceOrderId);

--- a/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
+++ b/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
+++ b/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
@@ -8,11 +8,16 @@ package com.liferay.commerce.internal.object.scope;
 import com.liferay.commerce.constants.CommerceOrderConstants;
 import com.liferay.commerce.model.CommerceOrder;
 import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.Serializable;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -59,6 +64,66 @@ public class CommerceOrderObjectScopeProviderImplTest {
 			0,
 			_commerceOrderObjectScopeProviderImpl.
 				getRootPanelCategoryKeys().length);
+	}
+
+	@Test
+	public void testGetScopeKey() {
+		long commerceOrderId = RandomTestUtil.randomLong();
+
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.getValues()
+		).thenReturn(
+			HashMapBuilder.<String, Serializable>put(
+				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId",
+				commerceOrderId
+			).build()
+		);
+
+		Assert.assertEquals(
+			String.valueOf(commerceOrderId),
+			_commerceOrderObjectScopeProviderImpl.getScopeKey(
+				_groupLocalService, objectEntry));
+
+		objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.getValues()
+		).thenReturn(
+			HashMapBuilder.<String, Serializable>put(
+				"r_commerceOrderToCommerceOrderAttachments_commerceOrderId", 0L
+			).build()
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectEntry.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			_groupLocalService.fetchGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		String groupKey = RandomTestUtil.randomString();
+
+		Mockito.when(
+			group.getGroupKey()
+		).thenReturn(
+			groupKey
+		);
+
+		Assert.assertEquals(
+			groupKey,
+			_commerceOrderObjectScopeProviderImpl.getScopeKey(
+				_groupLocalService, objectEntry));
 	}
 
 	@Test

--- a/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
+++ b/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
@@ -166,6 +166,8 @@ public class CommerceOrderObjectScopeProviderImplTest {
 		Assert.assertTrue(
 			_commerceOrderObjectScopeProviderImpl.isValidGroupId(groupId));
 
+		ServiceContextThreadLocal.popServiceContext();
+
 		serviceContext = new ServiceContext();
 
 		serviceContext.setAttribute(

--- a/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
+++ b/modules/apps/commerce/commerce-service/src/test/java/com/liferay/commerce/internal/object/scope/CommerceOrderObjectScopeProviderImplTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.commerce.internal.object.scope;
+
+import com.liferay.commerce.constants.CommerceOrderConstants;
+import com.liferay.commerce.model.CommerceOrder;
+import com.liferay.commerce.service.CommerceOrderLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Stefano Motta
+ */
+public class CommerceOrderObjectScopeProviderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetKey() {
+		Assert.assertEquals(
+			CommerceOrderConstants.OBJECT_DEFINITION_SCOPE,
+			_commerceOrderObjectScopeProviderImpl.getKey());
+	}
+
+	@Test
+	public void testGetRootPanelCategoryKeysIsEmpty() {
+		Assert.assertEquals(
+			0,
+			_commerceOrderObjectScopeProviderImpl.
+				getRootPanelCategoryKeys().length);
+	}
+
+	@Test
+	public void testIsGroupAware() {
+		Assert.assertTrue(_commerceOrderObjectScopeProviderImpl.isGroupAware());
+	}
+
+	@Test
+	public void testIsValidGroupId() {
+		Assert.assertFalse(
+			_commerceOrderObjectScopeProviderImpl.isValidGroupId(
+				RandomTestUtil.randomLong()));
+
+		long commerceOrderId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_commerceOrderLocalService.fetchCommerceOrder(commerceOrderId)
+		).thenReturn(
+			_commerceOrder
+		);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAttribute("commerceOrderId", commerceOrderId);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		Assert.assertFalse(
+			_commerceOrderObjectScopeProviderImpl.isValidGroupId(
+				RandomTestUtil.randomLong()));
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_commerceOrder.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Assert.assertTrue(
+			_commerceOrderObjectScopeProviderImpl.isValidGroupId(groupId));
+
+		serviceContext = new ServiceContext();
+
+		serviceContext.setAttribute(
+			"scopeKey", String.valueOf(commerceOrderId));
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		Assert.assertTrue(
+			_commerceOrderObjectScopeProviderImpl.isValidGroupId(groupId));
+	}
+
+	@Test
+	public void testResolveScopeKey() throws Exception {
+		long commerceOrderId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_commerceOrderLocalService.fetchCommerceOrder(commerceOrderId)
+		).thenReturn(
+			null
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Assert.assertNull(
+			_commerceOrderObjectScopeProviderImpl.resolveScopeKey(
+				companyId, String.valueOf(commerceOrderId),
+				_groupLocalService));
+
+		Mockito.when(
+			_commerceOrderLocalService.fetchCommerceOrder(commerceOrderId)
+		).thenReturn(
+			_commerceOrder
+		);
+
+		Mockito.when(
+			_commerceOrder.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Assert.assertNull(
+			_commerceOrderObjectScopeProviderImpl.resolveScopeKey(
+				companyId, String.valueOf(commerceOrderId),
+				_groupLocalService));
+
+		Mockito.when(
+			_commerceOrder.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_commerceOrder.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Assert.assertEquals(
+			String.valueOf(groupId),
+			_commerceOrderObjectScopeProviderImpl.resolveScopeKey(
+				companyId, String.valueOf(commerceOrderId),
+				_groupLocalService));
+	}
+
+	@Mock
+	private CommerceOrder _commerceOrder;
+
+	@Mock
+	private CommerceOrderLocalService _commerceOrderLocalService;
+
+	@InjectMocks
+	private CommerceOrderObjectScopeProviderImpl
+		_commerceOrderObjectScopeProviderImpl;
+
+	@Mock
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider.java
@@ -6,6 +6,8 @@
 package com.liferay.object.scope;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.vulcan.util.GroupUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -28,5 +30,20 @@ public interface ObjectScopeProvider {
 	public boolean isGroupAware();
 
 	public boolean isValidGroupId(long groupId);
+
+	public default String resolveScopeKey(
+			long companyId, String scopeKey,
+			GroupLocalService groupLocalService)
+		throws PortalException {
+
+		Long groupId = GroupUtil.getGroupId(
+			companyId, scopeKey, groupLocalService);
+
+		if (groupId == null) {
+			return null;
+		}
+
+		return String.valueOf(groupId);
+	}
 
 }

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider.java
@@ -5,7 +5,9 @@
 
 package com.liferay.object.scope;
 
+import com.liferay.object.model.ObjectEntry;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.vulcan.util.GroupUtil;
 
@@ -26,6 +28,18 @@ public interface ObjectScopeProvider {
 	public String getLabel(Locale locale);
 
 	public String[] getRootPanelCategoryKeys();
+
+	public default String getScopeKey(
+		GroupLocalService groupLocalService, ObjectEntry objectEntry) {
+
+		Group group = groupLocalService.fetchGroup(objectEntry.getGroupId());
+
+		if (group == null) {
+			return null;
+		}
+
+		return group.getGroupKey();
+	}
 
 	public boolean isGroupAware();
 

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/scope/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/scope/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -842,13 +842,8 @@ public class ObjectEntryDTOConverter
 			return null;
 		}
 
-		Group group = _groupLocalService.fetchGroup(objectEntry.getGroupId());
-
-		if (group == null) {
-			return null;
-		}
-
-		return group.getGroupKey();
+		return objectScopeProvider.getScopeKey(
+			_groupLocalService, objectEntry);
 	}
 
 	private Serializable _getValue(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -842,8 +842,7 @@ public class ObjectEntryDTOConverter
 			return null;
 		}
 
-		return objectScopeProvider.getScopeKey(
-			_groupLocalService, objectEntry);
+		return objectScopeProvider.getScopeKey(_groupLocalService, objectEntry);
 	}
 
 	private Serializable _getValue(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/feature/ObjectFeature.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/feature/ObjectFeature.java
@@ -6,6 +6,7 @@
 package com.liferay.object.rest.internal.jaxrs.feature;
 
 import com.liferay.object.rest.internal.jaxrs.param.converter.provider.ScopeKeyParamConverterProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -32,7 +33,8 @@ public class ObjectFeature implements Feature {
 	@Override
 	public boolean configure(FeatureContext featureContext) {
 		featureContext.register(
-			new ScopeKeyParamConverterProvider(_groupLocalService));
+			new ScopeKeyParamConverterProvider(
+				_groupLocalService, _objectScopeProviderRegistry));
 
 		return true;
 	}
@@ -45,5 +47,8 @@ public class ObjectFeature implements Feature {
 
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProvider.java
@@ -5,13 +5,16 @@
 
 package com.liferay.object.rest.internal.jaxrs.param.converter.provider;
 
-import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.vulcan.util.GroupUtil;
 
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
@@ -34,8 +37,12 @@ import org.apache.cxf.jaxrs.utils.AnnotationUtils;
 public class ScopeKeyParamConverterProvider
 	implements ParamConverter<String>, ParamConverterProvider {
 
-	public ScopeKeyParamConverterProvider(GroupLocalService groupLocalService) {
+	public ScopeKeyParamConverterProvider(
+		GroupLocalService groupLocalService,
+		ObjectScopeProviderRegistry objectScopeProviderRegistry) {
+
 		_groupLocalService = groupLocalService;
+		_objectScopeProviderRegistry = objectScopeProviderRegistry;
 	}
 
 	@Override
@@ -44,35 +51,42 @@ public class ScopeKeyParamConverterProvider
 			return null;
 		}
 
-		if (StringUtil.equals(
-				_objectDefinition.getScope(),
-				ObjectDefinitionConstants.SCOPE_DEPOT) ||
-			StringUtil.equals(
-				_objectDefinition.getScope(),
-				ObjectDefinitionConstants.SCOPE_SITE)) {
+		ObjectScopeProvider objectScopeProvider =
+			_objectScopeProviderRegistry.getObjectScopeProvider(
+				_objectDefinition.getScope());
 
-			String groupId = _getGroupId(_company.getCompanyId(), parameter);
-
-			if (groupId != null) {
-				return groupId;
-			}
-
-			String groupType = "asset library";
-
-			if (StringUtil.equals(
-					_objectDefinition.getScope(),
-					ObjectDefinitionConstants.SCOPE_SITE)) {
-
-				groupType = "site";
-			}
-
-			throw new NotFoundException(
-				StringBundler.concat(
-					"Unable to get a valid ", groupType, " with group ID ",
-					parameter));
+		if (!objectScopeProvider.isGroupAware()) {
+			throw new InternalServerErrorException(
+				"Unexpected scopeKey parameter for scope " +
+					_objectDefinition.getScope());
 		}
 
-		throw new InternalServerErrorException("Unexpected scopeKey parameter");
+		String groupId;
+
+		try {
+			groupId = objectScopeProvider.resolveScopeKey(
+				_company.getCompanyId(), parameter, _groupLocalService);
+		}
+		catch (PortalException portalException) {
+			throw new InternalServerErrorException(
+				portalException.getMessage(), portalException);
+		}
+
+		if (groupId == null) {
+			throw new NotFoundException(
+				StringBundler.concat(
+					"Unable to resolve scopeKey ", parameter, " for scope ",
+					_objectDefinition.getScope()));
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			serviceContext.setAttribute("scopeKey", parameter);
+		}
+
+		return groupId;
 	}
 
 	@Override
@@ -89,17 +103,6 @@ public class ScopeKeyParamConverterProvider
 	@Override
 	public String toString(String parameter) {
 		return String.valueOf(parameter);
-	}
-
-	private String _getGroupId(long companyId, String scopeKey) {
-		Long groupId = GroupUtil.getGroupId(
-			companyId, scopeKey, _groupLocalService);
-
-		if (groupId == null) {
-			return null;
-		}
-
-		return String.valueOf(groupId);
 	}
 
 	private boolean _hasScopeKeyAnnotation(Annotation[] annotations) {
@@ -123,6 +126,8 @@ public class ScopeKeyParamConverterProvider
 
 	@Context
 	private ObjectDefinition _objectDefinition;
+
+	private final ObjectScopeProviderRegistry _objectScopeProviderRegistry;
 
 	@Context
 	private UriInfo _uriInfo;

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.jaxrs.param.converter.provider;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Stefano Motta
+ */
+public class ScopeKeyParamConverterProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		_scopeKeyParamConverterProvider = new ScopeKeyParamConverterProvider(
+			_groupLocalService, _objectScopeProviderRegistry);
+
+		ReflectionTestUtil.setFieldValue(
+			_scopeKeyParamConverterProvider, "_company", _company);
+		ReflectionTestUtil.setFieldValue(
+			_scopeKeyParamConverterProvider, "_objectDefinition",
+			_objectDefinition);
+
+		Mockito.when(
+			_objectDefinition.getScope()
+		).thenReturn(
+			_SCOPE
+		);
+
+		Mockito.when(
+			_objectScopeProviderRegistry.getObjectScopeProvider(_SCOPE)
+		).thenReturn(
+			_objectScopeProvider
+		);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testFromString() throws Exception {
+		Assert.assertNull(_scopeKeyParamConverterProvider.fromString(null));
+
+		Mockito.when(
+			_objectScopeProvider.isGroupAware()
+		).thenReturn(
+			false
+		);
+
+		try {
+			_scopeKeyParamConverterProvider.fromString(
+				RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (InternalServerErrorException internalServerErrorException) {
+			Assert.assertNotNull(internalServerErrorException);
+		}
+
+		Mockito.when(
+			_objectScopeProvider.isGroupAware()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_objectScopeProvider.resolveScopeKey(
+				Mockito.anyLong(), Mockito.anyString(),
+				Mockito.any(GroupLocalService.class))
+		).thenReturn(
+			null
+		);
+
+		try {
+			_scopeKeyParamConverterProvider.fromString(
+				RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (NotFoundException notFoundException) {
+			Assert.assertNotNull(notFoundException);
+		}
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_company.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		String scopeKey = RandomTestUtil.randomString();
+		String groupId = String.valueOf(RandomTestUtil.randomLong());
+
+		Mockito.when(
+			_objectScopeProvider.resolveScopeKey(
+				companyId, scopeKey, _groupLocalService)
+		).thenReturn(
+			groupId
+		);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		Assert.assertEquals(
+			groupId, _scopeKeyParamConverterProvider.fromString(scopeKey));
+		Assert.assertEquals(scopeKey, serviceContext.getAttribute("scopeKey"));
+
+		Mockito.doThrow(
+			new PortalException()
+		).when(
+			_objectScopeProvider
+		).resolveScopeKey(
+			Mockito.anyLong(), Mockito.anyString(),
+			Mockito.any(GroupLocalService.class)
+		);
+
+		try {
+			_scopeKeyParamConverterProvider.fromString(
+				RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (InternalServerErrorException internalServerErrorException) {
+			Assert.assertNotNull(internalServerErrorException);
+		}
+	}
+
+	private static final String _SCOPE = RandomTestUtil.randomString();
+
+	@Mock
+	private Company _company;
+
+	@Mock
+	private GroupLocalService _groupLocalService;
+
+	@Mock
+	private ObjectDefinition _objectDefinition;
+
+	@Mock
+	private ObjectScopeProvider _objectScopeProvider;
+
+	@Mock
+	private ObjectScopeProviderRegistry _objectScopeProviderRegistry;
+
+	private ScopeKeyParamConverterProvider _scopeKeyParamConverterProvider;
+
+}

--- a/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
+++ b/modules/apps/object/object-rest-impl/src/test/java/com/liferay/object/rest/internal/jaxrs/param/converter/provider/ScopeKeyParamConverterProviderTest.java
@@ -124,8 +124,8 @@ public class ScopeKeyParamConverterProviderTest {
 			companyId
 		);
 
-		String scopeKey = RandomTestUtil.randomString();
 		String groupId = String.valueOf(RandomTestUtil.randomLong());
+		String scopeKey = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_objectScopeProvider.resolveScopeKey(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75148

With this PR I'm extracting the logic to "resolve" the scopeKey from the `ScopeKeyParamConverterProvider` to the `ObjectScopeProvider` so we could have scopes that are not directly a groupId (in our scenario we need to scope an object definition on a commerceOrder).

The logic for the existing scopes is untouched as I put their logic "as default"

Added the same logic to get the scopeKey in the DTO, asking for it to the scopeProvider

cc @gabrielwas 