### PR TITLE
LPD-87172 Scope Search locator to bypass side-nav strict-mode

### DIFF
--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -92,7 +92,8 @@ test(
 		await page.getByRole('link', {name: viewName}).waitFor();
 
 		await page
-			.getByPlaceholder('Search')
+			.getByRole('search')
+			.getByRole('searchbox', {name: 'Search'})
 			.fill('NonExistentView' + getRandomInt());
 
 		await page.keyboard.press('Enter');
@@ -2321,7 +2322,10 @@ test(
 
 		await page.getByRole('link', {name: viewNameB}).waitFor();
 
-		await page.getByPlaceholder('Search').fill(viewNameA);
+		await page
+			.getByRole('search')
+			.getByRole('searchbox', {name: 'Search'})
+			.fill(viewNameA);
 
 		await page.keyboard.press('Enter');
 


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87172

Unscoped `page.getByPlaceholder('Search')` hit strict-mode violations in two `objectView.spec.ts` tests because the portal's side navigation renders its own Search input alongside the page's management toolbar search. Scoping through the `search` landmark + `searchbox` role narrows the locator to the intended element.

Sites fixed:
- `tests/object-web/view/objectView.spec.ts:95` (assert no result message when searching for a custom view)
- `tests/object-web/view/objectView.spec.ts:2324` (can search for a custom view)

## Test plan

- [x] Both `objectView.spec.ts` tests pass locally.
- [x] Format check clean.