### PR TITLE
LPD-87192 Update Applications menu locators for new Control Panel UI

### DIFF
--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -101,7 +101,7 @@ export class ApplicationsMenuPage {
 			exact: true,
 			name: 'API Builder',
 		});
-		this.applicationsMenuTabButton = page.getByRole('tab', {
+		this.applicationsMenuTabButton = page.getByRole('menuitem', {
 			name: 'Applications',
 		});
 		this.appManagerMenuItem = page.getByRole('menuitem', {
@@ -274,7 +274,7 @@ export class ApplicationsMenuPage {
 			exact: true,
 			name: 'Picklists',
 		});
-		this.processBuilderItem = page.getByRole('menuitem', {
+		this.processBuilderItem = page.getByRole('link', {
 			exact: true,
 			name: 'Process Builder',
 		});


### PR DESCRIPTION
## Summary

The Control Panel's Applications menu now renders as `menuitem` (not `tab`) and its children are `link` roles (not `menuitem`). Updated `ApplicationsMenuPage` locators so the filter flow tests can reach Process Builder again.

## Test plan
- [x] `./node_modules/.bin/playwright test objectView.spec.ts -g "can edit a filter in custom view"`
- [x] `./node_modules/.bin/playwright test objectView.spec.ts -g "can filter entries by status in custom view"`
- [x] Format check passes