### PR TITLE
LPD-87171 Expect empty sanitized value for CKEditor 5 script input

### DIFF
--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/richTextCKEditor5.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/richTextCKEditor5.spec.ts
@@ -206,7 +206,7 @@ test(
 );
 
 const content = '<script>alert("Hello! I am an alert box!");</script>';
-const sanitizedContent = '<p>alert("Hello! I am an alert box!");</p>';
+const sanitizedContent = '';
 
 const assertRichTextContent = async (content, expected, newTabPage) => {
 	const sourceButton = newTabPage.getByRole('button', {


### PR DESCRIPTION
**Related Ticket:** https://liferay.atlassian.net/browse/LPD-87171

CKEditor 5 strips the entire `<script>…</script>` element (tag + inner text) by default, so the hidden input stores `""`. The previous expectation `<p>alert("…");</p>` described the input string of CKEditor4 sanitization, not what CKEditor 5 actually persists.

### Evidence from CKEditor 5 source

`packages/ckeditor5-engine/src/view/domconverter.ts` — the engine that converts between model/view and DOM — declares `script` in its `unsafeElements` list:

```ts
/**
 * A list of elements which may affect the editing experience. To avoid this, those elements are replaced with
 * `<span data-ck-unsafe-element="[element name]"></span>` while rendering in the editing mode.
 */
this.unsafeElements = [ 'script', 'style' ];
```

Source: https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-engine/src/view/domconverter.ts

During DOM conversion the whole `<script>` element — *and its children* — is replaced with the placeholder span. On `getData()` export that placeholder does not serialize back into `<script>`, and the original inner text is gone. That's why the hidden input stores `""` for input that was entirely wrapped in a script element.

The CKE4 sibling test in `richText.spec.ts:188` is unaffected and keeps its own (less strict) expectation.

## Test plan

- [x] `richTextCKEditor5.spec.ts:276` — "Can not add scripts to the rich text field @LPD-31212" passes locally.
- [x] Format check clean.