### PR TITLE
LPD-87190 Scope Picklists heading locator in listTypeDefinition.spec.ts

### DIFF
--- a/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
+++ b/modules/test/playwright/tests/object-web/list-type-definition/listTypeDefinition.spec.ts
@@ -73,7 +73,9 @@ async function importPicklistFromFile(
 
 	await page.waitForLoadState('networkidle');
 
-	await expect(page.getByText('Picklists')).toBeVisible({timeout: 30000});
+	await expect(page.getByRole('heading', {name: 'Picklists'})).toBeVisible({
+		timeout: 30000,
+	});
 
 	await page.locator('button[aria-haspopup="true"]').first().click();
 


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87190

`getByText('Picklists')` was matching both the left-nav link and the page heading, triggering strict-mode violations across the four picklist export/import tests that go through `importPicklistFromFile`. Scoping to `getByRole('heading', {name: 'Picklists'})` targets only the page heading.

## Test plan

- [x] `npx playwright test tests/object-web/list-type-definition/listTypeDefinition.spec.ts -g "can add entry with picklist field imported"` → 1 passed (12.5s).
- [x] Format check clean.