### PR TITLE
LPD-72651 | add ID-based methods to ObjectEntryManager interface

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -33,12 +33,27 @@ public interface ObjectEntryManager {
 			String scopeKey)
 		throws Exception;
 
+	public default void deleteObjectEntry(
+			ObjectDefinition objectDefinition, long objectEntryId)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public Page<ObjectEntry> getObjectEntries(
 			long companyId, ObjectDefinition objectDefinition, String scopeKey,
 			Aggregation aggregation, DTOConverterContext dtoConverterContext,
 			String filterString, Pagination pagination, String search,
 			Sort[] sorts)
 		throws Exception;
+
+	public default ObjectEntry getObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
 
 	public ObjectEntry getObjectEntry(
 			long companyId, DTOConverterContext dtoConverterContext,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -68,6 +68,15 @@ public interface ObjectEntryManager {
 			objectDefinition, existingObjectEntry, scopeKey);
 	}
 
+	public default ObjectEntry updateObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public ObjectEntry updateObjectEntry(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String externalReferenceCode, ObjectDefinition objectDefinition,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -51,6 +51,15 @@ public interface ObjectEntryManager {
 	public String getStorageType();
 
 	public default ObjectEntry partialUpdateObjectEntry(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long objectEntryId,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
+	public default ObjectEntry partialUpdateObjectEntry(
 			long companyId, DTOConverterContext dtoConverterContext,
 			String externalReferenceCode, ObjectDefinition objectDefinition,
 			ObjectEntry objectEntry, String scopeKey)

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 23.1.0
+version 23.2.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -326,14 +326,12 @@ public class ObjectEntryResourceImpl
 
 	@Override
 	public void deleteObjectEntry(Long objectEntryId) throws Exception {
-		DefaultObjectEntryManager defaultObjectEntryManager =
-			DefaultObjectEntryManagerProvider.provide(
-				_objectEntryManagerRegistry.getObjectEntryManager(
-					_objectDefinition.getCompanyId(),
-					_objectDefinition.getStorageType()));
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getCompanyId(),
+				_objectDefinition.getStorageType());
 
-		defaultObjectEntryManager.deleteObjectEntry(
-			_objectDefinition, objectEntryId);
+		objectEntryManager.deleteObjectEntry(_objectDefinition, objectEntryId);
 	}
 
 	@Override
@@ -636,13 +634,12 @@ public class ObjectEntryResourceImpl
 
 	@Override
 	public ObjectEntry getObjectEntry(Long objectEntryId) throws Exception {
-		DefaultObjectEntryManager defaultObjectEntryManager =
-			DefaultObjectEntryManagerProvider.provide(
-				_objectEntryManagerRegistry.getObjectEntryManager(
-					_objectDefinition.getCompanyId(),
-					_objectDefinition.getStorageType()));
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getCompanyId(),
+				_objectDefinition.getStorageType());
 
-		return defaultObjectEntryManager.getObjectEntry(
+		return objectEntryManager.getObjectEntry(
 			_getDTOConverterContext(objectEntryId), _objectDefinition,
 			objectEntryId);
 	}

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -865,13 +865,12 @@ public class ObjectEntryResourceImpl
 			Long objectEntryId, ObjectEntry objectEntry)
 		throws Exception {
 
-		DefaultObjectEntryManager defaultObjectEntryManager =
-			DefaultObjectEntryManagerProvider.provide(
-				_objectEntryManagerRegistry.getObjectEntryManager(
-					_objectDefinition.getCompanyId(),
-					_objectDefinition.getStorageType()));
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getCompanyId(),
+				_objectDefinition.getStorageType());
 
-		return defaultObjectEntryManager.partialUpdateObjectEntry(
+		return objectEntryManager.partialUpdateObjectEntry(
 			_getDTOConverterContext(objectEntryId), _objectDefinition,
 			objectEntryId, objectEntry);
 	}
@@ -1322,13 +1321,12 @@ public class ObjectEntryResourceImpl
 			Long objectEntryId, ObjectEntry objectEntry)
 		throws Exception {
 
-		DefaultObjectEntryManager defaultObjectEntryManager =
-			DefaultObjectEntryManagerProvider.provide(
-				_objectEntryManagerRegistry.getObjectEntryManager(
-					_objectDefinition.getCompanyId(),
-					_objectDefinition.getStorageType()));
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getCompanyId(),
+				_objectDefinition.getStorageType());
 
-		return defaultObjectEntryManager.updateObjectEntry(
+		return objectEntryManager.updateObjectEntry(
 			_getDTOConverterContext(objectEntryId), _objectDefinition,
 			objectEntryId, objectEntry);
 	}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/ObjectEntryManagerRegistryImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/ObjectEntryManagerRegistryImplTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.scope.CompanyScoped;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -101,6 +102,65 @@ public class ObjectEntryManagerRegistryImplTest {
 		Assert.assertNull(
 			_objectEntryManagerRegistry.getObjectEntryManager(
 				1, RandomTestUtil.randomString()));
+	}
+
+	@Test
+	@TestInfo("LPD-72651")
+	public void testObjectEntryManagerIdBasedDefaultMethods() throws Exception {
+
+		// Non-overriding manager: default methods throw
+		// UnsupportedOperationException
+
+		TestObjectEntryManager testObjectEntryManager =
+			new TestObjectEntryManager(0, false);
+
+		Assert.assertThrows(
+			UnsupportedOperationException.class,
+			() -> testObjectEntryManager.deleteObjectEntry(null, 0));
+		Assert.assertThrows(
+			UnsupportedOperationException.class,
+			() -> testObjectEntryManager.getObjectEntry(null, null, 0));
+		Assert.assertThrows(
+			UnsupportedOperationException.class,
+			() -> testObjectEntryManager.partialUpdateObjectEntry(
+				null, null, 0, null));
+		Assert.assertThrows(
+			UnsupportedOperationException.class,
+			() -> testObjectEntryManager.updateObjectEntry(
+				null, null, 0, null));
+
+		// Overriding manager: ID-based calls are dispatched without cast
+
+		TrackingObjectEntryManager trackingObjectEntryManager =
+			new TrackingObjectEntryManager();
+
+		ServiceRegistration<ObjectEntryManager> serviceRegistration = _register(
+			trackingObjectEntryManager);
+
+		try {
+			ObjectEntryManager objectEntryManager =
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					0, "tracking");
+
+			Assert.assertSame(trackingObjectEntryManager, objectEntryManager);
+
+			objectEntryManager.deleteObjectEntry(null, 1L);
+			objectEntryManager.getObjectEntry(null, null, 1L);
+			objectEntryManager.partialUpdateObjectEntry(null, null, 1L, null);
+			objectEntryManager.updateObjectEntry(null, null, 1L, null);
+
+			Assert.assertTrue(
+				trackingObjectEntryManager.deleteObjectEntryByIdCalled);
+			Assert.assertTrue(
+				trackingObjectEntryManager.getObjectEntryByIdCalled);
+			Assert.assertTrue(
+				trackingObjectEntryManager.partialUpdateObjectEntryByIdCalled);
+			Assert.assertTrue(
+				trackingObjectEntryManager.updateObjectEntryByIdCalled);
+		}
+		finally {
+			_unregister(serviceRegistration);
+		}
 	}
 
 	private ServiceRegistration<ObjectEntryManager> _register(
@@ -207,6 +267,118 @@ public class ObjectEntryManagerRegistryImplTest {
 
 		private final long _allowedCompanyId;
 		private final boolean _fail;
+
+	}
+
+	private static class TrackingObjectEntryManager
+		implements ObjectEntryManager {
+
+		@Override
+		public ObjectEntry addObjectEntry(
+				DTOConverterContext dtoConverterContext,
+				ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+				String scopeKey)
+			throws Exception {
+
+			return null;
+		}
+
+		@Override
+		public void deleteObjectEntry(
+				long companyId, DTOConverterContext dtoConverterContext,
+				String externalReferenceCode, ObjectDefinition objectDefinition,
+				String scopeKey)
+			throws Exception {
+		}
+
+		@Override
+		public void deleteObjectEntry(
+				ObjectDefinition objectDefinition, long objectEntryId)
+			throws Exception {
+
+			deleteObjectEntryByIdCalled = true;
+		}
+
+		@Override
+		public Page<ObjectEntry> getObjectEntries(
+				long companyId, ObjectDefinition objectDefinition,
+				String scopeKey, Aggregation aggregation,
+				DTOConverterContext dtoConverterContext, String filterString,
+				Pagination pagination, String search, Sort[] sorts)
+			throws Exception {
+
+			return null;
+		}
+
+		@Override
+		public ObjectEntry getObjectEntry(
+				DTOConverterContext dtoConverterContext,
+				ObjectDefinition objectDefinition, long objectEntryId)
+			throws Exception {
+
+			getObjectEntryByIdCalled = true;
+
+			return null;
+		}
+
+		@Override
+		public ObjectEntry getObjectEntry(
+				long companyId, DTOConverterContext dtoConverterContext,
+				String externalReferenceCode, ObjectDefinition objectDefinition,
+				String scopeKey)
+			throws Exception {
+
+			return null;
+		}
+
+		@Override
+		public String getStorageLabel(Locale locale) {
+			return "tracking";
+		}
+
+		@Override
+		public String getStorageType() {
+			return "tracking";
+		}
+
+		@Override
+		public ObjectEntry partialUpdateObjectEntry(
+				DTOConverterContext dtoConverterContext,
+				ObjectDefinition objectDefinition, long objectEntryId,
+				ObjectEntry objectEntry)
+			throws Exception {
+
+			partialUpdateObjectEntryByIdCalled = true;
+
+			return null;
+		}
+
+		@Override
+		public ObjectEntry updateObjectEntry(
+				DTOConverterContext dtoConverterContext,
+				ObjectDefinition objectDefinition, long objectEntryId,
+				ObjectEntry objectEntry)
+			throws Exception {
+
+			updateObjectEntryByIdCalled = true;
+
+			return null;
+		}
+
+		@Override
+		public ObjectEntry updateObjectEntry(
+				long companyId, DTOConverterContext dtoConverterContext,
+				String externalReferenceCode, ObjectDefinition objectDefinition,
+				ObjectEntry objectEntry, String scopeKey)
+			throws Exception {
+
+			return null;
+		}
+
+		public boolean deleteObjectEntryByIdCalled;
+		public boolean getObjectEntryByIdCalled;
+		public boolean partialUpdateObjectEntryByIdCalled;
+		public boolean updateObjectEntryByIdCalled;
 
 	}
 


### PR DESCRIPTION
related: [LPD-72651](https://liferay.atlassian.net/browse/LPD-72651)

What
Exposes four ID-based default methods on the ObjectEntryManager base interface:

deleteObjectEntry(ObjectDefinition, long objectEntryId)
getObjectEntry(DTOConverterContext, ObjectDefinition, long objectEntryId)
partialUpdateObjectEntry(DTOConverterContext, ObjectDefinition, long objectEntryId, ObjectEntry)
updateObjectEntry(DTOConverterContext, ObjectDefinition, long objectEntryId, ObjectEntry)
Each default throws UnsupportedOperationException, preserving backward compatibility for implementations that don't override them.

Why
ObjectEntryResourceImpl was calling DefaultObjectEntryManagerProvider.provide() to access these methods, which casts the manager to DefaultObjectEntryManager. For objects with a non-default storage type (e.g. proxy objects backed by SugarCRM or Salesforce), the cast fails with UnsupportedOperationException, breaking deleteObjectEntry(Long), getObjectEntry(Long), patchObjectEntry(Long, ObjectEntry), and putObjectEntry(Long, ObjectEntry).

The fix moves the four methods to the base interface and removes the cast from ObjectEntryResourceImpl, so each manager implementation can control its own behavior.

Test plan
ObjectEntryManagerRegistryImplTest#testObjectEntryManagerIdBasedDefaultMethods — new integration test verifying:
A non-overriding manager throws UnsupportedOperationException for all four ID-based methods.
A custom manager that overrides those methods receives the calls directly (no cast required).

[LPD-72651]: https://liferay.atlassian.net/browse/LPD-72651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ