### PR TITLE
LPD-89400 [Test Fix] Playwright test fixes

### DIFF
--- a/modules/test/playwright/tests/object-web/content-page-integration/env/portal-ext.properties
+++ b/modules/test/playwright/tests/object-web/content-page-integration/env/portal-ext.properties
@@ -1,0 +1,2 @@
+object.encryption.algorithm=AES
+object.encryption.key=D9z5Rwxkn+8SctNWW/q/OA==

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -4230,7 +4230,9 @@ test.describe('Manage object entries through View Object Entries', () => {
 		await viewObjectEntriesPage.goto(objectDefinition.className);
 
 		await expect(
-			page.getByText('Add ' + objectDefinition.label.en_US)
+			page
+				.getByTestId('managementToolbar')
+				.locator('[data-testid="fdsCreationActionButton"]')
 		).toBeVisible();
 
 		await expect(

--- a/modules/test/playwright/tests/object-web/export-import/env/portal-ext.properties
+++ b/modules/test/playwright/tests/object-web/export-import/env/portal-ext.properties
@@ -1,0 +1,2 @@
+object.encryption.algorithm=AES
+object.encryption.key=D9z5Rwxkn+8SctNWW/q/OA==

--- a/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
+++ b/modules/test/playwright/tests/object-web/relationship/objectRelationship.spec.ts
@@ -1033,7 +1033,7 @@ test.describe('Manage object relationships through Model Builder', () => {
 					objectFolderName: 'Default',
 				});
 
-				const searchInput = page.getByPlaceholder('Search');
+				const searchInput = page.getByRole('textbox', {name: 'Search'});
 
 				await searchInput.fill(objectDefinition2.label.en_US);
 			});

--- a/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
+++ b/modules/test/playwright/tests/object-web/validation/objectValidation.spec.ts
@@ -910,7 +910,7 @@ test.describe('Object Expression Builder Validation', () => {
 
 		await modalAddObjectValidationPage.fillObjectValidationInputs(
 			'',
-			'Groovy'
+			'Composite Key'
 		);
 
 		await expect(page.getByText('Required')).toBeVisible();

--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -1782,19 +1782,27 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const tomorrow = new Date(today);
-
-		tomorrow.setDate(tomorrow.getDate() + 1);
-
 		const formatDate = (d: Date) =>
 			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
-		await page.getByLabel('From').fill(formatDate(yesterday));
 		await page
-			.getByRole('textbox', {name: 'To'})
-			.fill(formatDate(tomorrow));
+			.getByRole('textbox', {name: 'From'})
+			.fill(formatDate(yesterday));
+
+		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
+
+		const formatDisplayDate = (d: Date) =>
+			`${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+
+		await expect(page.getByText('1 Result Found for:')).toBeVisible();
+
+		await expect(
+			page.getByRole('button', {
+				name: `Create Date: ${formatDisplayDate(yesterday)} - ${formatDisplayDate(today)}`,
+			})
+		).toBeVisible();
 
 		await expect(page.getByText('Entry Test').first()).toBeVisible();
 	}
@@ -1882,19 +1890,27 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const tomorrow = new Date(today);
-
-		tomorrow.setDate(tomorrow.getDate() + 1);
-
 		const formatDate = (d: Date) =>
 			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
-		await page.getByLabel('From').fill(formatDate(yesterday));
 		await page
-			.getByRole('textbox', {name: 'To'})
-			.fill(formatDate(tomorrow));
+			.getByRole('textbox', {name: 'From'})
+			.fill(formatDate(yesterday));
+
+		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
+
+		const formatDisplayDate = (d: Date) =>
+			`${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+
+		await expect(page.getByText('1 Result Found for:')).toBeVisible();
+
+		await expect(
+			page.getByRole('button', {
+				name: `Modified Date: ${formatDisplayDate(yesterday)} - ${formatDisplayDate(today)}`,
+			})
+		).toBeVisible();
 
 		await expect(page.getByText('Entry Test').first()).toBeVisible();
 	}


### PR DESCRIPTION
related issue: [LPD-89400](https://liferay.atlassian.net/browse/LPD-89400)

related tests:
```
object-web/content-page-integration/objectContentPageIntegration.spec.ts:1203:2 › Display Page › verify if the object entries are displayed when selecting to preview an object entry on a page template
object-web/entry/objectEntry.spec.ts:4177:2 › Manage object entries through View Object Entries › cannot view other users entry without view permission
object-web/export-import/objectExportImport.spec.ts:621:2 › Manage export/import object definitions with object entries › Can create an object entry of an object definition with 100 fields of all types after export and import
object-web/relationship/objectRelationship.spec.ts:966:2 › Manage object relationships through Model Builder › can search for object definition with relationship in model builder view @LPS-185676 › Search for the object definition that is on the other folder
object-web/validation/objectValidation.spec.ts:891:2 › Object Expression Builder Validation › label field is required when adding a new validation
object-web/view/objectView.spec.ts:1703:1 › can filter entries by create date in custom view
object-web/view/objectView.spec.ts > can filter entries by modified date in custom view
```

[LPD-89400]: https://liferay.atlassian.net/browse/LPD-89400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ