### PR TITLE
LPD-87199 Align filled and expected RichText entry length

### DIFF
--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -480,20 +480,20 @@ export class ViewObjectEntriesPage {
 					break;
 				}
 				case 'RichText': {
+					const entry = objectEntry[objectField.name]
+						.toString()
+						.substring(0, 35);
+
 					await this.fillObjectEntry({
 						objectFieldBusinessType: objectField.businessType,
 						objectFieldLabel: objectField.label['en_US'],
 						objectFieldName: objectField.name,
-						objectFieldValue: objectEntry[objectField.name]
-							.toString()
-							.substring(0, 35),
+						objectFieldValue: entry,
 					});
 
 					objectEntries.push({
 						businessType: objectField.businessType,
-						entry: objectEntry[objectField.name]
-							.toString()
-							.substring(0, 34),
+						entry,
 						name: objectField.name,
 					});
 


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87199

`fillObjectFields` was filling the RichText field with `substring(0, 35)` but pushing `substring(0, 34)` as the expected cell text, so the post-save assertion never matched. Store the 35-char value once and reuse it for both sides.

## Test plan

- [x] `tests/object-web/entry/objectEntry.spec.ts:1963` — "can add and update an entry with all object fields" passes locally.
- [x] Format check clean.