### PR TITLE
LPD-85011 Add missing ERC info field for proxy object entries

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -356,6 +356,10 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				objectEntry.getExpirationDate()));
 		objectEntryFieldValues.add(
 			new InfoFieldValue<>(
+				ObjectEntryInfoItemFields.externalReferenceCodeInfoField,
+				objectEntry.getExternalReferenceCode()));
+		objectEntryFieldValues.add(
+			new InfoFieldValue<>(
 				ObjectEntryInfoItemFields.modifiedDateInfoField,
 				objectEntry.getDateModified()));
 		objectEntryFieldValues.add(

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.provider;
+
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.field.reader.InfoItemFieldReaderFieldSetProvider;
+import com.liferay.layout.page.template.info.item.provider.DisplayPageInfoItemFieldSetProvider;
+import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.info.field.converter.ObjectFieldInfoFieldConverter;
+import com.liferay.object.info.item.ObjectEntryInfoItemFields;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.web.internal.model.ProxyObjectEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Yuri Monteiro
+ */
+public class ObjectEntryInfoItemFieldValuesProviderTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = Mockito.mock(ObjectDefinition.class);
+
+		Mockito.when(
+			_objectDefinition.isDefaultStorageType()
+		).thenReturn(
+			false
+		);
+
+		DisplayPageInfoItemFieldSetProvider
+			displayPageInfoItemFieldSetProvider = Mockito.mock(
+				DisplayPageInfoItemFieldSetProvider.class);
+
+		Mockito.when(
+			displayPageInfoItemFieldSetProvider.getInfoFieldValues(
+				Mockito.any(), Mockito.anyString(), Mockito.anyString(),
+				Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		InfoItemFieldReaderFieldSetProvider
+			infoItemFieldReaderFieldSetProvider = Mockito.mock(
+				InfoItemFieldReaderFieldSetProvider.class);
+
+		Mockito.when(
+			infoItemFieldReaderFieldSetProvider.getInfoFieldValues(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ObjectFieldLocalService objectFieldLocalService = Mockito.mock(
+			ObjectFieldLocalService.class);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		TemplateInfoItemFieldSetProvider templateInfoItemFieldSetProvider =
+			Mockito.mock(TemplateInfoItemFieldSetProvider.class);
+
+		Mockito.when(
+			templateInfoItemFieldSetProvider.getInfoFieldValues(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_objectEntryInfoItemFieldValuesProvider =
+			new ObjectEntryInfoItemFieldValuesProvider(
+				displayPageInfoItemFieldSetProvider,
+				Mockito.mock(DLAppLocalService.class),
+				Mockito.mock(DLURLHelper.class),
+				Mockito.mock(FriendlyURLEntryLocalService.class),
+				infoItemFieldReaderFieldSetProvider,
+				Mockito.mock(ListTypeEntryLocalService.class),
+				Mockito.mock(ObjectActionLocalService.class), _objectDefinition,
+				Mockito.mock(ObjectDefinitionLocalService.class),
+				Mockito.mock(ObjectFieldInfoFieldConverter.class),
+				Mockito.mock(ObjectEntryLocalService.class),
+				Mockito.mock(ObjectEntryManagerRegistry.class),
+				objectFieldLocalService,
+				Mockito.mock(ObjectRelatedModelsProviderRegistry.class),
+				Mockito.mock(ObjectRelationshipLocalService.class),
+				Mockito.mock(ObjectScopeProviderRegistry.class),
+				Mockito.mock(Portal.class), templateInfoItemFieldSetProvider,
+				Mockito.mock(UserLocalService.class));
+	}
+
+	@Test
+	public void testGetInfoItemFieldValuesExposesExternalReferenceCodeForProxyObjectEntries()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		com.liferay.object.rest.dto.v1_0.ObjectEntry dtoObjectEntry =
+			new com.liferay.object.rest.dto.v1_0.ObjectEntry();
+
+		dtoObjectEntry.setExternalReferenceCode(externalReferenceCode);
+		dtoObjectEntry.setProperties(Collections.emptyMap());
+
+		ObjectEntry serviceBuilderObjectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			serviceBuilderObjectEntry.getObjectEntryId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		ServiceContext serviceContext = Mockito.mock(ServiceContext.class);
+
+		Mockito.when(
+			serviceContext.getThemeDisplay()
+		).thenReturn(
+			new ThemeDisplay()
+		);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			InfoItemFieldValues infoItemFieldValues =
+				_objectEntryInfoItemFieldValuesProvider.getInfoItemFieldValues(
+					new ProxyObjectEntry(
+						serviceBuilderObjectEntry, dtoObjectEntry));
+
+			InfoFieldValue<Object> infoFieldValue =
+				infoItemFieldValues.getInfoFieldValue(
+					ObjectEntryInfoItemFields.externalReferenceCodeInfoField.
+						getName());
+
+			Assert.assertNotNull(infoFieldValue);
+			Assert.assertEquals(
+				externalReferenceCode, infoFieldValue.getValue());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	private ObjectDefinition _objectDefinition;
+	private ObjectEntryInfoItemFieldValuesProvider
+		_objectEntryInfoItemFieldValuesProvider;
+
+}

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -55,14 +55,6 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_objectDefinition = Mockito.mock(ObjectDefinition.class);
-
-		Mockito.when(
-			_objectDefinition.isDefaultStorageType()
-		).thenReturn(
-			false
-		);
-
 		DisplayPageInfoItemFieldSetProvider
 			displayPageInfoItemFieldSetProvider = Mockito.mock(
 				DisplayPageInfoItemFieldSetProvider.class);
@@ -84,6 +76,15 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				Mockito.anyString(), Mockito.any())
 		).thenReturn(
 			Collections.emptyList()
+		);
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.isDefaultStorageType()
+		).thenReturn(
+			false
 		);
 
 		ObjectFieldLocalService objectFieldLocalService = Mockito.mock(
@@ -113,7 +114,7 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				Mockito.mock(FriendlyURLEntryLocalService.class),
 				infoItemFieldReaderFieldSetProvider,
 				Mockito.mock(ListTypeEntryLocalService.class),
-				Mockito.mock(ObjectActionLocalService.class), _objectDefinition,
+				Mockito.mock(ObjectActionLocalService.class), objectDefinition,
 				Mockito.mock(ObjectDefinitionLocalService.class),
 				Mockito.mock(ObjectFieldInfoFieldConverter.class),
 				Mockito.mock(ObjectEntryLocalService.class),
@@ -127,16 +128,14 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 	}
 
 	@Test
-	public void testGetInfoItemFieldValuesExposesExternalReferenceCodeForProxyObjectEntries()
-		throws Exception {
-
+	public void testGetInfoItemFieldValuesProxyObjectEntry() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
 
-		com.liferay.object.rest.dto.v1_0.ObjectEntry dtoObjectEntry =
+		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 			new com.liferay.object.rest.dto.v1_0.ObjectEntry();
 
-		dtoObjectEntry.setExternalReferenceCode(externalReferenceCode);
-		dtoObjectEntry.setProperties(Collections.emptyMap());
+		objectEntry.setExternalReferenceCode(externalReferenceCode);
+		objectEntry.setProperties(Collections.emptyMap());
 
 		ObjectEntry serviceBuilderObjectEntry = Mockito.mock(ObjectEntry.class);
 
@@ -160,14 +159,13 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			InfoItemFieldValues infoItemFieldValues =
 				_objectEntryInfoItemFieldValuesProvider.getInfoItemFieldValues(
 					new ProxyObjectEntry(
-						serviceBuilderObjectEntry, dtoObjectEntry));
+						serviceBuilderObjectEntry, objectEntry));
 
 			InfoFieldValue<Object> infoFieldValue =
 				infoItemFieldValues.getInfoFieldValue(
 					ObjectEntryInfoItemFields.externalReferenceCodeInfoField.
 						getName());
 
-			Assert.assertNotNull(infoFieldValue);
 			Assert.assertEquals(
 				externalReferenceCode, infoFieldValue.getValue());
 		}
@@ -176,7 +174,6 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 		}
 	}
 
-	private ObjectDefinition _objectDefinition;
 	private ObjectEntryInfoItemFieldValuesProvider
 		_objectEntryInfoItemFieldValuesProvider;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85011

**What is being fixed:** When a Collection Display fragment is mapped
to the External Reference Code system field on an Object Definition
backed by a non-default storage type (a proxy object served by an
`ObjectEntryManager`), the fragment renders its placeholder text
instead of the entry's ERC. Default-storage objects render the same
mapping correctly.

**How it is being fixed:** `ObjectEntryInfoItemFieldValuesProvider`
has two paths for building info field values: one for the default
storage type and one for proxy entries served through an
`ObjectEntryManager`. The default-storage path already exposes
`externalReferenceCodeInfoField`, but the manager path was missing
it, so the framework had no value to render. This change adds the
matching `InfoFieldValue<>` entry to the manager path, restoring
parity for that field. 