### PR TITLE
LPD-91448 | allow extension-less file from documents and media be submitted if * is used as accepted extensions

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/attachment.ts
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/attachment.ts
@@ -9,13 +9,21 @@ export function validateFileExtension(
 	acceptedFileExtensions: string,
 	fileExtension: string
 ) {
-	const isValidExtension = acceptedFileExtensions
+	const extensions = acceptedFileExtensions
+		.trim()
 		.split(/\s*,\s*/)
-		.some(
-			(acceptedFileExtension) =>
-				acceptedFileExtension.toLowerCase() ===
-				fileExtension.toLowerCase()
-		);
+		.filter(Boolean);
+
+	if (extensions.includes('*')) {
+		return;
+	}
+
+	const normalizedFileExtension = fileExtension.toLowerCase();
+
+	const isValidExtension = extensions.some(
+		(acceptedFileExtension) =>
+			acceptedFileExtension.toLowerCase() === normalizedFileExtension
+	);
 
 	if (!isValidExtension) {
 		return {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/attachment.spec.ts
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/attachment.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {validateFileExtension} from '../../js/Attachment/util/attachment';
+
+jest.mock('frontend-js-web', () => ({
+	sub: (key: string, value: string) => `${key}: ${value}`,
+}));
+
+(globalThis as any).Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+};
+
+describe('validateFileExtension', () => {
+	describe('wildcard (*)', () => {
+		it('accepts an extension-less file when accepted extensions is *', () => {
+			expect(validateFileExtension('*', '')).toBeUndefined();
+		});
+
+		it('accepts a file with extension when accepted extensions is *', () => {
+			expect(validateFileExtension('*', 'pdf')).toBeUndefined();
+		});
+
+		it('accepts any file when * appears among other extensions', () => {
+			expect(validateFileExtension('pdf, *, jpg', 'txt')).toBeUndefined();
+		});
+	});
+
+	describe('explicit extension list', () => {
+		it('returns undefined when the file extension matches', () => {
+			expect(validateFileExtension('pdf', 'pdf')).toBeUndefined();
+		});
+
+		it('returns an error when an extension-less file is submitted', () => {
+			expect(validateFileExtension('pdf', '')).toMatchObject({
+				displayErrors: true,
+				valid: false,
+			});
+		});
+
+		it('returns an error when the extension does not match', () => {
+			expect(validateFileExtension('pdf, jpg', 'txt')).toMatchObject({
+				displayErrors: true,
+				valid: false,
+			});
+		});
+
+		it('performs a case-insensitive comparison', () => {
+			expect(validateFileExtension('PDF', 'pdf')).toBeUndefined();
+			expect(validateFileExtension('pdf', 'PDF')).toBeUndefined();
+		});
+	});
+});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -313,7 +313,7 @@ test(
 		await test.step('Login as CMS Administrator', async () => {
 			const user = await addCMSAdministrator(apiHelpers);
 
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 		});
 
 		await test.step('Delete all the contents so they can go into the Recycle Bin', async () => {


### PR DESCRIPTION
related: [LPD-91448](https://liferay.atlassian.net/browse/LPD-91448)

[LPD-91448]: https://liferay.atlassian.net/browse/LPD-91448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ