### PR TITLE
LPD-88515 Repeatable Fields Broken Due to XSS Fix

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/init.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/init.ftl
@@ -29,9 +29,9 @@
 <#assign
 	fieldNamespace = "_INSTANCE_" + fieldStructure.fieldNamespace
 
-	fieldName = fieldStructure.name
+	fieldName = htmlUtil.escapeAttribute(fieldStructure.name)
 
-	parentName = parentFieldStructure.name!""
+	parentName = htmlUtil.escapeAttribute(parentFieldStructure.name!"")
 	parentType = parentFieldStructure.type!""
 
 	isChildField = validator.isNotNull(parentName) && (stringUtil.equals(parentType, "radio") || stringUtil.equals(parentType, "select"))

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/render/test/DDMFormFieldFreeMarkerRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/render/test/DDMFormFieldFreeMarkerRendererTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.render.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Nícolas Moura
+ */
+@RunWith(Arquillian.class)
+public class DDMFormFieldFreeMarkerRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_originalSiteDefaultLocale = LocaleThreadLocal.getSiteDefaultLocale();
+		_originalThemeDisplayDefaultLocale =
+			LocaleThreadLocal.getThemeDisplayLocale();
+
+		LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setSiteDefaultLocale(_originalSiteDefaultLocale);
+		LocaleThreadLocal.setThemeDisplayLocale(
+			_originalThemeDisplayDefaultLocale);
+	}
+
+	@Test
+	public void testRenderEscapesFieldName() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
+			_SCRIPT, false, false, false);
+
+		ddmForm.addDDMFormField(ddmFormField);
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			_createDDMFormFieldRenderingContext();
+
+		String renderedHTML = _ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
+
+		Assert.assertFalse(
+			"Rendered HTML must not contain a raw <script> tag: " +
+				renderedHTML,
+			renderedHTML.contains("<script>"));
+	}
+
+	private DDMFormFieldRenderingContext _createDDMFormFieldRenderingContext()
+		throws Exception {
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _createThemeDisplay());
+
+		ddmFormFieldRenderingContext.setHttpServletRequest(
+			mockHttpServletRequest);
+
+		ddmFormFieldRenderingContext.setHttpServletResponse(
+			new MockHttpServletResponse());
+		ddmFormFieldRenderingContext.setLocale(LocaleUtil.US);
+		ddmFormFieldRenderingContext.setMode("");
+		ddmFormFieldRenderingContext.setNamespace("_TEST_NAMESPACE_");
+		ddmFormFieldRenderingContext.setPortletNamespace(
+			"_TEST_PORTLET_NAMESPACE_");
+		ddmFormFieldRenderingContext.setReadOnly(false);
+
+		return ddmFormFieldRenderingContext;
+	}
+
+	private ThemeDisplay _createThemeDisplay() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		return ContentLayoutTestUtil.getThemeDisplay(company, _group, layout);
+	}
+
+	private static final String _SCRIPT =
+		"contentu248f\"><script>alert(1)</script>x1ytosh593m";
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(filter = "ddm.form.field.renderer.type=freemarker")
+	private DDMFormFieldRenderer _ddmFormFieldRenderer;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Locale _originalSiteDefaultLocale;
+	private Locale _originalThemeDisplayDefaultLocale;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -9,14 +9,22 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
+import com.liferay.dynamic.data.mapping.render.DDMFormFieldRendererRegistry;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +36,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -149,6 +158,166 @@ public class RenderStructureFieldMVCResourceCommandTest {
 
 		Assert.assertEquals(
 			HtmlUtil.escapeAttribute(_SCRIPT), ddmFormField.getName());
+	}
+
+	@Test
+	public void testServeResource() throws Exception {
+		ResourceRequest resourceRequest = Mockito.mock(ResourceRequest.class);
+		ResourceResponse resourceResponse = Mockito.mock(
+			ResourceResponse.class);
+		HttpServletResponse httpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		_setUpPortal(resourceRequest, resourceResponse, httpServletResponse);
+
+		String fieldType = "text";
+
+		DDMFormField ddmFormField = _mockDDMFormField(fieldType);
+
+		String fieldName = ddmFormField.getName();
+
+		Mockito.when(
+			_httpServletRequest.getParameter("fieldName")
+		).thenReturn(
+			fieldName
+		);
+
+		String renderedHTML =
+			"<input name=\"" + fieldName + "\" type=\"text\" />";
+
+		RenderStructureFieldMVCResourceCommand
+			renderStructureFieldMVCResourceCommand =
+				new RenderStructureFieldMVCResourceCommand();
+
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand,
+			"_ddmFormFieldRendererRegistry",
+			_mockDDMFormFieldRendererRegistry(fieldType, renderedHTML));
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
+			_mockDDMFormDeserializer(fieldName, ddmFormField));
+		ReflectionTestUtil.setFieldValue(
+			renderStructureFieldMVCResourceCommand, "_portal", _portal);
+
+		try (MockedStatic<ServletResponseUtil> servletResponseUtilMockedStatic =
+				Mockito.mockStatic(ServletResponseUtil.class)) {
+
+			renderStructureFieldMVCResourceCommand.doServeResource(
+				resourceRequest, resourceResponse);
+
+			servletResponseUtilMockedStatic.verify(
+				() -> ServletResponseUtil.write(
+					httpServletResponse, renderedHTML),
+				Mockito.times(1));
+		}
+
+		Mockito.verify(
+			httpServletResponse
+		).setContentType(
+			ContentTypes.TEXT_HTML
+		);
+	}
+
+	private DDMFormDeserializer _mockDDMFormDeserializer(
+			String fieldName, DDMFormField ddmFormField)
+		throws Exception {
+
+		DDMForm ddmForm = Mockito.mock(DDMForm.class);
+
+		Mockito.when(
+			ddmForm.getDDMFormFieldsMap(true)
+		).thenReturn(
+			Collections.singletonMap(fieldName, ddmFormField)
+		);
+
+		DDMFormDeserializerDeserializeResponse
+			ddmFormDeserializerDeserializeResponse = Mockito.mock(
+				DDMFormDeserializerDeserializeResponse.class);
+
+		Mockito.when(
+			ddmFormDeserializerDeserializeResponse.getDDMForm()
+		).thenReturn(
+			ddmForm
+		);
+
+		DDMFormDeserializer ddmFormDeserializer = Mockito.mock(
+			DDMFormDeserializer.class);
+
+		Mockito.when(
+			ddmFormDeserializer.deserialize(Mockito.any())
+		).thenReturn(
+			ddmFormDeserializerDeserializeResponse
+		);
+
+		return ddmFormDeserializer;
+	}
+
+	private DDMFormField _mockDDMFormField(String fieldType) {
+		DDMFormField ddmFormField = Mockito.mock(DDMFormField.class);
+
+		Mockito.when(
+			ddmFormField.getName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			ddmFormField.getType()
+		).thenReturn(
+			fieldType
+		);
+
+		return ddmFormField;
+	}
+
+	private DDMFormFieldRendererRegistry _mockDDMFormFieldRendererRegistry(
+			String fieldType, String renderedHTML)
+		throws Exception {
+
+		DDMFormFieldRenderer ddmFormFieldRenderer = Mockito.mock(
+			DDMFormFieldRenderer.class);
+
+		Mockito.when(
+			ddmFormFieldRenderer.render(
+				Mockito.any(DDMFormField.class),
+				Mockito.any(DDMFormFieldRenderingContext.class))
+		).thenReturn(
+			renderedHTML
+		);
+
+		DDMFormFieldRendererRegistry ddmFormFieldRendererRegistry =
+			Mockito.mock(DDMFormFieldRendererRegistry.class);
+
+		Mockito.when(
+			ddmFormFieldRendererRegistry.getDDMFormFieldRenderer(fieldType)
+		).thenReturn(
+			ddmFormFieldRenderer
+		);
+
+		return ddmFormFieldRendererRegistry;
+	}
+
+	private void _setUpPortal(
+		ResourceRequest resourceRequest, ResourceResponse resourceResponse,
+		HttpServletResponse httpServletResponse) {
+
+		Mockito.when(
+			_portal.getHttpServletRequest(resourceRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
+
+		Mockito.when(
+			_portal.getHttpServletResponse(resourceResponse)
+		).thenReturn(
+			httpServletResponse
+		);
+
+		Mockito.when(
+			_portal.getOriginalServletRequest(_httpServletRequest)
+		).thenReturn(
+			_httpServletRequest
+		);
 	}
 
 	private static final String _SCRIPT =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -97,32 +97,11 @@ public class RenderStructureFieldMVCResourceCommandTest {
 	}
 
 	@Test
-	public void testGetDDMFormField() {
+	public void testGetDDMFormField() throws Exception {
 		Mockito.when(
 			_httpServletRequest.getParameter("fieldName")
 		).thenReturn(
 			HtmlUtil.escapeAttribute(_SCRIPT)
-		);
-
-		DDMFormDeserializer ddmFormDeserializer = Mockito.mock(
-			DDMFormDeserializer.class);
-
-		DDMFormDeserializerDeserializeResponse
-			ddmFormDeserializerDeserializeResponse = Mockito.mock(
-				DDMFormDeserializerDeserializeResponse.class);
-
-		Mockito.when(
-			ddmFormDeserializer.deserialize(Mockito.any())
-		).thenReturn(
-			ddmFormDeserializerDeserializeResponse
-		);
-
-		DDMForm ddmForm = Mockito.mock(DDMForm.class);
-
-		Mockito.when(
-			ddmFormDeserializerDeserializeResponse.getDDMForm()
-		).thenReturn(
-			ddmForm
 		);
 
 		DDMFormField mockDDMFormField = Mockito.mock(DDMFormField.class);
@@ -133,16 +112,10 @@ public class RenderStructureFieldMVCResourceCommandTest {
 			HtmlUtil.escapeAttribute(_SCRIPT)
 		);
 
-		Mockito.when(
-			ddmForm.getDDMFormFieldsMap(true)
-		).thenReturn(
-			Collections.singletonMap(
-				HtmlUtil.escapeAttribute(_SCRIPT), mockDDMFormField)
-		);
-
 		ReflectionTestUtil.setFieldValue(
 			_renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
-			ddmFormDeserializer);
+			_mockDDMFormDeserializer(
+				HtmlUtil.escapeAttribute(_SCRIPT), mockDDMFormField));
 
 		DDMFormField ddmFormField =
 			_renderStructureFieldMVCResourceCommand.getDDMFormField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -79,15 +79,11 @@ public class RenderStructureFieldMVCResourceCommandTest {
 			_SCRIPT
 		);
 
-		RenderStructureFieldMVCResourceCommand
-			renderStructureFieldMVCResourceCommand =
-				new RenderStructureFieldMVCResourceCommand();
-
 		ReflectionTestUtil.setFieldValue(
-			renderStructureFieldMVCResourceCommand, "_portal", _portal);
+			_renderStructureFieldMVCResourceCommand, "_portal", _portal);
 
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
-			renderStructureFieldMVCResourceCommand.
+			_renderStructureFieldMVCResourceCommand.
 				createDDMFormFieldRenderingContext(
 					_httpServletRequest,
 					Mockito.mock(HttpServletResponse.class));
@@ -144,16 +140,12 @@ public class RenderStructureFieldMVCResourceCommandTest {
 				HtmlUtil.escapeAttribute(_SCRIPT), mockDDMFormField)
 		);
 
-		RenderStructureFieldMVCResourceCommand
-			renderStructureFieldMVCResourceCommand =
-				new RenderStructureFieldMVCResourceCommand();
-
 		ReflectionTestUtil.setFieldValue(
-			renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
+			_renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
 			ddmFormDeserializer);
 
 		DDMFormField ddmFormField =
-			renderStructureFieldMVCResourceCommand.getDDMFormField(
+			_renderStructureFieldMVCResourceCommand.getDDMFormField(
 				_httpServletRequest);
 
 		Assert.assertEquals(
@@ -185,24 +177,22 @@ public class RenderStructureFieldMVCResourceCommandTest {
 		String renderedHTML =
 			"<input name=\"" + fieldName + "\" type=\"text\" />";
 
-		RenderStructureFieldMVCResourceCommand
-			renderStructureFieldMVCResourceCommand =
-				new RenderStructureFieldMVCResourceCommand();
-
 		ReflectionTestUtil.setFieldValue(
-			renderStructureFieldMVCResourceCommand,
+			_renderStructureFieldMVCResourceCommand,
 			"_ddmFormFieldRendererRegistry",
 			_mockDDMFormFieldRendererRegistry(fieldType, renderedHTML));
+
 		ReflectionTestUtil.setFieldValue(
-			renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
+			_renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
 			_mockDDMFormDeserializer(fieldName, ddmFormField));
+
 		ReflectionTestUtil.setFieldValue(
-			renderStructureFieldMVCResourceCommand, "_portal", _portal);
+			_renderStructureFieldMVCResourceCommand, "_portal", _portal);
 
 		try (MockedStatic<ServletResponseUtil> servletResponseUtilMockedStatic =
 				Mockito.mockStatic(ServletResponseUtil.class)) {
 
-			renderStructureFieldMVCResourceCommand.doServeResource(
+			_renderStructureFieldMVCResourceCommand.doServeResource(
 				resourceRequest, resourceResponse);
 
 			servletResponseUtilMockedStatic.verify(
@@ -326,5 +316,8 @@ public class RenderStructureFieldMVCResourceCommandTest {
 	private final HttpServletRequest _httpServletRequest = Mockito.mock(
 		HttpServletRequest.class);
 	private final Portal _portal = Mockito.mock(Portal.class);
+	private final RenderStructureFieldMVCResourceCommand
+		_renderStructureFieldMVCResourceCommand =
+			new RenderStructureFieldMVCResourceCommand();
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web-test/src/test/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommandTest.java
@@ -101,7 +101,7 @@ public class RenderStructureFieldMVCResourceCommandTest {
 		Mockito.when(
 			_httpServletRequest.getParameter("fieldName")
 		).thenReturn(
-			HtmlUtil.escapeAttribute(_SCRIPT)
+			_SCRIPT
 		);
 
 		DDMFormField mockDDMFormField = Mockito.mock(DDMFormField.class);
@@ -109,20 +109,18 @@ public class RenderStructureFieldMVCResourceCommandTest {
 		Mockito.when(
 			mockDDMFormField.getName()
 		).thenReturn(
-			HtmlUtil.escapeAttribute(_SCRIPT)
+			_SCRIPT
 		);
 
 		ReflectionTestUtil.setFieldValue(
 			_renderStructureFieldMVCResourceCommand, "_jsonDDMFormDeserializer",
-			_mockDDMFormDeserializer(
-				HtmlUtil.escapeAttribute(_SCRIPT), mockDDMFormField));
+			_mockDDMFormDeserializer(_SCRIPT, mockDDMFormField));
 
 		DDMFormField ddmFormField =
 			_renderStructureFieldMVCResourceCommand.getDDMFormField(
 				_httpServletRequest);
 
-		Assert.assertEquals(
-			HtmlUtil.escapeAttribute(_SCRIPT), ddmFormField.getName());
+		Assert.assertEquals(_SCRIPT, ddmFormField.getName());
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
@@ -113,9 +113,8 @@ public class RenderStructureFieldMVCResourceCommand
 			createDDMFormFieldRenderingContext(
 				httpServletRequest, httpServletResponse);
 
-		String ddmFormFieldHTML = HtmlUtil.escapeAttribute(
-			ddmFormFieldRenderer.render(
-				ddmFormField, ddmFormFieldRenderingContext));
+		String ddmFormFieldHTML = ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
 
 		httpServletResponse.setContentType(ContentTypes.TEXT_HTML);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88515

Resent from https://github.com/liferay-bpm/liferay-portal/pull/6084 after addressing the mock-helper convention concern raised on `brianchandotcom/liferay-portal#174270`.

Changes vs. previous resubmit:

- `testServeResource` rewritten to declare locals "as used" (per the Liferay Java convention `Variables-are-only-declared-as-used`) and ordered to follow burrito-style on calls with multiple locals, instead of the leading block of declarations the prior version had.
- A new private helper `_mockDDMFormField(String fieldType)` extracts the `DDMFormField` mock setup and returns a configured mock; the single-use sub-mocks (`DDMForm`, `DDMFormDeserializerDeserializeResponse`) stay inlined inside `_mockDDMFormDeserializer`.
- `_mockDDMFormDeserializer` signature changed from `(String fieldName, String fieldType)` to `(String fieldName, DDMFormField ddmFormField)` so it composes cleanly with the field mock owned by each test.
- `_renderStructureFieldMVCResourceCommand` extracted to a `private final` instance field and applied across `testCreateDDMFormFieldRenderingContext`, `testGetDDMFormField`, and `testServeResource` (separate commit).
- `testGetDDMFormField` reuses `_mockDDMFormDeserializer` to remove the inline deserializer chain that previously duplicated the helper's body (separate commit).