### PR TITLE
LPD-87197 Fix dependencies path in objectAction.spec.ts

### DIFF
--- a/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
+++ b/modules/test/playwright/tests/object-web/action/objectAction.spec.ts
@@ -318,7 +318,7 @@ test('can send notification email via download action', async ({
 	const fileChooser = await fileChooserPromise;
 
 	await fileChooser.setFiles(
-		path.join(__dirname, '../../dependencies', 'sampleFile.txt')
+		path.join(__dirname, '../dependencies', 'sampleFile.txt')
 	);
 
 	await viewObjectEntriesPage.page


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87197

`sampleFile.txt` lives at `modules/test/playwright/tests/object-web/dependencies/`, not `modules/test/playwright/tests/dependencies/`. Since `__dirname` for the spec is already inside `tests/object-web/action`, one `..` reaches the sibling `dependencies/` folder.

## Test plan

- [x] `npx playwright test tests/object-web/action/objectAction.spec.ts -g "can send notification email via download action"` → 1 passed (12.5s)