### PR TITLE
LPD-91367 Fix readOnly validation crash on one-to-many fields

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -482,23 +482,42 @@ public class ObjectFieldUtil {
 
 			if (Objects.equals(
 					objectField.getBusinessType(),
-					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) &&
+					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP) &&
 				Objects.equals(
-					JSONFactoryUtil.createJSONObject(
-						JSONFactoryUtil.looseSerialize(value)
-					).get(
-						"id"
-					),
-					existingValue.toString())) {
+					objectField.getRelationshipType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-				return;
+				if (Objects.equals(existingValue, value) ||
+					((existingValue != null) && (value != null) &&
+					 Objects.equals(
+						 String.valueOf(existingValue),
+						 String.valueOf(value)))) {
+
+					return;
+				}
 			}
+			else {
+				if (Objects.equals(
+						objectField.getBusinessType(),
+						ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) &&
+					Objects.equals(
+						JSONFactoryUtil.createJSONObject(
+							JSONFactoryUtil.looseSerialize(value)
+						).get(
+							"id"
+						),
+						existingValue.toString())) {
 
-			BigDecimal bigDecimal1 = new BigDecimal(existingValue.toString());
-			BigDecimal bigDecimal2 = new BigDecimal(value.toString());
+					return;
+				}
 
-			if (bigDecimal1.compareTo(bigDecimal2) == 0) {
-				return;
+				BigDecimal bigDecimal1 = new BigDecimal(
+					existingValue.toString());
+				BigDecimal bigDecimal2 = new BigDecimal(value.toString());
+
+				if (bigDecimal1.compareTo(bigDecimal2) == 0) {
+					return;
+				}
 			}
 		}
 		else if (Objects.equals(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -29,6 +29,7 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryManage
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryScopeExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryStatusExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryValuesExceptionMapper;
+import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectFieldReadOnlyExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectRelationshipDeletionTypeExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectEntryVersionExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectRelationshipExceptionMapper;
@@ -941,6 +942,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ObjectEntryScopeExceptionMapper::new,
 				() -> new ObjectEntryStatusExceptionMapper(_language),
 				() -> new ObjectEntryValuesExceptionMapper(_language),
+				ObjectFieldReadOnlyExceptionMapper::new,
 				() -> new ObjectRelationshipDeletionTypeExceptionMapper(
 					_language),
 				() -> new RequiredObjectEntryVersionExceptionMapper(_language),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyExceptionMapper.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectFieldReadOnlyException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * @author Yuri Monteiro
+ */
+@Provider
+public class ObjectFieldReadOnlyExceptionMapper
+	extends BaseExceptionMapper<ObjectFieldReadOnlyException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectFieldReadOnlyException objectFieldReadOnlyException) {
+
+		return new Problem(objectFieldReadOnlyException);
+	}
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/field/util/test/ObjectFieldUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/field/util/test/ObjectFieldUtilTest.java
@@ -8,8 +8,12 @@ package com.liferay.object.field.util.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.ObjectFieldReadOnlyException;
+import com.liferay.object.field.builder.ObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectField;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -23,6 +27,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.ClassRule;
@@ -75,6 +80,112 @@ public class ObjectFieldUtilTest {
 				values
 			).put(
 				objectField.getName(), RandomTestUtil.randomString()
+			).build());
+
+		// One to many relationship, custom object field
+
+		String objectRelationshipERCObjectFieldName =
+			"a" + RandomTestUtil.randomString();
+
+		ObjectField relationshipObjectField = new ObjectFieldBuilder(
+		).businessType(
+			ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP
+		).dbType(
+			ObjectFieldConstants.DB_TYPE_LONG
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+		).name(
+			"a" + RandomTestUtil.randomString()
+		).objectFieldSettings(
+			Collections.singletonList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.
+						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME
+				).value(
+					objectRelationshipERCObjectFieldName
+				).build())
+		).readOnly(
+			ObjectFieldConstants.READ_ONLY_TRUE
+		).relationshipType(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY
+		).build();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Map<String, Object> existingValues = HashMapBuilder.<String, Object>put(
+			objectRelationshipERCObjectFieldName, externalReferenceCode
+		).put(
+			relationshipObjectField.getName(), RandomTestUtil.randomLong()
+		).build();
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, existingValues,
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					objectRelationshipERCObjectFieldName,
+					RandomTestUtil.randomString()
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, new HashMap<>(),
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					objectRelationshipERCObjectFieldName,
+					RandomTestUtil.randomString()
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, new HashMap<>(),
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					relationshipObjectField.getName(),
+					RandomTestUtil.randomLong()
+				).build()));
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, existingValues,
+				Collections.singletonList(relationshipObjectField),
+				Collections.singletonMap(
+					objectRelationshipERCObjectFieldName, null)));
+
+		ObjectFieldUtil.validateReadOnlyObjectFields(
+			_ddmExpressionFactory, existingValues,
+			Collections.singletonList(relationshipObjectField),
+			HashMapBuilder.<String, Object>put(
+				objectRelationshipERCObjectFieldName, externalReferenceCode
+			).build());
+
+		int objectRelationshipId = RandomTestUtil.randomInt();
+
+		ObjectFieldUtil.validateReadOnlyObjectFields(
+			_ddmExpressionFactory,
+			HashMapBuilder.<String, Object>put(
+				objectRelationshipERCObjectFieldName, externalReferenceCode
+			).put(
+				relationshipObjectField.getName(),
+				Long.valueOf(objectRelationshipId)
+			).build(),
+			Collections.singletonList(relationshipObjectField),
+			HashMapBuilder.<String, Object>put(
+				relationshipObjectField.getName(),
+				Integer.valueOf(objectRelationshipId)
 			).build());
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91367

## What is being fixed

A PATCH or POST against an Object entry with a one-to-many relationship
marked readOnly (true or a conditional evaluating to true) crashed
instead of producing a clean readOnly violation. POST returned HTTP 500
with NullPointerException; PATCH returned HTTP 400 with
NumberFormatException. The root cause is in
`ObjectFieldUtil._validateNewValue`, which routes the one-to-many entry
through the BigDecimal branch: POST has no existing value yet, so
`existingValue.toString()` throws NPE; PATCH sees the ERC variant key
reconstructed by the Vulcan merge, and `new BigDecimal(<ERC string>)`
throws NFE.

## How it is being fixed

The first commit adds a one-to-many branch ahead of the numeric branch
in `_validateNewValue` that compares values through `String.valueOf`.
The branch is null-safe and normalizes Long, Integer, and String
identifiers consistently, so a genuine readOnly violation surfaces as
`ObjectFieldReadOnlyException` with its canonical message. The same
commit adds `ObjectFieldReadOnlyExceptionMapper` to `object-rest-impl`
and wires it into `ObjectDefinitionDeployerImpl`'s dynamic JAX-RS
application — `object-admin-rest-impl` already had its own mapper but
it does not cover `/o/c/...` traffic.

The second commit extends `ObjectFieldUtilTest` with regression
scenarios for PATCH ERC unchanged, PATCH ERC changed, POST with ERC,
and POST with Long FK (the customer's literal reproduction).