### PR TITLE
LPD-88179 Update libraries to Jakarta-native - BPM

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 12.4.0
+version 13.0.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
@@ -1,11 +1,10 @@
 dependencies {
 	compileInclude group: "com.jayway.jsonpath", name: "json-path", version: "2.9.0"
-	compileInclude group: "com.liferay", name: "org.hdrhistogram", version: "2.1.9.JAKARTA-LIFERAY-PATCHED-1"
 	compileInclude group: "com.netflix.archaius", name: "archaius-core", version: "0.4.1"
 	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.18"
 	compileInclude group: "io.reactivex", name: "rxjava", version: "1.2.0"
+	compileInclude group: "org.hdrhistogram", name: "HdrHistogram", version: "2.2.2"
 	compileOnly group: "com.liferay", name: "org.apache.commons.configuration", version: "1.10.LIFERAY-PATCHED-2"
-	compileOnly group: "com.liferay", name: "org.osgi.service.http.whiteboard", version: "1.1.1.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
@@ -15,6 +14,7 @@ dependencies {
 	compileOnly group: "net.minidev", name: "json-smart", version: "2.4.10"
 	compileOnly group: "org.apache.httpcomponents", name: "httpcore", version: "4.4.14"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.servlet", version: "2.0.0"
 	compileOnly group: "org.ow2.asm", name: "asm", version: "9.7"
 	compileOnly group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
 	testImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
-	testImplementation group: "com.liferay", name: "org.osgi.service.jaxrs", version: "1.0.0.JAKARTA-LIFERAY-PATCHED-1"
 	testImplementation group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testImplementation group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.1"
 	testImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
 	testImplementation project(":apps:depot:depot-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
 	testImplementation group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
-	testImplementation group: "com.liferay", name: "org.osgi.service.jaxrs", version: "1.0.0.JAKARTA-LIFERAY-PATCHED-1"
 	testImplementation group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testImplementation group: "org.osgi", name: "org.osgi.service.jaxrs", version: "1.0.1"
 	testImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-web")
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Site API
 Bundle-SymbolicName: com.liferay.headless.admin.site.api
-Bundle-Version: 24.3.1
+Bundle-Version: 24.4.0
 Export-Package:\
 	com.liferay.headless.admin.site.dto.v1_0,\
 	com.liferay.headless.admin.site.resource.v1_0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 24.3.0
+version 24.4.0

--- a/modules/apps/headless/headless-object/headless-object-impl/build.gradle
+++ b/modules/apps/headless/headless-object/headless-object-impl/build.gradle
@@ -1,7 +1,5 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations-jakarta", version: "2.2.28"

--- a/modules/apps/object/object-admin-rest-impl/build.gradle
+++ b/modules/apps/object/object-admin-rest-impl/build.gradle
@@ -1,7 +1,5 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.cxf.core", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
-	compileOnly group: "com.liferay", name: "org.apache.cxf.rt.frontend.jaxrs", version: "3.6.9.JAKARTA-LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type-api/bnd.bnd
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Object Dynamic Data Mapping Form Field Type API
 Bundle-SymbolicName: com.liferay.object.dynamic.data.mapping.form.field.type.api
-Bundle-Version: 1.3.1
+Bundle-Version: 1.4.0
 Export-Package: com.liferay.object.dynamic.data.mapping.form.field.type.constants

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type-api/src/main/resources/com/liferay/object/dynamic/data/mapping/form/field/type/constants/packageinfo
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type-api/src/main/resources/com/liferay/object/dynamic/data/mapping/form/field/type/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-88179

While developing this task, I observed that org.apache.cxf.core and org.apache.cxf.rt.frontend.jaxrs version 3.x.x are not compatible with Jakarta namespaces. However, upgrading to 4.x.x results in a loss of compatibility with the OSGi Activator.