### PR TITLE
LPD-92166 Fix v8_8_2 upgrade crash on missing picklist column

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v8_8_2/SchemaUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v8_8_2/SchemaUpgradeProcess.java
@@ -37,13 +37,22 @@ public class SchemaUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					alterColumnType(
+					_alterColumnType(
 						resultSet.getString("dbTableName"),
-						resultSet.getString("dbColumnName"),
-						"VARCHAR(75) null");
+						resultSet.getString("dbColumnName"));
 				}
 			}
 		}
+	}
+
+	private void _alterColumnType(String dbTableName, String dbColumnName)
+		throws Exception {
+
+		if (!hasColumn(dbTableName, dbColumnName)) {
+			return;
+		}
+
+		alterColumnType(dbTableName, dbColumnName, "VARCHAR(75) null");
 	}
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v8_8_2/test/SchemaUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v8_8_2/test/SchemaUpgradeProcessTest.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v8_8_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.list.type.entry.util.ListTypeEntryUtil;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.sql.Connection;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Yuri Monteiro
+ */
+@RunWith(Arquillian.class)
+public class SchemaUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_db = DBManagerUtil.getDB();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_listTypeDefinition =
+			_listTypeDefinitionLocalService.addListTypeDefinition(
+				null, TestPropsValues.getUserId(),
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				false,
+				Collections.singletonList(
+					ListTypeEntryUtil.createListTypeEntry(
+						RandomTestUtil.randomString())),
+				new ServiceContext());
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new PicklistObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).listTypeDefinitionId(
+					_listTypeDefinition.getListTypeDefinitionId()
+				).name(
+					_PICKLIST_OBJECT_FIELD_NAME
+				).build()));
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+
+		// Picklist column exists in the dynamic table
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			_objectDefinition.getObjectDefinitionId(),
+			_PICKLIST_OBJECT_FIELD_NAME);
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			Assert.assertTrue(
+				dbInspector.hasColumnType(
+					_objectDefinition.getDBTableName(),
+					objectField.getDBColumnName(), "VARCHAR(75) null"));
+		}
+
+		// Picklist column missing from the dynamic table
+
+		_db.runSQL(
+			StringBundler.concat(
+				"alter table ", _objectDefinition.getDBTableName(),
+				" drop column ", objectField.getDBColumnName()));
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.internal.upgrade.v8_8_2.SchemaUpgradeProcess";
+
+	private static final String _PICKLIST_OBJECT_FIELD_NAME =
+		"a" + RandomTestUtil.randomString();
+
+	private static DB _db;
+
+	@DeleteAfterTestRun
+	private ListTypeDefinition _listTypeDefinition;
+
+	@Inject
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}


### PR DESCRIPTION
Related issue: [LPD-92166](https://liferay.atlassian.net/browse/LPD-92166)

## What is being fixed

When upgrading from DXP 7.4 to a newer version, the v8_8_2
`SchemaUpgradeProcess` for the object module aborts with a
`SQLException` when an Object table is missing a picklist column that
the `ObjectField` metadata still references. The upgrade query selects
all approved picklist fields and calls `alterColumnType` on each one to
shrink the column from VARCHAR(280) to VARCHAR(75). When the column
does not exist on the dynamic table (for example because of historical
data corruption), the database rejects the ALTER and the whole major
upgrade is marked as failed.

## How it is being fixed

The first commit extracts the `alterColumnType` call into a private
`_alterColumnType(dbTableName, dbColumnName)` helper that guards the
call with `hasColumn(...)`. When the column is missing the helper
returns silently, so the upgrade chain continues. This mirrors the
same defensive pattern already used by
`v10_0_0/ObjectDefinitionUpgradeProcess._alterColumnName` in the same
module. The customer's metadata-to-schema mismatch survives the
upgrade and can be resolved separately, but the upgrade completes and
the portal boots normally.

The second commit adds an integration test that publishes a picklist
field, drops its physical column to recreate the inconsistent state,
and runs the upgrade step twice — once for the happy path (column
exists, gets altered to VARCHAR(75)) and once for the regression case
(column missing, upgrade is a no-op). Without the fix, the second
upgrade invocation throws `SQLException` and the test fails.

[LPD-92166]: https://liferay.atlassian.net/browse/LPD-92166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ