### PR TITLE
LPD-87247 Multi-upload in CMS Files fails with duplicate key violation on DLFolder unique constraint

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/attachment/AttachmentManagerImpl.java
@@ -32,6 +32,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.lock.LockProtectedAction;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
@@ -39,6 +40,9 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProvider;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -129,22 +133,36 @@ public class AttachmentManagerImpl implements AttachmentManager {
 			ServiceContext serviceContext, long userId)
 		throws PortalException {
 
-		Repository repository = _getRepository(
-			groupId, portletId, serviceContext);
+		LockProtectedAction<DLFolder> lockProtectedAction =
+			new LockProtectedAction<DLFolder>(
+				AttachmentManager.class,
+				StringUtil.merge(
+					new Object[] {groupId, portletId, userId},
+					StringPool.POUND),
+				10000, 100) {
 
-		DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
-			repository.getGroupId(), repository.getDlFolderId(),
-			String.valueOf(userId));
+				@Override
+				protected DLFolder performProtectedAction()
+					throws PortalException {
 
-		if (dlFolder != null) {
-			return dlFolder;
+					try {
+						return _getOrAddDLFolder(
+							companyId, groupId, portletId, serviceContext,
+							userId);
+					}
+					catch (Throwable throwable) {
+						throw new PortalException(throwable);
+					}
+				}
+
+			};
+
+		do {
+			lockProtectedAction.performAction();
 		}
+		while (lockProtectedAction.getReturnValue() == null);
 
-		return _dlFolderLocalService.addFolder(
-			null, _userLocalService.getGuestUserId(companyId),
-			repository.getGroupId(), repository.getRepositoryId(), false,
-			repository.getDlFolderId(), String.valueOf(userId), null, false,
-			_getServiceContext(serviceContext));
+		return lockProtectedAction.getReturnValue();
 	}
 
 	@Override
@@ -326,6 +344,33 @@ public class AttachmentManagerImpl implements AttachmentManager {
 		return value * _FILE_LENGTH_MB;
 	}
 
+	private DLFolder _getOrAddDLFolder(
+			long companyId, long groupId, String portletId,
+			ServiceContext serviceContext, long userId)
+		throws Throwable {
+
+		return TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				Repository repository = _getRepository(
+					groupId, portletId, serviceContext);
+
+				DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
+					repository.getGroupId(), repository.getDlFolderId(),
+					String.valueOf(userId));
+
+				if (dlFolder != null) {
+					return dlFolder;
+				}
+
+				return _dlFolderLocalService.addFolder(
+					null, _userLocalService.getGuestUserId(companyId),
+					repository.getGroupId(), repository.getRepositoryId(),
+					false, repository.getDlFolderId(), String.valueOf(userId),
+					null, false, _getServiceContext(serviceContext));
+			});
+	}
+
 	private Repository _getRepository(
 			long groupId, String portletId, ServiceContext serviceContext)
 		throws PortalException {
@@ -422,6 +467,10 @@ public class AttachmentManagerImpl implements AttachmentManager {
 	}
 
 	private static final long _FILE_LENGTH_MB = 1024 * 1024;
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRES_NEW, new Class<?>[] {Exception.class});
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/attachment/test/AttachmentManagerTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -47,11 +48,21 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -269,6 +280,80 @@ public class AttachmentManagerTest {
 		}
 	}
 
+	@Test
+	public void testGetOrAddFileEntryConcurrent() throws Exception {
+		_attachmentManager.getOrAddFileEntry(
+			_objectField.getCompanyId(), RandomTestUtil.randomString(),
+			DLTestUtil.randomTextFileBytes(), "warmup.png",
+			TestPropsValues.getGroupId(), _objectField.getObjectFieldId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			_THREAD_COUNT);
+
+		List<FileEntry> fileEntries = new CopyOnWriteArrayList<>();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.spi.SqlExceptionHelper",
+				LoggerTestUtil.OFF)) {
+
+			CountDownLatch finishCountDownLatch = new CountDownLatch(
+				_THREAD_COUNT);
+			CountDownLatch startCountDownLatch = new CountDownLatch(1);
+
+			User user = UserTestUtil.addUser();
+
+			ServiceContext serviceContext =
+				ServiceContextTestUtil.getServiceContext();
+
+			serviceContext.setUserId(user.getUserId());
+
+			for (int i = 0; i < _THREAD_COUNT; i++) {
+				String fileName = "file" + i + ".png";
+
+				executorService.submit(
+					new CompanyInheritableThreadLocalCallable<Runnable>(
+						() -> {
+							try {
+								startCountDownLatch.await();
+
+								fileEntries.add(
+									_attachmentManager.getOrAddFileEntry(
+										_objectField.getCompanyId(),
+										RandomTestUtil.randomString(),
+										DLTestUtil.randomTextFileBytes(),
+										fileName, TestPropsValues.getGroupId(),
+										_objectField.getObjectFieldId(),
+										serviceContext));
+							}
+							finally {
+								finishCountDownLatch.countDown();
+							}
+
+							return null;
+						}));
+			}
+
+			startCountDownLatch.countDown();
+
+			Assert.assertTrue(finishCountDownLatch.await(60, TimeUnit.SECONDS));
+		}
+		finally {
+			executorService.shutdown();
+		}
+
+		Assert.assertEquals(
+			fileEntries.toString(), _THREAD_COUNT, fileEntries.size());
+
+		Set<Long> folderIds = new HashSet<>();
+
+		for (FileEntry fileEntry : fileEntries) {
+			folderIds.add(fileEntry.getFolderId());
+		}
+
+		Assert.assertEquals(folderIds.toString(), 1, folderIds.size());
+	}
+
 	private ObjectDefinition _addObjectDefinition(String acceptedFileExtensions)
 		throws Exception {
 
@@ -317,6 +402,8 @@ public class AttachmentManagerTest {
 			TempFileEntryUtil.getTempFileName(fileName + extension),
 			FileUtil.createTempFile(content), mimeType);
 	}
+
+	private static final int _THREAD_COUNT = 8;
 
 	@Inject
 	private AttachmentManager _attachmentManager;


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPD-87247