### PR TITLE
LPD-86226 Hide New button in CMS Content Structures object folder

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.tsx
@@ -24,6 +24,7 @@ import objectDefinitionSystemDataRenderer from './FDSDataRenderers/ObjectDefinit
 import ObjectFolderCardHeader from './ObjectFolderCardHeader';
 import ObjectFoldersSideBar from './ObjectFoldersSidebar';
 import {
+	canCreateInObjectFolder,
 	deleteObjectDefinition,
 	getObjectFolderActions,
 } from './objectDefinitionUtil';
@@ -476,7 +477,9 @@ export default function ViewObjectDefinitions({
 												: undefined
 										}
 										creationMenu={
-											selectedObjectFolder
+											canCreateInObjectFolder(
+												selectedObjectFolder
+											)
 												? objectDefinitionsCreationMenu
 												: undefined
 										}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/objectDefinitionUtil.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/objectDefinitionUtil.ts
@@ -473,6 +473,16 @@ export function getObjectFolderActions({
 	return kebabOptions;
 }
 
+export function canCreateInObjectFolder(
+	folder?: Partial<ObjectFolder | undefined>
+): boolean {
+	if (!folder) {
+		return false;
+	}
+
+	return folder.externalReferenceCode !== 'L_CMS_CONTENT_STRUCTURES';
+}
+
 export async function getUpdatedModelBuilderStructurePayload(
 	baseResourceURL: string,
 	currentObjectFolderName: string

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ViewObjectDefinitions/objectDefinitionUtil.spec.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ViewObjectDefinitions/objectDefinitionUtil.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {canCreateInObjectFolder} from '../../components/ViewObjectDefinitions/objectDefinitionUtil';
+
+describe('canCreateInObjectFolder', () => {
+	it('returns false when no folder is selected', () => {
+		expect(canCreateInObjectFolder(undefined)).toBe(false);
+	});
+
+	it('returns true for a regular object folder', () => {
+		expect(canCreateInObjectFolder({externalReferenceCode: 'TST123'})).toBe(
+			true
+		);
+	});
+
+	it('returns false for the CMS Content Structures folder', () => {
+		expect(
+			canCreateInObjectFolder({
+				externalReferenceCode: 'L_CMS_CONTENT_STRUCTURES',
+			})
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86226

**What is being fixed:** In the Objects admin UI, the "New" button is
visible on the system-managed *CMS Content Structures* folder. The
backend correctly rejects creating an object definition under that
folder (`ObjectDefinitionResourceImpl` raises
`ObjectDefinitionStorageTypeException`), so the button only leads to
an error — the UI should hide it instead of letting the user click
into a dead end.

**How it is being fixed:** The conditional that decides whether the
folder view exposes a `creationMenu` was extracted from the JSX of
`ViewObjectDefinitions.tsx` into a small pure helper,
`isCreationMenuAllowed`, in `objectDefinitionUtil.ts`. The helper
mirrors the server-side restriction by returning `false` when the
selected folder's `externalReferenceCode` is
`L_CMS_CONTENT_STRUCTURES`, and `true` otherwise. A unit test in
`objectDefinitionUtil.spec.ts` covers the three relevant cases (no
folder selected, a regular folder, and the restricted CMS Content
Structures folder).