### PR TITLE
LPD-87204 Close object field side panel between iterations

### DIFF
--- a/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
+++ b/modules/test/playwright/pages/object-web/object-fields/ObjectFieldsPage.ts
@@ -224,6 +224,14 @@ export class ObjectFieldsPage {
 		});
 	}
 
+	async closeObjectFieldSidePanel() {
+		const cancelButton = this.iframeLocator.getByLabel('Cancel');
+
+		await cancelButton.click();
+
+		await cancelButton.waitFor({state: 'hidden'});
+	}
+
 	async saveObjectField() {
 		await this.editFieldSaveButton.click();
 

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2754,6 +2754,8 @@ test.describe('Manage object fields default value properties', () => {
 					'Error:Please fill out all required fields.',
 					{type: 'danger'}
 				);
+
+				await objectFieldsPage.closeObjectFieldSidePanel();
 			}
 		}
 	);


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87204

Added `ObjectFieldsPage.closeObjectFieldSidePanel()` (clicks the iframe's `Cancel` button) and called it at the end of each iteration so the next `openObjectField` isn't blocked by the previous side panel.

## Test plan

- [x] `default value fields are required` — passes locally (36.2s).
- [x] Format check clean.