### PR TITLE
LPD-88515 Repeatable Fields Broken Due to XSS Fix

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/init.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/init.ftl
@@ -29,9 +29,9 @@
 <#assign
 	fieldNamespace = "_INSTANCE_" + fieldStructure.fieldNamespace
 
-	fieldName = fieldStructure.name
+	fieldName = htmlUtil.escapeAttribute(fieldStructure.name)
 
-	parentName = parentFieldStructure.name!""
+	parentName = htmlUtil.escapeAttribute(parentFieldStructure.name!"")
 	parentType = parentFieldStructure.type!""
 
 	isChildField = validator.isNotNull(parentName) && (stringUtil.equals(parentType, "radio") || stringUtil.equals(parentType, "select"))

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/render/test/DDMFormFieldFreeMarkerRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/render/test/DDMFormFieldFreeMarkerRendererTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.render.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Nícolas Moura
+ */
+@RunWith(Arquillian.class)
+public class DDMFormFieldFreeMarkerRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_originalSiteDefaultLocale = LocaleThreadLocal.getSiteDefaultLocale();
+		_originalThemeDisplayDefaultLocale =
+			LocaleThreadLocal.getThemeDisplayLocale();
+
+		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setSiteDefaultLocale(_originalSiteDefaultLocale);
+		LocaleThreadLocal.setThemeDisplayLocale(
+			_originalThemeDisplayDefaultLocale);
+	}
+
+	@Test
+	public void testRenderEscapesFieldName() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
+			_SCRIPT, false, false, false);
+
+		ddmForm.addDDMFormField(ddmFormField);
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			_createDDMFormFieldRenderingContext();
+
+		String renderedHTML = _ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
+
+		Assert.assertFalse(
+			"Rendered HTML must not contain a raw <script> tag: " +
+				renderedHTML,
+			renderedHTML.contains("<script>"));
+	}
+
+	private DDMFormFieldRenderingContext _createDDMFormFieldRenderingContext()
+		throws Exception {
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _createThemeDisplay());
+
+		ddmFormFieldRenderingContext.setHttpServletRequest(
+			mockHttpServletRequest);
+
+		ddmFormFieldRenderingContext.setHttpServletResponse(
+			new MockHttpServletResponse());
+		ddmFormFieldRenderingContext.setLocale(LocaleUtil.US);
+		ddmFormFieldRenderingContext.setMode("");
+		ddmFormFieldRenderingContext.setNamespace("_TEST_NAMESPACE_");
+		ddmFormFieldRenderingContext.setPortletNamespace(
+			"_TEST_PORTLET_NAMESPACE_");
+		ddmFormFieldRenderingContext.setReadOnly(false);
+
+		return ddmFormFieldRenderingContext;
+	}
+
+	private ThemeDisplay _createThemeDisplay() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		return ContentLayoutTestUtil.getThemeDisplay(company, _group, layout);
+	}
+
+	private static final String _SCRIPT =
+		"contentu248f\"><script>alert(1)</script>x1ytosh593m";
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(filter = "ddm.form.field.renderer.type=freemarker")
+	private DDMFormFieldRenderer _ddmFormFieldRenderer;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Locale _originalSiteDefaultLocale;
+	private Locale _originalThemeDisplayDefaultLocale;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -9,14 +9,21 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRendererRegistry;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +35,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -151,11 +159,146 @@ public class RenderStructureFieldMVCResourceCommandTest {
 			HtmlUtil.escapeAttribute(_SCRIPT), ddmFormField.getName());
 	}
 
+	@Test
+	public void testServeResource() throws Exception {
+		Mockito.when(
+			_httpServletRequest.getParameter("fieldName")
+		).thenReturn(
+			_FIELD_NAME
+		);
+
+		_setUpDDMFormFieldRendererRegistry();
+		_setUpJSONDDMFormDeserializer();
+		_setUpPortal();
+
+		try (MockedStatic<ServletResponseUtil> servletResponseUtilMockedStatic =
+				Mockito.mockStatic(ServletResponseUtil.class)) {
+
+			_renderStructureFieldMVCResourceCommand.doServeResource(
+				_resourceRequest, _resourceResponse);
+
+			servletResponseUtilMockedStatic.verify(
+				() -> ServletResponseUtil.write(
+					_httpServletResponse, _RENDERED_HTML),
+				Mockito.times(1));
+		}
+
+		Mockito.verify(
+			_httpServletResponse
+		).setContentType(
+			ContentTypes.TEXT_HTML
+		);
+	}
+
+	private void _setUpDDMFormFieldRendererRegistry() throws Exception {
+		DDMFormFieldRenderer ddmFormFieldRenderer = Mockito.mock(
+			DDMFormFieldRenderer.class);
+
+		Mockito.when(
+			ddmFormFieldRenderer.render(
+				Mockito.any(DDMFormField.class),
+				Mockito.any(DDMFormFieldRenderingContext.class))
+		).thenReturn(
+			_RENDERED_HTML
+		);
+
+		Mockito.when(
+			_ddmFormFieldRendererRegistry.getDDMFormFieldRenderer(_FIELD_TYPE)
+		).thenReturn(
+			ddmFormFieldRenderer
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_renderStructureFieldMVCResourceCommand,
+			"_ddmFormFieldRendererRegistry", _ddmFormFieldRendererRegistry);
+	}
+
+	private void _setUpJSONDDMFormDeserializer() throws Exception {
+		DDMFormField ddmFormField = Mockito.mock(DDMFormField.class);
+
+		Mockito.when(
+			ddmFormField.getType()
+		).thenReturn(
+			_FIELD_TYPE
+		);
+
+		DDMForm ddmForm = Mockito.mock(DDMForm.class);
+
+		Mockito.when(
+			ddmForm.getDDMFormFieldsMap(true)
+		).thenReturn(
+			Collections.singletonMap(_FIELD_NAME, ddmFormField)
+		);
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse = Mockito.mock(
+				DDMFormDeserializerDeserializeResponse.class);
+
+		Mockito.when(
+			ddmFormDeserializerDeserializeResponse.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		Mockito.when(
+			_jsonDDMFormDeserializer.deserialize(Mockito.any())
+		).thenReturn(
+			ddmFormDeserializerDeserializeResponse
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
+			_jsonDDMFormDeserializer);
+	}
+
+	private void _setUpPortal() {
+		Mockito.when(
+			_portal.getHttpServletRequest(_resourceRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
+
+		Mockito.when(
+			_portal.getHttpServletResponse(_resourceResponse)
+		).thenReturn(
+			_httpServletResponse
+		);
+
+		Mockito.when(
+			_portal.getOriginalServletRequest(_httpServletRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_renderStructureFieldMVCResourceCommand, "_portal", _portal);
+	}
+
+	private static final String _FIELD_NAME = "fieldName";
+
+	private static final String _FIELD_TYPE = "text";
+
+	private static final String _RENDERED_HTML =
+		"<input name=\"" + _FIELD_NAME + "\" type=\"text\" />";
+
 	private static final String _SCRIPT =
 		"'\"></option><img onerror=alert(123) src=x>";
 
+	private final DDMFormFieldRendererRegistry _ddmFormFieldRendererRegistry =
+		Mockito.mock(DDMFormFieldRendererRegistry.class);
 	private final HttpServletRequest _httpServletRequest = Mockito.mock(
 		HttpServletRequest.class);
+	private final HttpServletResponse _httpServletResponse = Mockito.mock(
+		HttpServletResponse.class);
+	private final DDMFormDeserializer _jsonDDMFormDeserializer = Mockito.mock(
+		DDMFormDeserializer.class);
 	private final Portal _portal = Mockito.mock(Portal.class);
+	private final RenderStructureFieldMVCResourceCommand
+		_renderStructureFieldMVCResourceCommand =
+			new RenderStructureFieldMVCResourceCommand();
+	private final ResourceRequest _resourceRequest = Mockito.mock(
+		ResourceRequest.class);
+	private final ResourceResponse _resourceResponse = Mockito.mock(
+		ResourceResponse.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
@@ -113,9 +113,8 @@ public class RenderStructureFieldMVCResourceCommand
 			createDDMFormFieldRenderingContext(
 				httpServletRequest, httpServletResponse);
 
-		String ddmFormFieldHTML = HtmlUtil.escapeAttribute(
-			ddmFormFieldRenderer.render(
-				ddmFormField, ddmFormFieldRenderingContext));
+		String ddmFormFieldHTML = ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
 
 		httpServletResponse.setContentType(ContentTypes.TEXT_HTML);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88515

Resent from https://github.com/liferay-bpm/liferay-portal/pull/6077.

Mock setup in `RenderStructureFieldMVCResourceCommandTest.testServeResource` was rewritten to follow the strict BPM convention as used in `DownloadFileEntryMVCResourceCommandTest` and siblings: `_setUp<X>()` helpers are zero-arg and void, the SUT and its dependencies live as private final instance fields, scenario data lives as private static final constants, and each helper completes the setup with `ReflectionTestUtil.setFieldValue` against the SUT field.