### PR TITLE
LPD-91697 Fix IDOR in workflow task assignment across virtual instances

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -124,6 +124,15 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 				ActionKeys.VIEW);
 		}
 
+		User assigneeUser = _userLocalService.fetchUser(assigneeUserId);
+
+		if ((assigneeUser == null) ||
+			(assigneeUser.getCompanyId() != companyId)) {
+
+			throw new PrincipalException.MustHavePermission(
+				userId, User.class.getName(), assigneeUserId, ActionKeys.VIEW);
+		}
+
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setCompanyId(companyId);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
@@ -65,6 +65,12 @@ public class KaleoTaskModelResourcePermission
 			KaleoTaskInstanceToken kaleoTaskInstanceToken, String actionId)
 		throws PortalException {
 
+		if (kaleoTaskInstanceToken.getCompanyId() !=
+				permissionChecker.getCompanyId()) {
+
+			return false;
+		}
+
 		WorkflowTask workflowTask = _kaleoWorkflowModelConverter.toWorkflowTask(
 			kaleoTaskInstanceToken,
 			WorkflowContextUtil.convert(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.security.permission.SimplePermissionChecker;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.runtime.TaskManager;
 
 import org.junit.After;
 import org.junit.Before;
@@ -75,18 +76,30 @@ public class WorkflowTaskManagerImplTest {
 			null, null, null);
 	}
 
-	@Test(expected = PrincipalException.MustHavePermission.class)
-	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserDoesNotExist()
+	@Test
+	public void testAssignWorkflowTaskToUserWhenAssigneeUserBelongsToSameVirtualInstance()
 		throws Exception {
 
-		long companyId = RandomTestUtil.randomLong();
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskManagerImpl, "_taskManager",
+			Mockito.mock(TaskManager.class));
+
+		User assigneeUser = Mockito.mock(User.class);
 
 		long assigneeUserId = RandomTestUtil.randomLong();
 
 		Mockito.when(
 			_userLocalService.fetchUser(assigneeUserId)
 		).thenReturn(
-			null
+			assigneeUser
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assigneeUser.getCompanyId()
+		).thenReturn(
+			companyId
 		);
 
 		_workflowTaskManagerImpl.assignWorkflowTaskToUser(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
@@ -12,11 +12,11 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.security.permission.SimplePermissionChecker;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.workflow.kaleo.runtime.TaskManager;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -41,8 +41,16 @@ public class WorkflowTaskManagerImplTest {
 		ReflectionTestUtil.setFieldValue(
 			_workflowTaskManagerImpl, "_userLocalService", _userLocalService);
 
-		PermissionThreadLocal.setPermissionChecker(
-			_mockPermissionChecker(_USER_ID));
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
 	}
 
 	@After
@@ -50,72 +58,68 @@ public class WorkflowTaskManagerImplTest {
 		PermissionThreadLocal.setPermissionChecker(null);
 	}
 
-	@Test(expected = PrincipalException.MustHavePermission.class)
-	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserBelongsToDifferentVirtualInstance()
-		throws Exception {
+	@Test
+	public void testAssignWorkflowTaskToUser() throws Exception {
 
-		long companyId = RandomTestUtil.randomLong();
-		long assigneeUserId = RandomTestUtil.randomLong();
+		// User from different company
 
-		User assigneeUser = Mockito.mock(User.class);
+		long assigneeUserId1 = RandomTestUtil.randomLong();
+
+		User assigneeUser1 = Mockito.mock(User.class);
 
 		Mockito.when(
-			assigneeUser.getCompanyId()
+			_userLocalService.fetchUser(assigneeUserId1)
+		).thenReturn(
+			assigneeUser1
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assigneeUser1.getCompanyId()
 		).thenReturn(
 			companyId + 1
 		);
 
-		Mockito.when(
-			_userLocalService.fetchUser(assigneeUserId)
-		).thenReturn(
-			assigneeUser
-		);
+		try {
+			_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+				companyId, _USER_ID, RandomTestUtil.randomLong(),
+				assigneeUserId1, null, null, null);
 
-		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
-			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
-			null, null, null);
-	}
+			Assert.fail();
+		}
+		catch (PrincipalException.MustHavePermission principalException) {
+			Assert.assertEquals(
+				User.class.getName(), principalException.resourceName);
+			Assert.assertEquals(
+				assigneeUserId1, principalException.resourceId);
+		}
 
-	@Test
-	public void testAssignWorkflowTaskToUserWhenAssigneeUserBelongsToSameVirtualInstance()
-		throws Exception {
+		// User from same company
 
 		ReflectionTestUtil.setFieldValue(
 			_workflowTaskManagerImpl, "_taskManager",
 			Mockito.mock(TaskManager.class));
 
-		User assigneeUser = Mockito.mock(User.class);
+		long assigneeUserId2 = RandomTestUtil.randomLong();
 
-		long assigneeUserId = RandomTestUtil.randomLong();
+		User assigneeUser2 = Mockito.mock(User.class);
 
 		Mockito.when(
-			_userLocalService.fetchUser(assigneeUserId)
+			_userLocalService.fetchUser(assigneeUserId2)
 		).thenReturn(
-			assigneeUser
+			assigneeUser2
 		);
 
-		long companyId = RandomTestUtil.randomLong();
-
 		Mockito.when(
-			assigneeUser.getCompanyId()
+			assigneeUser2.getCompanyId()
 		).thenReturn(
 			companyId
 		);
 
 		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
-			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId2,
 			null, null, null);
-	}
-
-	private PermissionChecker _mockPermissionChecker(long userId) {
-		return new SimplePermissionChecker() {
-
-			@Override
-			public long getUserId() {
-				return userId;
-			}
-
-		};
 	}
 
 	private static final long _USER_ID = RandomTestUtil.randomLong();

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.permission.SimplePermissionChecker;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class WorkflowTaskManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_userLocalService = Mockito.mock(UserLocalService.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskManagerImpl, "_userLocalService", _userLocalService);
+
+		PermissionThreadLocal.setPermissionChecker(
+			_mockPermissionChecker(_USER_ID));
+	}
+
+	@After
+	public void tearDown() {
+		PermissionThreadLocal.setPermissionChecker(null);
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserBelongsToDifferentVirtualInstance()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+		long assigneeUserId = RandomTestUtil.randomLong();
+
+		User assigneeUser = Mockito.mock(User.class);
+
+		Mockito.when(
+			assigneeUser.getCompanyId()
+		).thenReturn(
+			companyId + 1
+		);
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId)
+		).thenReturn(
+			assigneeUser
+		);
+
+		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
+			null, null, null);
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAssignWorkflowTaskToUserThrowsExceptionWhenAssigneeUserDoesNotExist()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+
+		long assigneeUserId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId)
+		).thenReturn(
+			null
+		);
+
+		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId,
+			null, null, null);
+	}
+
+	private PermissionChecker _mockPermissionChecker(long userId) {
+		return new SimplePermissionChecker() {
+
+			@Override
+			public long getUserId() {
+				return userId;
+			}
+
+		};
+	}
+
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private UserLocalService _userLocalService;
+	private final WorkflowTaskManagerImpl _workflowTaskManagerImpl =
+		new WorkflowTaskManagerImpl();
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
@@ -5,12 +5,10 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.permission.resource;
 
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
-import com.liferay.portal.security.permission.SimplePermissionChecker;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.workflow.kaleo.KaleoWorkflowModelConverter;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
@@ -34,61 +32,67 @@ public class KaleoTaskModelResourcePermissionTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testContainsFalseWhenKaleoTaskInstanceTokenBelongsToDifferentVirtualInstance()
-		throws Exception {
+	public void testContains() throws Exception {
+
+		// Kaleo task instance token from different company
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken1 = Mockito.mock(
+			KaleoTaskInstanceToken.class);
 
 		long companyId = RandomTestUtil.randomLong();
 
-		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
-			KaleoTaskInstanceToken.class);
-
 		Mockito.when(
-			kaleoTaskInstanceToken.getCompanyId()
+			kaleoTaskInstanceToken1.getCompanyId()
 		).thenReturn(
 			companyId
+		);
+
+		PermissionChecker permissionChecker1 = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker1.getCompanyId()
+		).thenReturn(
+			companyId + 1
 		);
 
 		Assert.assertFalse(
 			_kaleoTaskModelResourcePermission.contains(
-				_mockPermissionChecker(companyId + 1), kaleoTaskInstanceToken,
-				null));
-	}
+				permissionChecker1, kaleoTaskInstanceToken1, null));
 
-	@Test
-	public void testWhenKaleoTaskInstanceTokenBelongsToSameVirtualInstance()
-		throws Exception {
+		// Kaleo task instance token from same company
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken2 = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		Mockito.when(
+			kaleoTaskInstanceToken2.getCompanyId()
+		).thenReturn(
+			companyId
+		);
 
 		KaleoWorkflowModelConverter kaleoWorkflowModelConverter = Mockito.mock(
 			KaleoWorkflowModelConverter.class);
-		WorkflowTaskPermission workflowTaskPermission = Mockito.mock(
-			WorkflowTaskPermission.class);
 
 		ReflectionTestUtil.setFieldValue(
 			_kaleoTaskModelResourcePermission, "_kaleoWorkflowModelConverter",
 			kaleoWorkflowModelConverter);
-		ReflectionTestUtil.setFieldValue(
-			_kaleoTaskModelResourcePermission, "_workflowTaskPermission",
-			workflowTaskPermission);
-
-		long companyId = RandomTestUtil.randomLong();
-
-		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
-			KaleoTaskInstanceToken.class);
-
-		Mockito.when(
-			kaleoTaskInstanceToken.getCompanyId()
-		).thenReturn(
-			companyId
-		);
 
 		WorkflowTask workflowTask = Mockito.mock(WorkflowTask.class);
 
 		Mockito.when(
 			kaleoWorkflowModelConverter.toWorkflowTask(
-				Mockito.eq(kaleoTaskInstanceToken), Mockito.any())
+				Mockito.eq(kaleoTaskInstanceToken2), Mockito.any())
 		).thenReturn(
 			workflowTask
 		);
+
+		WorkflowTaskPermission workflowTaskPermission = Mockito.mock(
+			WorkflowTaskPermission.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_kaleoTaskModelResourcePermission, "_workflowTaskPermission",
+			workflowTaskPermission);
 
 		Mockito.when(
 			workflowTaskPermission.contains(
@@ -97,29 +101,19 @@ public class KaleoTaskModelResourcePermissionTest {
 			true
 		);
 
+		PermissionChecker permissionChecker2 = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker2.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
 		Assert.assertTrue(
 			_kaleoTaskModelResourcePermission.contains(
-				_mockPermissionChecker(companyId), kaleoTaskInstanceToken,
-				null));
+				permissionChecker2, kaleoTaskInstanceToken2, null));
 	}
-
-	private PermissionChecker _mockPermissionChecker(long companyId) {
-		return new SimplePermissionChecker() {
-
-			@Override
-			public long getCompanyId() {
-				return companyId;
-			}
-
-			@Override
-			public User getUser() {
-				return _user;
-			}
-
-		};
-	}
-
-	private static final User _user = Mockito.mock(User.class);
 
 	private final KaleoTaskModelResourcePermission
 		_kaleoTaskModelResourcePermission =

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
@@ -7,10 +7,14 @@ package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.
 
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.security.permission.SimplePermissionChecker;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.KaleoWorkflowModelConverter;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.security.permission.WorkflowTaskPermission;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -47,6 +51,55 @@ public class KaleoTaskModelResourcePermissionTest {
 		Assert.assertFalse(
 			_kaleoTaskModelResourcePermission.contains(
 				_mockPermissionChecker(companyId + 1), kaleoTaskInstanceToken,
+				null));
+	}
+
+	@Test
+	public void testWhenKaleoTaskInstanceTokenBelongsToSameVirtualInstance()
+		throws Exception {
+
+		KaleoWorkflowModelConverter kaleoWorkflowModelConverter = Mockito.mock(
+			KaleoWorkflowModelConverter.class);
+		WorkflowTaskPermission workflowTaskPermission = Mockito.mock(
+			WorkflowTaskPermission.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_kaleoTaskModelResourcePermission, "_kaleoWorkflowModelConverter",
+			kaleoWorkflowModelConverter);
+		ReflectionTestUtil.setFieldValue(
+			_kaleoTaskModelResourcePermission, "_workflowTaskPermission",
+			workflowTaskPermission);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		Mockito.when(
+			kaleoTaskInstanceToken.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		WorkflowTask workflowTask = Mockito.mock(WorkflowTask.class);
+
+		Mockito.when(
+			kaleoWorkflowModelConverter.toWorkflowTask(
+				Mockito.eq(kaleoTaskInstanceToken), Mockito.any())
+		).thenReturn(
+			workflowTask
+		);
+
+		Mockito.when(
+			workflowTaskPermission.contains(
+				Mockito.any(), Mockito.eq(workflowTask), Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Assert.assertTrue(
+			_kaleoTaskModelResourcePermission.contains(
+				_mockPermissionChecker(companyId), kaleoTaskInstanceToken,
 				null));
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.permission.SimplePermissionChecker;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class KaleoTaskModelResourcePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContainsFalseWhenKaleoTaskInstanceTokenBelongsToDifferentVirtualInstance()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		Mockito.when(
+			kaleoTaskInstanceToken.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Assert.assertFalse(
+			_kaleoTaskModelResourcePermission.contains(
+				_mockPermissionChecker(companyId + 1), kaleoTaskInstanceToken,
+				null));
+	}
+
+	private PermissionChecker _mockPermissionChecker(long companyId) {
+		return new SimplePermissionChecker() {
+
+			@Override
+			public long getCompanyId() {
+				return companyId;
+			}
+
+			@Override
+			public User getUser() {
+				return _user;
+			}
+
+		};
+	}
+
+	private static final User _user = Mockito.mock(User.class);
+
+	private final KaleoTaskModelResourcePermission
+		_kaleoTaskModelResourcePermission =
+			new KaleoTaskModelResourcePermission();
+
+}


### PR DESCRIPTION

Related issue: https://liferay.atlassian.net/browse/LPD-91697

## Summary

- `KaleoTaskModelResourcePermission.contains()` now rejects tasks whose `companyId` does not match the requesting user's virtual instance, closing an IDOR that let a cross-instance admin pass the permission check.
- `WorkflowTaskManagerImpl.assignWorkflowTaskToUser()` now validates that the assignee user exists and belongs to the same company as the task, closing an IDOR that allowed assigning tasks to users from foreign virtual instances.
- Tests cover both rejection paths (different company, non-existent user) and the same-company pass-through for each fix.
