### PR TITLE
LPD-87202 Scope Search locator in selectDropdownItemWithSearch

### DIFF
--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -300,7 +300,7 @@ export class ViewObjectEntriesPage {
 	}
 
 	async selectDropdownItemWithSearch(optionName: string) {
-		await this.page.getByPlaceholder('Search').click();
+		await this.page.getByRole('textbox', {name: 'Search'}).click();
 		await this.page.getByRole('menuitem', {name: optionName}).click();
 	}
 


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87202

Replaced the unscoped `page.getByPlaceholder('Search')` in `ViewObjectEntriesPage.selectDropdownItemWithSearch` with `getByRole('textbox', {name: 'Search'})` — the side-navigation Search (type=search / role=searchbox) no longer collides with the dropdown Search (type=text / role=textbox).

## Test plan

- [x] `tests/object-web/hierarchy/objectDefinitionHierarchy.spec.ts:166` — "assert management of object entries that are account restricted" passes locally.
- [x] Format check clean.