### PR TITLE
LPD-91088 Check element membership when applying contains() to a JSONArray

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/ContainsFunction.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/ContainsFunction.java
@@ -35,8 +35,8 @@ public class ContainsFunction
 			return apply((JSONObjectImpl)object1, (JSONObjectImpl)object2);
 		}
 
-		if ((object1 instanceof JSONArray) && (object2 instanceof String)) {
-			return apply(object1.toString(), object2);
+		if (object1 instanceof JSONArray) {
+			return apply((JSONArray)object1, object2);
 		}
 
 		return apply(object1.toString(), object2.toString());
@@ -45,6 +45,26 @@ public class ContainsFunction
 	@Override
 	public String getName() {
 		return NAME;
+	}
+
+	protected Boolean apply(JSONArray jsonArray, Object value) {
+		if ((jsonArray == null) || (value == null)) {
+			return false;
+		}
+
+		String valueString = value.toString();
+
+		if (Validator.isNull(valueString)) {
+			return false;
+		}
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			if (Objects.equals(String.valueOf(jsonArray.get(i)), valueString)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	protected Boolean apply(JSONObject jsonObject1, JSONObject jsonObject2) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/ContainsFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/function/ContainsFunctionTest.java
@@ -5,6 +5,9 @@
 
 package com.liferay.dynamic.data.mapping.form.evaluator.internal.function;
 
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -32,6 +35,27 @@ public class ContainsFunctionTest {
 	}
 
 	@Test
+	public void testApplyJSONArray() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		ContainsFunction containsFunction = new ContainsFunction();
+
+		Assert.assertTrue(containsFunction.apply(JSONUtil.putAll(1L, 2L), "2"));
+		Assert.assertFalse(
+			containsFunction.apply(JSONUtil.putAll("apple", "banana"), "["));
+		Assert.assertFalse(
+			containsFunction.apply(JSONUtil.putAll("apple", "banana"), "app"));
+		Assert.assertTrue(
+			containsFunction.apply(
+				JSONUtil.putAll("apple", "banana"), "banana"));
+		Assert.assertFalse(
+			containsFunction.apply(
+				JSONUtil.putAll("apple", "banana"), "cherry"));
+	}
+
+	@Test
 	public void testApplyTrue() {
 		ContainsFunction containsFunction = new ContainsFunction();
 
@@ -44,7 +68,7 @@ public class ContainsFunctionTest {
 	public void testApplyWithNull1() {
 		ContainsFunction containsFunction = new ContainsFunction();
 
-		Boolean result = containsFunction.apply(null, "forms");
+		Boolean result = containsFunction.apply((Object)null, "forms");
 
 		Assert.assertFalse(result);
 	}
@@ -53,7 +77,7 @@ public class ContainsFunctionTest {
 	public void testApplyWithNull2() {
 		ContainsFunction containsFunction = new ContainsFunction();
 
-		Boolean result = containsFunction.apply("liferay", null);
+		Boolean result = containsFunction.apply("liferay", (Object)null);
 
 		Assert.assertFalse(result);
 	}


### PR DESCRIPTION
## Summary

 previously handled the  case by calling  on the array and then doing a case-insensitive substring search on the JSON literal. That produced semantically wrong results:

-  returned  (partial substring of an element).
-  returned  (JSON bracket from the stringified form).
-  returned  (string spanning multiple elements).

This change replaces the  branch with an explicit element-membership check: each element is 'd and compared to the needle. Strings, numbers, and any other scalar element type work consistently.

## Test plan

- New  in  covering match, partial-substring rejection, JSON-syntax rejection, no-match, and a numeric element.
- Existing , , ,  still pass.