### PR TITLE
LPD-90484 | allow standalone object actions trigger in a loop

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/engine/ObjectActionEngineImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/action/engine/ObjectActionEngineImpl.java
@@ -76,7 +76,15 @@ public class ObjectActionEngineImpl implements ObjectActionEngine {
 			objectDefinition, payloadJSONObject,
 			_userLocalService.getUser(userId));
 
+		boolean clearObjectEntryIdsMap =
+			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
+
 		try {
+			if (clearObjectEntryIdsMap) {
+				ObjectActionThreadLocal.clearObjectEntryIdsMap();
+			}
+
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(false);
 			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
 
 			_executeObjectAction(
@@ -86,6 +94,8 @@ public class ObjectActionEngineImpl implements ObjectActionEngine {
 					_systemObjectDefinitionManagerRegistry));
 		}
 		finally {
+			ObjectActionThreadLocal.setClearObjectEntryIdsMap(
+				clearObjectEntryIdsMap);
 			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(false);
 		}
 	}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectActionLocalServiceTest.java
@@ -2146,6 +2146,7 @@ public class ObjectActionLocalServiceTest {
 		throws Exception {
 
 		_testExecuteObjectActionMultipleTimesInTheSameThreadWithACustomObjectDefinition();
+		_testExecuteObjectActionMultipleTimesInTheSameThreadWithAStandaloneObjectAction();
 		_testExecuteObjectActionMultipleTimesInTheSameThreadWithASystemObjectDefinition();
 	}
 
@@ -3992,6 +3993,80 @@ public class ObjectActionLocalServiceTest {
 		_objectEntryLocalService.deleteObjectEntry(objectEntry6);
 
 		_objectActionLocalService.deleteObjectAction(objectAction3);
+	}
+
+	private void _testExecuteObjectActionMultipleTimesInTheSameThreadWithAStandaloneObjectAction()
+		throws Exception {
+
+		_publishCustomObjectDefinition();
+
+		ObjectAction objectAction = _addNotificationTemplateObjectAction(
+			ObjectActionTriggerConstants.KEY_STANDALONE, _objectDefinition);
+
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", RandomTestUtil.randomString()
+			).build());
+
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"firstName", RandomTestUtil.randomString()
+			).build());
+
+		List<NotificationQueueEntry> notificationQueueEntries =
+			_notificationQueueEntryLocalService.getNotificationEntries(
+				NotificationConstants.TYPE_EMAIL,
+				NotificationQueueEntryConstants.STATUS_SENT);
+
+		int initialCount = notificationQueueEntries.size();
+
+		for (ObjectEntry objectEntry :
+				Arrays.asList(objectEntry1, objectEntry2, objectEntry3)) {
+
+			_objectActionEngine.executeObjectAction(
+				objectAction.getName(),
+				ObjectActionTriggerConstants.KEY_STANDALONE,
+				_objectDefinition.getObjectDefinitionId(),
+				JSONUtil.put(
+					"objectEntry",
+					HashMapBuilder.putAll(
+						objectEntry.getModelAttributes()
+					).put(
+						"values", objectEntry.getValues()
+					).build()),
+				TestPropsValues.getUserId());
+		}
+
+		notificationQueueEntries =
+			_notificationQueueEntryLocalService.getNotificationEntries(
+				NotificationConstants.TYPE_EMAIL,
+				NotificationQueueEntryConstants.STATUS_SENT);
+
+		Assert.assertEquals(
+			notificationQueueEntries.toString(), initialCount + 3,
+			notificationQueueEntries.size());
+
+		for (NotificationQueueEntry notificationQueueEntry :
+				notificationQueueEntries.subList(
+					initialCount, notificationQueueEntries.size())) {
+
+			_notificationQueueEntryLocalService.deleteNotificationQueueEntry(
+				notificationQueueEntry);
+		}
+
+		_objectEntryLocalService.deleteObjectEntry(objectEntry1);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry2);
+		_objectEntryLocalService.deleteObjectEntry(objectEntry3);
+
+		_objectActionLocalService.deleteObjectAction(objectAction);
 	}
 
 	private void _testExecuteObjectActionMultipleTimesInTheSameThreadWithASystemObjectDefinition()


### PR DESCRIPTION
related: [LPD-90484](https://liferay.atlassian.net/browse/LPD-90484)

When ObjectActionEngine.executeObjectAction() is called directly for
multiple entries (e.g. from a Groovy script), the ThreadLocal deduplication
guard in _executeObjectAction() checked only the objectActionId — not the
specific entry — causing every call after the first to be silently skipped.

executeObjectAction() now clears and restores ObjectActionThreadLocal the
same way addObjectEntry() does, so each top-level call gets a clean state
while nested calls (inside an action) still cannot re-enter, preserving
infinite-loop protection.

[LPD-90484]: https://liferay.atlassian.net/browse/LPD-90484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ