### PR TITLE
LPD-91322 Persist country A2 for fixed phone number prefix

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldSettingConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldSettingConstants.java
@@ -42,6 +42,8 @@ public class ObjectFieldSettingConstants {
 
 	public static final String NAME_PREFIX = "prefix";
 
+	public static final String NAME_PREFIX_COUNTRY_A2 = "prefixCountryA2";
+
 	public static final String NAME_PREFIX_TYPE = "prefixType";
 
 	public static final String NAME_SHOW_COUNTER = "showCounter";

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/phone/number/PhoneNumberDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/phone/number/PhoneNumberDDMFormFieldTemplateContextContributor.java
@@ -66,6 +66,9 @@ public class PhoneNumberDDMFormFieldTemplateContextContributor
 		).put(
 			"prefix", GetterUtil.getString(ddmFormField.getProperty("prefix"))
 		).put(
+			"prefixCountryA2",
+			GetterUtil.getString(ddmFormField.getProperty("prefixCountryA2"))
+		).put(
 			"prefixType",
 			GetterUtil.getString(ddmFormField.getProperty("prefixType"))
 		).put(

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/PhoneNumber/PhoneNumber.tsx
@@ -37,6 +37,7 @@ interface BasePhoneNumberProps {
 	onFocus?: (event: React.FocusEvent) => void;
 	predefinedValue?: string;
 	prefix?: string;
+	prefixCountryA2?: string;
 	prefixType?: PrefixType;
 	readOnly?: boolean;
 	valid?: boolean;
@@ -84,6 +85,7 @@ const LocalizablePhoneNumber = ({
 	onFocus,
 	predefinedValue,
 	prefix,
+	prefixCountryA2,
 	prefixType = PREFIX_TYPE.DEFINED_BY_USER,
 	readOnly,
 	valid = true,
@@ -150,6 +152,7 @@ const LocalizablePhoneNumber = ({
 					onChange={handleChange}
 					onFocus={onFocus}
 					prefix={prefix}
+					prefixCountryA2={prefixCountryA2}
 					prefixType={prefixType}
 					value={currentValue}
 				/>
@@ -177,6 +180,7 @@ const NonLocalizablePhoneNumber = ({
 	onFocus,
 	predefinedValue,
 	prefix,
+	prefixCountryA2,
 	prefixType = PREFIX_TYPE.DEFINED_BY_USER,
 	readOnly,
 	valid = true,
@@ -231,6 +235,7 @@ const NonLocalizablePhoneNumber = ({
 					onChange={handleChange}
 					onFocus={onFocus}
 					prefix={prefix}
+					prefixCountryA2={prefixCountryA2}
 					prefixType={prefixType}
 					value={initialValue || predefinedValue}
 				/>

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/PhoneNumber/PhoneNumberInput.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/PhoneNumber/PhoneNumberInput.tsx
@@ -26,6 +26,7 @@ interface PhoneNumberInputProps {
 	onChange?: (event: {target: {value: string}}) => void;
 	onFocus?: (event: React.FocusEvent) => void;
 	prefix?: string;
+	prefixCountryA2?: CountryInfo['a2'];
 	prefixType?: PrefixType;
 	value?: string;
 }
@@ -39,6 +40,7 @@ export function PhoneNumberInput({
 	onChange,
 	onFocus,
 	prefix,
+	prefixCountryA2,
 	prefixType = PREFIX_TYPE.DEFINED_BY_USER,
 	value = '',
 }: PhoneNumberInputProps) {
@@ -47,18 +49,13 @@ export function PhoneNumberInput({
 		getDefaultCountry(countries)
 	);
 
-	const fixedCountry =
-		prefixType === PREFIX_TYPE.FIXED
-			? countries.find((country) => `+${country.idd}` === prefix)
-			: null;
-
-	const fixedFlagSymbol = fixedCountry ? getFlagSymbol(fixedCountry.a2) : '';
+	const fixedFlagSymbol = getFlagSymbol(prefixCountryA2 ?? '');
 
 	const handleValueChange = (country: CountryInfo, number: string) => {
 		if (onChange) {
 			const resolvedPrefix =
 				prefixType === PREFIX_TYPE.FIXED
-					? prefix || ''
+					? prefix ?? ''
 					: `+${country.idd}`;
 
 			const sanitizedNumber = number.replace(/\D/g, '');

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -39,6 +39,7 @@ export {PhoneNumberInput} from './components/PhoneNumber/PhoneNumberInput';
 export {
 	DEFAULT_COUNTRIES,
 	getCombinedValue,
+	getDefaultCountry,
 	getFlagSymbol,
 	parsePhoneValue,
 	PREFIX_TYPE,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PhoneNumberObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/PhoneNumberObjectFieldBusinessType.java
@@ -69,6 +69,7 @@ public class PhoneNumberObjectFieldBusinessType
 			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE,
 			ObjectFieldSettingConstants.NAME_DEFAULT_VALUE_TYPE,
 			ObjectFieldSettingConstants.NAME_PREFIX,
+			ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2,
 			ObjectFieldSettingConstants.NAME_PREFIX_TYPE,
 			ObjectFieldSettingConstants.NAME_UNIQUE_VALUES);
 	}
@@ -197,7 +198,9 @@ public class PhoneNumberObjectFieldBusinessType
 				ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER)) {
 
 			validateNotAllowedObjectFieldSettingNames(
-				SetUtil.fromArray(ObjectFieldSettingConstants.NAME_PREFIX),
+				SetUtil.fromArray(
+					ObjectFieldSettingConstants.NAME_PREFIX,
+					ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2),
 				objectField.getName(), objectFieldSettingsValues);
 		}
 		else if (Objects.equals(
@@ -220,6 +223,20 @@ public class PhoneNumberObjectFieldBusinessType
 				throw new ObjectFieldSettingValueException.InvalidValue(
 					objectField.getName(),
 					ObjectFieldSettingConstants.NAME_PREFIX, prefix);
+			}
+
+			String prefixCountryA2 = objectFieldSettingsValues.get(
+				ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2);
+
+			if (Validator.isNotNull(prefixCountryA2)) {
+				matcher = _prefixCountryA2Pattern.matcher(prefixCountryA2);
+
+				if (!matcher.matches()) {
+					throw new ObjectFieldSettingValueException.InvalidValue(
+						objectField.getName(),
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2,
+						prefixCountryA2);
+				}
 			}
 		}
 		else {
@@ -386,6 +403,8 @@ public class PhoneNumberObjectFieldBusinessType
 
 	private static final Pattern _phoneNumberPattern = Pattern.compile(
 		"^\\+[0-9]{7,15}$");
+	private static final Pattern _prefixCountryA2Pattern = Pattern.compile(
+		"^[A-Z]{2}$");
 	private static final Pattern _prefixPattern = Pattern.compile(
 		"^\\+[1-9][0-9]{0,2}$");
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/PhoneNumberObjectFieldBusinessTypeTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/PhoneNumberObjectFieldBusinessTypeTest.java
@@ -219,6 +219,76 @@ public class PhoneNumberObjectFieldBusinessTypeTest {
 				ObjectFieldSettingConstants.VALUE_INPUT_AS_VALUE
 			).build());
 
+		// Prefix country A2
+
+		AssertUtils.assertFailure(
+			ObjectFieldSettingValueException.InvalidValue.class,
+			StringBundler.concat(
+				"The value us of setting \"prefixCountryA2\" is invalid for ",
+				"object field \"", _OBJECT_FIELD_NAME, "\""),
+			() -> _objectFieldBusinessType.validateObjectFieldSettings(
+				_objectField,
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX
+					).value(
+						"+1"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+					).value(
+						"us"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+					).value(
+						ObjectFieldSettingConstants.VALUE_FIXED
+					).build())));
+		AssertUtils.assertFailure(
+			ObjectFieldSettingNameException.NotAllowedNames.class,
+			"The settings prefixCountryA2 are not allowed for object field " +
+				_OBJECT_FIELD_NAME,
+			() -> _objectFieldBusinessType.validateObjectFieldSettings(
+				_objectField,
+				Arrays.asList(
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+					).value(
+						"US"
+					).build(),
+					new ObjectFieldSettingBuilder(
+					).name(
+						ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+					).value(
+						ObjectFieldSettingConstants.VALUE_DEFINED_BY_USER
+					).build())));
+
+		_objectFieldBusinessType.validateObjectFieldSettings(
+			_objectField,
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX
+				).value(
+					"+1"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX_COUNTRY_A2
+				).value(
+					"US"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_PREFIX_TYPE
+				).value(
+					ObjectFieldSettingConstants.VALUE_FIXED
+				).build()));
+
 		// Prefix type
 
 		AssertUtils.assertFailure(

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/PhoneNumberProperties.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/PhoneNumberProperties.tsx
@@ -10,6 +10,7 @@ import {
 	PREFIX_TYPE,
 	PrefixType,
 	SingleSelect,
+	getDefaultCountry,
 } from '@liferay/object-js-components-web';
 import React from 'react';
 
@@ -39,12 +40,14 @@ export function PhoneNumberProperties({
 
 	const settings = normalizeFieldSettings(objectFieldSettings);
 
-	const prefix = settings.prefix || '+1';
+	const defaultCountry = getDefaultCountry(countries);
+
+	const prefixCountryA2 = settings.prefixCountryA2 || defaultCountry.a2;
 	const prefixType = settings.prefixType || PREFIX_TYPE.DEFINED_BY_USER;
 
 	const selectedCountry =
-		countries.find((country) => `+${country.idd}` === prefix) ||
-		countries[0];
+		countries.find((country) => country.a2 === prefixCountryA2) ||
+		defaultCountry;
 
 	const handlePrefixTypeChange = (value: PrefixType) => {
 		let updatedSettings = updateFieldSettings(objectFieldSettings, {
@@ -54,13 +57,20 @@ export function PhoneNumberProperties({
 
 		if (value === PREFIX_TYPE.DEFINED_BY_USER) {
 			updatedSettings = updatedSettings.filter(
-				(setting) => setting.name !== 'prefix'
+				(setting) =>
+					setting.name !== 'prefix' &&
+					setting.name !== 'prefixCountryA2'
 			);
 		}
 		else if (value === PREFIX_TYPE.FIXED) {
 			updatedSettings = updateFieldSettings(updatedSettings, {
 				name: 'prefix',
-				value: `+${countries[0].idd}`,
+				value: `+${defaultCountry.idd}`,
+			});
+
+			updatedSettings = updateFieldSettings(updatedSettings, {
+				name: 'prefixCountryA2',
+				value: defaultCountry.a2,
 			});
 		}
 
@@ -77,9 +87,14 @@ export function PhoneNumberProperties({
 	};
 
 	const handlePrefixChange = (country: CountryInfo) => {
-		const updatedSettings = updateFieldSettings(objectFieldSettings, {
+		let updatedSettings = updateFieldSettings(objectFieldSettings, {
 			name: 'prefix',
 			value: `+${country.idd}`,
+		});
+
+		updatedSettings = updateFieldSettings(updatedSettings, {
+			name: 'prefixCountryA2',
+			value: country.a2,
 		});
 
 		setValues({

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/types.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/types.d.ts
@@ -383,6 +383,7 @@ type ObjectFieldSettingName =
 	| 'objectRelationshipName'
 	| 'output'
 	| 'prefix'
+	| 'prefixCountryA2'
 	| 'prefixType'
 	| 'script'
 	| 'showCounter'

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -5756,10 +5756,11 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 	test(
 		'can add an entry with phone number object field where prefix type is fixed',
-		{tag: ['@LPD-83570']},
+		{tag: ['@LPD-83570', '@LPD-91322']},
 		async ({apiHelpers, page, viewObjectEntriesPage}) => {
 			const localNumber = '11987654321';
 			const prefix = '+1';
+			const prefixCountryA2 = 'US';
 
 			const objectFields = generateObjectFields({
 				objectFieldBusinessTypes: [
@@ -5774,6 +5775,10 @@ test.describe('Manage object entries through View Object Entries', () => {
 								name: 'prefix',
 								value: prefix,
 							},
+							{
+								name: 'prefixCountryA2',
+								value: prefixCountryA2,
+							},
 						],
 					},
 				],
@@ -5784,6 +5789,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 			const fieldContainer = page.getByRole('group', {
 				name: objectFieldLabel,
 			});
+
+			const usFlagIcon = fieldContainer.locator('svg.lexicon-icon-en-us');
 
 			let objectDefinition: ObjectDefinition;
 
@@ -5827,6 +5834,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 			await test.step('Fill the phone number field and save the entry', async () => {
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
 
+				await expect(usFlagIcon).toBeVisible();
+
 				await fieldContainer
 					.getByLabel('Phone Number')
 					.fill(localNumber);
@@ -5846,6 +5855,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 					.click();
 
 				await expect(fieldContainer.getByText(prefix)).toBeVisible();
+
+				await expect(usFlagIcon).toBeVisible();
 
 				await expect(
 					fieldContainer.getByLabel('Phone Number')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91322

## What is being fixed

When the Phone Number object field's prefix type was set to Fixed, only the IDD (e.g., `+1`) was persisted. Because the US and Canada share the `+1` calling code, reopening the field in Object Admin showed an ambiguous prefix and the originally selected country (with its flag) could not be restored.

## How it is being fixed

A new `prefixCountryA2` object field setting stores the ISO 3166-1 alpha-2 country code alongside the existing `prefix` (IDD). The Phone Number business type allows and validates the new setting, the DDM form field template context contributor forwards it to the React component, and the input and properties UIs read it for both the flag and the country picker selection. The `prefix` setting now stores the IDD with the leading `+`, and the React component reads `prefix` directly so the fixed prefix renders verbatim. 

Also updated the playwright test to check the correct flag icon is appearing for the fixed type.
<img width="775" height="113" alt="Screenshot 2026-05-21 at 7 56 37 PM" src="https://github.com/user-attachments/assets/cd58ff75-f202-44a0-a661-7b4fda9cb80b" />


This supersedes #6131.