### PR TITLE
LPD-88515 Repeatable Fields Broken Due to XSS Fix

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -9,14 +9,22 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRendererRegistry;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +36,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -149,6 +158,133 @@ public class RenderStructureFieldMVCResourceCommandTest {
 
 		Assert.assertEquals(
 			HtmlUtil.escapeAttribute(_SCRIPT), ddmFormField.getName());
+	}
+
+	@Test
+	public void testServeResource() throws Exception {
+		String fieldName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_httpServletRequest.getParameter("fieldName")
+		).thenReturn(
+			fieldName
+		);
+
+		DDMFormDeserializer ddmFormDeserializer = Mockito.mock(
+			DDMFormDeserializer.class);
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse = Mockito.mock(
+				DDMFormDeserializerDeserializeResponse.class);
+
+		Mockito.when(
+			ddmFormDeserializer.deserialize(Mockito.any())
+		).thenReturn(
+			ddmFormDeserializerDeserializeResponse
+		);
+
+		DDMForm ddmForm = Mockito.mock(DDMForm.class);
+
+		Mockito.when(
+			ddmFormDeserializerDeserializeResponse.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		DDMFormField ddmFormField = Mockito.mock(DDMFormField.class);
+
+		String fieldType = "text";
+
+		Mockito.when(
+			ddmFormField.getType()
+		).thenReturn(
+			fieldType
+		);
+
+		Mockito.when(
+			ddmForm.getDDMFormFieldsMap(true)
+		).thenReturn(
+			Collections.singletonMap(fieldName, ddmFormField)
+		);
+
+		DDMFormFieldRenderer ddmFormFieldRenderer = Mockito.mock(
+			DDMFormFieldRenderer.class);
+
+		String renderedHTML =
+			"<input name=\"" + fieldName + "\" type=\"text\" />";
+
+		Mockito.when(
+			ddmFormFieldRenderer.render(
+				Mockito.eq(ddmFormField),
+				Mockito.any(DDMFormFieldRenderingContext.class))
+		).thenReturn(
+			renderedHTML
+		);
+
+		DDMFormFieldRendererRegistry ddmFormFieldRendererRegistry =
+			Mockito.mock(DDMFormFieldRendererRegistry.class);
+
+		Mockito.when(
+			ddmFormFieldRendererRegistry.getDDMFormFieldRenderer(fieldType)
+		).thenReturn(
+			ddmFormFieldRenderer
+		);
+
+		HttpServletResponse httpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		ResourceRequest resourceRequest = Mockito.mock(ResourceRequest.class);
+		ResourceResponse resourceResponse = Mockito.mock(
+			ResourceResponse.class);
+
+		Mockito.when(
+			_portal.getHttpServletRequest(resourceRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
+
+		Mockito.when(
+			_portal.getHttpServletResponse(resourceResponse)
+		).thenReturn(
+			httpServletResponse
+		);
+
+		Mockito.when(
+			_portal.getOriginalServletRequest(_httpServletRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
+
+		RenderStructureFieldMVCResourceCommand
+			renderStructureFieldMVCResourceCommand =
+				new RenderStructureFieldMVCResourceCommand();
+
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand,
+			"_ddmFormFieldRendererRegistry", ddmFormFieldRendererRegistry);
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
+			ddmFormDeserializer);
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand, "_portal", _portal);
+
+		try (MockedStatic<ServletResponseUtil> servletResponseUtilMockedStatic =
+				Mockito.mockStatic(ServletResponseUtil.class)) {
+
+			renderStructureFieldMVCResourceCommand.doServeResource(
+				resourceRequest, resourceResponse);
+
+			servletResponseUtilMockedStatic.verify(
+				() -> ServletResponseUtil.write(
+					httpServletResponse, renderedHTML),
+				Mockito.times(1));
+		}
+
+		Mockito.verify(
+			httpServletResponse
+		).setContentType(
+			ContentTypes.TEXT_HTML
+		);
 	}
 
 	private static final String _SCRIPT =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
@@ -113,9 +113,8 @@ public class RenderStructureFieldMVCResourceCommand
 			createDDMFormFieldRenderingContext(
 				httpServletRequest, httpServletResponse);
 
-		String ddmFormFieldHTML = HtmlUtil.escapeAttribute(
-			ddmFormFieldRenderer.render(
-				ddmFormField, ddmFormFieldRenderingContext));
+		String ddmFormFieldHTML = ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
 
 		httpServletResponse.setContentType(ContentTypes.TEXT_HTML);
 


### PR DESCRIPTION
Related ticket [LPD-88515](https://liferay.atlassian.net/browse/LPD-88515)

The approach for this issue was to revert the changes introduced in [LPD-62034](https://liferay.atlassian.net/browse/LPD-62034), as they caused the regression. After testing on the master and 2025.q1.19 branches, the XSS issues reported in [LPD-56406](https://liferay.atlassian.net/browse/LPD-56406) and [LPD-62034](https://liferay.atlassian.net/browse/LPD-62034) no longer appear to occur. Following team discussion, the revert was considered a valid approach.

[LPD-88515]: https://liferay.atlassian.net/browse/LPD-88515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-62034]: https://liferay.atlassian.net/browse/LPD-62034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-56406]: https://liferay.atlassian.net/browse/LPD-56406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-62034]: https://liferay.atlassian.net/browse/LPD-62034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ