### PR TITLE
LPD-88550 Support ASSIGNEE field in search, indexing, and filtering

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.internal.layout.tab.screen.navigation.category.ObjectLayoutTabScreenNavigationCategory;
 import com.liferay.object.internal.notification.handler.ObjectDefinitionNotificationHandler;
 import com.liferay.object.internal.notification.term.contributor.ObjectDefinitionNotificationTermEvaluator;
@@ -141,6 +142,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
+		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectFolderLocalService objectFolderLocalService,
 		ObjectLayoutLocalService objectLayoutLocalService,
@@ -177,6 +179,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
+		_objectFieldBusinessTypeRegistry = objectFieldBusinessTypeRegistry;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectFolderLocalService = objectFolderLocalService;
 		_objectLayoutLocalService = objectLayoutLocalService;
@@ -324,6 +327,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						_accountEntryOrganizationRelLocalService,
 						_dlFileEntryLocalService,
 						_objectEntryFolderLocalService,
+						_objectFieldBusinessTypeRegistry,
 						_textEmbeddingDocumentContributor),
 					HashMapDictionaryBuilder.<String, Object>put(
 						"indexer.class.name", objectDefinition.getClassName()
@@ -649,6 +653,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
+	private final ObjectFieldBusinessTypeRegistry
+		_objectFieldBusinessTypeRegistry;
 	private final ObjectFieldLocalService _objectFieldLocalService;
 	private final ObjectFolderLocalService _objectFolderLocalService;
 	private final ObjectLayoutLocalService _objectLayoutLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
@@ -19,6 +19,7 @@ import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
@@ -39,6 +40,38 @@ import java.util.Locale;
  * @author Carolina Barbosa
  */
 public class ObjectEntrySearchUtil {
+
+	public static Predicate getAssigneeFieldPredicate(
+		Table<?> table, String dbColumnName, String search) {
+
+		String[] parts = StringUtil.split(search, CharPool.UNDERLINE);
+
+		if (parts.length != 2) {
+			return null;
+		}
+
+		long classNameId = GetterUtil.getLong(parts[0]);
+		long classPK = GetterUtil.getLong(parts[1]);
+
+		if ((classNameId == 0L) || (classPK == 0L)) {
+			return null;
+		}
+
+		Column<?, Long> classNameIdColumn = (Column<?, Long>)table.getColumn(
+			"classNameId_" + dbColumnName);
+		Column<?, Long> classPKColumn = (Column<?, Long>)table.getColumn(
+			"classPK_" + dbColumnName);
+
+		if ((classNameIdColumn == null) || (classPKColumn == null)) {
+			return null;
+		}
+
+		return classNameIdColumn.eq(
+			classNameId
+		).and(
+			classPKColumn.eq(classPK)
+		);
+	}
 
 	public static String getLanguageId() throws PortalException {
 		Locale locale = null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AssigneeObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/AssigneeObjectFieldBusinessType.java
@@ -82,6 +82,32 @@ public class AssigneeObjectFieldBusinessType
 		return values.get(objectField.getName());
 	}
 
+	public String getDisplayName(long classNameId, long classPK) {
+		String className = _portal.fetchClassName(classNameId);
+
+		if (StringUtil.equals(className, Role.class.getName())) {
+			Role role = _roleLocalService.fetchRole(classPK);
+
+			if (role != null) {
+				return role.getName();
+			}
+
+			return null;
+		}
+
+		if (StringUtil.equals(className, User.class.getName())) {
+			User user = _userLocalService.fetchUser(classPK);
+
+			if (user != null) {
+				return user.getFullName();
+			}
+
+			return null;
+		}
+
+		return null;
+	}
+
 	@Override
 	public Serializable getDTOValue(
 			DTOConverterContext dtoConverterContext,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/ObjectEntryModelSearchConfigurator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/ObjectEntryModelSearchConfigurator.java
@@ -7,6 +7,7 @@ package com.liferay.object.internal.search;
 
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.internal.search.spi.model.index.contributor.ObjectEntryModelDocumentContributor;
 import com.liferay.object.internal.search.spi.model.result.contributor.ObjectEntryModelSummaryContributor;
 import com.liferay.object.model.ObjectDefinition;
@@ -82,6 +83,7 @@ public class ObjectEntryModelSearchConfigurator
 				new ObjectEntryModelDocumentContributor(
 					_accountEntryOrganizationRelLocalService,
 					_dlFileEntryLocalService, _objectEntryFolderLocalService,
+					_objectFieldBusinessTypeRegistry,
 					_textEmbeddingDocumentContributor);
 
 		_modelDocumentContributorServiceRegistration =
@@ -226,6 +228,9 @@ public class ObjectEntryModelSearchConfigurator
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -14,6 +14,8 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
+import com.liferay.object.internal.field.business.type.AssigneeObjectFieldBusinessType;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
@@ -81,12 +83,14 @@ public class ObjectEntryModelDocumentContributor
 			accountEntryOrganizationRelLocalService,
 		DLFileEntryLocalService dlFileEntryLocalService,
 		ObjectEntryFolderLocalService objectEntryFolderLocalService,
+		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		TextEmbeddingDocumentContributor textEmbeddingDocumentContributor) {
 
 		_accountEntryOrganizationRelLocalService =
 			accountEntryOrganizationRelLocalService;
 		_dlFileEntryLocalService = dlFileEntryLocalService;
 		_objectEntryFolderLocalService = objectEntryFolderLocalService;
+		_objectFieldBusinessTypeRegistry = objectFieldBusinessTypeRegistry;
 		_textEmbeddingDocumentContributor = textEmbeddingDocumentContributor;
 	}
 
@@ -158,7 +162,39 @@ public class ObjectEntryModelDocumentContributor
 
 		if (StringUtil.equals(
 				objectField.getBusinessType(),
-				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+				ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE) &&
+			(fieldValue instanceof Map)) {
+
+			Map<String, Long> assigneeMap = (Map<String, Long>)fieldValue;
+
+			long classNameId = MapUtil.getLong(assigneeMap, "classNameId");
+			long classPK = MapUtil.getLong(assigneeMap, "classPK");
+
+			fieldValue = StringBundler.concat(
+				classNameId, StringPool.UNDERLINE, classPK);
+
+			AssigneeObjectFieldBusinessType assigneeObjectFieldBusinessType =
+				(AssigneeObjectFieldBusinessType)
+					_objectFieldBusinessTypeRegistry.getObjectFieldBusinessType(
+						ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE);
+
+			if (assigneeObjectFieldBusinessType != null) {
+				String assigneeName =
+					assigneeObjectFieldBusinessType.getDisplayName(
+						classNameId, classPK);
+
+				if (Validator.isNotNull(assigneeName)) {
+					_addField(
+						fieldArray, fieldName, "value_text", assigneeName);
+
+					_appendToContent(
+						objectContentHelper, locale, fieldName, assigneeName);
+				}
+			}
+		}
+		else if (StringUtil.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 			fieldValue = _getFileName(
 				GetterUtil.getLong(fieldValue), objectDefinition);
@@ -328,10 +364,10 @@ public class ObjectEntryModelDocumentContributor
 		}
 
 		document.addKeyword(
-			"objectDefinitionId", objectEntry.getObjectDefinitionId());
-		document.addKeyword(
 			"objectDefinitionExternalReferenceCode",
 			objectDefinition.getExternalReferenceCode());
+		document.addKeyword(
+			"objectDefinitionId", objectEntry.getObjectDefinitionId());
 		document.addKeyword(
 			"objectDefinitionName", objectDefinition.getShortName());
 
@@ -707,6 +743,8 @@ public class ObjectEntryModelDocumentContributor
 		_accountEntryOrganizationRelLocalService;
 	private final DLFileEntryLocalService _dlFileEntryLocalService;
 	private final ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+	private final ObjectFieldBusinessTypeRegistry
+		_objectFieldBusinessTypeRegistry;
 	private final TextEmbeddingDocumentContributor
 		_textEmbeddingDocumentContributor;
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributor.java
@@ -248,6 +248,30 @@ public class ObjectEntryKeywordQueryContributor
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE)) {
+
+			BooleanQuery assigneeBooleanQuery = new BooleanQuery();
+
+			String keywordFieldName =
+				"nestedFieldArray.value_keyword_lowercase";
+
+			assigneeBooleanQuery.add(
+				new TermQuery(keywordFieldName, StringUtil.toLowerCase(token)),
+				BooleanClauseOccur.SHOULD);
+
+			String textFieldName = "nestedFieldArray.value_text";
+
+			assigneeBooleanQuery.add(
+				new MatchQuery(textFieldName, token),
+				BooleanClauseOccur.SHOULD);
+
+			nestedBooleanQuery.add(
+				assigneeBooleanQuery, BooleanClauseOccur.MUST);
+
+			queryConfig.addHighlightFieldNames(keywordFieldName, textFieldName);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) ||
 				 Objects.equals(
 					 objectField.getDBType(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -69,6 +69,7 @@ import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.builder.LongIntegerObjectFieldBuilder;
 import com.liferay.object.field.builder.ObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.internal.dao.db.ObjectDBManagerUtil;
@@ -1086,12 +1087,12 @@ public class ObjectDefinitionLocalServiceImpl
 				_objectActionLocalService, objectDefinitionLocalService,
 				_objectDefinitionSettingLocalService,
 				_objectEntryFolderLocalService, _objectEntryLocalService,
-				_objectEntryService, _objectFieldLocalService,
-				_objectFolderLocalService, _objectLayoutLocalService,
-				_objectLayoutTabLocalService, _objectRelationshipLocalService,
-				_objectScopeProviderRegistry, _objectViewLocalService,
-				_organizationLocalService, _portal, _portletLocalService,
-				_resourceActions, _userLocalService,
+				_objectEntryService, _objectFieldBusinessTypeRegistry,
+				_objectFieldLocalService, _objectFolderLocalService,
+				_objectLayoutLocalService, _objectLayoutTabLocalService,
+				_objectRelationshipLocalService, _objectScopeProviderRegistry,
+				_objectViewLocalService, _organizationLocalService, _portal,
+				_portletLocalService, _resourceActions, _userLocalService,
 				_resourcePermissionLocalService, _searchLocalizationHelper,
 				_sharingModelResourcePermissionConfigurator,
 				_systemEventLocalService, _textEmbeddingDocumentContributor,
@@ -4003,6 +4004,9 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
+
+	@Reference
+	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3815,31 +3815,8 @@ public class ObjectEntryLocalServiceImpl
 		Predicate searchPredicate = null;
 
 		for (ObjectField objectField : objectFields) {
-			Table<?> table = _objectFieldLocalService.getTable(
-				objectDefinitionId, objectField.getName());
-
-			Column<?, ?> column = table.getColumn(
-				objectField.getDBColumnName());
-
-			if (column == null) {
-				continue;
-			}
-
-			Predicate objectFieldPredicate = null;
-
-			if (Objects.equals(
-					objectField.getRelationshipType(),
-					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
-
-				objectFieldPredicate = _getRelationshipObjectFieldPredicate(
-					column, objectField, search);
-			}
-			else {
-				objectFieldPredicate =
-					ObjectEntrySearchUtil.getObjectFieldPredicate(
-						objectField.getBusinessType(), column,
-						objectField.getDBType(), search);
-			}
+			Predicate objectFieldPredicate = _getObjectFieldPredicate(
+				objectDefinitionId, objectField, search);
 
 			if (objectFieldPredicate == null) {
 				continue;
@@ -4735,6 +4712,32 @@ public class ObjectEntryLocalServiceImpl
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
 		}
+	}
+
+	private Predicate _getObjectFieldPredicate(
+			long objectDefinitionId, ObjectField objectField, String search)
+		throws PortalException {
+
+		Table<?> table = _objectFieldLocalService.getTable(
+			objectDefinitionId, objectField.getName());
+
+		Column<?, ?> column = table.getColumn(objectField.getDBColumnName());
+
+		if (column == null) {
+			return null;
+		}
+
+		if (Objects.equals(
+				objectField.getRelationshipType(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+			return _getRelationshipObjectFieldPredicate(
+				column, objectField, search);
+		}
+
+		return ObjectEntrySearchUtil.getObjectFieldPredicate(
+			objectField.getBusinessType(), column, objectField.getDBType(),
+			search);
 	}
 
 	private GroupByStep _getOneToManyObjectEntriesGroupByStep(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4721,6 +4721,13 @@ public class ObjectEntryLocalServiceImpl
 		Table<?> table = _objectFieldLocalService.getTable(
 			objectDefinitionId, objectField.getName());
 
+		if (objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE)) {
+
+			return ObjectEntrySearchUtil.getAssigneeFieldPredicate(
+				table, objectField.getDBColumnName(), search);
+		}
+
 		Column<?, ?> column = table.getColumn(objectField.getDBColumnName());
 
 		if (column == null) {

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/search/spi/model/query/contributor/ObjectEntryKeywordQueryContributorTest.java
@@ -11,19 +11,27 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.bag.ObjectFieldBag;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
+import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.MatchQuery;
 import com.liferay.portal.kernel.search.NestedQuery;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -45,6 +53,53 @@ public class ObjectEntryKeywordQueryContributorTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	public void testContributeWithAssigneeObjectField() throws Exception {
+		ObjectDefinition objectDefinition = _mockObjectDefinition(false);
+
+		ObjectFieldBag objectFieldBag = objectDefinition.getObjectFieldBag();
+
+		ObjectField assigneeObjectField = _mockAssigneeObjectField(
+			RandomTestUtil.randomString());
+
+		Mockito.when(
+			objectFieldBag.getNonsystemIndexedObjectFields()
+		).thenReturn(
+			Arrays.asList(assigneeObjectField)
+		);
+
+		ArgumentCaptor<Query> argumentCaptor = ArgumentCaptor.forClass(
+			Query.class);
+
+		BooleanQuery booleanQuery = _mockBooleanQuery(argumentCaptor);
+
+		ObjectEntryKeywordQueryContributor objectEntryKeywordQueryContributor =
+			_createObjectEntryKeywordQueryContributor(objectDefinition);
+
+		String token = RandomTestUtil.randomString();
+
+		objectEntryKeywordQueryContributor.contribute(
+			token, booleanQuery, _mockKeywordQueryContributorHelper());
+
+		List<Query> queries = argumentCaptor.getAllValues();
+
+		Assert.assertEquals(1, _countNestedQueries(queries));
+
+		TermQuery termQuery = _findAssigneeTermQuery(queries);
+
+		Assert.assertNotNull(termQuery);
+
+		QueryTerm queryTerm = termQuery.getQueryTerm();
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase(token), queryTerm.getValue());
+
+		MatchQuery matchQuery = _findAssigneeMatchQuery(queries);
+
+		Assert.assertNotNull(matchQuery);
+		Assert.assertEquals(token, matchQuery.getValue());
+	}
+
+	@Test
 	public void testContributeWithCustomObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition = _mockObjectDefinition(false);
 
@@ -54,10 +109,10 @@ public class ObjectEntryKeywordQueryContributorTest {
 
 		BooleanQuery booleanQuery = _mockBooleanQuery(null);
 
-		ObjectEntryKeywordQueryContributor contributor =
+		ObjectEntryKeywordQueryContributor objectEntryKeywordQueryContributor =
 			_createObjectEntryKeywordQueryContributor(objectDefinition);
 
-		contributor.contribute(
+		objectEntryKeywordQueryContributor.contribute(
 			RandomTestUtil.randomString(), booleanQuery,
 			_mockKeywordQueryContributorHelper());
 
@@ -85,10 +140,10 @@ public class ObjectEntryKeywordQueryContributorTest {
 
 		BooleanQuery booleanQuery = _mockBooleanQuery(argumentCaptor);
 
-		ObjectEntryKeywordQueryContributor contributor =
+		ObjectEntryKeywordQueryContributor objectEntryKeywordQueryContributor =
 			_createObjectEntryKeywordQueryContributor(objectDefinition);
 
-		contributor.contribute(
+		objectEntryKeywordQueryContributor.contribute(
 			RandomTestUtil.randomString(), booleanQuery,
 			_mockKeywordQueryContributorHelper());
 
@@ -139,6 +194,136 @@ public class ObjectEntryKeywordQueryContributorTest {
 			Mockito.mock(SearchLocalizationHelper.class));
 	}
 
+	private MatchQuery _findAssigneeMatchQuery(List<Query> queries) {
+		for (Query assigneeQuery : _getAssigneeBooleanQueryClauses(queries)) {
+			if (!(assigneeQuery instanceof MatchQuery)) {
+				continue;
+			}
+
+			MatchQuery matchQuery = (MatchQuery)assigneeQuery;
+
+			if (Objects.equals(
+					matchQuery.getField(), "nestedFieldArray.value_text")) {
+
+				return matchQuery;
+			}
+		}
+
+		return null;
+	}
+
+	private TermQuery _findAssigneeTermQuery(List<Query> queries) {
+		for (Query assigneeQuery : _getAssigneeBooleanQueryClauses(queries)) {
+			if (!(assigneeQuery instanceof TermQuery)) {
+				continue;
+			}
+
+			TermQuery termQuery = (TermQuery)assigneeQuery;
+
+			QueryTerm queryTerm = termQuery.getQueryTerm();
+
+			if (Objects.equals(
+					queryTerm.getField(),
+					"nestedFieldArray.value_keyword_lowercase")) {
+
+				return termQuery;
+			}
+		}
+
+		return null;
+	}
+
+	private List<Query> _getAssigneeBooleanQueryClauses(List<Query> queries) {
+		for (Query query : queries) {
+			if (!(query instanceof NestedQuery)) {
+				continue;
+			}
+
+			NestedQuery nestedQuery = (NestedQuery)query;
+
+			BooleanQuery nestedBooleanQuery =
+				(BooleanQuery)nestedQuery.getQuery();
+
+			for (BooleanClause<Query> booleanClause :
+					nestedBooleanQuery.clauses()) {
+
+				Query innerQuery = booleanClause.getClause();
+
+				if (!(innerQuery instanceof BooleanQuery)) {
+					continue;
+				}
+
+				BooleanQuery assigneeBooleanQuery = (BooleanQuery)innerQuery;
+
+				List<Query> assigneeQueries = new ArrayList<>();
+
+				for (BooleanClause<Query> assigneeClause :
+						assigneeBooleanQuery.clauses()) {
+
+					assigneeQueries.add(assigneeClause.getClause());
+				}
+
+				return assigneeQueries;
+			}
+		}
+
+		return Collections.emptyList();
+	}
+
+	private ObjectField _mockAssigneeObjectField(String name) {
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getBusinessType()
+		).thenReturn(
+			ObjectFieldConstants.BUSINESS_TYPE_ASSIGNEE
+		);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			ObjectFieldConstants.DB_TYPE_LONG
+		);
+
+		Mockito.when(
+			objectField.getIndexedLanguageId()
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			objectField.getName()
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			objectField.isIndexed()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isIndexedAsKeyword()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectField.isMetadata()
+		).thenReturn(
+			false
+		);
+
+		return objectField;
+	}
+
 	private BooleanQuery _mockBooleanQuery(ArgumentCaptor<Query> argumentCaptor)
 		throws Exception {
 
@@ -167,16 +352,16 @@ public class ObjectEntryKeywordQueryContributorTest {
 	}
 
 	private KeywordQueryContributorHelper _mockKeywordQueryContributorHelper() {
-		KeywordQueryContributorHelper helper = Mockito.mock(
-			KeywordQueryContributorHelper.class);
+		KeywordQueryContributorHelper keywordQueryContributorHelper =
+			Mockito.mock(KeywordQueryContributorHelper.class);
 
 		Mockito.when(
-			helper.getSearchContext()
+			keywordQueryContributorHelper.getSearchContext()
 		).thenReturn(
 			_buildSearchContext()
 		);
 
-		return helper;
+		return keywordQueryContributorHelper;
 	}
 
 	private ObjectDefinition _mockObjectDefinition(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.internal.search.spi.model.index.contributor.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.builder.AssigneeObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -17,12 +18,18 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -135,6 +142,113 @@ public class ObjectEntryModelDocumentContributorTest {
 					objectFieldName, ": ", objectFieldValue, "pt_BR")));
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testContributeWithAssigneeObjectField() throws Exception {
+		String objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectFieldUtil.addCustomObjectField(
+			new AssigneeObjectFieldBuilder(
+			).indexed(
+				true
+			).labelMap(
+				RandomTestUtil.randomLocaleStringMap()
+			).name(
+				objectFieldName
+			).objectDefinitionId(
+				objectDefinition.getObjectDefinitionId()
+			).userId(
+				TestPropsValues.getUserId()
+			).build());
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		long roleClassNameId = _classNameLocalService.getClassNameId(
+			Role.class.getName());
+		long roleClassPK = role.getRoleId();
+
+		ObjectEntry roleObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName,
+				HashMapBuilder.put(
+					"classNameId", roleClassNameId
+				).put(
+					"classPK", roleClassPK
+				).build()
+			).build());
+
+		Document roleDocument = new DocumentImpl();
+
+		objectEntryModelDocumentContributor.contribute(
+			roleDocument, roleObjectEntry);
+
+		Field roleField = roleDocument.getField("objectEntryContent");
+
+		Assert.assertNotNull(roleField);
+
+		String roleValue = roleField.getValue();
+
+		Assert.assertTrue(
+			roleValue,
+			roleValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", roleClassNameId, "_", roleClassPK)));
+		Assert.assertTrue(
+			roleValue,
+			roleValue.contains(
+				StringBundler.concat(objectFieldName, ": ", role.getName())));
+
+		User user = UserTestUtil.addUser();
+
+		long userClassNameId = _classNameLocalService.getClassNameId(
+			User.class.getName());
+		long userClassPK = user.getUserId();
+
+		ObjectEntry userObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				objectFieldName,
+				HashMapBuilder.put(
+					"classNameId", userClassNameId
+				).put(
+					"classPK", userClassPK
+				).build()
+			).build());
+
+		Document userDocument = new DocumentImpl();
+
+		objectEntryModelDocumentContributor.contribute(
+			userDocument, userObjectEntry);
+
+		Field userField = userDocument.getField("objectEntryContent");
+
+		Assert.assertNotNull(userField);
+
+		String userValue = userField.getValue();
+
+		Assert.assertTrue(
+			userValue,
+			userValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", userClassNameId, "_", userClassPK)));
+		Assert.assertTrue(
+			userValue,
+			userValue.contains(
+				StringBundler.concat(
+					objectFieldName, ": ", user.getFullName())));
+	}
+
 	private ModelDocumentContributor<ObjectEntry>
 			_getObjectEntryModelDocumentContributor(
 				ObjectDefinition objectDefinition)
@@ -155,6 +269,9 @@ public class ObjectEntryModelDocumentContributorTest {
 
 		return bundleContext.getService(serviceReferences.get(0));
 	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88550

Resent from https://github.com/liferay-bpm/liferay-portal/pull/6071 after Brian's feedback on the forwarded PR (brianchandotcom/liferay-portal#174268).

Applied changes since the previous submission: reordered the local variable declarations in the ASSIGNEE branch of `ObjectEntryKeywordQueryContributor` to satisfy the burrito convention (receiver first, fillings declared right before use); renamed the unit test variable `contributor` to `objectEntryKeywordQueryContributor` and `helper` to `keywordQueryContributorHelper`; renamed the unit test method `testContributeWithAssigneeField` and the integration test method `testContributeAssignee` both to `testContributeWithAssigneeObjectField` for cross-file parity. Audit on the rest of the PR diff turned up no other instances of either pattern.

Also dropped the original commit `LPD-88550 Map ASSIGNEE business type to StringEntityField` after validation. The FDS picker composite filter goes through the DB predicate helper (`ObjectEntrySearchUtil.getAssigneeFieldPredicate`) and not OData, and the `assigneeUserExternalReferenceCode` OData filter routes through `AssigneeFieldPredicateProvider` which works with the default `IntegerEntityField` mapping (inherited via `DB_TYPE_LONG` fallthrough). The custom mapping was unnecessary for both paths and caused the request-side NPE in `testGetObjectEntriesWithAssigneeObjectField`. Removing it restores the master OData behavior.

Branch now has 3 commits; the production-code change for indexing and search landed on `LPD-88550 Handle ASSIGNEE business type in indexing, search, and DB filter paths` and the test renames on `LPD-88550 Add ASSIGNEE coverage for keyword query and document contributor`.