### PR TITLE
LPD-88577 Allow inheritance between modifiable system and custom objects

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryRelatedObjectsResourceTest.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -59,6 +60,8 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -657,6 +660,90 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testDeleteObjectEntryWithHierarchy() throws Exception {
+
+		// Modifiable system as child
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
+
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
+			_objectDefinition1.getObjectDefinitionId(),
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		ObjectEntry relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			modifiableSystemObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, RandomTestUtil.randomString()
+			).put(
+				objectField.getName(), _objectEntry1.getPrimaryKey()
+			).build());
+
+		Assert.assertEquals(
+			204,
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				_getEndpoint(_objectDefinition1, _objectEntry1.getPrimaryKey()),
+				Http.Method.DELETE));
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				_getEndpoint(
+					modifiableSystemObjectDefinition,
+					relatedObjectEntry.getPrimaryKey()),
+				Http.Method.GET));
+
+		// Modifiable system as parent
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			modifiableSystemObjectDefinition, objectFieldName,
+			RandomTestUtil.randomString());
+
+		objectRelationship = TreeTestUtil.bind(
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				objectField.getName(), objectEntry.getPrimaryKey()
+			).build());
+
+		Assert.assertEquals(
+			204,
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				_getEndpoint(
+					modifiableSystemObjectDefinition,
+					objectEntry.getPrimaryKey()),
+				Http.Method.DELETE));
+
+		Assert.assertEquals(
+			404,
+			HTTPTestUtil.invokeToHttpCode(
+				null,
+				_getEndpoint(
+					_objectDefinition2, relatedObjectEntry.getPrimaryKey()),
+				Http.Method.GET));
+	}
+
+	@Test
 	public void testGetByExternalReferenceCodeCurrentExternalReferenceCodeObjectRelationshipNamePage()
 		throws Exception {
 
@@ -994,6 +1081,82 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	}
 
 	@Test
+	public void testGetRelatedObjectEntriesWithHierarchy() throws Exception {
+
+		// Modifiable system as child
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
+
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
+			_objectDefinition1.getObjectDefinitionId(),
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		ObjectEntry relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			modifiableSystemObjectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName, RandomTestUtil.randomString()
+			).put(
+				objectField.getName(), _objectEntry1.getPrimaryKey()
+			).build());
+
+		_assertEquals(
+			relatedObjectEntry,
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				_getEndpoint(
+					objectRelationship.getName(), _objectDefinition1,
+					_objectEntry1.getPrimaryKey()),
+				Http.Method.GET
+			).getJSONArray(
+				"items"
+			));
+
+		// Modifiable system as parent
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			modifiableSystemObjectDefinition, objectFieldName,
+			RandomTestUtil.randomString());
+
+		objectRelationship = TreeTestUtil.bind(
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		objectField = _objectFieldLocalService.fetchObjectField(
+			objectRelationship.getObjectFieldId2());
+
+		relatedObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			_objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				objectField.getName(), objectEntry.getPrimaryKey()
+			).build());
+
+		_assertEquals(
+			relatedObjectEntry,
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				_getEndpoint(
+					objectRelationship.getName(),
+					modifiableSystemObjectDefinition,
+					objectEntry.getPrimaryKey()),
+				Http.Method.GET
+			).getJSONArray(
+				"items"
+			));
+	}
+
+	@Test
 	public void testGetRelatedSystemObjectsWhenRelationExists()
 		throws Exception {
 
@@ -1185,6 +1348,80 @@ public class ObjectEntryRelatedObjectsResourceTest {
 			_addObjectRelationship(
 				_objectDefinition1, _userSystemObjectDefinition,
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY));
+	}
+
+	@Test
+	public void testPostRelatedObjectEntryWithHierarchy() throws Exception {
+
+		// Modifiable system as child
+
+		String objectFieldName = "x" + RandomTestUtil.randomString();
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			_publishModifiableSystemObjectDefinition(objectFieldName);
+
+		ObjectRelationship objectRelationship = TreeTestUtil.bind(
+			_objectDefinition1.getObjectDefinitionId(),
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		String objectFieldValue1 = RandomTestUtil.randomString();
+
+		JSONObject relatedObjectEntryJSONObject =
+			HTTPTestUtil.invokeToJSONObject(
+				JSONFactoryUtil.createJSONObject(
+				).put(
+					objectFieldName, objectFieldValue1
+				).toJSONString(),
+				_getEndpoint(
+					objectRelationship.getName(), _objectDefinition1,
+					_objectEntry1.getPrimaryKey()),
+				Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			JSONUtil.getValue(
+				relatedObjectEntryJSONObject, "JSONObject/status",
+				"Object/code"));
+		Assert.assertEquals(
+			objectFieldValue1,
+			relatedObjectEntryJSONObject.get(objectFieldName));
+
+		// Modifiable system as parent
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			modifiableSystemObjectDefinition, objectFieldName,
+			RandomTestUtil.randomString());
+
+		objectRelationship = TreeTestUtil.bind(
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectDefinition2.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectRelationships.add(objectRelationship);
+
+		String objectFieldValue2 = RandomTestUtil.randomString();
+
+		relatedObjectEntryJSONObject = HTTPTestUtil.invokeToJSONObject(
+			JSONFactoryUtil.createJSONObject(
+			).put(
+				_OBJECT_FIELD_NAME_2, objectFieldValue2
+			).toJSONString(),
+			_getEndpoint(
+				objectRelationship.getName(), modifiableSystemObjectDefinition,
+				objectEntry.getPrimaryKey()),
+			Http.Method.POST);
+
+		Assert.assertEquals(
+			0,
+			JSONUtil.getValue(
+				relatedObjectEntryJSONObject, "JSONObject/status",
+				"Object/code"));
+		Assert.assertEquals(
+			objectFieldValue2,
+			relatedObjectEntryJSONObject.get(_OBJECT_FIELD_NAME_2));
 	}
 
 	@Test
@@ -1726,6 +1963,14 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		_objectDefinitionLocalService.updateObjectDefinition(objectDefinition);
 	}
 
+	private String _getEndpoint(
+		ObjectDefinition objectDefinition, long primaryKey) {
+
+		return StringBundler.concat(
+			objectDefinition.getRESTContextPath(), StringPool.SLASH,
+			primaryKey);
+	}
+
 	private String _getEndpoint(String name) {
 		return StringBundler.concat(
 			_objectDefinition1.getRESTContextPath(), StringPool.SLASH,
@@ -1735,6 +1980,13 @@ public class ObjectEntryRelatedObjectsResourceTest {
 	private String _getEndpoint(String name, long primaryKey) {
 		return StringBundler.concat(
 			_getEndpoint(name), StringPool.SLASH, primaryKey);
+	}
+
+	private String _getEndpoint(
+		String name, ObjectDefinition objectDefinition, long primaryKey) {
+
+		return StringBundler.concat(
+			_getEndpoint(objectDefinition, primaryKey), StringPool.SLASH, name);
 	}
 
 	private String _getEndpoint(
@@ -1774,6 +2026,23 @@ public class ObjectEntryRelatedObjectsResourceTest {
 		}
 
 		return systemObjectEntryJSONObject.getString("id");
+	}
+
+	private ObjectDefinition _publishModifiableSystemObjectDefinition(
+			String objectFieldName)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishSystemObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING,
+						RandomTestUtil.randomString(), objectFieldName)));
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
 	}
 
 	private void _testDeleteCustomObjectDefinition1WithCustomObjectDefinition2(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -328,10 +328,10 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword(
-			"objectDefinitionId", objectEntry.getObjectDefinitionId());
-		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",
 			objectDefinition.getExternalReferenceCode());
+		document.addKeyword(
+			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 		document.addKeyword(
 			"objectDefinitionName", objectDefinition.getShortName());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -1725,19 +1725,8 @@ public class ObjectRelationshipLocalServiceImpl
 					"an-edge-of-a-root-context");
 		}
 
-		if ((objectDefinition1.isModifiableAndSystem() &&
-			 !objectDefinition2.isSystem()) ||
-			(objectDefinition2.isModifiableAndSystem() &&
-			 !objectDefinition1.isSystem())) {
-
-			throw new ObjectRelationshipEdgeException(
-				"Inheritance between modifiable system and custom object " +
-					"definitions is not allowed",
-				"inheritance-between-modifiable-system-and-custom-object-" +
-					"definitions-is-not-allowed");
-		}
-		else if (objectDefinition1.isUnmodifiableSystemObject() ||
-				 objectDefinition2.isUnmodifiableSystemObject()) {
+		if (objectDefinition1.isUnmodifiableSystemObject() ||
+			objectDefinition2.isUnmodifiableSystemObject()) {
 
 			throw new ObjectRelationshipEdgeException(
 				"System object definitions cannot inherit configurations",

--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/ObjectDefinitionTestUtil.java
@@ -294,17 +294,24 @@ public class ObjectDefinitionTestUtil {
 	public static ObjectDefinition publishSystemObjectDefinition()
 		throws Exception {
 
-		ObjectDefinition objectDefinition = addModifiableSystemObjectDefinition(
-			TestPropsValues.getUserId(), null,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			"Test", null, null,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+		return publishSystemObjectDefinition(
 			Collections.singletonList(
 				ObjectFieldUtil.createObjectField(
 					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 					ObjectFieldConstants.DB_TYPE_STRING,
 					RandomTestUtil.randomString(), StringUtil.randomId())));
+	}
+
+	public static ObjectDefinition publishSystemObjectDefinition(
+			List<ObjectField> objectFields)
+		throws Exception {
+
+		ObjectDefinition objectDefinition = addModifiableSystemObjectDefinition(
+			TestPropsValues.getUserId(), null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			"Test", null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionConstants.SCOPE_COMPANY, null, 1, objectFields);
 
 		return ObjectDefinitionLocalServiceUtil.publishSystemObjectDefinition(
 			TestPropsValues.getUserId(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -770,6 +770,93 @@ public class ObjectDefinitionTreeUtilTest {
 	}
 
 	@Test
+	public void testBindObjectDefinitionsWithModifiableSystemObjectDefinition()
+		throws Exception {
+
+		// Modifiable system as child
+
+		ObjectDefinition modifiableSystemObjectDefinition =
+			ObjectDefinitionTestUtil.publishSystemObjectDefinition();
+
+		_testBindObjectDefinitions(
+			_objectDefinitionA, modifiableSystemObjectDefinition,
+			(objectDefinition1, objectDefinition2) ->
+				TreeTestUtil.assertRootObjectDefinitionIds(
+					LinkedHashMapBuilder.put(
+						objectDefinition1,
+						new ObjectDefinition[] {objectDefinition1}
+					).put(
+						objectDefinition2,
+						new ObjectDefinition[] {objectDefinition1}
+					).build()));
+
+		TreeTestUtil.unbind(
+			_objectDefinitionA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinitionA,
+				modifiableSystemObjectDefinition);
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			Collections.singletonList(objectRelationship));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				_objectDefinitionA, new ObjectDefinition[] {_objectDefinitionA}
+			).put(
+				modifiableSystemObjectDefinition,
+				new ObjectDefinition[] {_objectDefinitionA}
+			).build());
+
+		TreeTestUtil.unbind(
+			_objectDefinitionA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		// Modifiable system as parent
+
+		_testBindObjectDefinitions(
+			modifiableSystemObjectDefinition, _objectDefinitionB,
+			(objectDefinition1, objectDefinition2) ->
+				TreeTestUtil.assertRootObjectDefinitionIds(
+					LinkedHashMapBuilder.put(
+						objectDefinition1,
+						new ObjectDefinition[] {objectDefinition1}
+					).put(
+						objectDefinition2,
+						new ObjectDefinition[] {objectDefinition1}
+					).build()));
+
+		TreeTestUtil.unbind(
+			modifiableSystemObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, modifiableSystemObjectDefinition,
+			_objectDefinitionB);
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			Collections.singletonList(objectRelationship));
+
+		TreeTestUtil.assertRootObjectDefinitionIds(
+			LinkedHashMapBuilder.put(
+				modifiableSystemObjectDefinition,
+				new ObjectDefinition[] {modifiableSystemObjectDefinition}
+			).put(
+				_objectDefinitionB,
+				new ObjectDefinition[] {modifiableSystemObjectDefinition}
+			).build());
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {modifiableSystemObjectDefinition.getName()},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
+	@Test
 	public void testBindObjectDefinitionsWithObjectEntries() throws Exception {
 		ObjectEntry objectEntryA1 = ObjectEntryTestUtil.addObjectEntry(
 			0, _objectDefinitionA.getObjectDefinitionId(), Map.of());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -246,30 +246,6 @@ public class ObjectRelationshipLocalServiceTest {
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				"able", false, ObjectRelationshipConstants.TYPE_MANY_TO_MANY,
 				null));
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Inheritance between modifiable system and custom object " +
-				"definitions is not allowed",
-			() -> _objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_modifiableSystemObjectDefinition.getObjectDefinitionId(),
-				_objectDefinition1.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null));
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Inheritance between modifiable system and custom object " +
-				"definitions is not allowed",
-			() -> _objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_modifiableSystemObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null));
 
 		ObjectDefinition userObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
@@ -1001,23 +977,6 @@ public class ObjectRelationshipLocalServiceTest {
 		TreeTestUtil.deleteObjectDefinitionHierarchy(
 			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
 			_objectEntryLocalService, _objectRelationshipLocalService);
-
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Inheritance between modifiable system and custom object " +
-				"definitions is not allowed",
-			() -> _bindObjectDefinitions(
-				ObjectRelationshipTestUtil.addObjectRelationship(
-					_objectRelationshipLocalService,
-					_modifiableSystemObjectDefinition, _objectDefinition1)));
-		AssertUtils.assertFailure(
-			ObjectRelationshipEdgeException.class,
-			"Inheritance between modifiable system and custom object " +
-				"definitions is not allowed",
-			() -> _bindObjectDefinitions(
-				ObjectRelationshipTestUtil.addObjectRelationship(
-					_objectRelationshipLocalService, _objectDefinition1,
-					_modifiableSystemObjectDefinition)));
 
 		ObjectRelationship objectRelationship3 =
 			_objectRelationshipLocalService.addObjectRelationship(


### PR DESCRIPTION
Related Issue: [LPD-88577](https://liferay.atlassian.net/browse/LPD-88577)

## What is being fixed

The Root Object Model framework restricted `edge=true` inheritance
relationships to same-type pairs only — Custom + Custom or Modifiable
System + Modifiable System. Cross-type inheritance (a custom Object
Definition inheriting from a modifiable system one, or vice versa) was
forbidden as a precaution during the original Root Model rollout. This
story removes that restriction so an Object Admin can create inheritance
in either direction. Unmodifiable system Object Definitions (e.g.,
User, Account) remain forbidden.

## How it is being fixed

The cross-type rejection block in
`ObjectRelationshipLocalServiceImpl._validateEdge` was removed, leaving
only the unmodifiable system check. The change is gated by the existing
feature flag `LPD-34594`, which already wraps the entire `_validateEdge`
method, so no new flag is required.

The four existing negative assertions in `ObjectRelationshipLocalServiceTest`
were converted to positive cases that exercise both directions —
modifiable system as parent and as child — through both
`addObjectRelationship` and `updateObjectRelationship` (toggle
`edge=false → true`). Two new tests were added: one verifies cascade
delete propagation across cross-type entries, the other verifies that
`rootObjectDefinitionIds` is set on the child when the modifiable system
side is the root. The unmodifiable-system tests remain as failure cases.

Coverage was also added in `ObjectEntryRelatedObjectsResourceTest` to
exercise the same scenarios at the REST layer: entry creation through
the related-objects endpoint and cascade delete of the parent in both
directions.

[LPD-88577]: https://liferay.atlassian.net/browse/LPD-88577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ