### PR TITLE
LPD-85624 Workflow Metrics UI breaks after new DXP look and feel implementation

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/completion-velocity/CompletionVelocityCard.es.js
@@ -102,7 +102,7 @@ function CompletionVelocityCard({routeParams}) {
 
 	return (
 		<PromisesResolver promises={promises}>
-			<ClayPanel className="mt-4">
+			<ClayPanel className="mt-4" displayType="secondary">
 				<CompletionVelocityCard.Header
 					disableFilters={filtersError}
 					prefixKey={prefixKey}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-assignee-card/PerformanceByAssigneeCard.es.js
@@ -126,7 +126,7 @@ function PerformanceByAssigneeCard({routeParams}) {
 	}, [filtersError, routeParams, timeRange.dateEnd, timeRange.dateStart]);
 
 	return (
-		<ClayPanel className="mt-4 tabs-card">
+		<ClayPanel className="mt-4 tabs-card" displayType="secondary">
 			<PromisesResolver promises={promises}>
 				<PerformanceByAssigneeCard.Header
 					disableFilters={filtersError}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/performance-by-step-card/PerformanceByStepCard.es.js
@@ -124,7 +124,7 @@ function PerformanceByStepCard({routeParams}) {
 	}, [filtersError, routeParams, timeRange.dateEnd, timeRange.dateStart]);
 
 	return (
-		<ClayPanel className="mt-4 tabs-card">
+		<ClayPanel className="mt-4 tabs-card" displayType="secondary">
 			<PromisesResolver promises={promises}>
 				<PerformanceByStepCard.Header
 					disableFilters={filtersError}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/process-items/ProcessItemsCard.es.js
@@ -44,7 +44,7 @@ const ProcessItemsCard = ({
 
 	return (
 		<PromisesResolver promises={promises}>
-			<ClayPanel className="mt-4">
+			<ClayPanel className="mt-4" displayType="secondary">
 				<ProcessItemsCard.Header
 					data={data}
 					description={description}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-assignee-card/WorkloadByAssigneeCard.es.js
@@ -88,7 +88,10 @@ function WorkloadByAssigneeCard({routeParams}) {
 
 	return (
 		<PromisesResolver promises={promises}>
-			<ClayPanel className="mt-4 workload-by-assignee-card">
+			<ClayPanel
+				className="mt-4 workload-by-assignee-card"
+				displayType="secondary"
+			>
 				<WorkloadByAssigneeCard.Header processId={processId} />
 
 				<div className="border-bottom container-nav">

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/process-metrics/workload-by-step-card/WorkloadByStepCard.es.js
@@ -26,7 +26,7 @@ function WorkloadByStepCard({processId, routeParams}) {
 
 	return (
 		<PromisesResolver promises={promises}>
-			<ClayPanel className="mt-4">
+			<ClayPanel className="mt-4" displayType="secondary">
 				<PanelHeaderWithOptions
 					className="tabs-panel-header"
 					description={Liferay.Language.get(


### PR DESCRIPTION
related issue: [LPD-85624](https://liferay.atlassian.net/browse/LPD-85624)

### Motivation:
❎ **current behavior:**

After the DXP UI update, workflow metric charts have lost their containers. Without these visual boundaries, data points appear "floating" and disconnected, making it difficult for users to distinguish between separate data sets.

✅ **expected behavior:**

Even with the removal of the gray background, charts should be enclosed in defined containers (such as cards with borders).
**Why?** Elements within the same boundary are perceived as a group. Restoring these containers reduces cognitive load, allowing users to scan and interpret different metrics as distinct, organized sections.

### Before changes:
<img width="1406" height="3146" alt="image-20260408-204445" src="https://github.com/user-attachments/assets/2b01509c-0b03-4a1c-9d7d-e17a8420ce14" />
<img width="2170" height="1748" alt="image-20260408-204436" src="https://github.com/user-attachments/assets/cc372159-9725-42ea-bb9c-8ac163eeb33a" />

### After changes:
<img width="1740" height="867" alt="image" src="https://github.com/user-attachments/assets/4dd85a1e-9a12-4068-a369-bf34d31c9c5e" />
<img width="2172" height="1312" alt="image" src="https://github.com/user-attachments/assets/bd575972-7b66-4294-8977-e34dcf8c25a5" />

[LPD-85624]: https://liferay.atlassian.net/browse/LPD-85624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ