### PR TITLE
LPD-76967 Extra line on the bottom of comment section (Project Detail and Task)

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
@@ -244,10 +244,11 @@ export default function CommentsPanel({
 
 			{comments.length ? (
 				<ul className="p-0">
-					{comments.map((comment) => (
+					{comments.map((comment, index) => (
 						<CommentNode
 							comment={comment}
 							editorConfig={editorConfig}
+							isLast={index === comments.length - 1}
 							key={comment.commentId}
 							onDeleteComment={deleteComment}
 							onSaveComment={saveComment}
@@ -262,12 +263,14 @@ export default function CommentsPanel({
 function CommentNode({
 	comment,
 	editorConfig,
+	isLast,
 	onDeleteComment,
 	onSaveComment,
 	parentCommentId,
 }: {
 	comment: Comment;
 	editorConfig: LiferayEditorConfig;
+	isLast: boolean;
 	onDeleteComment: (
 		commentId: string,
 		parentCommentId?: string
@@ -293,7 +296,8 @@ function CommentNode({
 		<>
 			<li
 				className={classNames('list-unstyled pl-3', {
-					'border-bottom pr-3 py-3': comment.rootComment,
+					'border-bottom': comment.rootComment && !isLast,
+					'pr-3 py-3': comment.rootComment,
 				})}
 			>
 				<article>
@@ -379,10 +383,13 @@ function CommentNode({
 
 					{comment.children?.length ? (
 						<ul className="border-left border-secondary pl-0">
-							{comment.children.map((child: Comment) => (
+							{comment.children.map((child: Comment, index) => (
 								<CommentNode
 									comment={child}
 									editorConfig={editorConfig}
+									isLast={
+										index === comment.children.length - 1
+									}
 									key={child.commentId}
 									onDeleteComment={onDeleteComment}
 									onSaveComment={onSaveComment}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/panels/CommentsPanel.tsx
@@ -226,7 +226,11 @@ export default function CommentsPanel({
 	return (
 		<>
 			{addCommentURL && (
-				<div className="border-bottom pb-2 px-3">
+				<div
+					className={classNames('pb-2 px-3', {
+						'border-bottom': comments.length,
+					})}
+				>
 					<label>{Liferay.Language.get('add-comment')}</label>
 
 					<CommentEditor


### PR DESCRIPTION
# Summary of Changes

The line at the bottom is removed when there are no comments.
The line is also removed for the last comment. 
(The current behavior of having no lines between child comments is kept.)

# Motivation / Context

[LPD-76967](https://liferay.atlassian.net/browse/LPD-76967)

Lines are meant to be separators between (root) comments so they shouldn't be there when there are no comments at all or after the last comment.

# Technical Approach

- Check if there are any comments to skip the CSS class `border-bottom`.
- Check for the last comment to also skip the CSS class `border-bottom`. 
- - This requires adding a prop `isLast` to `<CommentNode`. 
- - The children comments have a computed prop `isLast` but is not used because for these comments no border is displayed. 

# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [x] Not applicable (explain why)

Aesthetic change, not functional.

**Manual Testing**

- Environment: Liferay with CMS and CMP (activating beta feature flag LPD-58677)
- Steps:
  1. Create a space in CMS.
  2. Create a Project.
  3. In the activity section check the Comments tab.
- Expected result: When there are no comments, there should be no horizontal line at the bottom, nor should there be after the last comment.
- Actual result: There's a horizontal line when there are no comments and after the last comment, when there are some.
(Same thing for tasks associated to projects.)

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/3e6baa30-d3b7-4a52-8765-2598e68727bc) |![after](https://github.com/user-attachments/assets/0d63307a-b033-4d88-8887-b0279d190968) |


# Alternatives Considered

The original [LPD-76967](https://liferay.atlassian.net/browse/LPD-76967) doesn't consider the case of removing the line after the last comment or it considers it's ok to have it.

I've chosen to add a second commit to remove this line as well, based on the idea that lines should separate comments. If it's not something the team wants, please revert or remove that second commit. 

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.


[LPD-76967]: https://liferay.atlassian.net/browse/LPD-76967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-76967]: https://liferay.atlassian.net/browse/LPD-76967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ