### PR TITLE
LPD-89027 Defer DocumentLibrary file deletions to Save

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -109,6 +109,10 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		).put(
 			"fileEntryDeleteURL",
 			() -> {
+				if (ddmFormFieldRenderingContext.isReadOnly()) {
+					return null;
+				}
+
 				HttpServletRequest httpServletRequest =
 					ddmFormFieldRenderingContext.getHttpServletRequest();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -518,19 +518,29 @@ const Main = ({
 	};
 
 	const deleteFileEntry = useCallback(
-		(fileEntryId) => {
+		(fileEntryId, {beacon = false} = {}) => {
 			if (!fileEntryId || !fileEntryDeleteURL) {
+				return;
+			}
+
+			const formData = convertToFormData({
+				[`${portletNamespace}oldFileEntryId`]: fileEntryId,
+			});
+
+			// Use sendBeacon on unload because async XHRs are cancelled when
+			// the page tears down; foreground paths keep XHR for parity with
+			// the rest of the field.
+
+			if (beacon && navigator.sendBeacon) {
+				navigator.sendBeacon(fileEntryDeleteURL, formData);
+
 				return;
 			}
 
 			const request = new XMLHttpRequest();
 
 			request.open('POST', fileEntryDeleteURL);
-			request.send(
-				convertToFormData({
-					[`${portletNamespace}oldFileEntryId`]: fileEntryId,
-				})
-			);
+			request.send(formData);
 		},
 		[fileEntryDeleteURL, portletNamespace]
 	);
@@ -641,6 +651,13 @@ const Main = ({
 		showUploadPermissionMessage;
 
 	useEffect(() => {
+
+		// Capture the file entry that was attached when the page loaded.
+		// The unload handler later compares this against the *current* value
+		// to decide whether the user replaced the file without saving — so it
+		// must reflect the page-load state, not the latest edit. That is why
+		// the deps array is empty.
+
 		originalFileEntryIdRef.current = getFileEntryId(value);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -659,20 +676,22 @@ const Main = ({
 				currentFileEntryId &&
 				currentFileEntryId !== originalFileEntryId
 			) {
-				deleteFileEntry(currentFileEntryId);
+				deleteFileEntry(currentFileEntryId, {beacon: true});
 			}
 
 			pendingDeletionsRef.current.forEach((fileEntryId) => {
 				if (fileEntryId !== originalFileEntryId) {
-					deleteFileEntry(fileEntryId);
+					deleteFileEntry(fileEntryId, {beacon: true});
 				}
 			});
 		};
 
 		window.addEventListener('beforeunload', handleBeforeUnload);
+		Liferay.on('beforeNavigate', handleBeforeUnload);
 
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload);
+			Liferay.detach('beforeNavigate', handleBeforeUnload);
 		};
 	}, [currentValue, deleteFileEntry, readOnly]);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -647,7 +647,7 @@ const Main = ({
 	}, []);
 
 	useEffect(() => {
-		window.onbeforeunload = function () {
+		const handleBeforeUnload = () => {
 			if (readOnly || submitButtonClicked) {
 				return;
 			}
@@ -662,15 +662,17 @@ const Main = ({
 				deleteFileEntry(currentFileEntryId);
 			}
 
-			if (!originalFileEntryId) {
-				pendingDeletionsRef.current.forEach((fileEntryId) =>
-					deleteFileEntry(fileEntryId)
-				);
-			}
+			pendingDeletionsRef.current.forEach((fileEntryId) => {
+				if (fileEntryId !== originalFileEntryId) {
+					deleteFileEntry(fileEntryId);
+				}
+			});
 		};
 
+		window.addEventListener('beforeunload', handleBeforeUnload);
+
 		return () => {
-			window.onbeforeunload = null;
+			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
 	}, [currentValue, deleteFileEntry, readOnly, submitButtonClicked]);
 
@@ -688,21 +690,9 @@ const Main = ({
 		Liferay.on('paginationControlsSubmitButtonClicked', onSubmit);
 
 		return () => {
-			Liferay.detach('paginationControlsSubmitButtonClicked');
+			Liferay.detach('paginationControlsSubmitButtonClicked', onSubmit);
 		};
 	}, [deleteFileEntry]);
-
-	useEffect(() => {
-		const onCancel = () => {
-			pendingDeletionsRef.current = [];
-		};
-
-		Liferay.on('paginationControlsCancelButtonClicked', onCancel);
-
-		return () => {
-			Liferay.detach('paginationControlsCancelButtonClicked');
-		};
-	}, []);
 
 	return (
 		<FieldBase

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -17,7 +17,7 @@ import {
 import {ReactFieldBase as FieldBase} from 'dynamic-data-mapping-form-field-type/api';
 import {openSelectionModal} from 'frontend-js-components-web';
 import {formatStorage, sub} from 'frontend-js-web';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 const CardItem = ({fileEntryTitle, fileEntryURL}) => {
 	return (
@@ -299,6 +299,9 @@ const Main = ({
 	const [progress, setProgress] = useState(0);
 	const [submitButtonClicked, setSubmitButtonClicked] = useState(false);
 
+	const originalFileEntryIdRef = useRef(null);
+	const pendingDeletionsRef = useRef([]);
+
 	const isSignedIn = Liferay.ThemeDisplay.isSignedIn();
 
 	const getErrorMessages = (
@@ -497,32 +500,56 @@ const Main = ({
 		return !supportedExtensions.includes(fileExtension);
 	};
 
-	const deleteFileEntry = useCallback(() => {
-		const request = new XMLHttpRequest();
-
-		let oldFileEntryId = 0;
+	const getFileEntryId = (fileEntryValue) => {
+		if (!fileEntryValue) {
+			return null;
+		}
 
 		try {
-			const fileEntry = JSON.parse(value);
+			const fileEntry = JSON.parse(fileEntryValue);
 
-			oldFileEntryId = fileEntry.fileEntryId;
+			return fileEntry.fileEntryId || null;
 		}
 		catch (error) {
-			console.error('Unable to parse JSON', value);
+			console.error('Unable to parse JSON', fileEntryValue);
+
+			return null;
+		}
+	};
+
+	const deleteFileEntry = useCallback(
+		(fileEntryId) => {
+			if (!fileEntryId) {
+				return;
+			}
+
+			const request = new XMLHttpRequest();
+
+			request.open('POST', fileEntryDeleteURL);
+			request.send(
+				convertToFormData({
+					[`${portletNamespace}oldFileEntryId`]: fileEntryId,
+				})
+			);
+		},
+		[fileEntryDeleteURL, portletNamespace]
+	);
+
+	const stagePendingDeletion = (fileEntryId) => {
+		if (!fileEntryId || pendingDeletionsRef.current.includes(fileEntryId)) {
+			return;
 		}
 
-		request.open('POST', fileEntryDeleteURL);
-		request.send(
-			convertToFormData({
-				[`${portletNamespace}oldFileEntryId`]: oldFileEntryId,
-			})
-		);
-	}, [fileEntryDeleteURL, portletNamespace, value]);
+		pendingDeletionsRef.current = [
+			...pendingDeletionsRef.current,
+			fileEntryId,
+		];
+	};
 
 	const handleOnClearButtonClicked = (event, isSignedIn) => {
 		onFocus(event);
 
-		deleteFileEntry();
+		stagePendingDeletion(getFileEntryId(currentValue));
 
 		setCurrentValue(null);
 
@@ -544,26 +571,12 @@ const Main = ({
 	const handleUploadSelectButtonClicked = (event, currentValue) => {
 		onFocus(event);
 
-		let oldFileEntryId = 0;
+		stagePendingDeletion(getFileEntryId(currentValue));
 
-		if (currentValue) {
-			try {
-				const fileEntry = JSON.parse(currentValue);
-
-				oldFileEntryId = fileEntry.fileEntryId;
-
-				uploadFileEntry(event, oldFileEntryId);
-			}
-			catch (error) {
-				console.error('Unable to parse JSON', currentValue);
-			}
-		}
-		else {
-			uploadFileEntry(event, oldFileEntryId);
-		}
+		uploadFileEntry(event);
 	};
 
-	const uploadFileEntry = (event, oldFileEntryId) => {
+	const uploadFileEntry = (event) => {
 		const file = event.target.files[0];
 
 		if (isExceededUploadRequestSizeLimit(file.size)) {
@@ -617,7 +630,7 @@ const Main = ({
 		request.send(
 			convertToFormData({
 				[`${portletNamespace}file`]: file,
-				[`${portletNamespace}oldFileEntryId`]: oldFileEntryId,
+				[`${portletNamespace}oldFileEntryId`]: 0,
 			})
 		);
 	};
@@ -628,28 +641,66 @@ const Main = ({
 		showUploadPermissionMessage;
 
 	useEffect(() => {
+		originalFileEntryIdRef.current = getFileEntryId(value);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
 		window.onbeforeunload = function () {
-			if (!submitButtonClicked) {
-				deleteFileEntry();
+			if (readOnly || submitButtonClicked) {
+				return;
+			}
+
+			const currentFileEntryId = getFileEntryId(currentValue);
+			const originalFileEntryId = originalFileEntryIdRef.current;
+
+			if (
+				currentFileEntryId &&
+				currentFileEntryId !== originalFileEntryId
+			) {
+				deleteFileEntry(currentFileEntryId);
+			}
+
+			if (!originalFileEntryId) {
+				pendingDeletionsRef.current.forEach((fileEntryId) =>
+					deleteFileEntry(fileEntryId)
+				);
 			}
 		};
 
 		return () => {
 			window.onbeforeunload = null;
 		};
-	}, [deleteFileEntry, submitButtonClicked]);
+	}, [currentValue, deleteFileEntry, readOnly, submitButtonClicked]);
 
 	useEffect(() => {
-		Liferay.on(
-			'paginationControlsSubmitButtonClicked',
+		const onSubmit = () => {
+			pendingDeletionsRef.current.forEach((fileEntryId) =>
+				deleteFileEntry(fileEntryId)
+			);
 
-			() => {
-				setSubmitButtonClicked(true);
-			}
-		);
+			pendingDeletionsRef.current = [];
+
+			setSubmitButtonClicked(true);
+		};
+
+		Liferay.on('paginationControlsSubmitButtonClicked', onSubmit);
 
 		return () => {
 			Liferay.detach('paginationControlsSubmitButtonClicked');
+		};
+	}, [deleteFileEntry]);
+
+	useEffect(() => {
+		const onCancel = () => {
+			pendingDeletionsRef.current = [];
+		};
+
+		Liferay.on('paginationControlsCancelButtonClicked', onCancel);
+
+		return () => {
+			Liferay.detach('paginationControlsCancelButtonClicked');
 		};
 	}, []);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -19,24 +19,32 @@ import {openSelectionModal} from 'frontend-js-components-web';
 import {formatStorage, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
-const CardItem = ({fileEntryTitle, fileEntryURL}) => {
-	return (
-		<ClayCard horizontal>
-			<ClayCard.Body>
-				<div className="card-col-content card-col-gutters">
-					<div className="h4 text-truncate" title={fileEntryTitle}>
-						{fileEntryTitle}
-					</div>
-				</div>
+const MIME_TO_EXTENSION = {
+	'application/msword': 'doc',
+	'application/vnd.ms-excel': 'xls',
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+		'docx',
+	'text/plain': 'txt',
+};
 
-				<div className="card-col-field">
-					<a download={fileEntryTitle} href={fileEntryURL}>
-						<ClayIcon symbol="download" />
-					</a>
-				</div>
-			</ClayCard.Body>
-		</ClayCard>
-	);
+const SUBMIT_EVENT = 'paginationControlsSubmitButtonClicked';
+
+const getFileEntryId = (fileEntryValue) => {
+	if (!fileEntryValue) {
+		return null;
+	}
+
+	try {
+		const fileEntry = JSON.parse(fileEntryValue);
+
+		return fileEntry.fileEntryId || null;
+	}
+	catch (error) {
+		console.error('Unable to parse JSON', fileEntryValue);
+
+		return null;
+	}
 };
 
 const getValue = (value) => {
@@ -49,6 +57,39 @@ const getValue = (value) => {
 	}
 
 	return JSON.stringify(value);
+};
+
+const hasInvalidExtension = (value, acceptedExtensions) => {
+	if (!value || !acceptedExtensions) {
+		return false;
+	}
+
+	let fileEntryJSON;
+
+	try {
+		fileEntryJSON = JSON.parse(value);
+	}
+	catch (error) {
+		return false;
+	}
+
+	let fileExtension = fileEntryJSON.extension?.toLowerCase();
+
+	if (!fileExtension && fileEntryJSON.mimeType) {
+		fileExtension =
+			MIME_TO_EXTENSION[fileEntryJSON.mimeType.toLowerCase()] ||
+			fileEntryJSON.mimeType.split('/')[1]?.toLowerCase();
+	}
+
+	if (!fileExtension) {
+		return false;
+	}
+
+	const supportedExtensions = acceptedExtensions
+		.split(',')
+		.map((ext) => ext.trim().toLowerCase());
+
+	return !supportedExtensions.includes(fileExtension);
 };
 
 function transformFileEntryProperties({fileEntryTitle, value}) {
@@ -69,6 +110,26 @@ function transformFileEntryProperties({fileEntryTitle, value}) {
 			? [value.title]
 			: [];
 }
+
+const CardItem = ({fileEntryTitle, fileEntryURL}) => {
+	return (
+		<ClayCard horizontal>
+			<ClayCard.Body>
+				<div className="card-col-content card-col-gutters">
+					<div className="h4 text-truncate" title={fileEntryTitle}>
+						{fileEntryTitle}
+					</div>
+				</div>
+
+				<div className="card-col-field">
+					<a download={fileEntryTitle} href={fileEntryURL}>
+						<ClayIcon symbol="download" />
+					</a>
+				</div>
+			</ClayCard.Body>
+		</ClayCard>
+	);
+};
 
 const DocumentLibrary = ({
 	accessibleProps,
@@ -260,6 +321,122 @@ const GuestUploadFile = ({
 	);
 };
 
+function useFileLifecycle({
+	currentValue,
+	fileEntryDeleteURL,
+	portletNamespace,
+	readOnly,
+	value,
+}) {
+	const originalFileEntryIdRef = useRef(null);
+	const pendingDeletionsRef = useRef([]);
+	const submitButtonClickedRef = useRef(false);
+
+	const deleteFileEntry = useCallback(
+		(fileEntryId, {beacon = false} = {}) => {
+			if (!fileEntryId || !fileEntryDeleteURL) {
+				return;
+			}
+
+			const formData = convertToFormData({
+				[`${portletNamespace}oldFileEntryId`]: fileEntryId,
+			});
+
+			// Use sendBeacon on unload because async XHRs are cancelled when
+			// the page tears down; foreground paths keep XHR for parity with
+			// the rest of the field.
+
+			if (beacon && navigator.sendBeacon) {
+				navigator.sendBeacon(fileEntryDeleteURL, formData);
+
+				return;
+			}
+
+			const request = new XMLHttpRequest();
+
+			request.open('POST', fileEntryDeleteURL);
+			request.send(formData);
+		},
+		[fileEntryDeleteURL, portletNamespace]
+	);
+
+	const stagePendingDeletion = (fileEntryId) => {
+		if (!fileEntryId || pendingDeletionsRef.current.includes(fileEntryId)) {
+			return;
+		}
+
+		pendingDeletionsRef.current = [
+			...pendingDeletionsRef.current,
+			fileEntryId,
+		];
+	};
+
+	useEffect(() => {
+
+		// Capture the file entry that was attached when the page loaded.
+		// The unload handler later compares this against the *current* value
+		// to decide whether the user replaced the file without saving — so it
+		// must reflect the page-load state, not the latest edit. That is why
+		// the deps array is empty.
+
+		originalFileEntryIdRef.current = getFileEntryId(value);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		const handleBeforeUnload = () => {
+			if (readOnly || submitButtonClickedRef.current) {
+				return;
+			}
+
+			const currentFileEntryId = getFileEntryId(currentValue);
+			const originalFileEntryId = originalFileEntryIdRef.current;
+
+			if (
+				currentFileEntryId &&
+				currentFileEntryId !== originalFileEntryId
+			) {
+				deleteFileEntry(currentFileEntryId, {beacon: true});
+			}
+
+			pendingDeletionsRef.current.forEach((fileEntryId) => {
+				if (fileEntryId !== originalFileEntryId) {
+					deleteFileEntry(fileEntryId, {beacon: true});
+				}
+			});
+		};
+
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		Liferay.on('beforeNavigate', handleBeforeUnload);
+
+		return () => {
+			window.removeEventListener('beforeunload', handleBeforeUnload);
+			Liferay.detach('beforeNavigate', handleBeforeUnload);
+		};
+	}, [currentValue, deleteFileEntry, readOnly]);
+
+	useEffect(() => {
+		const onSubmit = () => {
+			pendingDeletionsRef.current.forEach((fileEntryId) =>
+				deleteFileEntry(fileEntryId)
+			);
+
+			pendingDeletionsRef.current = [];
+
+			submitButtonClickedRef.current = true;
+		};
+
+		Liferay.on(SUBMIT_EVENT, onSubmit);
+
+		return () => {
+			Liferay.detach(SUBMIT_EVENT, onSubmit);
+		};
+	}, [deleteFileEntry]);
+
+	return {stagePendingDeletion};
+}
+
 const Main = ({
 	_onBlur,
 	_onFocus,
@@ -298,11 +475,20 @@ const Main = ({
 	const [valid, setValid] = useState(initialValid);
 	const [progress, setProgress] = useState(0);
 
-	const originalFileEntryIdRef = useRef(null);
-	const pendingDeletionsRef = useRef([]);
-	const submitButtonClickedRef = useRef(false);
+	const {stagePendingDeletion} = useFileLifecycle({
+		currentValue,
+		fileEntryDeleteURL,
+		portletNamespace,
+		readOnly,
+		value,
+	});
 
 	const isSignedIn = Liferay.ThemeDisplay.isSignedIn();
+
+	const hasCustomError =
+		(!isSignedIn && !allowGuestUsers) ||
+		maximumSubmissionLimitReached ||
+		showUploadPermissionMessage;
 
 	const getErrorMessages = (
 		errorMessage,
@@ -359,24 +545,26 @@ const Main = ({
 	}, [allowGuestUsers, isSignedIn, showUploadPermissionMessage]);
 
 	useEffect(() => {
-		const objectFieldInvalidExtension =
-			isObjectFieldInvalidExtension(value);
+		const invalidExtension = hasInvalidExtension(
+			value,
+			objectFieldAcceptedFileExtensions
+		);
 
-		setCurrentValue(objectFieldInvalidExtension ? null : value);
-		setDisplayErrors(
-			objectFieldInvalidExtension ? true : initialDisplayErrors
-		);
+		setCurrentValue(invalidExtension ? null : value);
+		setDisplayErrors(invalidExtension ? true : initialDisplayErrors);
 		setErrorMessage(
-			getErrorMessages(
-				initialErrorMessage,
-				isSignedIn,
-				objectFieldInvalidExtension
-			)
+			getErrorMessages(initialErrorMessage, isSignedIn, invalidExtension)
 		);
-		setValid(objectFieldInvalidExtension ? false : initialValid);
+		setValid(invalidExtension ? false : initialValid);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [initialDisplayErrors, initialErrorMessage, initialValid, value]);
+	}, [
+		initialDisplayErrors,
+		initialErrorMessage,
+		initialValid,
+		objectFieldAcceptedFileExtensions,
+		value,
+	]);
 
 	const checkMaximumRepetitions = () => {
 		const visitor = new PagesVisitor(pages);
@@ -396,29 +584,6 @@ const Main = ({
 		return repetitionsCounter === maximumRepetitions;
 	};
 
-	const handleFieldChanged = (selectedItem) => {
-		if (selectedItem?.value) {
-			setCurrentValue(selectedItem.value);
-
-			onChange(selectedItem, selectedItem.value);
-		}
-	};
-
-	const handleSelectButtonClicked = ({portletNamespace}, event) => {
-		onFocus(event);
-
-		openSelectionModal({
-			onClose: () => onBlur(event),
-			onSelect: handleFieldChanged,
-			selectEventName: `${portletNamespace}selectDocumentLibrary`,
-			title: sub(
-				Liferay.Language.get('select-x'),
-				Liferay.Language.get('document')
-			),
-			url: itemSelectorURL,
-		});
-	};
-
 	const configureErrorMessage = (message) => {
 		setErrorMessage(message);
 
@@ -434,14 +599,6 @@ const Main = ({
 		if (ddmFormSubmitButton) {
 			ddmFormSubmitButton.disabled = disable;
 		}
-	};
-
-	const handleGuestUploadFileChanged = (errorMessage, event, value) => {
-		configureErrorMessage(errorMessage);
-
-		setCurrentValue(value);
-
-		onChange(event, value ? value : '{}');
 	};
 
 	const isExceededUploadRequestSizeLimit = (fileSize) => {
@@ -464,96 +621,35 @@ const Main = ({
 		return true;
 	};
 
-	const isObjectFieldInvalidExtension = (value) => {
-		if (!value || !objectFieldAcceptedFileExtensions) {
-			return false;
-		}
+	const handleGuestUploadFileChanged = (errorMessage, event, value) => {
+		configureErrorMessage(errorMessage);
 
-		const fileEntryJSON = JSON.parse(value);
+		setCurrentValue(value);
 
-		let fileExtension = fileEntryJSON.extension?.toLowerCase();
-
-		if (!fileExtension && fileEntryJSON.mimeType) {
-			const mimeToExt = {
-				'application/msword': 'doc',
-				'application/vnd.ms-excel': 'xls',
-				'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-					'xlsx',
-				'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-					'docx',
-				'text/plain': 'txt',
-			};
-
-			fileExtension =
-				mimeToExt[fileEntryJSON.mimeType.toLowerCase()] ||
-				fileEntryJSON.mimeType.split('/')[1]?.toLowerCase();
-		}
-
-		if (!fileExtension) {
-			return false;
-		}
-
-		const supportedExtensions = objectFieldAcceptedFileExtensions
-			.split(', ')
-			.map((ext) => ext.trim().toLowerCase());
-
-		return !supportedExtensions.includes(fileExtension);
+		onChange(event, value ? value : '{}');
 	};
 
-	const getFileEntryId = (fileEntryValue) => {
-		if (!fileEntryValue) {
-			return null;
-		}
+	const handleFieldChanged = (selectedItem) => {
+		if (selectedItem?.value) {
+			setCurrentValue(selectedItem.value);
 
-		try {
-			const fileEntry = JSON.parse(fileEntryValue);
-
-			return fileEntry.fileEntryId || null;
-		}
-		catch (error) {
-			console.error('Unable to parse JSON', fileEntryValue);
-
-			return null;
+			onChange(selectedItem, selectedItem.value);
 		}
 	};
 
-	const deleteFileEntry = useCallback(
-		(fileEntryId, {beacon = false} = {}) => {
-			if (!fileEntryId || !fileEntryDeleteURL) {
-				return;
-			}
+	const handleSelectButtonClicked = (event) => {
+		onFocus(event);
 
-			const formData = convertToFormData({
-				[`${portletNamespace}oldFileEntryId`]: fileEntryId,
-			});
-
-			// Use sendBeacon on unload because async XHRs are cancelled when
-			// the page tears down; foreground paths keep XHR for parity with
-			// the rest of the field.
-
-			if (beacon && navigator.sendBeacon) {
-				navigator.sendBeacon(fileEntryDeleteURL, formData);
-
-				return;
-			}
-
-			const request = new XMLHttpRequest();
-
-			request.open('POST', fileEntryDeleteURL);
-			request.send(formData);
-		},
-		[fileEntryDeleteURL, portletNamespace]
-	);
-
-	const stagePendingDeletion = (fileEntryId) => {
-		if (!fileEntryId || pendingDeletionsRef.current.includes(fileEntryId)) {
-			return;
-		}
-
-		pendingDeletionsRef.current = [
-			...pendingDeletionsRef.current,
-			fileEntryId,
-		];
+		openSelectionModal({
+			onClose: () => onBlur(event),
+			onSelect: handleFieldChanged,
+			selectEventName: `${portletNamespace}selectDocumentLibrary`,
+			title: sub(
+				Liferay.Language.get('select-x'),
+				Liferay.Language.get('document')
+			),
+			url: itemSelectorURL,
+		});
 	};
 
 	const handleOnClearButtonClicked = (event, isSignedIn) => {
@@ -645,74 +741,6 @@ const Main = ({
 		);
 	};
 
-	const hasCustomError =
-		(!isSignedIn && !allowGuestUsers) ||
-		maximumSubmissionLimitReached ||
-		showUploadPermissionMessage;
-
-	useEffect(() => {
-
-		// Capture the file entry that was attached when the page loaded.
-		// The unload handler later compares this against the *current* value
-		// to decide whether the user replaced the file without saving — so it
-		// must reflect the page-load state, not the latest edit. That is why
-		// the deps array is empty.
-
-		originalFileEntryIdRef.current = getFileEntryId(value);
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
-	useEffect(() => {
-		const handleBeforeUnload = () => {
-			if (readOnly || submitButtonClickedRef.current) {
-				return;
-			}
-
-			const currentFileEntryId = getFileEntryId(currentValue);
-			const originalFileEntryId = originalFileEntryIdRef.current;
-
-			if (
-				currentFileEntryId &&
-				currentFileEntryId !== originalFileEntryId
-			) {
-				deleteFileEntry(currentFileEntryId, {beacon: true});
-			}
-
-			pendingDeletionsRef.current.forEach((fileEntryId) => {
-				if (fileEntryId !== originalFileEntryId) {
-					deleteFileEntry(fileEntryId, {beacon: true});
-				}
-			});
-		};
-
-		window.addEventListener('beforeunload', handleBeforeUnload);
-		Liferay.on('beforeNavigate', handleBeforeUnload);
-
-		return () => {
-			window.removeEventListener('beforeunload', handleBeforeUnload);
-			Liferay.detach('beforeNavigate', handleBeforeUnload);
-		};
-	}, [currentValue, deleteFileEntry, readOnly]);
-
-	useEffect(() => {
-		const onSubmit = () => {
-			pendingDeletionsRef.current.forEach((fileEntryId) =>
-				deleteFileEntry(fileEntryId)
-			);
-
-			pendingDeletionsRef.current = [];
-
-			submitButtonClickedRef.current = true;
-		};
-
-		Liferay.on('paginationControlsSubmitButtonClicked', onSubmit);
-
-		return () => {
-			Liferay.detach('paginationControlsSubmitButtonClicked', onSubmit);
-		};
-	}, [deleteFileEntry]);
-
 	return (
 		<FieldBase
 			{...otherProps}
@@ -764,15 +792,7 @@ const Main = ({
 					onClearButtonClicked={(event) => {
 						handleOnClearButtonClicked(event, value, isSignedIn);
 					}}
-					onSelectButtonClicked={(event) =>
-						handleSelectButtonClicked(
-							{
-								itemSelectorURL,
-								portletNamespace,
-							},
-							event
-						)
-					}
+					onSelectButtonClicked={handleSelectButtonClicked}
 					placeholder={placeholder}
 					readOnly={hasCustomError ? true : readOnly}
 					value={currentValue || ''}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -297,10 +297,10 @@ const Main = ({
 	const [displayErrors, setDisplayErrors] = useState(initialDisplayErrors);
 	const [valid, setValid] = useState(initialValid);
 	const [progress, setProgress] = useState(0);
-	const [submitButtonClicked, setSubmitButtonClicked] = useState(false);
 
 	const originalFileEntryIdRef = useRef(null);
 	const pendingDeletionsRef = useRef([]);
+	const submitButtonClickedRef = useRef(false);
 
 	const isSignedIn = Liferay.ThemeDisplay.isSignedIn();
 
@@ -519,7 +519,7 @@ const Main = ({
 
 	const deleteFileEntry = useCallback(
 		(fileEntryId) => {
-			if (!fileEntryId) {
+			if (!fileEntryId || !fileEntryDeleteURL) {
 				return;
 			}
 
@@ -648,7 +648,7 @@ const Main = ({
 
 	useEffect(() => {
 		const handleBeforeUnload = () => {
-			if (readOnly || submitButtonClicked) {
+			if (readOnly || submitButtonClickedRef.current) {
 				return;
 			}
 
@@ -674,7 +674,7 @@ const Main = ({
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
-	}, [currentValue, deleteFileEntry, readOnly, submitButtonClicked]);
+	}, [currentValue, deleteFileEntry, readOnly]);
 
 	useEffect(() => {
 		const onSubmit = () => {
@@ -684,7 +684,7 @@ const Main = ({
 
 			pendingDeletionsRef.current = [];
 
-			setSubmitButtonClicked(true);
+			submitButtonClickedRef.current = true;
 		};
 
 		Liferay.on('paginationControlsSubmitButtonClicked', onSubmit);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
@@ -253,6 +253,33 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 	}
 
 	@Test
+	public void testGetParametersInReadOnlyContextDoesNotEmitFileEntryDeleteURL() {
+		ThemeDisplay themeDisplay = _mockThemeDisplay();
+
+		Mockito.when(
+			themeDisplay.isSignedIn()
+		).thenReturn(
+			Boolean.TRUE
+		);
+
+		DocumentLibraryDDMFormFieldTemplateContextContributor
+			documentLibraryDDMFormFieldTemplateContextContributor = _createSpy(
+				true, themeDisplay);
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			_createDDMFormFieldRenderingContext();
+
+		ddmFormFieldRenderingContext.setReadOnly(true);
+
+		Map<String, Object> parameters =
+			documentLibraryDDMFormFieldTemplateContextContributor.getParameters(
+				new DDMFormField("field", "document_library"),
+				ddmFormFieldRenderingContext);
+
+		Assert.assertNull(parameters.get("fileEntryDeleteURL"));
+	}
+
+	@Test
 	public void testGetParametersShouldContainFileEntryURL()
 		throws PortalException {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {act, cleanup, render} from '@testing-library/react';
+import {act, cleanup, fireEvent, render} from '@testing-library/react';
 import {PageProvider} from 'data-engine-js-components-web';
 import React from 'react';
 
@@ -13,9 +13,34 @@ const globalLanguageDirection = Liferay.Language.direction;
 
 const spritemap = 'icons.svg';
 
+const fileEntryDeleteURL = 'http://test.local/delete-file-entry';
+const guestUploadURL = 'http://test.local/upload-file-entry';
+
 const defaultDocumentLibraryConfig = {
 	name: 'uploadField',
 	spritemap,
+};
+
+const valueWithFileEntry = (id) =>
+	JSON.stringify({
+		fileEntryId: id,
+		groupId: 1,
+		title: `file-${id}`,
+		uuid: `uuid-${id}`,
+	});
+
+const formDataValue = (formData, key) => {
+	if (!formData || typeof formData.entries !== 'function') {
+		return null;
+	}
+
+	for (const [entryKey, entryValue] of formData.entries()) {
+		if (entryKey === key || entryKey.endsWith(key)) {
+			return entryValue;
+		}
+	}
+
+	return null;
 };
 
 const DocumentLibraryWithProvider = (props) => (
@@ -347,5 +372,280 @@ describe('Field DocumentLibrary', () => {
 		);
 
 		expect(guestUploadFieldInput).not.toBe(null);
+	});
+
+	describe('file deletion lifecycle', () => {
+		const originalXMLHttpRequest = global.XMLHttpRequest;
+
+		let xhrInstances;
+		let eventBus;
+
+		const renderField = (props = {}) =>
+			render(
+				<DocumentLibraryWithProvider
+					{...defaultDocumentLibraryConfig}
+					fileEntryDeleteURL={fileEntryDeleteURL}
+					guestUploadURL={guestUploadURL}
+					onBlur={jest.fn()}
+					onChange={jest.fn()}
+					onFocus={jest.fn()}
+					{...props}
+				/>
+			);
+
+		const triggerBeforeUnload = () => {
+			act(() => {
+				if (window.onbeforeunload) {
+					window.onbeforeunload();
+				}
+			});
+		};
+
+		const fireGlobal = (name) => {
+			act(() => {
+				(eventBus.get(name) || [])
+					.slice()
+					.forEach((handler) => handler());
+			});
+		};
+
+		const completeUpload = (newFileEntryId) => {
+			const uploadXhr = xhrInstances.find(
+				(instance) => instance.url === guestUploadURL
+			);
+
+			expect(uploadXhr).toBeDefined();
+
+			uploadXhr.responseText = JSON.stringify({
+				file: valueParsed(newFileEntryId),
+				success: true,
+			});
+
+			uploadXhr.readyState = 4;
+
+			const readyStateChangeHandler =
+				uploadXhr.addEventListener.mock.calls.find(
+					([name]) => name === 'readystatechange'
+				)[1];
+
+			act(() => readyStateChangeHandler({}));
+		};
+
+		const valueParsed = (id) => JSON.parse(valueWithFileEntry(id));
+
+		const deleteCalls = () =>
+			xhrInstances
+				.filter((instance) => instance.url === fileEntryDeleteURL)
+				.map((instance) =>
+					Number(
+						formDataValue(
+							instance.send.mock.calls[0]?.[0],
+							'oldFileEntryId'
+						)
+					)
+				);
+
+		const expectDeleted = (...ids) =>
+			expect(deleteCalls().sort()).toEqual([...ids].sort());
+
+		const expectNoDeletes = () => expect(deleteCalls()).toEqual([]);
+
+		const clickClear = () => {
+			const clearButton = document.querySelector(
+				'[aria-label="unselect-file"]'
+			);
+
+			expect(clearButton).not.toBe(null);
+
+			act(() => {
+				fireEvent.click(clearButton);
+			});
+		};
+
+		const triggerGuestUpload = () => {
+			const fileInput = document.getElementById(
+				'uploadFieldinputFileGuestUpload'
+			);
+
+			expect(fileInput).not.toBe(null);
+
+			act(() => {
+				fireEvent.change(fileInput, {
+					target: {
+						files: [
+							new File(['hello'], 'hello.txt', {
+								type: 'text/plain',
+							}),
+						],
+					},
+				});
+			});
+		};
+
+		beforeEach(() => {
+			xhrInstances = [];
+
+			global.XMLHttpRequest = jest.fn(() => {
+				const instance = {
+					addEventListener: jest.fn(),
+					open: jest.fn(function (method, url) {
+						this.url = url;
+					}),
+					readyState: 0,
+					responseText: '',
+					send: jest.fn(),
+					upload: {addEventListener: jest.fn()},
+					url: '',
+				};
+
+				xhrInstances.push(instance);
+
+				return instance;
+			});
+
+			eventBus = new Map();
+
+			Liferay.on.mockImplementation((name, handler) => {
+				if (!eventBus.has(name)) {
+					eventBus.set(name, []);
+				}
+
+				eventBus.get(name).push(handler);
+			});
+
+			Liferay.detach.mockImplementation((name, handler) => {
+				if (handler) {
+					const handlers = eventBus.get(name) || [];
+					const index = handlers.indexOf(handler);
+
+					if (index >= 0) {
+						handlers.splice(index, 1);
+					}
+				}
+				else {
+					eventBus.delete(name);
+				}
+			});
+
+			Liferay.fire.mockImplementation((name) => {
+				(eventBus.get(name) || [])
+					.slice()
+					.forEach((handler) => handler());
+			});
+
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => true);
+		});
+
+		afterEach(() => {
+			global.XMLHttpRequest = originalXMLHttpRequest;
+			window.onbeforeunload = null;
+		});
+
+		it('deletes both the previous and current upload on new-entry abandon after replace', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({allowGuestUsers: true, value: '{}'});
+
+			triggerGuestUpload();
+			completeUpload(88);
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(88, 99);
+		});
+
+		it('deletes only the replacement on unload when replacing in edit mode', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(99);
+		});
+
+		it('deletes the new entry session upload on abandon', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({allowGuestUsers: true, value: '{}'});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(99);
+		});
+
+		it('deletes the original on Save after Clear', () => {
+			renderField({value: valueWithFileEntry(42)});
+
+			clickClear();
+			fireGlobal('paginationControlsSubmitButtonClicked');
+
+			expectDeleted(42);
+		});
+
+		it('deletes the previous on Save after Replace', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			fireGlobal('paginationControlsSubmitButtonClicked');
+
+			expectDeleted(42);
+		});
+
+		it('does not delete on unload when editing an existing entry without changes', () => {
+			renderField({value: valueWithFileEntry(42)});
+
+			triggerBeforeUnload();
+
+			expectNoDeletes();
+		});
+
+		it('does not delete on unload when read-only (LPP-63922)', () => {
+			renderField({readOnly: true, value: valueWithFileEntry(42)});
+
+			triggerBeforeUnload();
+
+			expectNoDeletes();
+		});
+
+		it('does not delete when Clear is followed by Cancel (LPP-63917)', () => {
+			renderField({value: valueWithFileEntry(42)});
+
+			clickClear();
+			fireGlobal('paginationControlsCancelButtonClicked');
+			triggerBeforeUnload();
+
+			expectNoDeletes();
+		});
+
+		it('preserves the original on Cancel after Replace and cleans the orphan on unload', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			fireGlobal('paginationControlsCancelButtonClicked');
+			triggerBeforeUnload();
+
+			expectDeleted(99);
+		});
 	});
 });

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -395,9 +395,7 @@ describe('Field DocumentLibrary', () => {
 
 		const triggerBeforeUnload = () => {
 			act(() => {
-				if (window.onbeforeunload) {
-					window.onbeforeunload();
-				}
+				window.dispatchEvent(new Event('beforeunload'));
 			});
 		};
 
@@ -538,7 +536,23 @@ describe('Field DocumentLibrary', () => {
 
 		afterEach(() => {
 			global.XMLHttpRequest = originalXMLHttpRequest;
-			window.onbeforeunload = null;
+		});
+
+		it('cleans up intermediate replacements on unload after multiple replaces in edit mode', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(88);
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(88, 99);
 		});
 
 		it('deletes both the previous and current upload on new-entry abandon after replace', () => {
@@ -626,7 +640,6 @@ describe('Field DocumentLibrary', () => {
 			renderField({value: valueWithFileEntry(42)});
 
 			clickClear();
-			fireGlobal('paginationControlsCancelButtonClicked');
 			triggerBeforeUnload();
 
 			expectNoDeletes();
@@ -642,7 +655,6 @@ describe('Field DocumentLibrary', () => {
 
 			triggerGuestUpload();
 			completeUpload(99);
-			fireGlobal('paginationControlsCancelButtonClicked');
 			triggerBeforeUnload();
 
 			expectDeleted(99);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -381,8 +381,10 @@ describe('Field DocumentLibrary', () => {
 	});
 
 	describe('file deletion lifecycle', () => {
+		const originalSendBeacon = navigator.sendBeacon;
 		const originalXMLHttpRequest = global.XMLHttpRequest;
 
+		let beaconCalls;
 		let xhrInstances;
 		let eventBus;
 
@@ -402,6 +404,12 @@ describe('Field DocumentLibrary', () => {
 		const triggerBeforeUnload = () => {
 			act(() => {
 				window.dispatchEvent(new Event('beforeunload'));
+			});
+		};
+
+		const triggerBeforeNavigate = () => {
+			act(() => {
+				Liferay.fire('beforeNavigate');
 			});
 		};
 
@@ -437,8 +445,8 @@ describe('Field DocumentLibrary', () => {
 
 		const valueParsed = (id) => JSON.parse(valueWithFileEntry(id));
 
-		const deleteCalls = () =>
-			xhrInstances
+		const deleteCalls = () => {
+			const xhrDeletes = xhrInstances
 				.filter((instance) => instance.url === fileEntryDeleteURL)
 				.map((instance) =>
 					Number(
@@ -448,6 +456,15 @@ describe('Field DocumentLibrary', () => {
 						)
 					)
 				);
+
+			const beaconDeletes = beaconCalls
+				.filter((call) => call.url === fileEntryDeleteURL)
+				.map((call) =>
+					Number(formDataValue(call.formData, 'oldFileEntryId'))
+				);
+
+			return [...xhrDeletes, ...beaconDeletes];
+		};
 
 		const expectDeleted = (...ids) =>
 			expect(deleteCalls().sort()).toEqual([...ids].sort());
@@ -505,7 +522,14 @@ describe('Field DocumentLibrary', () => {
 		beforeEach(() => {
 			openSelectionModal.mockReset();
 
+			beaconCalls = [];
 			xhrInstances = [];
+
+			navigator.sendBeacon = jest.fn((url, formData) => {
+				beaconCalls.push({formData, url});
+
+				return true;
+			});
 
 			global.XMLHttpRequest = jest.fn(() => {
 				const instance = {
@@ -560,6 +584,7 @@ describe('Field DocumentLibrary', () => {
 
 		afterEach(() => {
 			global.XMLHttpRequest = originalXMLHttpRequest;
+			navigator.sendBeacon = originalSendBeacon;
 		});
 
 		it('cleans up intermediate replacements on unload after multiple replaces in edit mode', () => {
@@ -650,6 +675,21 @@ describe('Field DocumentLibrary', () => {
 			triggerBeforeUnload();
 
 			expectNoDeletes();
+		});
+
+		it('cleans up the orphan on SPA navigation away from a replaced entry', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeNavigate();
+
+			expectDeleted(99);
 		});
 
 		it('does not delete on unload when read-only (LPP-63922)', () => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -5,9 +5,15 @@
 
 import {act, cleanup, fireEvent, render} from '@testing-library/react';
 import {PageProvider} from 'data-engine-js-components-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React from 'react';
 
 import DocumentLibrary from '../../../src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es';
+
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
+	openSelectionModal: jest.fn(),
+}));
 
 const globalLanguageDirection = Liferay.Language.direction;
 
@@ -480,7 +486,25 @@ describe('Field DocumentLibrary', () => {
 			});
 		};
 
+		const selectViaModal = (newFileEntryId) => {
+			openSelectionModal.mockImplementation(({onSelect}) => {
+				act(() =>
+					onSelect({value: valueWithFileEntry(newFileEntryId)})
+				);
+			});
+
+			const selectButton = document.getElementById('uploadField');
+
+			expect(selectButton).not.toBe(null);
+
+			act(() => {
+				fireEvent.click(selectButton);
+			});
+		};
+
 		beforeEach(() => {
+			openSelectionModal.mockReset();
+
 			xhrInstances = [];
 
 			global.XMLHttpRequest = jest.fn(() => {
@@ -632,6 +656,15 @@ describe('Field DocumentLibrary', () => {
 			renderField({readOnly: true, value: valueWithFileEntry(42)});
 
 			triggerBeforeUnload();
+
+			expectNoDeletes();
+		});
+
+		it('does not delete the previous on Save when replaced via the document selector', () => {
+			renderField({value: valueWithFileEntry(42)});
+
+			selectViaModal(99);
+			fireGlobal('paginationControlsSubmitButtonClicked');
 
 			expectNoDeletes();
 		});


### PR DESCRIPTION
## What is being fixed

Two customer-reported file-loss bugs in the DocumentLibrary form field. The field destroys the underlying Documents and Media file immediately on UI gestures (Clear, page unload) instead of treating destruction as part of an explicit Save click. As a result, uploaded files vanish after innocent user actions such as refreshing the entry view or clicking Cancel.

## How it is being fixed

The field stages deletions in browser memory while the user is editing and commits them only when the form's **Save** button is clicked. Refresh, navigate-away, and Cancel never delete a persisted file. The page unload still cleans up *transient* uploads from the current session so abandoning a fresh form does not leave trash, but it identifies "transient" by ID equality against the file that was attached when the page loaded — that one is sacred.

Files selected from Documents and Media via the **document selector** are not touched by the form field. The selector picks pre-existing files that may belong to other contexts (other entries, web content, assets), so the form does not assume ownership.

## Two distinct UIs to keep in mind

The field renders one of two UIs depending on context:

- **Guest filling a public form** — sees a file input. Can upload, replace by uploading again, clear, submit.
- **Signed-in admin editing an entry** — sees a document selector. Can clear, or pick a different existing file from Documents and Media. There is no admin "upload" path through this field.

The bugs are reported in the admin context; the file in the field is owned by the DDM default user (created by the original guest upload). Both UIs share the same state machine, so the tables below cover both.

## Use cases for review

### Bugs fixed — admin viewing or editing a guest-submitted entry

| User action | Master | This branch |
|---|---|---|
| Admin opens entry **view** → refresh | File is deleted from Documents and Media; entry list shows "Content is temporarily unavailable" | File is preserved |
| Admin opens for **edit** → refresh without any change | File is deleted | File is preserved |
| Admin opens for edit → click **Clear** → click **Cancel** | File is deleted (Clear took effect immediately) | File is preserved |

### Behavior preserved — admin viewing or editing a guest-submitted entry

| User action | Outcome (master and branch agree) |
|---|---|
| Admin opens for edit → **Clear** → **Save** | File is deleted from Documents and Media; field becomes empty on the saved entry |
| Admin opens for edit → uses **document selector** to pick a different file → **Save** | New file is referenced by the entry; the previously-attached file is **left intact** in Documents and Media (it may be in use elsewhere) |
| Admin opens for edit → uses document selector → refresh / Cancel | Previously-attached file is left intact |

### Behavior preserved — guest filling out a public form

| User action | Outcome (master and branch agree) |
|---|---|
| Guest submits a form with a file upload | File saved with the entry |
| Guest uploads a file, uploads a different one, submits | Only the latest is saved with the entry; the abandoned upload is cleaned up |
| Guest uploads a file then closes the tab without submitting | Upload is cleaned up |