### PR TITLE
LPD-87493 Normalize leading and consecutive slashes in object entry friendly URLs

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -8132,12 +8132,12 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		Assert.assertEquals(
-			jsonObject.get("externalReferenceCode"),
+			jsonObject.getString("externalReferenceCode"),
 			jsonObject.getString("friendlyUrlPath"));
 
 		jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
-				"friendlyUrlPath", "Test URL"
+				"friendlyUrlPath", StringPool.SLASH
 			).toString(),
 			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
 
@@ -8148,7 +8148,12 @@ public class ObjectEntryResourceTest {
 			Http.Method.GET);
 
 		Assert.assertEquals(
-			"test-url", jsonObject.getString("friendlyUrlPath"));
+			jsonObject.getString("externalReferenceCode"),
+			jsonObject.getString("friendlyUrlPath"));
+
+		_assertGetObjectEntryWithFriendlyURL("hello-world", "/hello-world");
+		_assertGetObjectEntryWithFriendlyURL("parent/child", "parent//child");
+		_assertGetObjectEntryWithFriendlyURL("test-url", "Test URL");
 	}
 
 	@Test
@@ -15850,6 +15855,26 @@ public class ObjectEntryResourceTest {
 		Assert.assertEquals(
 			String.valueOf(expectedObjectFieldValue),
 			String.valueOf(itemJSONObject.get(expectedObjectFieldName)));
+	}
+
+	private void _assertGetObjectEntryWithFriendlyURL(
+			String expectedFriendlyUrlPath, String friendlyUrlPath)
+		throws Exception {
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"friendlyUrlPath", friendlyUrlPath
+			).toString(),
+			_objectDefinition1.getRESTContextPath(), Http.Method.POST);
+
+		jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			_objectDefinition1.getRESTContextPath() + StringPool.SLASH +
+				jsonObject.getString("id"),
+			Http.Method.GET);
+
+		Assert.assertEquals(
+			expectedFriendlyUrlPath, jsonObject.getString("friendlyUrlPath"));
 	}
 
 	private void _assertInvocations(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2690,15 +2690,21 @@ public class ObjectEntryLocalServiceImpl
 		Map<String, String> urlTitleMap = new HashMap<>();
 
 		for (Map.Entry<String, String> entry : friendlyUrlMap.entrySet()) {
-			if (Validator.isNull(entry.getValue())) {
+			String friendlyURL = entry.getValue();
+
+			if (Validator.isNull(friendlyURL)) {
 				continue;
+			}
+
+			if (friendlyURL.startsWith(StringPool.SLASH)) {
+				friendlyURL = friendlyURL.replaceAll("^/+", StringPool.BLANK);
 			}
 
 			urlTitleMap.put(
 				entry.getKey(),
 				_friendlyURLEntryLocalService.getUniqueUrlTitle(
 					groupId, classNameId, objectEntry.getObjectEntryId(),
-					entry.getValue(), entry.getKey()));
+					friendlyURL, entry.getKey()));
 		}
 
 		urlTitleMap.computeIfAbsent(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2700,6 +2700,10 @@ public class ObjectEntryLocalServiceImpl
 				friendlyURL = friendlyURL.replaceAll("^/+", StringPool.BLANK);
 			}
 
+			if (friendlyURL.contains(StringPool.SLASH)) {
+				friendlyURL = friendlyURL.replaceAll("/+", StringPool.SLASH);
+			}
+
 			urlTitleMap.put(
 				entry.getKey(),
 				_friendlyURLEntryLocalService.getUniqueUrlTitle(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2704,6 +2704,10 @@ public class ObjectEntryLocalServiceImpl
 				friendlyURL = friendlyURL.replaceAll("/+", StringPool.SLASH);
 			}
 
+			if (Validator.isNull(friendlyURL)) {
+				continue;
+			}
+
 			urlTitleMap.put(
 				entry.getKey(),
 				_friendlyURLEntryLocalService.getUniqueUrlTitle(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87493                                                                                                                
   
  **What is being fixed:** When a user creates a new CMS Basic Web Content (or any CMS object entry) with a `friendlyUrlPath` that has a leading slash like     
  `/hello`, the stored URL title keeps that leading slash. The display-page URL builder then concatenates it after another `/`
  (`groupFriendlyURL.replaceFirst("/", "") + "/" + urlTitle`), producing a double slash like `asset-library-xxx//hello` and a 404 when the user clicks through. 
                                                      
  **How it is being fixed:** Normalize the friendly URL at the save path, mirroring the pattern already used by                                                 
  `JournalArticleLocalServiceImpl._getUrlTitleMap`. In `ObjectEntryLocalServiceImpl._addFriendlyURLEntry` — the shared add and update entry point for any object
   definition with friendly URL customization — strip leading slashes (`^/+` → `""`), collapse consecutive interior slashes (`/+` → `/`), and skip the entry if 
  the result is empty before delegating to `FriendlyURLEntryLocalService.getUniqueUrlTitle`. The fix applies to both Basic Web Content and Basic Document, and
  the leading-slash strip coexists cleanly with LPD-85642's interior-slash support — single `/` separators between segments are preserved.

  **Tests:** `ObjectEntryResourceTest.testGetObjectEntryWithFriendlyURL` was extended to cover the new normalization, and the helper that drives the            
  explicit-input cases was renamed to `_assertGetObjectEntryWithFriendlyURL` to match the test name:
                                                                                                                                                                
  - (no `friendlyUrlPath` supplied) → falls back to the entry's external reference code (existing)                                                              
  - `/` → empty after stripping, falls back to the entry's external reference code (new)
  - `/hello-world` → `hello-world` (leading-slash strip)                                                                                                        
  - `parent//child` → `parent/child` (consecutive interior slash collapse)                                                                                      
  - `Test URL` → `test-url` (existing whitespace + capitals normalization)                                                                                      
                                                                                                                                                                
  Run with:                                                                                                                                                     
                                                                                                                                                                
      gradlew -p modules/apps/object/object-rest-test testIntegration --tests  com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest.testGetObjectEntryWithFriendlyURL
                                                                                                                                                                
  ---                                                 
                                         
  _AI-assisted with Claude Code (Opus 4.7)._ 