### PR TITLE
LPD-87208 Prevent Model Builder sidebar from overlaying Control Panel

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
@@ -8,6 +8,15 @@
 	}
 }
 
+.side-navigation-container.c-slideout-push-start
+	~ .flex-grow-1
+	.lfr-objects__model-builder-custom-vertical-bar.c-slideout-start {
+	@include media-breakpoint-up(md) {
+		inset-inline-start: $c-slideout-sidebar-width;
+		z-index: calc(#{$zindex-c-slideout} - 1);
+	}
+}
+
 .side-panel-content {
 	background-color: $light;
 	display: flex;


### PR DESCRIPTION
 ## Jira                                                                                                                                            
                                                                                                                                                     
  [LPD-87208](https://liferay.atlassian.net/browse/LPD-87208)


## Summary                                                          

  - When the Control Panel side navigation is open, the Model Builder's                                                                              
    fixed left sidebar previously rendered at `left: 0` on top of the
    Control Panel menu, hiding its items and blocking pointer events.                                                                                
  - Offset the sidebar by the Control Panel width (320px) when the                                                                                   
    container has `c-slideout-push-start`, and drop its `z-index` below                                                                              
    Clay's `.c-slideout` (975) so the toggle animation slides it out                                                                                 
    from behind the Control Panel instead of flashing over it.                                                                                       
                                                                                                                                                     


[LPD-87208]: https://liferay.atlassian.net/browse/LPD-87208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ