### PR TITLE
LPD-57406 Stabilize workflowDefinitions client extension test

### DIFF
--- a/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/workflowDefinitions.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-kaleo-designer-web/main/workflowDefinitions.spec.ts
@@ -129,15 +129,20 @@ test('LPD-49034 Custom Workflow Action Client Extension not working when the ass
 				.getByText('Approved')
 		).toBeVisible();
 	}).toPass({
-		intervals: [1000],
-		timeout: 5000,
+		intervals: [2000],
+		timeout: 15000,
 	});
 
 	const journalArticleTitle2 = getRandomString();
 
 	await journalPage.goToCreateArticle();
 
-	await journalPage.fillArticleData(journalArticleTitle2, getRandomString());
+	await journalPage.articleTitleInput.fill(journalArticleTitle2);
+
+	await page
+		.locator('[data-qa-id="content"]')
+		.getByRole('textbox', {name: 'Rich Text Editor'})
+		.fill(getRandomString());
 
 	const row = page
 		.frameLocator('iframe[title="Select Basic Web Content"]')
@@ -169,8 +174,8 @@ test('LPD-49034 Custom Workflow Action Client Extension not working when the ass
 				.getByText('Approved')
 		).toBeVisible();
 	}).toPass({
-		intervals: [1000],
-		timeout: 5000,
+		intervals: [2000],
+		timeout: 15000,
 	});
 
 	await workflowPage.goto(site.friendlyUrlPath);


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-57406

## What is being fixed

The `workflowDefinitions.spec.ts > LPD-49034 Custom Workflow Action Client Extension not working when the asset has related contents` test is consistently flaky on CI. It fails in two places: the `toPass` blocks waiting for the "Approved" badge, and the second article's creation flow.

The "Approved" badge depends on a callback from an external Spring Boot client extension (`liferay-sample-etc-spring-boot`). The previous timeout of 5 seconds is below the realistic round-trip latency on CI, so the assertion times out before the workflow callback completes. Two prior fixes (LPD-75177) tightened the polling but kept the same 5-second budget, so the test continued to flake.

The downstream failure happens after `goToCreateArticle` for the second article: `fillArticleData` calls `articleContentTextBox.click()`, but the shared `JournalPage` page object targets the editor via `getByTestId('content')`, which does not resolve against the current bundle DOM. The Content editor is now identified by `data-qa-id="content"`.

## How it is being fixed

The two `toPass` blocks now wait up to 15 seconds with 2-second intervals, giving the client extension enough headroom on CI while still exiting on the first poll on a healthy run.

The second article fill no longer goes through `journalPage.fillArticleData`, since that method depends on the broken shared locator. The spec inlines the title fill against the public `articleTitleInput` locator and targets the Content rich text editor directly via `[data-qa-id="content"]`. This keeps the fix scoped to this spec instead of touching `JournalPage.ts`, which is owned by another team and used by other specs.