### PR TITLE
LPD-89028 Stop mutating values map when processValue is a no-op

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -8146,16 +8146,19 @@ public class ObjectEntryLocalServiceImpl
 			if (!objectField.isLocalized() &&
 				(values.get(objectField.getName()) != null)) {
 
-				values.put(
-					objectField.getName(),
-					objectFieldBusinessType.processValue(
-						objectField, values.get(objectField.getName())));
+				Serializable value = values.get(objectField.getName());
+
+				Serializable processedValue =
+					objectFieldBusinessType.processValue(objectField, value);
+
+				if (!Objects.equals(value, processedValue)) {
+					values.put(objectField.getName(), processedValue);
+				}
 
 				_validateValues(
 					dlFileEntriesMap, existingValues, groupId, guestUser,
 					objectDefinition, objectEntryId, objectField, userId,
-					validationErrors, values.get(objectField.getName()),
-					StringPool.BLANK);
+					validationErrors, processedValue, StringPool.BLANK);
 			}
 
 			Map<String, Serializable> localizedValues =
@@ -8169,14 +8172,19 @@ public class ObjectEntryLocalServiceImpl
 			for (Map.Entry<String, Serializable> entry :
 					localizedValues.entrySet()) {
 
-				entry.setValue(
-					objectFieldBusinessType.processValue(
-						objectField, entry.getValue()));
+				Serializable value = entry.getValue();
+
+				Serializable processedValue =
+					objectFieldBusinessType.processValue(objectField, value);
+
+				if (!Objects.equals(value, processedValue)) {
+					entry.setValue(processedValue);
+				}
 
 				_validateValues(
 					dlFileEntriesMap, existingValues, groupId, guestUser,
 					objectDefinition, objectEntryId, objectField, userId,
-					validationErrors, entry.getValue(), entry.getKey());
+					validationErrors, processedValue, entry.getKey());
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89028

## Failing Test

`com.liferay.object.rest.internal.headless.batch.engine.resource.v1_0.test.ImportTaskResourceTest.testDeleteImportTask`

`modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/headless/batch/engine/resource/v1_0/test/ImportTaskResourceTest.java`

```
java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractMap.put(AbstractMap.java:209)
	at com.liferay.object.service.impl.ObjectEntryLocalServiceImpl._validateValues(ObjectEntryLocalServiceImpl.java:8036)
	at com.liferay.object.service.impl.ObjectEntryLocalServiceImpl.addObjectEntry(ObjectEntryLocalServiceImpl.java:422)
	at com.liferay.object.rest.test.util.ObjectEntryTestUtil.addObjectEntry(ObjectEntryTestUtil.java:46)
	at com.liferay.object.rest.internal.headless.batch.engine.resource.v1_0.test.ImportTaskResourceTest._testDeleteImportTask(ImportTaskResourceTest.java:619)
```

## Root Cause

Commit `580998cdc0695` ("LPD-70691 Add new PhoneNumber Object Field Type") introduced an unconditional `values.put(...)` (and `entry.setValue(...)`) inside `ObjectEntryLocalServiceImpl._validateValues` so that the canonicalized value from `ObjectFieldBusinessType.processValue` would propagate downstream. The default `processValue` is identity for every business type other than PhoneNumber, so the put is a no-op data-wise yet still throws `UnsupportedOperationException` whenever a caller legitimately passes an immutable map (`Collections.singletonMap`, `Map.of`, ...). The failing test passes `Collections.singletonMap(fieldName, randomString())`, so the very first put trips the exception during `addObjectEntry`.

## Fix

Capture the input value in a local, compute the processed value, and only call `put`/`setValue` when the processed value differs from the input. Pass the processed value directly into the recursive `_validateValues` call so the validation still runs against the canonicalized form. PhoneNumber-style canonicalization keeps working when the values map is mutable, while every caller that passes an immutable map for non-transforming fields (Text, Number, …) is no longer broken by validation.

- `modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java`

## Why are there no tests?

The regression is already covered by the existing integration test `ImportTaskResourceTest.testDeleteImportTask`, which fails on `master` and passes with this change. No new test is needed.

cc: @4lejandrito 