### PR TITLE
LPD-87855 Preserve empty default value when saving structure

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtil.java
@@ -216,10 +216,16 @@ public class DataDefinitionDDMFormUtil {
 			_toDDMFormFields(
 				dataDefinitionField.getNestedDataDefinitionFields(),
 				ddmFormFieldTypeServicesRegistry, languageId));
-		ddmFormField.setPredefinedValue(
-			LocalizedValueUtil.toLocalizedValue(
-				dataDefinitionField.getDefaultValue(),
-				LocaleUtil.fromLanguageId(languageId)));
+
+		Map<String, Object> defaultValue =
+			dataDefinitionField.getDefaultValue();
+
+		if (MapUtil.isNotEmpty(defaultValue)) {
+			ddmFormField.setPredefinedValue(
+				LocalizedValueUtil.toLocalizedValue(
+					defaultValue, LocaleUtil.fromLanguageId(languageId)));
+		}
+
 		ddmFormField.setReadOnly(
 			GetterUtil.getBoolean(dataDefinitionField.getReadOnly()));
 		ddmFormField.setRepeatable(

--- a/modules/apps/data-engine/data-engine-rest-api/src/test/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtilTest.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/test/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtilTest.java
@@ -82,6 +82,14 @@ public class DataDefinitionDDMFormUtilTest {
 	}
 
 	@Test
+	public void testToDDMForm() {
+		_testToDDMFormWithEmptyDataDefinition();
+		_testToDDMFormWithNullDataDefinition();
+		_testToDDMFormWithoutDefaultValue(null);
+		_testToDDMFormWithoutDefaultValue(Collections.emptyMap());
+	}
+
+	@Test
 	public void testToDDMFormEquals() {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
 			SetUtil.fromArray(LocaleUtil.BRAZIL, LocaleUtil.US), LocaleUtil.US);
@@ -185,29 +193,6 @@ public class DataDefinitionDDMFormUtilTest {
 					}
 				},
 				_ddmFormFieldTypeServicesRegistry));
-	}
-
-	@Test
-	public void testToDDMFormWithEmptyDataDefinition() {
-		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
-			new DataDefinition(), null);
-
-		Assert.assertTrue(SetUtil.isEmpty(ddmForm.getAvailableLocales()));
-		Assert.assertTrue(ListUtil.isEmpty(ddmForm.getDDMFormFields()));
-		Assert.assertEquals(
-			"en_US", LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()));
-	}
-
-	@Test
-	public void testToDDMFormWithNullDataDefinition() {
-		Assert.assertEquals(
-			new DDMForm(), DataDefinitionDDMFormUtil.toDDMForm(null, null));
-	}
-
-	@Test
-	public void testToDDMFormWithoutDefaultValue() {
-		_testToDDMFormWithoutDefaultValue(Collections.emptyMap());
-		_testToDDMFormWithoutDefaultValue(null);
 	}
 
 	private DataDefinitionField[] _getDataDefinitionFields() {
@@ -326,6 +311,21 @@ public class DataDefinitionDDMFormUtilTest {
 		).when(
 			ddmFormFieldType
 		).getDDMFormFieldTypeSettings();
+	}
+
+	private void _testToDDMFormWithEmptyDataDefinition() {
+		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
+			new DataDefinition(), null);
+
+		Assert.assertTrue(SetUtil.isEmpty(ddmForm.getAvailableLocales()));
+		Assert.assertTrue(ListUtil.isEmpty(ddmForm.getDDMFormFields()));
+		Assert.assertEquals(
+			"en_US", LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()));
+	}
+
+	private void _testToDDMFormWithNullDataDefinition() {
+		Assert.assertEquals(
+			new DDMForm(), DataDefinitionDDMFormUtil.toDDMForm(null, null));
 	}
 
 	private void _testToDDMFormWithoutDefaultValue(

--- a/modules/apps/data-engine/data-engine-rest-api/src/test/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtilTest.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/test/java/com/liferay/data/engine/rest/dto/v2_0/util/DataDefinitionDDMFormUtilTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -203,6 +204,12 @@ public class DataDefinitionDDMFormUtilTest {
 			new DDMForm(), DataDefinitionDDMFormUtil.toDDMForm(null, null));
 	}
 
+	@Test
+	public void testToDDMFormWithoutDefaultValue() {
+		_testToDDMFormWithoutDefaultValue(Collections.emptyMap());
+		_testToDDMFormWithoutDefaultValue(null);
+	}
+
 	private DataDefinitionField[] _getDataDefinitionFields() {
 		return new DataDefinitionField[] {
 			new DataDefinitionField() {
@@ -319,6 +326,36 @@ public class DataDefinitionDDMFormUtilTest {
 		).when(
 			ddmFormFieldType
 		).getDDMFormFieldTypeSettings();
+	}
+
+	private void _testToDDMFormWithoutDefaultValue(
+		Map<String, Object> defaultValueMap) {
+
+		DDMForm ddmForm = DataDefinitionDDMFormUtil.toDDMForm(
+			new DataDefinition() {
+				{
+					availableLanguageIds = new String[] {"en_US"};
+					dataDefinitionFields = new DataDefinitionField[] {
+						new DataDefinitionField() {
+							{
+								defaultValue = defaultValueMap;
+								fieldType = "text";
+								name = "name1";
+							}
+						}
+					};
+					defaultLanguageId = "en_US";
+				}
+			},
+			_ddmFormFieldTypeServicesRegistry);
+
+		List<DDMFormField> ddmFormFields = ddmForm.getDDMFormFields();
+
+		Assert.assertEquals(ddmFormFields.toString(), 1, ddmFormFields.size());
+		Assert.assertNull(
+			ddmFormFields.get(
+				0
+			).getPredefinedValue());
 	}
 
 	private void _whenLanguageIsAvailableLocale(Locale locale) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87855

# What is this trying to solve?

When a Web Content Structure had its default values reset (Edit Default Values → Reset Values) and the user then edited the structure (e.g., changed a field label) and saved, the field's `defaultValue` was silently repopulated with `{"en_US": ""}` instead of remaining `{}`. This made every subsequent structure-edit cycle leak the instance default language back into the export, defeating the user's reset.

# How am I fixing it?

The round-trip from `DataDefinitionField.defaultValue` to `DDMFormField.predefinedValue` runs through `LocalizedValueUtil.toLocalizedValue`, which deliberately seeds an empty input with `{<defaultLocale>: ""}` (introduced by LPD-41969 for the label/tip paths). Because that seeding is load-bearing for the other localized fields, the fix sits at the call site instead of the shared util: `DataDefinitionDDMFormUtil._toDDMFormField` now skips `setPredefinedValue` whenever `defaultValue` is null or empty. A freshly constructed `DDMFormField` leaves `predefinedValue` at null, and `LocalizedValueUtil.toLocalizedValuesMap(null)` returns `Collections.emptyMap()`, so a null `predefinedValue` round-trips back to `defaultValue: {}` on read — preserving the user's reset across structure edits.

# How can you verify that it works?

Run the included automated tests.