### PR TITLE
LPD-87169 Use attribute selector for RulesBuilder field-*-id locators

### DIFF
--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/RulesBuilderPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/RulesBuilderPage.ts
@@ -41,20 +41,26 @@ export class RulesBuilderPage {
 			.filter({hasText: 'ActionsDoAutofillFrom Data'})
 			.getByRole('combobox')
 			.nth(1);
-		this.conditionLeftFormFieldSelect = page.getByTestId('field-left-id');
-		this.conditionOperatorSelect = page.getByTestId('field-operator-id');
-		this.conditionOperatorValueSourceSelect = page.getByTestId(
-			'field-binary-operator-id'
+		this.conditionLeftFormFieldSelect = page.locator(
+			'[data-testid="field-left-id"]'
+		);
+		this.conditionOperatorSelect = page.locator(
+			'[data-testid="field-operator-id"]'
+		);
+		this.conditionOperatorValueSourceSelect = page.locator(
+			'[data-testid="field-binary-operator-id"]'
 		);
 		this.conditionRightFormFieldInput = page.locator('#field-right-id');
-		this.conditionRightFormFieldSelect = page.getByTestId('field-right-id');
+		this.conditionRightFormFieldSelect = page.locator(
+			'[data-testid="field-right-id"]'
+		);
 		this.dataProviderInputSelect = page
 			.locator('div.data-provider-parameter-container')
-			.nth(0)
+			.filter({hasText: "Data Provider's Input:"})
 			.getByRole('combobox');
 		this.dataProviderOutputSelect = page
 			.locator('div.data-provider-parameter-container')
-			.nth(1)
+			.filter({hasText: "Data Provider's Output:"})
 			.getByRole('combobox');
 		this.page = page;
 		this.rulesTab = page.getByRole('button', {name: 'Rules'});


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87169

After LPD-80449 switched the `dynamic-data-mapping-form-web.main` playwright config to `testIdAttribute: 'data-qa-id'`, `page.getByTestId('field-*-id')` stopped resolving the rule builder comboboxes (they still render with `data-testid`). Switched the four `field-*-id` locators to attribute-selector form. Also narrowed `dataProviderInputSelect` / `dataProviderOutputSelect` from positional `.nth(0|1)` to text-scoped matches on the "Data Provider's Input:" / "Data Provider's Output:" headings so each locator works independently of the other section's presence.

## Test plan

- [x] `formRules.spec.ts:57` — "Assert multiple selection field associated with rules"
- [x] `formRules.spec.ts:233` — "Assert that Show action rule is not triggered when typing into an unrelated field"
- [x] `formRules.spec.ts:307` — "Select from list with multiple selections allowed is auto-filled by data provider"
- [x] `formFields.spec.ts:483` — "Assert edition of a rich text field predefined value that contains a rule"
- [x] `formSubmission.spec.ts:212` — "can submit manual entry while using data provider autofill rule"
- [x] Format check clean.