### PR TITLE
LPD-69461 Headers in Forms Admin are using text-default, a CSS class that no longer exists. Modified by font-weight-normal

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record_set_descriptive.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record_set_descriptive.jsp
@@ -23,12 +23,12 @@ dateSearchEntry.setDate(ddlRecordSet.getModifiedDate());
 	</aui:a>
 </h2>
 
-<span class="text-default">
+<span class="font-weight-normal">
 	<div class="record-set-description">
 		<%= HtmlUtil.escape(ddlRecordSet.getDescription(locale)) %>
 	</div>
 </span>
-<span class="text-default">
+<span class="font-weight-normal">
 	<span class="record-set-id">
 		<liferay-ui:message key="id" />: <%= ddlRecordSet.getRecordSetId() %>
 	</span>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/data_provider_descriptive.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/data_provider_descriptive.jsp
@@ -20,13 +20,13 @@ DDMDataProviderInstance ddmDataProviderInstance = (DDMDataProviderInstance)row.g
 		</aui:a>
 	</div>
 
-	<div class="h5 text-default">
+	<div class="font-weight-normal h5">
 		<div class="text-truncate">
 			<%= HtmlUtil.escape(ddmDataProviderInstance.getDescription(locale)) %>
 		</div>
 	</div>
 
-	<div class="h5 text-default">
+	<div class="font-weight-normal h5">
 		<span class="data-provider-instance-id">
 			<liferay-ui:message key="id" />: <%= ddmDataProviderInstance.getDataProviderInstanceId() %>
 		</span>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -54,7 +54,7 @@ td.lfr-name-column {
 	margin-top: $baseline * 4;
 }
 
-.liferay-ddm-form-builder-rule-builder-content .text-default {
+.liferay-ddm-form-builder-rule-builder-content .font-weight-normal {
 	font-weight: normal;
 }
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set_descriptive.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set_descriptive.jsp
@@ -24,13 +24,13 @@ dateSearchEntry.setDate(ddmStructure.getModifiedDate());
 		</aui:a>
 	</div>
 
-	<div class="h5 text-default">
+	<div class="font-weight-normal h5">
 		<div class="form-instance-description text-truncate">
 			<%= HtmlUtil.escape(ddmStructure.getDescription(locale)) %>
 		</div>
 	</div>
 
-	<div class="h5 text-default">
+	<div class="font-weight-normal h5">
 		<span class="form-instance-id">
 			<liferay-ui:message key="id" />: <%= ddmStructure.getStructureId() %>
 		</span>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_descriptive.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance_descriptive.jsp
@@ -59,12 +59,12 @@ dateSearchEntry.setDate(ddmFormInstance.getModifiedDate());
 		</c:choose>
 	</h2>
 
-	<span class="text-default">
+	<span class="font-weight-normal">
 		<div class="form-instance-description text-truncate">
 			<%= HtmlUtil.replaceNewLine(HtmlUtil.escape(ddmFormInstance.getDescription(locale))) %>
 		</div>
 	</span>
-	<span class="text-default">
+	<span class="font-weight-normal">
 		<span class="form-instance-id">
 			<liferay-ui:message key="id" />: <%= ddmFormInstance.getFormInstanceId() %>
 		</span>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.es.js
@@ -28,9 +28,11 @@ export function RuleEditor({onCancel, onSave, rule, ...otherProps}) {
 			onSubmit={(event) => event.preventDefault()}
 		>
 			<div className="form-rule-builder-header">
-				<h2 className="text-default">{Liferay.Language.get('rule')}</h2>
+				<h2 className="font-weight-normal">
+					{Liferay.Language.get('rule')}
+				</h2>
 
-				<div className="h4 text-default">
+				<div className="font-weight-normal h4">
 					{Liferay.Language.get(
 						'define-condition-and-action-to-change-fields-and-elements-on-the-form'
 					)}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleList.es.js
@@ -461,7 +461,7 @@ export function RuleList({
 }) {
 	return (
 		<div className="form-rule-list">
-			<h1 className="text-default">
+			<h1 className="font-weight-normal">
 				{Liferay.Language.get('rule-builder')}
 			</h1>
 


### PR DESCRIPTION
Issue
Replace text-default, a CSS class that no longer exists

How I fixed it
References modified by font-weight-normal

Tests
No existing tests changes required.
<img width="2206" height="1128" alt="image" src="https://github.com/user-attachments/assets/5a07f85f-62e9-407b-943c-56ef04435ab9" />
