### PR TITLE
LPD-70691 LPD-90189 Show required error for empty phone number field

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
@@ -35,6 +35,7 @@ interface BasePhoneNumberProps {
 	name: string;
 	onBlur?: (event: React.FocusEvent) => void;
 	onFocus?: (event: React.FocusEvent) => void;
+	pageValidationFailed?: boolean;
 	predefinedValue?: string;
 	prefix?: string;
 	prefixType?: PrefixType;
@@ -93,7 +94,7 @@ const LocalizablePhoneNumber = ({
 	const disabled = readOnly || otherProps.disabled;
 
 	const validationState =
-		touched || otherProps.displayErrors
+		touched || otherProps.pageValidationFailed
 			? getValidationState(currentValue)
 			: {};
 
@@ -167,7 +168,7 @@ const NonLocalizablePhoneNumber = ({
 	const disabled = readOnly || otherProps.disabled;
 
 	const validationState =
-		touched || otherProps.displayErrors
+		touched || otherProps.pageValidationFailed
 			? getValidationState(combinedValue)
 			: {};
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
@@ -58,25 +58,21 @@ type PhoneNumberProps =
 	| (NonLocalizablePhoneNumberProps & {localizedObjectField?: false});
 
 const getValidationState = (value: string) => {
-	if (!value) {
-		return {displayErrors: false, errorMessage: undefined, valid: true};
+	if (value && !PHONE_NUMBER_PATTERN.test(value)) {
+		return {
+			displayErrors: true,
+			errorMessage: Liferay.Language.get(
+				'please-enter-a-valid-phone-number'
+			),
+			valid: false,
+		};
 	}
 
-	const valid = PHONE_NUMBER_PATTERN.test(value);
-
-	return {
-		displayErrors: !valid,
-		errorMessage: valid
-			? undefined
-			: Liferay.Language.get('please-enter-a-valid-phone-number'),
-		valid,
-	};
+	return {};
 };
 
 const LocalizablePhoneNumber = ({
 	countries = [],
-	displayErrors,
-	errorMessage,
 	fieldName,
 	name,
 	onBlur,
@@ -86,33 +82,25 @@ const LocalizablePhoneNumber = ({
 	prefix,
 	prefixType = PREFIX_TYPE.DEFINED_BY_USER,
 	readOnly,
-	valid = true,
 	value = {} as LocalizedValue<string>,
 	...otherProps
 }: LocalizablePhoneNumberProps) => {
 	const {availableLocales, editingLanguageId} = useFormState();
 
-	const [validationState, setValidationState] = useState({
-		displayErrors,
-		errorMessage,
-		valid,
-	});
+	const [touched, setTouched] = useState(false);
 
 	const currentValue = value[editingLanguageId] ?? predefinedValue ?? '';
 	const disabled = readOnly || otherProps.disabled;
 
+	const validationState =
+		touched || otherProps.displayErrors
+			? getValidationState(currentValue)
+			: {};
+
 	const handleBlur = (event: React.FocusEvent) => {
-		setValidationState(getValidationState(currentValue));
+		setTouched(true);
 
 		onBlur?.(event);
-	};
-
-	const handleLanguageClicked = (localeId: Liferay.Language.Locale) => {
-		if (validationState.displayErrors) {
-			setValidationState(
-				getValidationState(value[localeId] ?? predefinedValue ?? '')
-			);
-		}
 	};
 
 	const handleChange = (event: {target: {value: string}}) => {
@@ -120,14 +108,6 @@ const LocalizablePhoneNumber = ({
 			...value,
 			[editingLanguageId]: event.target.value,
 		} as LocalizedValue<string>;
-
-		// Re-getValidationState on change only while an error is already visible,
-		// so the message clears live as the user fixes it (typing or
-		// country switch) without flashing on first entry.
-
-		if (validationState.displayErrors) {
-			setValidationState(getValidationState(event.target.value));
-		}
 
 		onChange?.({target: {value: newValue}});
 	};
@@ -158,7 +138,6 @@ const LocalizablePhoneNumber = ({
 					<LocalesDropdown
 						availableLocales={availableLocales}
 						fieldName={fieldName}
-						onLanguageClicked={handleLanguageClicked}
 						value={value}
 					/>
 				</ClayInput.GroupItem>
@@ -169,8 +148,6 @@ const LocalizablePhoneNumber = ({
 
 const NonLocalizablePhoneNumber = ({
 	countries = [],
-	displayErrors,
-	errorMessage,
 	name,
 	onBlur,
 	onChange,
@@ -179,37 +156,29 @@ const NonLocalizablePhoneNumber = ({
 	prefix,
 	prefixType = PREFIX_TYPE.DEFINED_BY_USER,
 	readOnly,
-	valid = true,
 	value: initialValue,
 	...otherProps
 }: NonLocalizablePhoneNumberProps) => {
 	const [combinedValue, setCombinedValue] = useState(
 		initialValue || predefinedValue || ''
 	);
-	const [validationState, setValidationState] = useState({
-		displayErrors,
-		errorMessage,
-		valid,
-	});
+	const [touched, setTouched] = useState(false);
 
 	const disabled = readOnly || otherProps.disabled;
 
+	const validationState =
+		touched || otherProps.displayErrors
+			? getValidationState(combinedValue)
+			: {};
+
 	const handleBlur = (event: React.FocusEvent) => {
-		setValidationState(getValidationState(combinedValue));
+		setTouched(true);
 
 		onBlur?.(event);
 	};
 
 	const handleChange = (event: {target: {value: string}}) => {
 		setCombinedValue(event.target.value);
-
-		// Re-getValidationState on change only while an error is already visible,
-		// so the message clears as the user fixes it without flashing on
-		// first entry.
-
-		if (validationState.displayErrors) {
-			setValidationState(getValidationState(event.target.value));
-		}
 
 		onChange?.(event);
 	};

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -5678,7 +5678,12 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const prefix = '+1';
 
 			const objectFields = generateObjectFields({
-				objectFieldBusinessTypes: ['PhoneNumber'],
+				objectFieldBusinessTypes: [
+					{
+						businessType: 'PhoneNumber',
+						required: true,
+					},
+				],
 			});
 
 			const objectFieldLabel = objectFields[0].label!['en_US'];
@@ -5686,6 +5691,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const fieldContainer = page.getByRole('group', {
 				name: objectFieldLabel,
 			});
+
+			const phoneNumberInput = fieldContainer.getByLabel('Phone Number');
 
 			let objectDefinition: ObjectDefinition;
 
@@ -5710,6 +5717,43 @@ test.describe('Manage object entries through View Object Entries', () => {
 				);
 			});
 
+			await test.step('Verify the validation error messages are displayed', async () => {
+				const formGroup = page.locator('.form-group', {
+					has: fieldContainer,
+				});
+
+				const formatErrorMessage = formGroup.getByText(
+					'Please enter a valid phone number.'
+				);
+				const requiredErrorMessage = formGroup.getByText(
+					'This field is required.'
+				);
+
+				await phoneNumberInput.focus();
+
+				await phoneNumberInput.blur();
+
+				await expect(requiredErrorMessage).toBeVisible();
+
+				await page.reload();
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(requiredErrorMessage).toBeVisible();
+
+				await phoneNumberInput.fill('1');
+
+				await phoneNumberInput.blur();
+
+				await expect(formatErrorMessage).toBeVisible();
+
+				await phoneNumberInput.clear();
+
+				await expect(formatErrorMessage).not.toBeVisible();
+
+				await expect(requiredErrorMessage).toBeVisible();
+			});
+
 			await test.step('Select the "United States" prefix, fill the phone number field, and save the entry', async () => {
 				await fieldContainer.getByLabel('Country Code').click();
 
@@ -5717,9 +5761,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
 
-				await fieldContainer
-					.getByLabel('Phone Number')
-					.fill(localNumber);
+				await phoneNumberInput.fill(localNumber);
 
 				await viewObjectEntriesPage.saveObjectEntryButton.click();
 
@@ -5739,9 +5781,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 					fieldContainer.getByLabel('Country Code')
 				).toHaveText(prefix);
 
-				await expect(
-					fieldContainer.getByLabel('Phone Number')
-				).toHaveValue(localNumber);
+				await expect(phoneNumberInput).toHaveValue(localNumber);
 			});
 
 			await test.step('Verify that the country code icon is correct for the local number entered', async () => {
@@ -5775,6 +5815,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 								value: prefix,
 							},
 						],
+						required: true,
 					},
 				],
 			});
@@ -5784,6 +5825,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const fieldContainer = page.getByRole('group', {
 				name: objectFieldLabel,
 			});
+
+			const phoneNumberInput = fieldContainer.getByLabel('Phone Number');
 
 			let objectDefinition: ObjectDefinition;
 
@@ -5808,28 +5851,47 @@ test.describe('Manage object entries through View Object Entries', () => {
 				);
 			});
 
-			await test.step('Verify the error message is displayed', async () => {
-				const errorMessage = page
-					.locator('.form-group', {has: fieldContainer})
-					.getByText('Please enter a valid phone number.');
+			await test.step('Verify the validation error messages are displayed', async () => {
+				const formGroup = page.locator('.form-group', {
+					has: fieldContainer,
+				});
 
-				await fieldContainer.getByLabel('Phone Number').fill('1');
+				const formatErrorMessage = formGroup.getByText(
+					'Please enter a valid phone number.'
+				);
+				const requiredErrorMessage = formGroup.getByText(
+					'This field is required.'
+				);
 
-				await fieldContainer.getByLabel('Phone Number').blur();
+				await phoneNumberInput.focus();
 
-				await expect(errorMessage).toBeVisible();
+				await phoneNumberInput.blur();
 
-				await fieldContainer.getByLabel('Phone Number').clear();
+				await expect(requiredErrorMessage).toBeVisible();
 
-				await expect(errorMessage).not.toBeVisible();
+				await page.reload();
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(requiredErrorMessage).toBeVisible();
+
+				await phoneNumberInput.fill('1');
+
+				await phoneNumberInput.blur();
+
+				await expect(formatErrorMessage).toBeVisible();
+
+				await phoneNumberInput.clear();
+
+				await expect(formatErrorMessage).not.toBeVisible();
+
+				await expect(requiredErrorMessage).toBeVisible();
 			});
 
 			await test.step('Fill the phone number field and save the entry', async () => {
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
 
-				await fieldContainer
-					.getByLabel('Phone Number')
-					.fill(localNumber);
+				await phoneNumberInput.fill(localNumber);
 
 				await viewObjectEntriesPage.saveObjectEntryButton.click();
 
@@ -5847,9 +5909,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
 
-				await expect(
-					fieldContainer.getByLabel('Phone Number')
-				).toHaveValue(localNumber);
+				await expect(phoneNumberInput).toHaveValue(localNumber);
 			});
 		}
 	);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90189

## What is being fixed

When a phone number field was marked as required and left empty, no error message appeared on submit. The DDM form engine validated the required field and passed updated props (`displayErrors: true`, `valid: false`, `errorMessage: "This field is required."`) to the React component, but local validation state in the component initialized to `{displayErrors: false, valid: true}` and permanently masked the engine's required-error props.

## How it is being fixed

- Flow the props through `{...otherProps}` to `FieldBase` untouched.
- A `touched` flag ensures the format error only appears after the first blur, preserving the existing "no flash while typing" UX.
- Added playwright tests to check for proper required error messages.

**Side Note:**
Not changing anything with this in this PR, but I wanted to note that the required error doesn't appear on blur for inputs with localization. The message will appear after submit though. See this demo:

https://github.com/user-attachments/assets/a364cce7-12ed-4816-a914-b956d1d0a9d4


