### PR TITLE
LPD-87683 [Test Fix] HSQL dead lock issue in com.liferay.object.definition.tree.manager.test.ObjectDefinitionTreeUtilTest

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
@@ -612,7 +612,7 @@ public class ObjectDefinitionTreeUtil {
 						objectRelationship.getObjectFieldId2());
 
 				_performActions(
-					false, objectDefinition1, objectEntryLocalService, true,
+					false, objectDefinition1, objectEntryLocalService, false,
 					objectEntry -> _runSQL(
 						objectRelationshipPersistence,
 						StringBundler.concat(


### PR DESCRIPTION
[LPD-87683](https://liferay.atlassian.net/browse/LPD-87683)
[LPD-87721](https://liferay.atlassian.net/browse/LPD-87721)                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                
## What changed

In `ObjectDefinitionTreeUtil._updateObjectDefinitionTree`, the parallel
`ActionableDynamicQuery` that propagates `rootObjectEntryId` to child
entries is now sequential (`parallel=false`). The reindex call right after
it stays parallel.

## Why it solves the problem

The HSQL deadlock comes from a classic parent/worker cycle:

- The parent transaction holds row locks on `ObjectEntry`.
- The parallel workers open new transactions and try to update the same
  table — they can't, because the parent still holds the locks.
- The parent waits on `FutureTask.get()` for the workers to finish.
- HSQL has no deadlock detector, so the test hangs forever.

Making the propagation sequential removes the workers entirely. The parent
does the updates itself, in its own transaction. No workers, no cycle, no
deadlock.

As a bonus, this also restores atomicity: if the parent transaction rolls
back, the propagation rolls back with it. Today the parallel workers
commit independently, so a parent rollback can leave orphan rows.

## Why the performance hit doesn't matter

This is an edge case. The code only runs when:

- An Object Definition's tree relationship is created or removed
  (`unbindObjectDefinitions` / `_publishObjectDefinition`).
- The affected definition is `isApproved()` and has child entries.

It's admin-path code, not request-path. It runs rarely, on a bounded
number of entries, and isn't user-facing latency. Running it sequentially
adds a few seconds at most in realistic tenants — nobody will notice.

## Precedent

Same pattern was applied in
https://github.com/brianchandotcom/liferay-portal/pull/171562.

[LPD-87683]: https://liferay.atlassian.net/browse/LPD-87683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LPD-87721]: https://liferay.atlassian.net/browse/LPD-87721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ