### PR TITLE
LPD-88942 Increment object playwright projects in test.properties

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -2896,25 +2896,10 @@
     modules.includes.public[modules-semantic-versioning][bpm]=${bpm.testing.modules}
 
     playwright.test.project[playwright-js-tomcat101-*][bpm]=\
+        ${object.playwright.projects},\
         calendar-web.main,\
         dynamic-data-mapping-form-web.main,\
         notification-web.main,\
-        object-web.action,\
-        object-web.client-extension,\
-        object-web.entry,\
-        object-web.field,\
-        object-web.folder,\
-        object-web.forms-integration,\
-        object-web.hierarchy,\
-        object-web.layout,\
-        object-web.list-type-definition,\
-        object-web.main,\
-        object-web.notification,\
-        object-web.relationship,\
-        object-web.salesforce,\
-        object-web.validation,\
-        object-web.view,\
-        object-web.workflow,\
         portal-workflow-kaleo-designer-web.main,\
         portal-workflow-kaleo-forms-web.main,\
         portal-workflow-metrics-web.main,\
@@ -4818,9 +4803,9 @@
         apps/object/**
 
     object.playwright.projects=\
-        notification.main,\
         object-web.action,\
         object-web.client-extension,\
+        object-web.content-page-integration,\
         object-web.entry,\
         object-web.export-import,\
         object-web.field,\
@@ -4833,6 +4818,7 @@
         object-web.notification,\
         object-web.relationship,\
         object-web.salesforce,\
+        object-web.upgrade,\
         object-web.validation,\
         object-web.view,\
         object-web.workflow


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88942

## What is being fixed

The `object.playwright.projects` list in `test.properties` was missing two playwright projects that already exist under `modules/test/playwright/tests/object-web` (`content-page-integration` and `upgrade`) and contained a stale `notification.main` entry that does not match any registered project. The `[bpm]` batch was also duplicating each `object-web.*` entry inline, so future additions had to be made in two places.

## How it is being fixed

`object.playwright.projects` is updated to list every `object-web` playwright project that currently exists, and the `[bpm]` batch now expands `${object.playwright.projects}` instead of repeating each entry.