### PR TITLE
LPD-87198 Pass __dirname to selectFileFromUserComputer

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -546,7 +546,7 @@ cmsTest.describe('Manage attachment ObjectField storage locations', () => {
 				.click();
 
 			await viewObjectEntriesPage.selectFileFromUserComputer(
-				path.join(__dirname, '../../dependencies'),
+				__dirname,
 				'astronaut.png',
 				1
 			);


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87198

`selectFileFromUserComputer` internally joins `dirName` with `'../dependencies'`. The caller in the CMS-storage test was pre-resolving the parent directory with `path.join(__dirname, '../../dependencies')`, which double-relatived and pointed at a nonexistent `tests/dependencies` folder. Passing `__dirname` matches the 7 other callers.

## Test plan

- [x] `tests/object-web/entry/objectEntry.spec.ts:440` — "can submit object entry with CMS storages types" passes locally.
- [x] Format check clean.