### PR TITLE
LPD-91322 Persist country A2 for fixed phone number prefix

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldSettingConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldSettingConstants.java
@@ -42,6 +42,8 @@ public class ObjectFieldSettingConstants {
 
 	public static final String NAME_PREFIX = "prefix";
 
+	public static final String NAME_PREFIX_COUNTRY_A2 = "prefixCountryA2";
+
 	public static final String NAME_PREFIX_TYPE = "prefixType";
 
 	public static final String NAME_SHOW_COUNTER = "showCounter";

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/phone/number/PhoneNumberDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/phone/number/PhoneNumberDDMFormFieldTemplateContextContributor.java
@@ -66,6 +66,9 @@ public class PhoneNumberDDMFormFieldTemplateContextContributor
 		).put(
 			"prefix", GetterUtil.getString(ddmFormField.getProperty("prefix"))
 		).put(
+			"prefixCountryA2",
+			GetterUtil.getString(ddmFormField.getProperty("prefixCountryA2"))
+		).put(
 			"prefixType",
 			GetterUtil.getString(ddmFormField.getProperty("prefixType"))
 		).put(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PhoneNumberObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PhoneNumberObjectFieldBusinessType.java
@@ -69,6 +69,7 @@ public class PhoneNumberObjectFieldBusinessType
 			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE,
 			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE_TYPE,
 			ObjectFieldSettingConstants.NAME_PREFIX,
+			ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2,
 			ObjectFieldSettingConstants.NAME_PREFIX_TYPE,
 			ObjectFieldSettingConstants.NAME_UNIQUE_VALUES);
 	}
@@ -197,7 +198,9 @@ public class PhoneNumberObjectFieldBusinessType
 				ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER)) {
 
 			validateNotAllowedObjectFieldSettingNames(
-				SetUtil.fromArray(ObjectFieldSettingConstants.NAME_PREFIX),
+				SetUtil.fromArray(
+					ObjectFieldSettingConstants.NAME_PREFIX,
+					ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2),
 				objectField.getName(), objectFieldSettingsValues);
 		}
 		else if (Objects.equals(
@@ -220,6 +223,20 @@ public class PhoneNumberObjectFieldBusinessType
 				throw new ObjectFieldSettingValueException.InvalidValue(
 					objectField.getName(),
 					ObjectFieldSettingConstants.NAME_PREFIX, prefix);
+			}
+
+			String prefixCountryA2 = objectFieldSettingsValues.get(
+				ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2);
+
+			if (Validator.isNotNull(prefixCountryA2)) {
+				matcher = _prefixCountryA2Pattern.matcher(prefixCountryA2);
+
+				if (!matcher.matches()) {
+					throw new ObjectFieldSettingValueException.InvalidValue(
+						objectField.getName(),
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2,
+						prefixCountryA2);
+				}
 			}
 		}
 		else {
@@ -386,6 +403,8 @@ public class PhoneNumberObjectFieldBusinessType
 
 	private static final Pattern _phoneNumberPattern = Pattern.compile(
 		"^\\+[0-9]{7,15}$");
+	private static final Pattern _prefixCountryA2Pattern = Pattern.compile(
+		"^[A-Z]{2}$");
 	private static final Pattern _prefixPattern = Pattern.compile(
 		"^\\+[1-9][0-9]{0,2}$");
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/PhoneNumberObjectFieldBusinessTypeTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/PhoneNumberObjectFieldBusinessTypeTest.java
@@ -219,6 +219,76 @@ public class PhoneNumberObjectFieldBusinessTypeTest {
 				ObjectFieldSettingConstants.VALUE_INPUT_AS_VALUE
 			).build());
 
+		// Prefix country A2
+
+		AssertUtils.assertFailure(
+			ObjectFieldSettingValueException.InvalidValue.class,
+			StringBundler.concat(
+				"The value us of setting \"prefixCountryA2\" is invalid for ",
+				"object field \"", _OBJECT_FIELD_NAME, "\""),
+			() -> _objectFieldBusinessType.validateObjectFieldSettings(
+				_objectField,
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX
+					).value(
+						"+1"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+					).value(
+						"us"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+					).value(
+						ObjectFieldSettingConstants.VALUE_FIXED
+					).build())));
+		AssertUtils.assertFailure(
+			ObjectFieldSettingNameException.NotAllowedNames.class,
+			"The settings prefixCountryA2 are not allowed for object field " +
+				_OBJECT_FIELD_NAME,
+			() -> _objectFieldBusinessType.validateObjectFieldSettings(
+				_objectField,
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+					).value(
+						"US"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+					).value(
+						ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER
+					).build())));
+
+		_objectFieldBusinessType.validateObjectFieldSettings(
+			_objectField,
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX
+				).value(
+					"+1"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+				).value(
+					"US"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+				).value(
+					ObjectFieldSettingConstants.VALUE_FIXED
+				).build()));
+
 		// Prefix type
 
 		AssertUtils.assertFailure(


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-91322

## What is being fixed

When configuring a Phone Number field with `prefixType=fixed`, the admin
picks a country from a flag dropdown. Multiple countries share the same
IDD (United States and Canada both use `+1`), so saving only the prefix
loses the country distinction. On reload, the configuration UI cannot
tell which country was selected and the flag always renders as the first
match in the country list.

## How it is being fixed

This backend-only PR introduces a new object field setting,
`prefixCountryA2`, that stores the ISO 3166-1 alpha-2 code of the
country chosen by the admin. The setting is optional — legacy fields
without it continue to work via the existing IDD-match fallback in the
front-end.

`PhoneNumberObjectFieldBusinessType` accepts the new setting in
`getAllowedObjectFieldSettingsNames`, rejects it when
`prefixType=definedByUser`, and validates the format `^[A-Z]{2}$` when
`prefixType=fixed`. The setting is also exposed through
`PhoneNumberDDMFormFieldTemplateContextContributor` so the entry-render
side receives the country A2 to display the matching flag next to the
fixed prefix. Persistence flows through the default field-setting
contributor automatically.