### PR TITLE
LPD-85642 Preserve urlTitle slashes after peeling the group prefix

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -96,17 +96,15 @@ public class ObjectEntryLayoutDisplayPageProvider
 		getLayoutDisplayPageObjectProvider(long groupId, String urlTitle) {
 
 		if (urlTitle.contains(StringPool.SLASH)) {
-			String[] urlNames = urlTitle.split(StringPool.SLASH);
+			String[] urlNames = urlTitle.split(StringPool.SLASH, 2);
 
-			if (urlNames.length > 1) {
-				Group group = _groupLocalService.fetchFriendlyURLGroup(
-					CompanyThreadLocal.getCompanyId(),
-					StringPool.SLASH + urlNames[0]);
+			Group group = _groupLocalService.fetchFriendlyURLGroup(
+				CompanyThreadLocal.getCompanyId(),
+				StringPool.SLASH + urlNames[0]);
 
-				if (group != null) {
-					return getLayoutDisplayPageObjectProvider(
-						group.getGroupId(), urlNames[1]);
-				}
+			if (group != null) {
+				return getLayoutDisplayPageObjectProvider(
+					group.getGroupId(), urlNames[1]);
 			}
 		}
 

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProviderTest.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.layout.display.page;
+
+import com.liferay.asset.util.AssetHelper;
+import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
+import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ObjectEntryLayoutDisplayPageProviderTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_groupLocalService = Mockito.mock(GroupLocalService.class);
+		_objectDefinition = Mockito.mock(ObjectDefinition.class);
+		_objectEntryLocalService = Mockito.mock(ObjectEntryLocalService.class);
+
+		_objectEntryLayoutDisplayPageProvider =
+			new ObjectEntryLayoutDisplayPageProvider(
+				Mockito.mock(AssetHelper.class), _groupLocalService,
+				Mockito.mock(InfoItemFriendlyURLProvider.class),
+				_objectDefinition,
+				Mockito.mock(ObjectDefinitionLocalService.class),
+				_objectEntryLocalService,
+				Mockito.mock(ObjectEntryManager.class),
+				Mockito.mock(ObjectRelationshipLocalService.class),
+				Mockito.mock(UserLocalService.class));
+	}
+
+	@Test
+	public void testGetLayoutDisplayPageObjectProvider() {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_COMPANY_ID)) {
+
+			_testGetLayoutDisplayPageObjectProviderWithGroupPrefix();
+			_testGetLayoutDisplayPageObjectProviderWithGroupPrefixAndNestedUrlTitle();
+			_testGetLayoutDisplayPageObjectProviderWithSlashWithoutGroupPrefix();
+			_testGetLayoutDisplayPageObjectProviderWithoutSlash();
+		}
+	}
+
+	private void _assertGetLayoutDisplayPageObjectProvider(
+		ObjectEntry expectedObjectEntry, String urlTitle) {
+
+		LayoutDisplayPageObjectProvider<ObjectEntry>
+			layoutDisplayPageObjectProvider =
+				_objectEntryLayoutDisplayPageProvider.
+					getLayoutDisplayPageObjectProvider(
+						_REQUEST_GROUP_ID, urlTitle);
+
+		Assert.assertNotNull(layoutDisplayPageObjectProvider);
+		Assert.assertSame(
+			expectedObjectEntry,
+			layoutDisplayPageObjectProvider.getDisplayObject());
+	}
+
+	private void _setUpFriendlyURLGroup(String friendlyURL, long groupId) {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		Mockito.when(
+			_groupLocalService.fetchFriendlyURLGroup(_COMPANY_ID, friendlyURL)
+		).thenReturn(
+			group
+		);
+	}
+
+	private ObjectEntry _setUpObjectEntry(long groupId, String urlTitle) {
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(
+				groupId, _objectDefinition, urlTitle)
+		).thenReturn(
+			objectEntry
+		);
+
+		return objectEntry;
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderWithGroupPrefix() {
+		ObjectEntry objectEntry = _setUpObjectEntry(_GROUP_ID, "parent/child");
+
+		_setUpFriendlyURLGroup(
+			StringPool.SLASH + _GROUP_FRIENDLY_URL, _GROUP_ID);
+
+		_assertGetLayoutDisplayPageObjectProvider(
+			objectEntry, _GROUP_FRIENDLY_URL + "/parent/child");
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderWithGroupPrefixAndNestedUrlTitle() {
+		ObjectEntry objectEntry = _setUpObjectEntry(
+			_GROUP_ID, "parent/child/grandchild");
+
+		_setUpFriendlyURLGroup(
+			StringPool.SLASH + _GROUP_FRIENDLY_URL, _GROUP_ID);
+
+		_assertGetLayoutDisplayPageObjectProvider(
+			objectEntry, _GROUP_FRIENDLY_URL + "/parent/child/grandchild");
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderWithoutSlash() {
+		ObjectEntry objectEntry = _setUpObjectEntry(
+			_REQUEST_GROUP_ID, _URL_TITLE);
+
+		_assertGetLayoutDisplayPageObjectProvider(objectEntry, _URL_TITLE);
+	}
+
+	private void _testGetLayoutDisplayPageObjectProviderWithSlashWithoutGroupPrefix() {
+		ObjectEntry objectEntry = _setUpObjectEntry(
+			_REQUEST_GROUP_ID, "parent/child");
+
+		_assertGetLayoutDisplayPageObjectProvider(objectEntry, "parent/child");
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final String _GROUP_FRIENDLY_URL =
+		RandomTestUtil.randomString();
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final long _REQUEST_GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final String _URL_TITLE = RandomTestUtil.randomString();
+
+	private GroupLocalService _groupLocalService;
+	private ObjectDefinition _objectDefinition;
+	private ObjectEntryLayoutDisplayPageProvider
+		_objectEntryLayoutDisplayPageProvider;
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85642

**What is being fixed:** Basic Web Content articles in the new CMS whose
friendlyURL contains a forward slash (e.g. `hello/goodbye`) returned a 404
when clicking through to their default Display Page Template. The resolver
split the urlTitle on every slash and recursed with only the second segment,
dropping everything past it.

**How it is being fixed:** `ObjectEntryLayoutDisplayPageProvider` now uses
`split(SLASH, 2)` so the segment after the leading group friendly URL prefix
keeps its slashes intact and reaches `fetchObjectEntry` as the full urlTitle.

## Tests

Added unit test `ObjectEntryLayoutDisplayPageProviderTest` covering: group
prefix + slashed urlTitle, group prefix + nested urlTitle, slashed urlTitle
without group prefix, and single-segment urlTitle.

    gradlew -p modules/apps/object/object-web test --tests '*ObjectEntryLayoutDisplayPageProviderTest'

## Out of scope

A separate producer-side bug surfaced during manual testing: a leading slash
in the article's friendlyURL (e.g. `/hello/goodbye`) yields a double-slash
URL like `asset-library-XXXX//hello/goodbye`. Legacy web content normalizes
this on write; the new CMS does not. Tracked separately in
[LPD-87493](https://liferay.atlassian.net/browse/LPD-87493).

---

_AI-assisted with Claude Code (Opus 4.7)._

[LPD-87493]: https://liferay.atlassian.net/browse/LPD-87493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ