### PR TITLE
LPD-92227 | enhance performance in requests that use ERC-based filters

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -82,6 +82,7 @@ import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.sql.dsl.expression.Predicate;
@@ -783,9 +784,14 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		Long[] groupIds = groupIdsList.toArray(new Long[0]);
+		Predicate predicate;
 
-		Predicate predicate = _filterFactory.create(
-			filterExpression, objectDefinition);
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(groupId)) {
+
+			predicate = _filterFactory.create(
+				filterExpression, objectDefinition);
+		}
 
 		int start = _getStartPosition(pagination);
 		int end = _getEndPosition(pagination);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -79,6 +79,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					objectDefinition2, objectFieldLocalService),
 				objectDefinition2DynamicObjectDefinitionTable,
 				objectDefinition2ExtensionDynamicObjectDefinitionTable,
+				objectDefinition2,
 				DSLQueryFactoryUtil.select(objectRelationshipColumn),
 				predicate);
 		}
@@ -101,6 +102,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 						objectDefinition1, objectFieldLocalService),
 					objectDefinition1DynamicObjectDefinitionTable,
 					getExtensionDynamicObjectDefinitionTable(objectDefinition1),
+					objectDefinition1,
 					DSLQueryFactoryUtil.select(
 						objectDefinition1DynamicObjectDefinitionTable.
 							getPrimaryKeyColumn()),
@@ -163,7 +165,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				dynamicObjectDefinitionLocalizationTable,
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable,
-			FromStep fromStep, Predicate predicate)
+			ObjectDefinition objectDefinition, FromStep fromStep,
+			Predicate predicate)
 		throws PortalException {
 
 		return column.in(
@@ -185,7 +188,14 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					dynamicObjectDefinitionLocalizationTable,
 					dynamicObjectDefinitionTable, null)
 			).where(
-				predicate
+				ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+					objectDefinition.getObjectDefinitionId()
+				).and(
+					ObjectEntryTable.INSTANCE.companyId.eq(
+						objectDefinition.getCompanyId())
+				).and(
+					predicate
+				)
 			));
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.related.models;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.internal.entry.util.ObjectEntrySearchUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -21,6 +22,8 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.StringUtil;
 
 /**
  * @author Luis Miguel Barcos
@@ -193,6 +196,18 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				).and(
 					ObjectEntryTable.INSTANCE.companyId.eq(
 						objectDefinition.getCompanyId())
+				).and(
+					() -> {
+						if (StringUtil.equals(
+								objectDefinition.getScope(),
+								ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+							return ObjectEntryTable.INSTANCE.groupId.eq(0L);
+						}
+
+						return ObjectEntryTable.INSTANCE.groupId.eq(
+							GroupThreadLocal.getGroupId());
+					}
 				).and(
 					predicate
 				)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.internal.related.models;
 
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
@@ -17,6 +18,8 @@ import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.StringUtil;
 
 /**
  * @author Luis Miguel Barcos
@@ -94,6 +97,20 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 						).and(
 							ObjectEntryTable.INSTANCE.companyId.eq(
 								relatedObjectDefinition.getCompanyId())
+						).and(
+							() -> {
+								if (StringUtil.equals(
+										relatedObjectDefinition.getScope(),
+										ObjectDefinitionConstants.
+											SCOPE_COMPANY)) {
+
+									return ObjectEntryTable.INSTANCE.groupId.eq(
+										0L);
+								}
+
+								return ObjectEntryTable.INSTANCE.groupId.eq(
+									GroupThreadLocal.getGroupId());
+							}
 						).and(
 							predicate
 						)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -89,7 +89,14 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 								getPrimaryKeyColumn()
 						)
 					).where(
-						predicate
+						ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+							relatedObjectDefinition.getObjectDefinitionId()
+						).and(
+							ObjectEntryTable.INSTANCE.companyId.eq(
+								relatedObjectDefinition.getCompanyId())
+						).and(
+							predicate
+						)
 					))
 			));
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4744,6 +4744,9 @@ public class ObjectEntryLocalServiceImpl
 			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
 				objectDefinition.getObjectDefinitionId()
 			).and(
+				ObjectEntryTable.INSTANCE.companyId.eq(
+					objectDefinition.getCompanyId())
+			).and(
 				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
 					ObjectEntryTable.INSTANCE.objectEntryId
 				).or(

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryObjectRelatedModelsPredicateProviderImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryObjectRelatedModelsPredicateProviderImplTest.java
@@ -1,0 +1,334 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.related.models;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class ObjectEntryObjectRelatedModelsPredicateProviderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testObjectEntry1toMObjectRelatedModelsPredicateProviderImplWithCompanyScope()
+		throws Exception {
+
+		_testObjectEntry1toMObjectRelatedModelsPredicateProviderImpl(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+	}
+
+	@Test
+	public void testObjectEntry1toMObjectRelatedModelsPredicateProviderImplWithSiteScope()
+		throws Exception {
+
+		_testObjectEntry1toMObjectRelatedModelsPredicateProviderImpl(
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	@Test
+	public void testObjectEntryMtoMObjectRelatedModelsPredicateProviderImplWithCompanyScope()
+		throws Exception {
+
+		_testObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl(
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+	}
+
+	@Test
+	public void testObjectEntryMtoMObjectRelatedModelsPredicateProviderImplWithSiteScope()
+		throws Exception {
+
+		_testObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl(
+			ObjectDefinitionConstants.SCOPE_SITE);
+	}
+
+	private void _assertPredicateSqlContainsIndexFilters(String predicateSql) {
+		Assert.assertTrue(
+			predicateSql,
+			predicateSql.contains("ObjectEntry.objectDefinitionId"));
+		Assert.assertTrue(
+			predicateSql, predicateSql.contains("ObjectEntry.companyId"));
+		Assert.assertTrue(
+			predicateSql, predicateSql.contains("ObjectEntry.groupId"));
+	}
+
+	private ObjectDefinition _createObjectDefinition(
+		long companyId, String dbTableName, long objectDefinitionId,
+		String scope) {
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			objectDefinition.getDBTableName()
+		).thenReturn(
+			dbTableName
+		);
+
+		Mockito.when(
+			objectDefinition.getExtensionDBTableName()
+		).thenReturn(
+			dbTableName + "x"
+		);
+
+		Mockito.when(
+			objectDefinition.getObjectDefinitionId()
+		).thenReturn(
+			objectDefinitionId
+		);
+
+		Mockito.when(
+			objectDefinition.getPKObjectFieldDBColumnName()
+		).thenReturn(
+			_PK_OBJECT_FIELD_DB_COLUMN_NAME
+		);
+
+		Mockito.when(
+			objectDefinition.getPKObjectFieldName()
+		).thenReturn(
+			_PK_OBJECT_FIELD_NAME
+		);
+
+		Mockito.when(
+			objectDefinition.getScope()
+		).thenReturn(
+			scope
+		);
+
+		return objectDefinition;
+	}
+
+	private ObjectFieldLocalService
+		_createObjectFieldLocalServiceWithEmptyFields() {
+
+		ObjectFieldLocalService objectFieldLocalService = Mockito.mock(
+			ObjectFieldLocalService.class);
+
+		Mockito.when(
+			objectFieldLocalService.getLocalizedObjectFields(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		return objectFieldLocalService;
+	}
+
+	private ObjectFieldLocalService
+		_createObjectFieldLocalServiceWithRelationshipField(
+			long objectDefinitionId, String dbTableName,
+			String relationshipColumnName) {
+
+		ObjectFieldLocalService objectFieldLocalService =
+			_createObjectFieldLocalServiceWithEmptyFields();
+
+		ObjectField relationshipObjectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			relationshipObjectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_AUTO_INCREMENT)
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			relationshipObjectField.getDBColumnNames()
+		).thenReturn(
+			new String[] {relationshipColumnName}
+		);
+
+		Mockito.when(
+			relationshipObjectField.getDBType()
+		).thenReturn(
+			ObjectFieldConstants.DB_TYPE_LONG
+		);
+
+		Mockito.when(
+			relationshipObjectField.hasInsertValues()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			relationshipObjectField.isLocalized()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(
+				objectDefinitionId, dbTableName)
+		).thenReturn(
+			List.of(relationshipObjectField)
+		);
+
+		return objectFieldLocalService;
+	}
+
+	private ObjectRelationship _createObjectRelationship(
+		long objectDefinitionId1, long objectDefinitionId2) {
+
+		ObjectRelationship objectRelationship = Mockito.mock(
+			ObjectRelationship.class);
+
+		Mockito.when(
+			objectRelationship.getDBTableName()
+		).thenReturn(
+			"MappingTable_"
+		);
+
+		Mockito.when(
+			objectRelationship.getName()
+		).thenReturn(
+			_RELATIONSHIP_NAME
+		);
+
+		Mockito.when(
+			objectRelationship.getObjectDefinitionId1()
+		).thenReturn(
+			objectDefinitionId1
+		);
+
+		Mockito.when(
+			objectRelationship.getObjectDefinitionId2()
+		).thenReturn(
+			objectDefinitionId2
+		);
+
+		Mockito.when(
+			objectRelationship.isReverse()
+		).thenReturn(
+			false
+		);
+
+		return objectRelationship;
+	}
+
+	private void _testObjectEntry1toMObjectRelatedModelsPredicateProviderImpl(
+			String scope)
+		throws Exception {
+
+		long objectDefinitionId = RandomTestUtil.randomLong();
+
+		String dbTableName = "Object_" + objectDefinitionId + "_";
+
+		ObjectDefinition objectDefinition = _createObjectDefinition(
+			RandomTestUtil.randomLong(), dbTableName, objectDefinitionId,
+			scope);
+		ObjectFieldLocalService objectFieldLocalService =
+			_createObjectFieldLocalServiceWithRelationshipField(
+				objectDefinitionId, dbTableName, _RELATIONSHIP_COLUMN_NAME);
+
+		ObjectRelationship objectRelationship = _createObjectRelationship(
+			objectDefinitionId, objectDefinitionId);
+
+		Predicate predicate;
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			predicate =
+				new ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl(
+					objectDefinition, objectFieldLocalService
+				).getPredicate(
+					objectRelationship,
+					ObjectEntryTable.INSTANCE.externalReferenceCode.eq(
+						RandomTestUtil.randomString()),
+					objectDefinition
+				);
+		}
+
+		_assertPredicateSqlContainsIndexFilters(predicate.toString());
+	}
+
+	private void _testObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl(
+			String scope)
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+		long objectDefinitionId = RandomTestUtil.randomLong();
+		long childObjectDefinitionId = RandomTestUtil.randomLong();
+
+		ObjectDefinition objectDefinition = _createObjectDefinition(
+			companyId, "Object_" + objectDefinitionId + "_", objectDefinitionId,
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+		ObjectFieldLocalService objectFieldLocalService =
+			_createObjectFieldLocalServiceWithEmptyFields();
+		ObjectRelationship objectRelationship = _createObjectRelationship(
+			objectDefinitionId, childObjectDefinitionId);
+		ObjectDefinition relatedObjectDefinition = _createObjectDefinition(
+			companyId, "Object_" + childObjectDefinitionId + "_",
+			childObjectDefinitionId, scope);
+
+		Predicate predicate;
+
+		try (SafeCloseable safeCloseable =
+				GroupThreadLocal.setGroupIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			predicate =
+				new ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl(
+					objectDefinition, objectFieldLocalService
+				).getPredicate(
+					objectRelationship,
+					ObjectEntryTable.INSTANCE.externalReferenceCode.eq(
+						RandomTestUtil.randomString()),
+					relatedObjectDefinition
+				);
+		}
+
+		_assertPredicateSqlContainsIndexFilters(predicate.toString());
+	}
+
+	private static final String _PK_OBJECT_FIELD_DB_COLUMN_NAME =
+		"objectEntryId";
+
+	private static final String _PK_OBJECT_FIELD_NAME = "c_objectEntryId";
+
+	private static final String _RELATIONSHIP_COLUMN_NAME =
+		"r_testRelationship_c_objectEntryId";
+
+	private static final String _RELATIONSHIP_NAME = "testRelationship";
+
+}


### PR DESCRIPTION
**Problem**

  ERC-based relationship filters — used when querying object entries via REST API with expressions like r_relationshipName_c_parentERC eq 'value' — produce
  full table scans on the ObjectEntry table instead of using the composite B-tree index IX_11E61545.

  **Impact**

  Any ERC filter on a relationship field becomes O(n) on the total number of object entries in the database, causing severe query performance degradation at
  scale.

  **Cause**

  The 1:M and M:M relationship predicate providers built their ObjectEntry subquery filtering only by externalReferenceCode, omitting objectDefinitionId,
  companyId, and groupId — the three leading columns of IX_11E61545. Without all four columns present, the optimizer cannot navigate the index. The same gap
  existed in DefaultObjectEntryManagerImpl.getPrimaryKeys, which was also missing companyId.

  **Resolution**

  Added objectDefinitionId, companyId, and a scope-aware groupId filter to the ObjectEntry subqueries in both predicate providers. For groupId:
  company-scoped object definitions always use 0; site-scoped ones read from GroupThreadLocal, which DefaultObjectEntryManagerImpl now sets via
  setGroupIdWithSafeCloseable before building the filter predicate. Also added companyId to the top-level ObjectEntry predicate in
  DefaultObjectEntryManagerImpl.getPrimaryKeys.
