### PR TITLE
LPD-79679 Add an ObjectDefinition-agnostic getValuesListCount overload

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 123.0.0
+Bundle-Version: 123.1.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalService.java
@@ -513,6 +513,12 @@ public interface ObjectEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getValuesListCount(
+			long companyId, Long[] groupIds, Long[] objectDefinitionIds,
+			Predicate predicate)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getValuesListCount(
 			Long[] groupIds, long companyId, long userId,
 			long objectDefinitionId, Predicate predicate,
 			boolean preferApproved, String search)
@@ -620,4 +626,4 @@ public interface ObjectEntryLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:709473226
+// LIFERAY-SERVICE-BUILDER-HASH:-404821026

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceUtil.java
@@ -695,6 +695,15 @@ public class ObjectEntryLocalServiceUtil {
 	}
 
 	public static int getValuesListCount(
+			long companyId, Long[] groupIds, Long[] objectDefinitionIds,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate)
+		throws PortalException {
+
+		return getService().getValuesListCount(
+			companyId, groupIds, objectDefinitionIds, predicate);
+	}
+
+	public static int getValuesListCount(
 			Long[] groupIds, long companyId, long userId,
 			long objectDefinitionId,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
@@ -894,4 +903,4 @@ public class ObjectEntryLocalServiceUtil {
 			ObjectEntryLocalServiceUtil.class, ObjectEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:233544416
+// LIFERAY-SERVICE-BUILDER-HASH:-191694864

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryLocalServiceWrapper.java
@@ -797,6 +797,16 @@ public class ObjectEntryLocalServiceWrapper
 
 	@Override
 	public int getValuesListCount(
+			long companyId, Long[] groupIds, Long[] objectDefinitionIds,
+			com.liferay.petra.sql.dsl.expression.Predicate predicate)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _objectEntryLocalService.getValuesListCount(
+			companyId, groupIds, objectDefinitionIds, predicate);
+	}
+
+	@Override
+	public int getValuesListCount(
 			Long[] groupIds, long companyId, long userId,
 			long objectDefinitionId,
 			com.liferay.petra.sql.dsl.expression.Predicate predicate,
@@ -1032,4 +1042,4 @@ public class ObjectEntryLocalServiceWrapper
 	private ObjectEntryLocalService _objectEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1537866868
+// LIFERAY-SERVICE-BUILDER-HASH:428269909

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 85.0.0
+version 85.1.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -328,10 +328,10 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword(
-			"objectDefinitionId", objectEntry.getObjectDefinitionId());
-		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",
 			objectDefinition.getExternalReferenceCode());
+		document.addKeyword(
+			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 		document.addKeyword(
 			"objectDefinitionName", objectDefinition.getShortName());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -1851,6 +1851,20 @@ public class ObjectEntryLocalServiceImpl
 			this::getValues);
 	}
 
+	@Override
+	public int getValuesListCount(
+			long companyId, Long[] groupIds, Long[] objectDefinitionIds,
+			Predicate predicate)
+		throws PortalException {
+
+		return objectEntryPersistence.dslQueryCount(
+			_getObjectEntriesGroupByStep(
+				companyId,
+				DSLQueryFactoryUtil.countDistinct(
+					ObjectEntryTable.INSTANCE.objectEntryId),
+				groupIds, objectDefinitionIds, predicate));
+	}
+
 	public int getValuesListCount(
 			Long[] groupIds, long companyId, long userId,
 			long objectDefinitionId, Predicate predicate,
@@ -4656,6 +4670,52 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private GroupByStep _getObjectEntriesGroupByStep(
+			long companyId, FromStep fromStep, Long[] groupIds,
+			Long[] objectDefinitionIds, Predicate predicate)
+		throws PortalException {
+
+		return fromStep.from(
+			ObjectEntryTable.INSTANCE
+		).where(
+			ObjectEntryTable.INSTANCE.companyId.eq(
+				companyId
+			).and(
+				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
+					ObjectEntryTable.INSTANCE.objectEntryId
+				).or(
+					ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(0L)
+				).withParentheses()
+			).and(
+				ObjectEntryTable.INSTANCE.status.neq(
+					WorkflowConstants.STATUS_IN_TRASH)
+			).and(
+				() -> {
+					if (ArrayUtil.isEmpty(groupIds)) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
+				}
+			).and(
+				() -> {
+					if (ArrayUtil.isEmpty(objectDefinitionIds)) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.objectDefinitionId.in(
+						objectDefinitionIds);
+				}
+			).and(
+				predicate
+			).and(
+				_getHeadObjectEntryPredicate(false)
+			).and(
+				_getPermissionWherePredicate(groupIds, objectDefinitionIds)
+			)
+		);
+	}
+
+	private GroupByStep _getObjectEntriesGroupByStep(
 			Long[] groupIds, FromStep fromStep,
 			ObjectDefinition objectDefinition, Predicate predicate,
 			boolean preferApproved, String search)
@@ -4933,6 +4993,59 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		return permissionWherePredicate;
+	}
+
+	private Predicate _getPermissionWherePredicate(
+			Long[] groupIds, Long[] objectDefinitionIds)
+		throws PortalException {
+
+		if (ArrayUtil.isEmpty(groupIds) ||
+			ArrayUtil.isEmpty(objectDefinitionIds) ||
+			(PermissionThreadLocal.getPermissionChecker() == null)) {
+
+			return null;
+		}
+
+		Predicate permissionWherePredicate = null;
+
+		for (Long objectDefinitionId : objectDefinitionIds) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionPersistence.findByPrimaryKey(
+					objectDefinitionId);
+
+			if (objectDefinition.isAccountEntryRestricted()) {
+				throw new PortalException(
+					"Account entry restricted object definitions are not " +
+						"supported");
+			}
+
+			Predicate objectDefinitionPermissionWherePredicate =
+				_getPermissionWherePredicate(
+					DynamicObjectDefinitionTableUtil.
+						getDynamicObjectDefinitionTable(
+							false, objectDefinition, _objectFieldLocalService),
+					groupIds);
+
+			Predicate objectDefinitionPredicate =
+				ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+					objectDefinitionId);
+
+			if (objectDefinitionPermissionWherePredicate != null) {
+				objectDefinitionPredicate = objectDefinitionPredicate.and(
+					Predicate.withParentheses(
+						objectDefinitionPermissionWherePredicate));
+			}
+
+			if (permissionWherePredicate == null) {
+				permissionWherePredicate = objectDefinitionPredicate;
+			}
+			else {
+				permissionWherePredicate = permissionWherePredicate.or(
+					objectDefinitionPredicate);
+			}
+		}
+
+		return Predicate.withParentheses(permissionWherePredicate);
 	}
 
 	private Column<?, Long> _getPrimaryKeyColumn(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -98,6 +98,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.model.ObjectFolder;
@@ -5575,6 +5576,237 @@ public class ObjectEntryLocalServiceTest {
 			24, values2, valuesList.get(1), selectedObjectFieldNames);
 		_assertObjectEntryValues(
 			24, values3, valuesList.get(2), selectedObjectFieldNames);
+	}
+
+	@Test
+	public void testGetValuesListCountByObjectDefinitionIds() throws Exception {
+
+		// Add object entry on irrelevant group
+
+		Group irrelevantGroup = GroupTestUtil.addGroup();
+
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), "name")),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry1 = _addObjectEntry(
+			irrelevantGroup.getGroupId(),
+			objectDefinition1.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry1.getObjectEntryId(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		// Add object entry on irrelevant object definition
+
+		ObjectDefinition irrelevantObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), "name")),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry2 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			irrelevantObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry2.getObjectEntryId(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		// Add object entry with distant expiration date
+
+		ObjectEntry objectEntry3 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition1.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		Date now = new Date();
+
+		objectEntry3.setExpirationDate(
+			new Date(now.getTime() + (10 * Time.DAY)));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry3);
+
+		// Add object entry with future review date
+
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), "name")),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		ObjectEntry objectEntry4 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition2.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry4.setReviewDate(new Date(now.getTime() + (5 * Time.DAY)));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry4);
+
+		// Add object entry with imminent expiration date
+
+		ObjectEntry objectEntry5 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition1.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry5.setExpirationDate(
+			new Date(now.getTime() + (3 * Time.DAY)));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry5);
+
+		// Add object entry with overdue expiration date
+
+		ObjectEntry objectEntry6 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition1.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry6.setExpirationDate(new Date(now.getTime() - Time.DAY));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry6);
+
+		// Add object entry with overdue review date
+
+		ObjectEntry objectEntry7 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition2.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		objectEntry7.setReviewDate(new Date(now.getTime() - (2 * Time.DAY)));
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry7);
+
+		// Add object entry with status draft
+
+		ObjectEntry objectEntry8 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition2.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry8.getObjectEntryId(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		// Add object entry with status expired
+
+		ObjectEntry objectEntry9 = _addObjectEntry(
+			TestPropsValues.getGroupId(),
+			objectDefinition2.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"name", RandomTestUtil.randomString()
+			).build());
+
+		_objectEntryLocalService.updateStatus(
+			TestPropsValues.getUserId(), objectEntry9.getObjectEntryId(),
+			WorkflowConstants.STATUS_EXPIRED, serviceContext);
+
+		Long[] groupIds = {TestPropsValues.getGroupId()};
+		Long[] objectDefinitionIds = {
+			objectDefinition1.getObjectDefinitionId(),
+			objectDefinition2.getObjectDefinitionId()
+		};
+
+		// Predicate with imminent expiration date
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(), groupIds, objectDefinitionIds,
+				ObjectEntryTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_APPROVED
+				).and(
+					ObjectEntryTable.INSTANCE.expirationDate.gt(now)
+				).and(
+					ObjectEntryTable.INSTANCE.expirationDate.lte(
+						new Date(now.getTime() + (7 * Time.DAY)))
+				)));
+
+		// Predicate with irrelevant group
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(),
+				new Long[] {irrelevantGroup.getGroupId()}, objectDefinitionIds,
+				ObjectEntryTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_DRAFT)));
+
+		// Predicate with irrelevant object definition
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(), groupIds,
+				new Long[] {irrelevantObjectDefinition.getObjectDefinitionId()},
+				ObjectEntryTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_DRAFT)));
+
+		// Predicate with overdue review date
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(), groupIds, objectDefinitionIds,
+				ObjectEntryTable.INSTANCE.reviewDate.lt(now)));
+
+		// Predicate with status draft
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(), groupIds, objectDefinitionIds,
+				ObjectEntryTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_DRAFT)));
+
+		// Predicate with status expired
+
+		Assert.assertEquals(
+			1,
+			_objectEntryLocalService.getValuesListCount(
+				TestPropsValues.getCompanyId(), groupIds, objectDefinitionIds,
+				ObjectEntryTable.INSTANCE.status.eq(
+					WorkflowConstants.STATUS_EXPIRED)));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			irrelevantObjectDefinition);
+
+		GroupTestUtil.deleteGroup(irrelevantGroup);
 	}
 
 	@FeatureFlag("LPD-17564")


### PR DESCRIPTION
## Summary

Add a new `ObjectEntryLocalService.getValuesListCount` overload that counts `ObjectEntry` rows across multiple `ObjectDefinition`s **without joining the per-definition dynamic tables**. The new path queries `ObjectEntryTable` directly with a caller-supplied `Predicate`.

```java
int getValuesListCount(
    Long[] groupIds, long companyId,
    Long[] objectDefinitionIds, Predicate predicate)
```

## Why

The existing overload (`getValuesListCount(... long objectDefinitionId, Predicate, boolean preferApproved, String search)`) is **per-definition**: it builds a `FROM` over the dynamic object-definition table, the extension table, and joins the localization table. That contract is right when filtering or sorting by a definition-specific custom field, but it has two costs that don't fit the use case we're working on:

1. **Many definitions, one count.** For LPD-79669 (CMS quick-filter chips: *In Draft*, *Expiring Soon*, *Expired*, *Review Date Overdue*) we need a single number that aggregates entries across all CMS `ObjectDefinition`s in a depot. Calling the existing overload N times and summing would be N queries with N×(dynamic+extension+localization) joins per chip — not viable on a depot with several CMS definitions.

2. **The predicate doesn't need definition columns.** All the CMS quick-filter predicates only reference columns that are native to `ObjectEntryTable` itself (`status`, `expirationDate`, `reviewDate`). The dynamic/extension/localization joins are dead weight for this use case.

This overload addresses both: a single count, across an arbitrary set of definitions, against `ObjectEntryTable` columns only.

## How

- New public method on `ObjectEntryLocalServiceImpl` (regenerated into the `Util` / `Wrapper` / interface via Service Builder).
- New private helper `_getObjectEntriesGroupByStepWithoutDefinition` whose `FROM` is `ObjectEntryTable.INSTANCE` (no dynamic-table joins). Where clause keeps the standard invariants: `companyId`, `groupId IN (...)`, `objectDefinitionId IN (...)`, `status != IN_TRASH`, root-entry restriction, `_getHeadObjectEntryPredicate(false)`, and the user-supplied `predicate`.
- Permission filtering via new `_getPermissionWherePredicateForDefinitions(groupIds, objectDefinitionIds)`: for each `objectDefinitionId`, an `(objectDefinitionId = X) AND <permX>` branch is OR-ed. The per-definition `_getPermissionWherePredicate(...)` is reused.

## Limitation

This overload does **not** support `ObjectDefinition`s with `accountEntryRestricted = true`. The existing `_getPermissionWherePredicate` builds a predicate that references a column of the per-definition dynamic table (the account-entry-restricted custom field). That column is not in the `FROM` clause of the new query, so the resulting SQL would be invalid at runtime. The CMS object definitions we care about today are not account-restricted; if that changes the path will have to be revised (skip that branch, or add per-definition joins).

## Test plan

New integration test `ObjectEntryLocalServiceTest.testGetValuesListCountByObjectDefinitionIds`:

- Creates three site-scoped `ObjectDefinition`s (two relevant + one used to verify isolation) plus an "irrelevant" `Group`.
- Seeds nine entries covering: `expiringSoon` (APPROVED, expDate = now+3d), an entry beyond the 7-day window, an already-expired-by-date entry, `DRAFT`, `EXPIRED`, `reviewDate` overdue / future, and exclusion cases (entry on the irrelevant definition, entry on the irrelevant group).
- Asserts the new method returns the expected count for each of the four CMS quick-filter predicates: `status = DRAFT`, `status = EXPIRED`, `status = APPROVED AND expirationDate > now AND expirationDate <= now+7d`, and `reviewDate < now`.
- Asserts isolation by `objectDefinitionIds` (irrelevant definition only counts when explicitly passed) and by `groupIds` (irrelevant group only counts when explicitly passed).

`gw testIntegration --tests com.liferay.object.service.test.ObjectEntryLocalServiceTest.testGetValuesListCountByObjectDefinitionIds` passes locally.

## Commits

1. `LPD-79679 Add an ObjectDefinition-agnostic getValuesListCount overload` — public method + private helpers in `ObjectEntryLocalServiceImpl`.
2. `LPD-79679 buildService` — Service Builder regeneration of `ObjectEntryLocalService`, `ObjectEntryLocalServiceUtil`, `ObjectEntryLocalServiceWrapper`.
3. `LPD-79679 Add test` — the integration test described above.
4. `LPD-79679 Semver` — `Bundle-Version` 123.0.0 → 123.1.0 and `packageinfo` 85.0.0 → 85.1.0 (minor: new public API surface).