### PR TITLE
LPD-78756 UI Inconsistency in "Leaving Object Model Builder" Modal

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -4,7 +4,6 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayForm from '@clayui/form';
 import ClayModal, {ClayModalProvider, useModal} from '@clayui/modal';
 import React from 'react';
 
@@ -36,13 +35,11 @@ export function RedirectToEditObjectDetailsModal({
 					</ClayModal.Header>
 
 					<ClayModal.Body>
-						<ClayForm>
-							<p>
-								{Liferay.Language.get(
-									'you-are-leaving-object-model-builder-and-opening-the-object-admin-page-view-in-a-new-tab'
-								)}
-							</p>
-						</ClayForm>
+						<p>
+							{Liferay.Language.get(
+								'you-are-leaving-object-model-builder-and-opening-the-object-admin-page-view-in-a-new-tab'
+							)}
+						</p>
 					</ClayModal.Body>
 
 					<ClayModal.Footer

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -44,7 +44,7 @@ export function RedirectToEditObjectDetailsModal({
 
 					<ClayModal.Footer
 						last={
-							<ClayButton.Group key={1} spaced>
+							<ClayButton.Group spaced>
 								<ClayButton
 									displayType="secondary"
 									onClick={onClose}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -46,9 +46,6 @@ export function RedirectToEditObjectDetailsModal({
 						last={
 							<ClayButton.Group key={1} spaced>
 								<ClayButton
-									aria-labelledby={Liferay.Language.get(
-										'cancel'
-									)}
 									displayType="secondary"
 									onClick={onClose}
 								>
@@ -56,9 +53,6 @@ export function RedirectToEditObjectDetailsModal({
 								</ClayButton>
 
 								<ClayButton
-									aria-labelledby={Liferay.Language.get(
-										'open-page-view'
-									)}
 									displayType="info"
 									onClick={handleSubmit}
 								>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -29,49 +29,47 @@ export function RedirectToEditObjectDetailsModal({
 		<>
 			<ClayModalProvider>
 				<ClayModal center observer={observer} status="info">
-						<ClayModal.Header
-							closeButtonAriaLabel={Liferay.Language.get('close')}
-						>
-							{Liferay.Language.get(
-								'leaving-object-model-builder'
-							)}
-						</ClayModal.Header>
+					<ClayModal.Header
+						closeButtonAriaLabel={Liferay.Language.get('close')}
+					>
+						{Liferay.Language.get('leaving-object-model-builder')}
+					</ClayModal.Header>
 
-						<ClayModal.Body>
-							<ClayForm>
+					<ClayModal.Body>
+						<ClayForm>
 							<p>
 								{Liferay.Language.get(
 									'you-are-leaving-object-model-builder-and-opening-the-object-admin-page-view-in-a-new-tab'
 								)}
 							</p>
-							</ClayForm>
-						</ClayModal.Body>
+						</ClayForm>
+					</ClayModal.Body>
 
-						<ClayModal.Footer
-							last={
-								<ClayButton.Group key={1} spaced>
-									<ClayButton
-										aria-labelledby={Liferay.Language.get(
-											'cancel'
-										)}
-										displayType="secondary"
-										onClick={onClose}
-									>
-										{Liferay.Language.get('cancel')}
-									</ClayButton>
+					<ClayModal.Footer
+						last={
+							<ClayButton.Group key={1} spaced>
+								<ClayButton
+									aria-labelledby={Liferay.Language.get(
+										'cancel'
+									)}
+									displayType="secondary"
+									onClick={onClose}
+								>
+									{Liferay.Language.get('cancel')}
+								</ClayButton>
 
-									<ClayButton
-										aria-labelledby={Liferay.Language.get(
-											'open-page-view'
-										)}
-										displayType="info"
-										onClick={handleSubmit}
-									>
-										{Liferay.Language.get('open-page-view')}
-									</ClayButton>
-								</ClayButton.Group>
-							}
-						/>
+								<ClayButton
+									aria-labelledby={Liferay.Language.get(
+										'open-page-view'
+									)}
+									displayType="info"
+									onClick={handleSubmit}
+								>
+									{Liferay.Language.get('open-page-view')}
+								</ClayButton>
+							</ClayButton.Group>
+						}
+					/>
 				</ClayModal>
 			</ClayModalProvider>
 		</>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -63,7 +63,7 @@ export function RedirectToEditObjectDetailsModal({
 										aria-labelledby={Liferay.Language.get(
 											'open-page-view'
 										)}
-										displayType="primary"
+										displayType="info"
 										onClick={handleSubmit}
 									>
 										{Liferay.Language.get('open-page-view')}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -29,7 +29,6 @@ export function RedirectToEditObjectDetailsModal({
 		<>
 			<ClayModalProvider>
 				<ClayModal center observer={observer} status="info">
-					<ClayForm>
 						<ClayModal.Header
 							closeButtonAriaLabel={Liferay.Language.get('close')}
 						>
@@ -39,11 +38,13 @@ export function RedirectToEditObjectDetailsModal({
 						</ClayModal.Header>
 
 						<ClayModal.Body>
+							<ClayForm>
 							<p>
 								{Liferay.Language.get(
 									'you-are-leaving-object-model-builder-and-opening-the-object-admin-page-view-in-a-new-tab'
 								)}
 							</p>
+							</ClayForm>
 						</ClayModal.Body>
 
 						<ClayModal.Footer
@@ -71,7 +72,6 @@ export function RedirectToEditObjectDetailsModal({
 								</ClayButton.Group>
 							}
 						/>
-					</ClayForm>
 				</ClayModal>
 			</ClayModalProvider>
 		</>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/RedirectToEditObjectDetailsModal.tsx
@@ -55,7 +55,6 @@ export function RedirectToEditObjectDetailsModal({
 										)}
 										displayType="secondary"
 										onClick={onClose}
-										size="sm"
 									>
 										{Liferay.Language.get('cancel')}
 									</ClayButton>
@@ -66,7 +65,6 @@ export function RedirectToEditObjectDetailsModal({
 										)}
 										displayType="primary"
 										onClick={handleSubmit}
-										size="sm"
 									>
 										{Liferay.Language.get('open-page-view')}
 									</ClayButton>


### PR DESCRIPTION
# Summary of Changes

When editing an object definition from the Object Model Builder it's possible to move to the Edit in page view. The move is not direct, but there's a modal informing the user they're leaving the Object Model Builder. 

This modal is currently shown:
* with small buttons,
* with incorrect info button for "Open Page View" (color is wrong, for instance),
* without the expected dividing line between the header and body (at least at many zoom values).

# Motivation / Context

[LPD-78756](https://liferay.atlassian.net/browse/LPD-78756)

- The goal is to ensure UI consistency for this modal

# Technical Approach

The relevant class is `RedirectToEditObjectDetailsModal.tsx`.

The small button is fixed by removing the explicit prop the set it to be so.

The incorrect info button is fixed by using the correct prop value for `displayType` in `<ClayButton>`.

The missing dividing line between header and body is due to an incorrect placement of the element `<ClayForm>` between `<ClayModal>` and `<ClayModal.Header>`. There should be no such element since these are expected to be direct siblings (see [here](https://liferay.slack.com/archives/CNBG06JS3/p1777886302031749)). The fix is to move the element `<ClayForm>` inside `<ClayModal.Body>`.


# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [x] Not applicable (explain why)

UI changes. No behavior changed.

**Manual Testing**

- Steps:
  1. In an Objects foldet, click on Object Model Builder.
  2. Select any of the objects, click on the 3-dot menu (ellipsis) icon on the top-right corner of the object card.
  3. Click on the option "Edit in Page View"
- Expected result: The modal shows UI consistency with respect to the rest of the portal
- Actual result: Buttons are small, not using the `info` style and the dividing line between header and body is missing.

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|<img width="1890" height="955" alt="LPD-78756_before" src="https://github.com/user-attachments/assets/fa3f4865-898a-44ce-bb02-bf40475bc0f7" /> |<img width="1876" height="943" alt="LPD-78756_after" src="https://github.com/user-attachments/assets/3f45c591-18d2-4845-9b8d-08d7ee4ccd49" /> |

# Alternatives Considered

For the dividing line issue, I considered some other alternatives:
* Since the problem is the existence of an element between `<ClayModal>` and `<ClayModal.Header>` I thought about directly deleting it. Although I've seen to issues coming from this, I decided to keep `<ClayForm>` and trust the team decision on whether to delete it or not.  
* Another option was to move `<ClayForm>` outside `<ClayModal>` but following [the thread mentioned above](https://liferay.slack.com/archives/CNBG06JS3/p1777886302031749) I placed it inside`<ClayBody>`. There might be better placements for it, though.

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.

[LPD-78756]: https://liferay.atlassian.net/browse/LPD-78756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ