### PR TITLE
LPD-89355 Preserve folder membership on no-op upsert

### DIFF
--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/ObjectFolderResourceImpl.java
@@ -19,7 +19,6 @@ import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectFolderResource;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectConstants;
-import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.exception.ObjectFolderItemObjectDefinitionIdException;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -306,27 +305,28 @@ public class ObjectFolderResourceImpl extends BaseObjectFolderResourceImpl {
 				serviceBuilderObjectDefinition.getObjectDefinitionId());
 		}
 
-		com.liferay.object.model.ObjectFolder
-			defaultServiceBuilderObjectFolder =
-				_objectFolderService.getObjectFolderByExternalReferenceCode(
-					ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_DEFAULT,
-					contextCompany.getCompanyId());
+		if (!objectFolderItems.isEmpty()) {
+			com.liferay.object.model.ObjectFolder
+				defaultServiceBuilderObjectFolder =
+					_objectFolderLocalService.getDefaultObjectFolder(
+						contextCompany.getCompanyId());
 
-		for (Long objectDefinitionId : serviceBuilderObjectDefinitionIds) {
-			com.liferay.object.model.ObjectDefinition
-				serviceBuilderObjectDefinition =
-					_objectDefinitionLocalService.fetchObjectDefinition(
-						objectDefinitionId);
+			for (Long objectDefinitionId : serviceBuilderObjectDefinitionIds) {
+				com.liferay.object.model.ObjectDefinition
+					serviceBuilderObjectDefinition =
+						_objectDefinitionLocalService.fetchObjectDefinition(
+							objectDefinitionId);
 
-			if (serviceBuilderObjectDefinition.isLinkedToObjectFolder(
-					objectFolderId)) {
+				if (serviceBuilderObjectDefinition.isLinkedToObjectFolder(
+						objectFolderId)) {
 
-				continue;
+					continue;
+				}
+
+				_objectDefinitionLocalService.updateObjectFolderId(
+					objectDefinitionId,
+					defaultServiceBuilderObjectFolder.getObjectFolderId());
 			}
-
-			_objectDefinitionLocalService.updateObjectFolderId(
-				objectDefinitionId,
-				defaultServiceBuilderObjectFolder.getObjectFolderId());
 		}
 
 		objectFolderItems.removeAll(unlinkedObjectFolderItems);

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectFolderResourceTest.java
@@ -114,6 +114,55 @@ public class ObjectFolderResourceTest extends BaseObjectFolderResourceTestCase {
 	}
 
 	@Override
+	@Test
+	public void testPutObjectFolder() throws Exception {
+		super.testPutObjectFolder();
+
+		ObjectDefinition finalObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+		ObjectFolder postObjectFolder = testPostObjectFolder_addObjectFolder(
+			new ObjectFolder() {
+				{
+					setExternalReferenceCode(RandomTestUtil.randomString());
+					setLabel(
+						Collections.singletonMap(
+							"en_US", RandomTestUtil.randomString()));
+					setName(
+						StringUtil.toLowerCase(RandomTestUtil.randomString()));
+					setObjectFolderItems(
+						new ObjectFolderItem[] {
+							new ObjectFolderItem() {
+								{
+									setLinkedObjectDefinition(false);
+									setObjectDefinitionExternalReferenceCode(
+										finalObjectDefinition.
+											getExternalReferenceCode());
+									setPositionX(0);
+									setPositionY(0);
+								}
+							}
+						});
+				}
+			});
+
+		postObjectFolder.setObjectFolderItems(new ObjectFolderItem[0]);
+
+		ObjectFolder putObjectFolder = objectFolderResource.putObjectFolder(
+			postObjectFolder.getId(), postObjectFolder);
+
+		ObjectFolderItem[] objectFolderItems =
+			putObjectFolder.getObjectFolderItems();
+
+		Assert.assertEquals(
+			Arrays.toString(objectFolderItems), 1, objectFolderItems.length);
+
+		Assert.assertEquals(
+			finalObjectDefinition.getExternalReferenceCode(),
+			objectFolderItems[0].getObjectDefinitionExternalReferenceCode());
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"label"};
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1328,9 +1328,18 @@ public class ObjectDefinitionLocalServiceImpl
 
 		long oldObjectFolderId = objectDefinition.getObjectFolderId();
 
-		objectDefinition.setObjectFolderId(
-			_getObjectFolderId(
-				objectDefinition.getCompanyId(), objectFolderId));
+		if (objectFolderId == oldObjectFolderId) {
+			return objectDefinition;
+		}
+
+		long newObjectFolderId = _getObjectFolderId(
+			objectDefinition.getCompanyId(), objectFolderId);
+
+		if (newObjectFolderId == oldObjectFolderId) {
+			return objectDefinition;
+		}
+
+		objectDefinition.setObjectFolderId(newObjectFolderId);
 
 		objectDefinition = objectDefinitionPersistence.update(objectDefinition);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89355

## What is being fixed

On a 2025.Q3 → 2026.Q1 upgrade, every cluster pod fails to boot because the CMS site initializer can no longer re-import its folders. `01-object-folder.batch-engine-data.json` ships with `"objectFolderItems": []` for every CMS folder. On a fresh install those folders are empty, so the upsert is a no-op; on upgrade the existing CMS object definitions are evicted to the default folder, which LPD-83357's `ObjectDefinitionModelListener` rejects with `ObjectDefinitionObjectFolderIdException`.

## How it is being fixed

`ObjectFolderResourceImpl._addObjectFolderResources` now skips the eviction loop when the upsert payload supplies no `objectFolderItems`, so a metadata-only refresh leaves existing membership untouched. The default-folder lookup that the loop needs has been swapped over to the dedicated `ObjectFolderLocalService.getDefaultObjectFolder` helper. As a defensive cleanup on the same path, `ObjectDefinitionLocalServiceImpl.updateObjectFolderId` now short-circuits when the resolved new folder id matches the current one, with an even earlier short-circuit on the raw input that avoids an extra folder lookup.

A regression test in `ObjectFolderResourceTest.testPutObjectFolder` re-`PUT`s a folder containing a definition with empty `objectFolderItems` and asserts the definition stays in place.