### PR TITLE
LPD-87203 Use CKEditor 5 editable locator for richText default value test

### DIFF
--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -2613,7 +2613,7 @@ test.describe('Manage object fields default value properties', () => {
 				objectDefinition.label['en_US']
 			);
 
-			const richTextEditor = page.frameLocator('iframe[title="editor"]');
+			const richTextEditor = page.getByLabel('Rich Text Editor').nth(1);
 
 			await expect(richTextEditor.getByRole('paragraph')).toHaveText(
 				'defaultValueRichText'


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87203

Switched `page.frameLocator('iframe[title="editor"]')` to `page.getByLabel('Rich Text Editor').nth(1)` — the RichText field now renders CKEditor 5 (no iframe) by default, and the role-based locator matches both editors.

## Test plan

- [x] `tests/object-web/field/objectField.spec.ts:2578` — "can create, read, update and delete the default value of a richText field" passes locally.
- [x] Format check clean.