### PR TITLE
LPD-90725 Suppress text field tooltip while focused

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Text/Text.es.js
@@ -13,6 +13,7 @@ import {ReactFieldBase as FieldBase} from 'dynamic-data-mapping-form-field-type/
 import {sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
+import {useHideTooltipOnFocus} from '../hooks/useHideTooltipOnFocus.es';
 import {useSyncValue} from '../hooks/useSyncValue.es';
 import fieldPopoverMap from '../util/fieldPopoverMap';
 import {getTooltipTitle} from '../util/tooltip';
@@ -98,6 +99,8 @@ const Text = ({
 		editingLanguageId
 	);
 
+	const focusedTooltip = useHideTooltipOnFocus();
+
 	const inputRef = useRef(null);
 
 	const prevEditingLanguageId = usePrevious(editingLanguageId);
@@ -160,7 +163,10 @@ const Text = ({
 			<ClayTooltipProvider autoAlign>
 				<div
 					data-tooltip-align="top"
-					{...getTooltipTitle({placeholder, value})}
+					ref={focusedTooltip.tooltipWrapperRef}
+					{...(focusedTooltip.isFocused
+						? {}
+						: getTooltipTitle({placeholder, value}))}
 				>
 					<ClayInput
 						{...accessibleProps}
@@ -175,6 +181,7 @@ const Text = ({
 						maxLength={showCounter ? '' : maxLength}
 						name={name}
 						onBlur={(event) => {
+							focusedTooltip.onBlur();
 							onBlur(event);
 
 							if (!preventChangeHandlerOnBlur) {
@@ -182,7 +189,10 @@ const Text = ({
 							}
 						}}
 						onChange={handleChangeInput}
-						onFocus={onFocus}
+						onFocus={(event) => {
+							focusedTooltip.onFocus();
+							onFocus(event);
+						}}
 						onKeyDown={onKeyDown}
 						placeholder={placeholder}
 						ref={inputRef}
@@ -227,12 +237,17 @@ const Textarea = ({
 }) => {
 	const [value, setValue] = useSyncValue(initialValue, syncDelay);
 
+	const focusedTooltip = useHideTooltipOnFocus();
+
 	return (
 		<>
 			<ClayTooltipProvider autoAlign>
 				<div
 					data-tooltip-align="top"
-					{...getTooltipTitle({placeholder, value})}
+					ref={focusedTooltip.tooltipWrapperRef}
+					{...(focusedTooltip.isFocused
+						? {}
+						: getTooltipTitle({placeholder, value}))}
 				>
 					<textarea
 						{...accessibleProps}
@@ -245,12 +260,18 @@ const Textarea = ({
 						id={id}
 						lang={editingLanguageId?.replaceAll('_', '-')}
 						name={name}
-						onBlur={onBlur}
+						onBlur={(event) => {
+							focusedTooltip.onBlur();
+							onBlur(event);
+						}}
 						onChange={(event) => {
 							setValue(event.target.value);
 							onChange(event);
 						}}
-						onFocus={onFocus}
+						onFocus={(event) => {
+							focusedTooltip.onFocus();
+							onFocus(event);
+						}}
 						placeholder={placeholder}
 						style={disabled ? {resize: 'none'} : null}
 						value={value}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/hooks/useHideTooltipOnFocus.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/hooks/useHideTooltipOnFocus.es.js
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useRef, useState} from 'react';
+
+/**
+ * Tracks input focus state and cancels any in-flight ClayTooltipProvider
+ * tooltip so the field tooltip doesn't obstruct the input while typing.
+ * Consumers attach `tooltipWrapperRef` to the tooltip wrapper, gate the wrapper's
+ * `title` on `isFocused`, and call `onFocus`/`onBlur` from the input's focus
+ * and blur handlers.
+ */
+export function useHideTooltipOnFocus() {
+	const [isFocused, setIsFocused] = useState(false);
+	const tooltipWrapperRef = useRef(null);
+
+	return {
+		isFocused,
+		onBlur: () => setIsFocused(false),
+		onFocus: () => {
+			setIsFocused(true);
+			tooltipWrapperRef.current?.dispatchEvent(
+				new MouseEvent('mouseout', {bubbles: true})
+			);
+		},
+		tooltipWrapperRef,
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/Text.es.js
@@ -109,6 +109,65 @@ describe('Field Text', () => {
 		});
 	});
 
+	it('clears the wrapper title while the input is focused', () => {
+		const {container} = render(
+			<TextWithProvider
+				{...defaultTextConfig}
+				onBlur={jest.fn()}
+				onChange={jest.fn()}
+				onFocus={jest.fn()}
+				value="some long value"
+			/>
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(100);
+		});
+
+		const input = container.querySelector('input');
+		const wrapper = container.querySelector('[data-tooltip-align="top"]');
+
+		expect(wrapper.getAttribute('title')).toBe('some long value');
+
+		fireEvent.focus(input);
+
+		expect(wrapper.hasAttribute('title')).toBe(false);
+
+		fireEvent.blur(input);
+
+		expect(wrapper.getAttribute('title')).toBe('some long value');
+	});
+
+	it('clears the wrapper title while the textarea is focused', () => {
+		const {container} = render(
+			<TextWithProvider
+				{...defaultTextConfig}
+				displayStyle="multiline"
+				onBlur={jest.fn()}
+				onChange={jest.fn()}
+				onFocus={jest.fn()}
+				value="some long value"
+			/>
+		);
+
+		act(() => {
+			jest.advanceTimersByTime(100);
+		});
+
+		const textarea = container.querySelector('textarea');
+		const wrapper = container.querySelector('[data-tooltip-align="top"]');
+
+		expect(wrapper.getAttribute('title')).toBe('some long value');
+
+		fireEvent.focus(textarea);
+
+		expect(wrapper.hasAttribute('title')).toBe(false);
+
+		fireEvent.blur(textarea);
+
+		expect(wrapper.getAttribute('title')).toBe('some long value');
+	});
+
 	it('does not have aria-invalid attribute on first render when it is required', () => {
 		const {container} = render(
 			<TextWithProvider {...defaultTextConfig} required={true} />


### PR DESCRIPTION
# What is this trying to solve?
Ticket: https://liferay.atlassian.net/browse/LPD-90725.

When a Text field on a web content has a long value, focusing the input and hovering over it shows a tooltip that displays the full value and obstructs the input. The tooltip should only appear while the field is not focused.

# How am I fixing it?
Tracking focus state in `Text.es.js` and clearing the wrapper's `title` while focused so hovers can't trigger a tooltip. Also dispatching `mouseout` on focus to cancel any tooltip already scheduled.
`ClayTooltipProvider` captures the title on hover and shows the tooltip after a timeout, so clearing `title` alone does not dismiss one in flight:
  1. Mouse enters input → provider reads `title="long value"`, starts timer.
  2. Few `ms` later, user clicks the input → focus fires → code sets `title=""` on the div.
  3. Later, the timer fires → tooltip appears with `"long value"` (the value captured in step 1).
The `mouseout` dispatch drives the provider's hide path, which cancels the timer.

Kept the conditional inline in `Text.es.js` rather than adding a `focused` parameter through the shared `util/tooltip.ts` helper. `getTooltipTitle` is also used by `DatePicker`, `Numeric`, `SingleSelect`, and the `Textarea` variant in the same file, none of which need focus-aware behavior. If another field grows the same issue, the conditional can be lifted into the helper then.

The `mouseout` dispatch on focus can either run unconditionally (current) or be gated on the wrapper  - `if ( tooltipWrapperRef.current?.hasAttribute( 'data-restore-title' ) ) {}` above line 194. 
Checking with  `data-restore-title` gate approach is more precise - `mouseout` only fires when a tooltip actually needs to be dismissed, avoiding spurious events on every focus (e.g. tabbing through a form). Trades a small coupling to a private attribute for slightly cleaner runtime behavior.
However, unconditional dispatch (current approach) keeps the fix independent of clay's internals - `data-restore-title` is a private detail of `ClayTooltipProvider`, and a rename or refactor on the clay side would silently break the gated check and reintroduce the bug. 

# How can you verify that it works?
Run the included automated tests.
