### PR TITLE
LPD-71488 Notifications template subject value does not persist when switching language

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/ContentContainer/ContentContainer.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/ContentContainer/ContentContainer.tsx
@@ -50,22 +50,6 @@ export default function ContentContainer({
 	setValues,
 	values,
 }: ContentContainerProps) {
-	const handleSelectedLocaleChange = (label: Liferay.Language.Locale) => {
-		const currentSubjectValue = values.subject[selectedLocale];
-		const targetSubjectValue = values.subject[label];
-
-		if (!targetSubjectValue && currentSubjectValue) {
-			setValues({
-				subject: {
-					...values.subject,
-					[label]: currentSubjectValue,
-				},
-			});
-		}
-
-		setSelectedLocale(label);
-	};
-
 	return (
 		<Card title={Liferay.Language.get('content')}>
 			<Text as="span" color="secondary">
@@ -91,7 +75,6 @@ export default function ContentContainer({
 				}}
 				placeholder=""
 				required
-				selectedLocale={selectedLocale}
 				translations={values.subject}
 			/>
 
@@ -118,7 +101,7 @@ export default function ContentContainer({
 							label={Liferay.Language.get('template')}
 							name="template"
 							onSelectedLocaleChange={({label}) =>
-								handleSelectedLocaleChange(label)
+								setSelectedLocale(label)
 							}
 							onTranslationsChange={(translation) => {
 								setValues({
@@ -136,7 +119,7 @@ export default function ContentContainer({
 								baseResourceURL={baseResourceURL}
 								objectDefinitions={objectDefinitions}
 								selectedLocale={selectedLocale}
-								setSelectedLocale={handleSelectedLocaleChange}
+								setSelectedLocale={setSelectedLocale}
 								setValues={setValues}
 								values={values}
 							/>

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/ContentContainer/ContentContainer.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/ContentContainer/ContentContainer.tsx
@@ -50,6 +50,22 @@ export default function ContentContainer({
 	setValues,
 	values,
 }: ContentContainerProps) {
+	const handleSelectedLocaleChange = (label: Liferay.Language.Locale) => {
+		const currentSubjectValue = values.subject[selectedLocale];
+		const targetSubjectValue = values.subject[label];
+
+		if (!targetSubjectValue && currentSubjectValue) {
+			setValues({
+				subject: {
+					...values.subject,
+					[label]: currentSubjectValue,
+				},
+			});
+		}
+
+		setSelectedLocale(label);
+	};
+
 	return (
 		<Card title={Liferay.Language.get('content')}>
 			<Text as="span" color="secondary">
@@ -102,7 +118,7 @@ export default function ContentContainer({
 							label={Liferay.Language.get('template')}
 							name="template"
 							onSelectedLocaleChange={({label}) =>
-								setSelectedLocale(label)
+								handleSelectedLocaleChange(label)
 							}
 							onTranslationsChange={(translation) => {
 								setValues({
@@ -120,7 +136,7 @@ export default function ContentContainer({
 								baseResourceURL={baseResourceURL}
 								objectDefinitions={objectDefinitions}
 								selectedLocale={selectedLocale}
-								setSelectedLocale={setSelectedLocale}
+								setSelectedLocale={handleSelectedLocaleChange}
 								setValues={setValues}
 								values={values}
 							/>

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/ContentContainer.spec.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/ContentContainer.spec.tsx
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, {useState} from 'react';
+
+import ContentContainer from '../components/ContentContainer/ContentContainer';
+
+// Holds the props received by RichTextLocalized on each render so tests
+// can call onTranslationsChange / onSelectedLocaleChange directly.
+
+let richTextProps: {
+	onSelectedLocaleChange: (locale: {
+		label: Liferay.Language.Locale;
+		symbol: string;
+	}) => void;
+	onTranslationsChange: (translations: LocalizedValue<string>) => void;
+};
+
+jest.mock('@liferay/object-js-components-web', () => ({
+	Card: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+	FormError: {},
+	RichTextLocalized: (props: typeof richTextProps) => {
+		richTextProps = props;
+
+		return null;
+	},
+	SingleSelect: () => null,
+}));
+
+jest.mock('../components/ContentContainer/Attachments', () => ({
+	Attachments: () => null,
+}));
+
+const initialValues: NotificationTemplate = {
+	attachmentObjectFieldIds: [],
+	body: {en_US: ''},
+	description: '',
+	editorType: 'richText',
+	externalReferenceCode: '',
+	name: '',
+	objectDefinitionExternalReferenceCode: '',
+	objectDefinitionId: null,
+	recipientType: 'email',
+	recipients: [],
+	subject: {en_US: ''},
+	system: false,
+	type: 'email',
+};
+
+function ContentContainerWrapper() {
+	const [selectedLocale, setSelectedLocale] =
+		useState<Liferay.Language.Locale>('en_US');
+
+	const [values, setValues] = useState<NotificationTemplate>(initialValues);
+
+	const handleSetValues = (partial: Partial<NotificationTemplate>) => {
+		setValues((current) => ({...current, ...partial}));
+	};
+
+	return (
+		<ContentContainer
+			baseResourceURL=""
+			editorConfig={{}}
+			errors={{}}
+			objectDefinitions={[]}
+			selectedLocale={selectedLocale}
+			setSelectedLocale={setSelectedLocale}
+			setValues={handleSetValues}
+			values={values}
+		/>
+	);
+}
+
+describe('ContentContainer: subject persistence on locale switch', () => {
+	it('pre-fills the new locale subject with the current locale value on locale switch', () => {
+		const mockSetValues = jest.fn();
+
+		render(
+			<ContentContainer
+				baseResourceURL=""
+				editorConfig={{}}
+				errors={{}}
+				objectDefinitions={[]}
+				selectedLocale="en_US"
+				setSelectedLocale={() => {}}
+				setValues={mockSetValues}
+				values={{...initialValues, subject: {en_US: 'Hello'}}}
+			/>
+		);
+
+		act(() => {
+			richTextProps.onSelectedLocaleChange({
+				label: 'pt_BR',
+				symbol: 'pt-br',
+			});
+		});
+
+		expect(mockSetValues).toHaveBeenCalledWith({
+			subject: {en_US: 'Hello', pt_BR: 'Hello'},
+		});
+	});
+
+	it('preserves subject value when the template locale is switched', async () => {
+		render(<ContentContainerWrapper />);
+
+		const subjectInput = screen.getByRole('textbox');
+
+		await userEvent.type(subjectInput, 'Hello');
+
+		expect(subjectInput).toHaveValue('Hello');
+
+		act(() => {
+			richTextProps.onSelectedLocaleChange({
+				label: 'pt_BR',
+				symbol: 'pt-br',
+			});
+		});
+
+		expect(subjectInput).toHaveValue('Hello');
+	});
+
+	it('does not overwrite subject when body and locale change together', async () => {
+		render(<ContentContainerWrapper />);
+
+		const subjectInput = screen.getByRole('textbox');
+
+		await userEvent.type(subjectInput, 'Hello');
+
+		act(() => {
+			richTextProps.onTranslationsChange({en_US: 'body content'});
+			richTextProps.onSelectedLocaleChange({
+				label: 'pt_BR',
+				symbol: 'pt-br',
+			});
+		});
+
+		expect(subjectInput).toHaveValue('Hello');
+	});
+});

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/ContentContainer.spec.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/tests/ContentContainer.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -10,8 +10,10 @@ import React, {useState} from 'react';
 
 import ContentContainer from '../components/ContentContainer/ContentContainer';
 
-// Holds the props received by RichTextLocalized on each render so tests
-// can call onTranslationsChange / onSelectedLocaleChange directly.
+/**
+ * Holds the props received by RichTextLocalized on each render so tests
+ * can call onTranslationsChange / onSelectedLocaleChange directly.
+ */
 
 let richTextProps: {
 	onSelectedLocaleChange: (locale: {
@@ -19,6 +21,7 @@ let richTextProps: {
 		symbol: string;
 	}) => void;
 	onTranslationsChange: (translations: LocalizedValue<string>) => void;
+	selectedLocale: Liferay.Language.Locale;
 };
 
 jest.mock('@liferay/object-js-components-web', () => ({
@@ -76,8 +79,8 @@ function ContentContainerWrapper() {
 	);
 }
 
-describe('ContentContainer: subject persistence on locale switch', () => {
-	it('pre-fills the new locale subject with the current locale value on locale switch', () => {
+describe('ContentContainer: subject is independent from template locale', () => {
+	it('does not copy the subject across locales when the template locale switches', () => {
 		const mockSetValues = jest.fn();
 
 		render(
@@ -100,12 +103,10 @@ describe('ContentContainer: subject persistence on locale switch', () => {
 			});
 		});
 
-		expect(mockSetValues).toHaveBeenCalledWith({
-			subject: {en_US: 'Hello', pt_BR: 'Hello'},
-		});
+		expect(mockSetValues).not.toHaveBeenCalled();
 	});
 
-	it('preserves subject value when the template locale is switched', async () => {
+	it('preserves the subject value when the template locale is switched', async () => {
 		render(<ContentContainerWrapper />);
 
 		const subjectInput = screen.getByRole('textbox');
@@ -121,24 +122,7 @@ describe('ContentContainer: subject persistence on locale switch', () => {
 			});
 		});
 
-		expect(subjectInput).toHaveValue('Hello');
-	});
-
-	it('does not overwrite subject when body and locale change together', async () => {
-		render(<ContentContainerWrapper />);
-
-		const subjectInput = screen.getByRole('textbox');
-
-		await userEvent.type(subjectInput, 'Hello');
-
-		act(() => {
-			richTextProps.onTranslationsChange({en_US: 'body content'});
-			richTextProps.onSelectedLocaleChange({
-				label: 'pt_BR',
-				symbol: 'pt-br',
-			});
-		});
-
+		expect(richTextProps.selectedLocale).toBe('pt_BR');
 		expect(subjectInput).toHaveValue('Hello');
 	});
 });

--- a/modules/test/playwright/tests/notification-web/main/emailNotificationTemplate.spec.ts
+++ b/modules/test/playwright/tests/notification-web/main/emailNotificationTemplate.spec.ts
@@ -553,6 +553,8 @@ test.describe('Email notification template', () => {
 			'<h1>Hello World</h1>'
 		);
 
+		await emailNotificationTemplatePage.richTextSourceButton.click();
+
 		await emailNotificationTemplatePage.saveButton.click();
 
 		await notificationTemplatesPage
@@ -931,7 +933,7 @@ test.describe('Email notification template', () => {
 	});
 
 	test(
-		'Verify User Groups are now supported for Email Notification Templates',
+		'can use User Groups for Email Notification Templates',
 		{tag: '@LPD-57577'},
 		async ({
 			apiHelpers,


### PR DESCRIPTION
related issue: [LPD-71488](https://liferay.atlassian.net/browse/LPD-71488)

resent from here: https://github.com/liferay-bpm/liferay-portal/pull/6045

test results:
<img width="780" height="303" alt="image" src="https://github.com/user-attachments/assets/51856c6c-9b5e-47ad-8f95-30964dcdecaa" />
<img width="545" height="355" alt="image" src="https://github.com/user-attachments/assets/32f44c86-4d01-4641-8737-cb63ba6a7153" />


[LPD-71488]: https://liferay.atlassian.net/browse/LPD-71488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ