### PR TITLE
LPD-87921 While reindexing dont fetch the nested field values using fieldset name.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesConverterUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesConverterUtil.java
@@ -57,29 +57,6 @@ public class DDMFormValuesConverterUtil {
 		return newDDMFormFieldValues;
 	}
 
-	public static List<DDMFormFieldValue> getDDMFormFieldValues(
-		Collection<DDMFormField> ddmFormFields,
-		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap) {
-
-		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
-
-		for (DDMFormField ddmFormField : ddmFormFields) {
-			List<DDMFormFieldValue> ddmFormFieldValues =
-				ddmFormFieldValuesMap.get(ddmFormField.getName());
-
-			if (ddmFormFieldValues != null) {
-				for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
-					_populateNestedValues(
-						ddmFormField, ddmFormFieldValue, ddmFormFieldValuesMap);
-
-					newDDMFormFieldValues.add(ddmFormFieldValue);
-				}
-			}
-		}
-
-		return newDDMFormFieldValues;
-	}
-
 	private static DDMFormFieldValue _createDefaultDDMFormFieldValue(
 		DDMFormField ddmFormField) {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -1223,7 +1223,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 			DDMForm ddmForm = ddmStructure.getFullHierarchyDDMForm(false);
 
 			List<DDMFormFieldValue> ddmFormFieldValues =
-				DDMFormValuesConverterUtil.getDDMFormFieldValues(
+				DDMFormValuesConverterUtil.addMissingDDMFormFieldValues(
 					ddmForm.getDDMFormFields(),
 					ddmFormValues.getDDMFormFieldValuesMap(true));
 


### PR DESCRIPTION
# What is this trying to solve?

[{LPD-87921}
](https://liferay.atlassian.net/browse/LPD-87921)
When running reindex the nested ddm field values of a ddm form are fetched using fieldset name in getDDMFromFieldValue, which gives empty results.

# How am I fixing it?

Reusing addMissingDDMFormFieldValues which is identical to the getDDMFromFieldValue method and also aligns the indexer with the same conversion path used everywhere else.

# How can you verify that it works?

  This scenario is already covered by testAddMissingNestedDDMFormFieldValues