### PR TITLE
LPD-88550 Support ASSIGNEE field in search, indexing, and filtering

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -96,7 +96,14 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 		if (Objects.equals(
 				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME)) {
+				ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE)) {
+
+			return new StringEntityField(
+				objectField.getName(), locale -> objectField.getName());
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_DATE_TIME)) {
 
 			return new DateTimeEntityField(
 				objectField.getName(), locale -> objectField.getName(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.internal.layout.tab.screen.navigation.category.ObjectLayoutTabScreenNavigationCategory;
 import com.liferay.object.internal.notification.handler.ObjectDefinitionNotificationHandler;
 import com.liferay.object.internal.notification.term.contributor.ObjectDefinitionNotificationTermEvaluator;
@@ -141,6 +142,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
+		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectFolderLocalService objectFolderLocalService,
 		ObjectLayoutLocalService objectLayoutLocalService,
@@ -177,6 +179,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
+		_objectFieldBusinessTypeRegistry = objectFieldBusinessTypeRegistry;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectFolderLocalService = objectFolderLocalService;
 		_objectLayoutLocalService = objectLayoutLocalService;
@@ -324,6 +327,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						_accountEntryOrganizationRelLocalService,
 						_dlFileEntryLocalService,
 						_objectEntryFolderLocalService,
+						_objectFieldBusinessTypeRegistry,
 						_textEmbeddingDocumentContributor),
 					HashMapDictionaryBuilder.<String, Object>put(
 						"indexer.class.name", objectDefinition.getClassName()
@@ -649,6 +653,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
+	private final ObjectFieldBusinessTypeRegistry
+		_objectFieldBusinessTypeRegistry;
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectFolderLocalService _objectFolderLocalService;
 	private final ObjectLayoutLocalService _objectLayoutLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
@@ -19,6 +19,7 @@ import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -39,6 +40,38 @@ import java.util.Locale;
  * @author Carolina Barbosa
  */
 public class ObjectEntrySearchUtil {
+
+	public static Predicate getAssigneeFieldPredicate(
+		Table<?> table, String dbColumnName, String search) {
+
+		String[] parts = StringUtil.split(search, CharPool.UNDERLINE);
+
+		if (parts.length != 2) {
+			return null;
+		}
+
+		long classNameId = GetterUtil.getLong(parts[0]);
+		long classPK = GetterUtil.getLong(parts[1]);
+
+		if ((classNameId == 0L) || (classPK == 0L)) {
+			return null;
+		}
+
+		Column<?, Long> classNameIdColumn = (Column<?, Long>)table.getColumn(
+			"classNameId_" + dbColumnName);
+		Column<?, Long> classPKColumn = (Column<?, Long>)table.getColumn(
+			"classPK_" + dbColumnName);
+
+		if ((classNameIdColumn == null) || (classPKColumn == null)) {
+			return null;
+		}
+
+		return classNameIdColumn.eq(
+			classNameId
+		).and(
+			classPKColumn.eq(classPK)
+		);
+	}
 
 	public static String getLanguageId() throws PortalException {
 		Locale locale = null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AssigneeObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AssigneeObjectFieldBusinessType.java
@@ -82,6 +82,32 @@ public class AssigneeObjectFieldBusinessType
 		return values.get(objectField.getName());
 	}
 
+	public String getDisplayName(long classNameId, long classPK) {
+		String className = _portal.fetchClassName(classNameId);
+
+		if (StringUtil.equals(className, Role.class.getName())) {
+			Role role = _roleLocalService.fetchRole(classPK);
+
+			if (role != null) {
+				return role.getName();
+			}
+
+			return null;
+		}
+
+		if (StringUtil.equals(className, User.class.getName())) {
+			User user = _userLocalService.fetchUser(classPK);
+
+			if (user != null) {
+				return user.getFullName();
+			}
+
+			return null;
+		}
+
+		return null;
+	}
+
 	@Override
 	public Serializable getDTOValue(
 			DTOConverterContext dtoConverterContext,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/ObjectEntryModelSearchConfigurator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/ObjectEntryModelSearchConfigurator.java
@@ -7,6 +7,7 @@ package com.liferay.object.internal.search;
 
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.internal.search.spi.model.index.contributor.ObjectEntryModelDocumentContributor;
 import com.liferay.object.internal.search.spi.model.result.contributor.ObjectEntryModelSummaryContributor;
 import com.liferay.object.model.ObjectDefinition;
@@ -82,6 +83,7 @@ public class ObjectEntryModelSearchConfigurator
 				new ObjectEntryModelDocumentContributor(
 					_accountEntryOrganizationRelLocalService,
 					_dlFileEntryLocalService, _objectEntryFolderLocalService,
+					_objectFieldBusinessTypeRegistry,
 					_textEmbeddingDocumentContributor);
 
 		_modelDocumentContributorServiceRegistration =
@@ -226,6 +228,9 @@ public class ObjectEntryModelSearchConfigurator
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -14,6 +14,8 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
+import com.liferay.object.internal.field.business.type.AssigneeObjectFieldBusinessType;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -81,12 +83,14 @@ public class ObjectEntryModelDocumentContributor
 			accountEntryOrganizationRelLocalService,
 		DLFileEntryLocalService dlFileEntryLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
+		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		TextEmbeddingDocumentContributor textEmbeddingDocumentContributor) {
 
 		_accountEntryOrganizationRelLocalService =
 			accountEntryOrganizationRelLocalService;
 		_dlFileEntryLocalService = dlFileEntryLocalService;
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+		_objectFieldBusinessTypeRegistry = objectFieldBusinessTypeRegistry;
 		_textEmbeddingDocumentContributor = textEmbeddingDocumentContributor;
 	}
 
@@ -158,7 +162,39 @@ public class ObjectEntryModelDocumentContributor
 
 		if (StringUtil.equals(
 				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+				ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE) &&
+			(fieldValue instanceof Map)) {
+
+			Map<String, Long> assigneeMap = (Map<String, Long>)fieldValue;
+
+			long classNameId = MapUtil.getLong(assigneeMap, "classNameId");
+			long classPK = MapUtil.getLong(assigneeMap, "classPK");
+
+			fieldValue = StringBundler.concat(
+				classNameId, StringPool.UNDERLINE, classPK);
+
+			AssigneeObjectFieldBusinessType assigneeObjectFieldBusinessType =
+				(AssigneeObjectFieldBusinessType)
+					_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
+						ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE);
+
+			if (assigneeObjectFieldBusinessType != null) {
+				String assigneeName =
+					assigneeObjectFieldBusinessType.getDisplayName(
+						classNameId, classPK);
+
+				if (Validator.isNotNull(assigneeName)) {
+					_addField(
+						fieldArray, fieldName, "value_text", assigneeName);
+
+					_appendToContent(
+						objectContentHelper, locale, fieldName, assigneeName);
+				}
+			}
+		}
+		else if (StringUtil.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 			fieldValue = _getFileName(
 				GetterUtil.getLong(fieldValue), objectDefinition);
@@ -328,10 +364,10 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword(
-			"objectDefinitionId", objectEntry.getObjectDefinitionId());
-		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",
 			objectDefinition.getExternalReferenceCode());
+		document.addKeyword(
+			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 		document.addKeyword(
 			"objectDefinitionName", objectDefinition.getShortName());
 
@@ -707,6 +743,8 @@ public class ObjectEntryModelDocumentContributor
 		_accountEntryOrganizationRelLocalService;
 	private final DLFileEntryLocalService _dlFileEntryLocalService;
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+	private final ObjectFieldBusinessTypeRegistry
+		_objectFieldBusinessTypeRegistry;
 	private final TextEmbeddingDocumentContributor
 		_textEmbeddingDocumentContributor;
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -248,6 +248,28 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE)) {
+
+			String keywordFieldName =
+				"nestedFieldArray.value_keyword_lowercase";
+			String textFieldName = "nestedFieldArray.value_text";
+
+			BooleanQuery assigneeBooleanQuery = new BooleanQuery();
+
+			assigneeBooleanQuery.add(
+				new TermQuery(keywordFieldName, StringUtil.toLowerCase(token)),
+				BooleanClauseOccur.SHOULD);
+			assigneeBooleanQuery.add(
+				new MatchQuery(textFieldName, token),
+				BooleanClauseOccur.SHOULD);
+
+			nestedBooleanQuery.add(
+				assigneeBooleanQuery, BooleanClauseOccur.MUST);
+
+			queryConfig.addHighlightFieldNames(keywordFieldName, textFieldName);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) ||
 				 Objects.equals(
 					 objectField.getDBType(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -69,6 +69,7 @@ import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.builder.LongIntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.ObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.internal.dao.db.ObjectDBManagerUtil;
@@ -1086,12 +1087,12 @@ public class ObjectDefinitionLocalServiceImpl
 				_objectActionLocalService, objectDefinitionLocalService,
 				_objectDefinitionSettingLocalService,
 				_objectEntryFolderLocalService, _objectEntryLocalService,
-				_objectEntryService, _objectFieldLocalService,
-				_objectFolderLocalService, _objectLayoutLocalService,
-				_objectLayoutTabLocalService, _objectRelationshipLocalService,
-				_objectScopeProviderRegistry, _objectViewLocalService,
-				_organizationLocalService, _portal, _portletLocalService,
-				_resourceActions, _userLocalService,
+				_objectEntryService, _objectFieldBusinessTypeRegistry,
+				_objectFieldLocalService, _objectFolderLocalService,
+				_objectLayoutLocalService, _objectLayoutTabLocalService,
+				_objectRelationshipLocalService, _objectScopeProviderRegistry,
+				_objectViewLocalService, _organizationLocalService, _portal,
+				_portletLocalService, _resourceActions, _userLocalService,
 				_resourcePermissionLocalService, _searchLocalizationHelper,
 				_sharingModelResourcePermissionConfigurator,
 				_systemEventLocalService, _textEmbeddingDocumentContributor,
@@ -4003,6 +4004,9 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
+
+	@Reference
+	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3815,31 +3815,8 @@ public class ObjectEntryLocalServiceImpl
 		Predicate searchPredicate = null;
 
 		for (ObjectField objectField : objectFields) {
-			Table<?> table = _objectFieldLocalService.getTable(
-				objectDefinitionId, objectField.getName());
-
-			Column<?, ?> column = table.getColumn(
-				objectField.getDBColumnName());
-
-			if (column == null) {
-				continue;
-			}
-
-			Predicate objectFieldPredicate = null;
-
-			if (Objects.equals(
-					objectField.getRelationshipType(),
-					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
-
-				objectFieldPredicate = _getRelationshipObjectFieldPredicate(
-					column, objectField, search);
-			}
-			else {
-				objectFieldPredicate =
-					ObjectEntrySearchUtil.getObjectFieldPredicate(
-						objectField.getBusinessType(), column,
-						objectField.getDBType(), search);
-			}
+			Predicate objectFieldPredicate = _getObjectFieldPredicate(
+				objectDefinitionId, objectField, search);
 
 			if (objectFieldPredicate == null) {
 				continue;
@@ -4735,6 +4712,32 @@ public class ObjectEntryLocalServiceImpl
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
 		}
+	}
+
+	private Predicate _getObjectFieldPredicate(
+			long objectDefinitionId, ObjectField objectField, String search)
+		throws PortalException {
+
+		Table<?> table = _objectFieldLocalService.getTable(
+			objectDefinitionId, objectField.getName());
+
+		Column<?, ?> column = table.getColumn(objectField.getDBColumnName());
+
+		if (column == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectField.getRelationshipType(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+			return _getRelationshipObjectFieldPredicate(
+				column, objectField, search);
+		}
+
+		return ObjectEntrySearchUtil.getObjectFieldPredicate(
+			objectField.getBusinessType(), column, objectField.getDBType(),
+			search);
 	}
 
 	private GroupByStep _getOneToManyObjectEntriesGroupByStep(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4721,6 +4721,13 @@ public class ObjectEntryLocalServiceImpl
 		Table<?> table = _objectFieldLocalService.getTable(
 			objectDefinitionId, objectField.getName());
 
+		if (objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE)) {
+
+			return ObjectEntrySearchUtil.getAssigneeFieldPredicate(
+				table, objectField.getDBColumnName(), search);
+		}
+
 		Column<?, ?> column = table.getColumn(objectField.getDBColumnName());
 
 		if (column == null) {

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -11,19 +11,27 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
+import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -43,6 +51,53 @@ public class ObjectEntryKeywordQueryContributorTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContributeWithAssigneeField() throws Exception {
+		ObjectDefinition objectDefinition = _mockObjectDefinition(false);
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		ObjectField assigneeObjectField = _mockAssigneeObjectField(
+			RandomTestUtil.randomString());
+
+		Mockito.when(
+			objectFieldBag.getNonsystemIndexedObjectFields()
+		).thenReturn(
+			Arrays.asList(assigneeObjectField)
+		);
+
+		ArgumentCaptor<Query> argumentCaptor = ArgumentCaptor.forClass(
+			Query.class);
+
+		BooleanQuery booleanQuery = _mockBooleanQuery(argumentCaptor);
+
+		ObjectEntryKeywordQueryContributor contributor =
+			_createObjectEntryKeywordQueryContributor(objectDefinition);
+
+		String token = RandomTestUtil.randomString();
+
+		contributor.contribute(
+			token, booleanQuery, _mockKeywordQueryContributorHelper());
+
+		List<Query> queries = argumentCaptor.getAllValues();
+
+		Assert.assertEquals(1, _countNestedQueries(queries));
+
+		TermQuery termQuery = _findAssigneeTermQuery(queries);
+
+		Assert.assertNotNull(termQuery);
+
+		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(token), queryTerm.getValue());
+
+		MatchQuery matchQuery = _findAssigneeMatchQuery(queries);
+
+		Assert.assertNotNull(matchQuery);
+		Assert.assertEquals(token, matchQuery.getValue());
+	}
 
 	@Test
 	public void testContributeWithCustomObjectDefinition() throws Exception {
@@ -137,6 +192,136 @@ public class ObjectEntryKeywordQueryContributorTest {
 			objectDefinition, Mockito.mock(ObjectFieldLocalService.class),
 			Mockito.mock(ObjectViewLocalService.class),
 			Mockito.mock(SearchLocalizationHelper.class));
+	}
+
+	private MatchQuery _findAssigneeMatchQuery(List<Query> queries) {
+		for (Query assigneeQuery : _getAssigneeBooleanQueryClauses(queries)) {
+			if (!(assigneeQuery instanceof MatchQuery)) {
+				continue;
+			}
+
+			MatchQuery matchQuery = (MatchQuery)assigneeQuery;
+
+			if (Objects.equals(
+					matchQuery.getField(), "nestedFieldArray.value_text")) {
+
+				return matchQuery;
+			}
+		}
+
+		return null;
+	}
+
+	private TermQuery _findAssigneeTermQuery(List<Query> queries) {
+		for (Query assigneeQuery : _getAssigneeBooleanQueryClauses(queries)) {
+			if (!(assigneeQuery instanceof TermQuery)) {
+				continue;
+			}
+
+			TermQuery termQuery = (TermQuery)assigneeQuery;
+
+			QueryTerm queryTerm = termQuery.getQueryTerm();
+
+			if (Objects.equals(
+					queryTerm.getField(),
+					"nestedFieldArray.value_keyword_lowercase")) {
+
+				return termQuery;
+			}
+		}
+
+		return null;
+	}
+
+	private List<Query> _getAssigneeBooleanQueryClauses(List<Query> queries) {
+		for (Query query : queries) {
+			if (!(query instanceof NestedQuery)) {
+				continue;
+			}
+
+			NestedQuery nestedQuery = (NestedQuery)query;
+
+			BooleanQuery nestedBooleanQuery =
+				(BooleanQuery)nestedQuery.getQuery();
+
+			for (BooleanClause<Query> booleanClause :
+					nestedBooleanQuery.clauses()) {
+
+				Query innerQuery = booleanClause.getClause();
+
+				if (!(innerQuery instanceof BooleanQuery)) {
+					continue;
+				}
+
+				BooleanQuery assigneeBooleanQuery = (BooleanQuery)innerQuery;
+
+				List<Query> assigneeQueries = new ArrayList<>();
+
+				for (BooleanClause<Query> assigneeClause :
+						assigneeBooleanQuery.clauses()) {
+
+					assigneeQueries.add(assigneeClause.getClause());
+				}
+
+				return assigneeQueries;
+			}
+		}
+
+		return Collections.emptyList();
+	}
+
+	private ObjectField _mockAssigneeObjectField(String name) {
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE
+		);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			ObjectFieldConstants.DB_TYPE_LONG
+		);
+
+		Mockito.when(
+			objectField.getIndexedLanguageId()
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.isIndexed()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectField.isMetadata()
+		).thenReturn(
+			false
+		);
+
+		return objectField;
 	}
 
 	private BooleanQuery _mockBooleanQuery(ArgumentCaptor<Query> argumentCaptor)

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.internal.search.spi.model.index.contributor.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.builder.AssigneeObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -17,12 +18,18 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -135,6 +142,113 @@ public class ObjectEntryModelDocumentContributorTest {
 					objectFieldName, ": ", objectFieldValue, "pt_BR")));
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testContributeAssignee() throws Exception {
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectFieldUtil.addCustomObjectField(
+			new AssigneeObjectFieldBuilder(
+			).indexed(
+				true
+			).labelMap(
+				RandomTestUtil.randomLocaleStringMap()
+			).name(
+				objectFieldName
+			).objectDefinitionId(
+				objectDefinition.getObjectDefinitionId()
+			).userId(
+				TestPropsValues.getUserId()
+			).build());
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		long roleClassNameId = _classNameLocalService.getClassNameId(
+			Role.class.getName());
+		long roleClassPK = role.getRoleId();
+
+		ObjectEntry roleObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName,
+				HashMapBuilder.put(
+					"classNameId", roleClassNameId
+				).put(
+					"classPK", roleClassPK
+				).build()
+			).build());
+
+		Document roleDocument = new DocumentImpl();
+
+		objectEntryModelDocumentContributor.contribute(
+			roleDocument, roleObjectEntry);
+
+		Field roleField = roleDocument.getField("objectEntryContent");
+
+		Assert.assertNotNull(roleField);
+
+		String roleValue = roleField.getValue();
+
+		Assert.assertTrue(
+			roleValue,
+			roleValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", roleClassNameId, "_", roleClassPK)));
+		Assert.assertTrue(
+			roleValue,
+			roleValue.contains(
+				StringBundler.concat(objectFieldName, ": ", role.getName())));
+
+		User user = UserTestUtil.addUser();
+
+		long userClassNameId = _classNameLocalService.getClassNameId(
+			User.class.getName());
+		long userClassPK = user.getUserId();
+
+		ObjectEntry userObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName,
+				HashMapBuilder.put(
+					"classNameId", userClassNameId
+				).put(
+					"classPK", userClassPK
+				).build()
+			).build());
+
+		Document userDocument = new DocumentImpl();
+
+		objectEntryModelDocumentContributor.contribute(
+			userDocument, userObjectEntry);
+
+		Field userField = userDocument.getField("objectEntryContent");
+
+		Assert.assertNotNull(userField);
+
+		String userValue = userField.getValue();
+
+		Assert.assertTrue(
+			userValue,
+			userValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", userClassNameId, "_", userClassPK)));
+		Assert.assertTrue(
+			userValue,
+			userValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", user.getFullName())));
+	}
+
 	private ModelDocumentContributor<ObjectEntry>
 			_getObjectEntryModelDocumentContributor(
 				ObjectDefinition objectDefinition)
@@ -155,6 +269,9 @@ public class ObjectEntryModelDocumentContributorTest {
 
 		return bundleContext.getService(serviceReferences.get(0));
 	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88550

## What is being fixed

On generic Object Definitions with an Assignee field, free-text search by display name does nothing — typing `Test` in the listing search box, in `GET /o/c/<plural>?search=Test`, or in `GET /o/search/v1.0/search?search=Test` returns no result for entries that should match (e.g., entries assigned to a user named "Test Test"), or returns all entries when other fields happen to substring-match. The same paths also fail when the input is the composite shape `<classNameId>_<classPK>` that FDS pickers and structured filters emit under the hood, so any UI that resolves through search drops the Assignee filter silently. Every entry save also emits a stray WARN flagging the framework's silent rejection of the Assignee value at index time. Scope: generic, user-created Object Definitions; CMP system objects and DB-side OData are unaffected.

---

## How it is being fixed

Two paths, ordered by user-visible impact.

The display-name path (free-text search by name): `AssigneeObjectFieldBusinessType.getDisplayName(classNameId, classPK)` resolves the user/role and returns `User.getFullName()` or `Role.getName()`. `ObjectEntryModelDocumentContributor` adds an ASSIGNEE branch that writes the resolved display name into the analyzed `value_text` sub-field (and falls through to the existing String chain for the composite). `ObjectEntryKeywordQueryContributor` ORs `MatchQuery(value_text, token)` for word-by-word display-name match with `TermQuery(value_keyword_lowercase, lowercased token)` for composite exact match, both inside the existing nested predicate.

The composite path (FDS picker / structured filter): `ObjectEntrySearchUtil.getAssigneeFieldPredicate` parses the `<classNameId>_<classPK>` token and returns a conjunctive Predicate against the per-column `classNameId_*` / `classPK_*` columns; `ObjectEntryLocalServiceImpl._getObjectFieldPredicate` (extracted from the prior `_fillPredicate` loop body for clarity) dispatches to the util when the field is ASSIGNEE. `ObjectEntryEntityModel` maps ASSIGNEE to `StringEntityField` so OData sees the field correctly.

---

## How can it be tested

Automated:

**Unit test:** `ObjectEntryKeywordQueryContributorTest.testContributeWithAssigneeField`

```bash
cd modules
../gradlew :apps:object:object-service:test --tests com.liferay.object.internal.search.spi.model.query.contributor.ObjectEntryKeywordQueryContributorTest
```

Asserts the assignee branch produces a nested `BooleanQuery` containing `MatchQuery` on `nestedFieldArray.value_text` (display-name word match) and `TermQuery` on `nestedFieldArray.value_keyword_lowercase` (composite exact match), joined by SHOULD.

**Integration test:** `ObjectEntryModelDocumentContributorTest.testContributeAssignee`

```bash
cd modules
../gradlew :apps:object:object-test:testIntegration --tests com.liferay.object.internal.search.spi.model.index.contributor.test.ObjectEntryModelDocumentContributorTest
```

Asserts `objectEntryContent` contains both the display name (`role.getName()` for Role, `user.getFullName()` for User) and the composite (`<classNameId>_<classPK>`) for Role and User scenarios.

Manual:

1. Create a custom Object Definition with an Assignee field. Publish.
2. Create one entry assigned to a User whose full name is `Test Test`, and another entry assigned to a Role named `Site Admin`.
3. Open the auto-generated admin listing for the definition and verify in the search box:
    - Typing `Test` returns the entry assigned to `Test Test`.
    - Typing `Site Admin` returns the entry assigned to that role.
    - Typing the composite `<classNameId>_<classPK>` returns the exact entry.
4. Open an FDS view that exposes the Assignee column, pick a User or Role from the column-filter picker — entries are filtered correctly.
5. After saving entries, confirm no `ObjectEntryModelDocumentContributor:289 ... unsupported value` WARN appears in `catalina.out`.
