### PR TITLE
LPD-89588 Reduce externalReferenceCode column length to varchar(500)

### DIFF
--- a/modules/apps/changeset/changeset-service/bnd.bnd
+++ b/modules/apps/changeset/changeset-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Changeset Service
 Bundle-SymbolicName: com.liferay.changeset.service
 Bundle-Version: 4.0.38
-Liferay-Require-SchemaVersion: 2.1.0
+Liferay-Require-SchemaVersion: 2.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
@@ -34,6 +34,11 @@ public class ChangesetServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.addColumns(
 				"ChangesetEntry",
 				"classExternalReferenceCode VARCHAR(1000) null"));
+
+		registry.register(
+			"2.1.0", "2.2.0",
+			new com.liferay.changeset.internal.upgrade.v2_2_0.
+				ChangesetEntryClassExternalReferenceCodeUpgradeProcess());
 	}
 
 }

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v2_2_0/ChangesetEntryClassExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v2_2_0/ChangesetEntryClassExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.changeset.internal.upgrade.v2_2_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Roselaine Marques
+ */
+public class ChangesetEntryClassExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DBType dbType = DBManagerUtil.getDB(
+		).getDBType();
+
+		String lengthFunction = "CHAR_LENGTH";
+		String substringFunction = "SUBSTRING";
+
+		if (dbType == DBType.ORACLE) {
+			lengthFunction = "LENGTH";
+			substringFunction = "SUBSTR";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			lengthFunction = "LEN";
+		}
+
+		String collisionCheckSQL = StringBundler.concat(
+			"select 1 from ChangesetEntry where ", lengthFunction,
+			"(classExternalReferenceCode) > 500 group by ",
+			"changesetCollectionId, classNameId, ", substringFunction,
+			"(classExternalReferenceCode, 1, 500) having count(*) > 1");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				collisionCheckSQL);
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				throw new UpgradeException(
+					"Unable to truncate classExternalReferenceCode in " +
+						"ChangesetEntry: truncation would produce duplicate " +
+							"unique index entries.");
+			}
+		}
+
+		runSQL(
+			StringBundler.concat(
+				"update ChangesetEntry set classExternalReferenceCode = ",
+				substringFunction,
+				"(classExternalReferenceCode, 1, 500) where ", lengthFunction,
+				"(classExternalReferenceCode) > 500"));
+
+		List<IndexMetadata> indexMetadatas = dropIndexes(
+			"ChangesetEntry", "classExternalReferenceCode");
+
+		alterColumnType(
+			"ChangesetEntry", "classExternalReferenceCode",
+			"VARCHAR(500) null");
+
+		addIndexes(connection, indexMetadatas);
+	}
+
+}

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/model/impl/ChangesetEntryModelImpl.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/model/impl/ChangesetEntryModelImpl.java
@@ -89,7 +89,7 @@ public class ChangesetEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ChangesetEntry (changesetEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,changesetCollectionId LONG,classExternalReferenceCode VARCHAR(1000) null,classNameId LONG,classPK LONG)";
+		"create table ChangesetEntry (changesetEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,changesetCollectionId LONG,classExternalReferenceCode VARCHAR(500) null,classNameId LONG,classPK LONG)";
 
 	public static final String TABLE_SQL_DROP = "drop table ChangesetEntry";
 
@@ -998,4 +998,4 @@ public class ChangesetEntryModelImpl
 	private ChangesetEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1408157551
+// LIFERAY-SERVICE-BUILDER-HASH:28292003

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -22,7 +22,7 @@
 		<field name="modifiedDate" type="Date" />
 		<field name="changesetCollectionId" type="long" />
 		<field name="classExternalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="classNameId" type="long" />
 		<field name="classPK" type="long" />

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/indexes.sql
@@ -2,7 +2,7 @@ create index IX_9AC55E11 on ChangesetCollection (companyId, name[$COLUMN_LENGTH:
 create unique index IX_ABEEE793 on ChangesetCollection (groupId, name[$COLUMN_LENGTH:75$]);
 create index IX_EE4B4B0E on ChangesetCollection (groupId, userId);
 
-create unique index IX_71B99FC2 on ChangesetEntry (changesetCollectionId, classNameId, classExternalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_71B99FC2 on ChangesetEntry (changesetCollectionId, classNameId, classExternalReferenceCode[$COLUMN_LENGTH:500$]);
 create unique index IX_EF48912A on ChangesetEntry (changesetCollectionId, classNameId, classPK);
 create index IX_A9985762 on ChangesetEntry (classNameId, groupId);
 create index IX_CEB6AFA2 on ChangesetEntry (companyId);

--- a/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/changeset/changeset-service/src/main/resources/META-INF/sql/tables.sql
@@ -19,7 +19,7 @@ create table ChangesetEntry (
 	createDate DATE null,
 	modifiedDate DATE null,
 	changesetCollectionId LONG,
-	classExternalReferenceCode VARCHAR(1000) null,
+	classExternalReferenceCode VARCHAR(500) null,
 	classNameId LONG,
 	classPK LONG
 );

--- a/modules/apps/changeset/changeset-service/src/main/resources/service.properties
+++ b/modules/apps/changeset/changeset-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.changeset.service
-    build.number=2
-    build.date=1771891431368
+    build.number=3
+    build.date=1779972556861

--- a/modules/apps/changeset/changeset-test/build.gradle
+++ b/modules/apps/changeset/changeset-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:changeset:changeset-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest.java
@@ -57,18 +57,16 @@ public class ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest {
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into ChangesetEntry (changesetEntryId, ",
-				"classExternalReferenceCode) values (",
-				changesetEntryId1, ", '",
-				_OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+				"classExternalReferenceCode) values (", changesetEntryId1,
+				", '", _OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
 
 		long changesetEntryId2 = RandomTestUtil.nextLong();
 
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into ChangesetEntry (changesetEntryId, ",
-				"classExternalReferenceCode) values (",
-				changesetEntryId2, ", '",
-				_MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+				"classExternalReferenceCode) values (", changesetEntryId2,
+				", '", _MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
 
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator, _CLASS_NAME);
@@ -88,10 +86,11 @@ public class ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest {
 			}
 
 			try (Connection connection = DataAccess.getConnection();
-				 PreparedStatement preparedStatement =
-					 connection.prepareStatement(
-						 "select classExternalReferenceCode from ChangesetEntry " +
-							 "where changesetEntryId = ?")) {
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select classExternalReferenceCode from " +
+							"ChangesetEntry where changesetEntryId = ?")) {
 
 				preparedStatement.setLong(1, changesetEntryId1);
 
@@ -116,8 +115,7 @@ public class ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest {
 			_db.runSQL(
 				StringBundler.concat(
 					"delete from ChangesetEntry where changesetEntryId in (",
-					changesetEntryId1, ", ", changesetEntryId2,
-					")"));
+					changesetEntryId1, ", ", changesetEntryId2, ")"));
 		}
 	}
 
@@ -128,8 +126,8 @@ public class ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest {
 	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
 		"a".repeat(500);
 
-	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
-		"a".repeat(501);
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE = "a".repeat(
+		501);
 
 	private static DB _db;
 

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v2_2_0/test/ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.changeset.internal.upgrade.v2_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class ChangesetEntryClassExternalReferenceCodeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_db = DBManagerUtil.getDB();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_db.runSQLTemplate(
+			"alter_column_type ChangesetEntry classExternalReferenceCode " +
+				"VARCHAR(1000) null",
+			true);
+
+		long changesetEntryId1 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ChangesetEntry (changesetEntryId, ",
+				"classExternalReferenceCode) values (",
+				changesetEntryId1, ", '",
+				_OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+
+		long changesetEntryId2 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ChangesetEntry (changesetEntryId, ",
+				"classExternalReferenceCode) values (",
+				changesetEntryId2, ", '",
+				_MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		try {
+			upgradeProcess.upgrade();
+
+			try (Connection connection = DataAccess.getConnection()) {
+				DBInspector dbInspector = new DBInspector(connection);
+
+				Assert.assertTrue(
+					dbInspector.hasColumnType(
+						"ChangesetEntry", "classExternalReferenceCode",
+						"VARCHAR(500) null"));
+				Assert.assertTrue(
+					dbInspector.hasIndex("ChangesetEntry", "IX_71B99FC2"));
+			}
+
+			try (Connection connection = DataAccess.getConnection();
+				 PreparedStatement preparedStatement =
+					 connection.prepareStatement(
+						 "select classExternalReferenceCode from ChangesetEntry " +
+							 "where changesetEntryId = ?")) {
+
+				preparedStatement.setLong(1, changesetEntryId1);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("classExternalReferenceCode"));
+				}
+
+				preparedStatement.setLong(1, changesetEntryId2);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("classExternalReferenceCode"));
+				}
+			}
+		}
+		finally {
+			_db.runSQL(
+				StringBundler.concat(
+					"delete from ChangesetEntry where changesetEntryId in (",
+					changesetEntryId1, ", ", changesetEntryId2,
+					")"));
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.changeset.internal.upgrade.v2_2_0." +
+			"ChangesetEntryClassExternalReferenceCodeUpgradeProcess";
+
+	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(500);
+
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(501);
+
+	private static DB _db;
+
+	@Inject(
+		filter = "component.name=com.liferay.changeset.internal.upgrade.registry.ChangesetServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.110
-Liferay-Require-SchemaVersion: 4.2.8
+Liferay-Require-SchemaVersion: 4.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -149,6 +149,11 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			"4.2.7", "4.2.8",
 			UpgradeProcessFactory.addColumns(
 				"OAuth2Authorization", "audiences TEXT null"));
+
+		registry.register(
+			"4.2.8", "4.3.0",
+			new com.liferay.oauth2.provider.internal.upgrade.v4_3_0.
+				OAuth2ApplicationExternalReferenceCodeUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ApplicationExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ApplicationExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_3_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Roselaine Marques
+ */
+public class OAuth2ApplicationExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DBType dbType = DBManagerUtil.getDB(
+		).getDBType();
+
+		String lengthFunction = "CHAR_LENGTH";
+		String substringFunction = "SUBSTRING";
+
+		if (dbType == DBType.ORACLE) {
+			lengthFunction = "LENGTH";
+			substringFunction = "SUBSTR";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			lengthFunction = "LEN";
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select 1 from OAuth2Application where ", lengthFunction,
+					"(externalReferenceCode) > 500 group by companyId, ",
+					substringFunction,
+					"(externalReferenceCode, 1, 500) having count(*) > 1"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				throw new UpgradeException(
+					"Unable to truncate externalReferenceCode in " +
+						"OAuth2Application: truncation would produce " +
+							"duplicate unique index entries.");
+			}
+		}
+
+		runSQL(
+			StringBundler.concat(
+				"update OAuth2Application set externalReferenceCode = ",
+				substringFunction, "(externalReferenceCode, 1, 500) where ",
+				lengthFunction, "(externalReferenceCode) > 500"));
+
+		List<IndexMetadata> indexMetadatas = dropIndexes(
+			"OAuth2Application", "externalReferenceCode");
+
+		alterColumnType(
+			"OAuth2Application", "externalReferenceCode", "VARCHAR(500) null");
+
+		addIndexes(connection, indexMetadatas);
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -115,7 +115,7 @@ public class OAuth2ApplicationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
+		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
 
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 
@@ -1678,4 +1678,4 @@ public class OAuth2ApplicationModelImpl
 	private OAuth2Application _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:308768319
+// LIFERAY-SERVICE-BUILDER-HASH:-123573437

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -4,7 +4,7 @@
 	<model name="com.liferay.oauth2.provider.model.OAuth2Application">
 		<field name="uuid" type="String" />
 		<field name="externalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="oAuth2ApplicationId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/indexes.sql
@@ -3,7 +3,7 @@ create index IX_2F541817 on OA2Auths_OA2ScopeGrants (oAuth2ScopeGrantId);
 
 create index IX_523E5C67 on OAuth2Application (companyId, clientId[$COLUMN_LENGTH:75$]);
 create index IX_949C9C01 on OAuth2Application (companyId, clientProfile);
-create unique index IX_67BC29B0 on OAuth2Application (companyId, externalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_67BC29B0 on OAuth2Application (companyId, externalReferenceCode[$COLUMN_LENGTH:500$]);
 create index IX_361558F9 on OAuth2Application (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_282ECE83 on OAuth2ApplicationScopeAliases (companyId);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -7,7 +7,7 @@ create table OA2Auths_OA2ScopeGrants (
 
 create table OAuth2Application (
 	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(1000) null,
+	externalReferenceCode VARCHAR(500) null,
 	oAuth2ApplicationId LONG not null primary key,
 	companyId LONG,
 	userId LONG,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=3
-    build.date=1778151133558
+    build.number=4
+    build.date=1780331622524

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -24,8 +24,8 @@ dependencies {
 	testIntegrationImplementation group: "org.mockito", name: "mockito-core", version: "1.10.8"
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
-	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	testIntegrationImplementation group: "org.mockito", name: "mockito-core", version: "1.10.8"
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_3_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_db = DBManagerUtil.getDB();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_db.runSQLTemplate(
+			"alter_column_type OAuth2Application externalReferenceCode " +
+				"VARCHAR(1000) null",
+			true);
+
+		long oAuth2ApplicationId1 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into OAuth2Application (oAuth2ApplicationId, ",
+				"externalReferenceCode) values (", oAuth2ApplicationId1,
+				", '", _OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+
+		long oAuth2ApplicationId2 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into OAuth2Application (oAuth2ApplicationId, ",
+				"externalReferenceCode) values (", oAuth2ApplicationId2,
+				", '", _MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		try {
+			upgradeProcess.upgrade();
+
+			try (Connection connection = DataAccess.getConnection()) {
+				DBInspector dbInspector = new DBInspector(connection);
+
+				Assert.assertTrue(
+					dbInspector.hasColumnType(
+						"OAuth2Application", "externalReferenceCode",
+						"VARCHAR(500) null"));
+				Assert.assertTrue(
+					dbInspector.hasIndex("OAuth2Application", "IX_67BC29B0"));
+			}
+
+			try (Connection connection = DataAccess.getConnection();
+				 PreparedStatement preparedStatement =
+					 connection.prepareStatement(
+						 "select externalReferenceCode from OAuth2Application " +
+							 "where oAuth2ApplicationId = ?")) {
+
+				preparedStatement.setLong(1, oAuth2ApplicationId1);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("externalReferenceCode"));
+				}
+
+				preparedStatement.setLong(1, oAuth2ApplicationId2);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("externalReferenceCode"));
+				}
+			}
+		}
+		finally {
+			_db.runSQL(
+				StringBundler.concat(
+					"delete from OAuth2Application where oAuth2ApplicationId ",
+					"in (", oAuth2ApplicationId1, ", ",
+					oAuth2ApplicationId2, ")"));
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.oauth2.provider.internal.upgrade.v4_3_0." +
+			"OAuth2ApplicationExternalReferenceCodeUpgradeProcess";
+
+	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(500);
+
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(501);
+
+	private static DB _db;
+
+	@Inject(
+		filter = "component.name=com.liferay.oauth2.provider.internal.upgrade.registry.OAuth2ServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/test/OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest.java
@@ -57,16 +57,16 @@ public class OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest {
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into OAuth2Application (oAuth2ApplicationId, ",
-				"externalReferenceCode) values (", oAuth2ApplicationId1,
-				", '", _OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+				"externalReferenceCode) values (", oAuth2ApplicationId1, ", '",
+				_OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
 
 		long oAuth2ApplicationId2 = RandomTestUtil.nextLong();
 
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into OAuth2Application (oAuth2ApplicationId, ",
-				"externalReferenceCode) values (", oAuth2ApplicationId2,
-				", '", _MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+				"externalReferenceCode) values (", oAuth2ApplicationId2, ", '",
+				_MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
 
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator, _CLASS_NAME);
@@ -86,10 +86,11 @@ public class OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest {
 			}
 
 			try (Connection connection = DataAccess.getConnection();
-				 PreparedStatement preparedStatement =
-					 connection.prepareStatement(
-						 "select externalReferenceCode from OAuth2Application " +
-							 "where oAuth2ApplicationId = ?")) {
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select externalReferenceCode from OAuth2Application " +
+							"where oAuth2ApplicationId = ?")) {
 
 				preparedStatement.setLong(1, oAuth2ApplicationId1);
 
@@ -114,8 +115,8 @@ public class OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest {
 			_db.runSQL(
 				StringBundler.concat(
 					"delete from OAuth2Application where oAuth2ApplicationId ",
-					"in (", oAuth2ApplicationId1, ", ",
-					oAuth2ApplicationId2, ")"));
+					"in (", oAuth2ApplicationId1, ", ", oAuth2ApplicationId2,
+					")"));
 		}
 	}
 
@@ -126,8 +127,8 @@ public class OAuth2ApplicationExternalReferenceCodeUpgradeProcessTest {
 	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
 		"a".repeat(500);
 
-	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
-		"a".repeat(501);
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE = "a".repeat(
+		501);
 
 	private static DB _db;
 

--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.245
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 12.1.0
+Liferay-Require-SchemaVersion: 12.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -708,6 +708,11 @@ public class ObjectServiceUpgradeStepRegistrator
 			"12.0.0", "12.1.0",
 			new com.liferay.object.internal.upgrade.v12_1_0.
 				ObjectDefinitionSettingUpgradeProcess());
+
+		registry.register(
+			"12.1.0", "12.2.0",
+			new com.liferay.object.internal.upgrade.v12_2_0.
+				ObjectEntryExternalReferenceCodeUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_2_0/ObjectEntryExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_2_0/ObjectEntryExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v12_2_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Roselaine Marques
+ */
+public class ObjectEntryExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DBType dbType = DBManagerUtil.getDB(
+		).getDBType();
+
+		String lengthFunction = "CHAR_LENGTH";
+		String substringFunction = "SUBSTRING";
+
+		if (dbType == DBType.ORACLE) {
+			lengthFunction = "LENGTH";
+			substringFunction = "SUBSTR";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			lengthFunction = "LEN";
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select 1 from ObjectEntry where ", lengthFunction,
+					"(externalReferenceCode) > 500 group by ",
+					"objectDefinitionId, groupId, companyId, ",
+					substringFunction,
+					"(externalReferenceCode, 1, 500) having count(*) > 1"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				throw new UpgradeException(
+					"Unable to truncate externalReferenceCode in " +
+						"ObjectEntry: truncation would produce duplicate " +
+							"unique index entries.");
+			}
+		}
+
+		runSQL(
+			StringBundler.concat(
+				"update ObjectEntry set externalReferenceCode = ",
+				substringFunction, "(externalReferenceCode, 1, 500) where ",
+				lengthFunction, "(externalReferenceCode) > 500"));
+
+		List<IndexMetadata> indexMetadatas = dropIndexes(
+			"ObjectEntry", "externalReferenceCode");
+
+		alterColumnType(
+			"ObjectEntry", "externalReferenceCode", "VARCHAR(500) null");
+
+		addIndexes(connection, indexMetadatas);
+	}
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryModelImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryModelImpl.java
@@ -114,7 +114,7 @@ public class ObjectEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table ObjectEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,objectEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,headObjectEntryId LONG,objectDefinitionId LONG,objectEntryFolderId LONG,rootObjectEntryId LONG,defaultLanguageId VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,treePath STRING null,version INTEGER,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+		"create table ObjectEntry (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,objectEntryId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,headObjectEntryId LONG,objectDefinitionId LONG,objectEntryFolderId LONG,rootObjectEntryId LONG,defaultLanguageId VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,treePath STRING null,version INTEGER,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 
 	public static final String TABLE_SQL_DROP = "drop table ObjectEntry";
 
@@ -1696,4 +1696,4 @@ public class ObjectEntryModelImpl
 	private ObjectEntry _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:671948158
+// LIFERAY-SERVICE-BUILDER-HASH:-1138446778

--- a/modules/apps/object/object-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -103,7 +103,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
 		<field name="externalReferenceCode" type="String">
-			<hint name="max-length">1000</hint>
+			<hint name="max-length">500</hint>
 		</field>
 		<field name="objectEntryId" type="long" />
 		<field name="groupId" type="long" />

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/indexes.sql
@@ -28,7 +28,7 @@ create index IX_46A48D35 on ObjectEntry (groupId, companyId, objectEntryFolderId
 create index IX_4F10AA1B on ObjectEntry (groupId, objectEntryFolderId);
 create unique index IX_28B2B723 on ObjectEntry (groupId, uuid_[$COLUMN_LENGTH:75$]);
 create index IX_FBF73125 on ObjectEntry (headObjectEntryId);
-create unique index IX_11E61545 on ObjectEntry (objectDefinitionId, groupId, companyId, externalReferenceCode[$COLUMN_LENGTH:1000$]);
+create unique index IX_11E61545 on ObjectEntry (objectDefinitionId, groupId, companyId, externalReferenceCode[$COLUMN_LENGTH:500$]);
 create index IX_622DB416 on ObjectEntry (objectDefinitionId, groupId, status);
 create index IX_A388E5A0 on ObjectEntry (objectDefinitionId, status);
 create index IX_68B7FB2 on ObjectEntry (objectDefinitionId, userId, createDate);

--- a/modules/apps/object/object-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/object/object-service/src/main/resources/META-INF/sql/tables.sql
@@ -84,7 +84,7 @@ create table ObjectDefinitionSetting (
 create table ObjectEntry (
 	mvccVersion LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(1000) null,
+	externalReferenceCode VARCHAR(500) null,
 	objectEntryId LONG not null primary key,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/object/object-service/src/main/resources/service.properties
+++ b/modules/apps/object/object-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.object.service
-    build.number=14
-    build.date=1772637766496
+    build.number=15
+    build.date=1779972841986

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v12_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryExternalReferenceCodeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		_db = DBManagerUtil.getDB();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_db.runSQLTemplate(
+			"alter_column_type ObjectEntry externalReferenceCode " +
+				"VARCHAR(1000) null",
+			true);
+
+		long objectEntryId1 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ObjectEntry (mvccVersion, objectEntryId, ",
+				"externalReferenceCode) values (0, ", objectEntryId1,
+				", '", _OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+
+		long objectEntryId2 = RandomTestUtil.nextLong();
+
+		_db.runSQL(
+			StringBundler.concat(
+				"insert into ObjectEntry (mvccVersion, objectEntryId, ",
+				"externalReferenceCode) values (0, ", objectEntryId2,
+				", '", _MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		try {
+			upgradeProcess.upgrade();
+
+			try (Connection connection = DataAccess.getConnection()) {
+				DBInspector dbInspector = new DBInspector(connection);
+
+				Assert.assertTrue(
+					dbInspector.hasColumnType(
+						"ObjectEntry", "externalReferenceCode",
+						"VARCHAR(500) null"));
+				Assert.assertTrue(
+					dbInspector.hasIndex("ObjectEntry", "IX_11E61545"));
+			}
+
+			try (Connection connection = DataAccess.getConnection();
+				 PreparedStatement preparedStatement =
+					 connection.prepareStatement(
+						 "select externalReferenceCode from ObjectEntry " +
+							 "where objectEntryId = ?")) {
+
+				preparedStatement.setLong(1, objectEntryId1);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("externalReferenceCode"));
+				}
+
+				preparedStatement.setLong(1, objectEntryId2);
+
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					Assert.assertTrue(resultSet.next());
+					Assert.assertEquals(
+						_MAX_LENGTH_EXTERNAL_REFERENCE_CODE,
+						resultSet.getString("externalReferenceCode"));
+				}
+			}
+		}
+		finally {
+			_db.runSQL(
+				StringBundler.concat(
+					"delete from ObjectEntry where objectEntryId in (",
+					objectEntryId1, ", ", objectEntryId2,
+					")"));
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.internal.upgrade.v12_2_0." +
+			"ObjectEntryExternalReferenceCodeUpgradeProcess";
+
+	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(500);
+
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
+		"a".repeat(501);
+
+	private static DB _db;
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v12_2_0/test/ObjectEntryExternalReferenceCodeUpgradeProcessTest.java
@@ -57,16 +57,16 @@ public class ObjectEntryExternalReferenceCodeUpgradeProcessTest {
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into ObjectEntry (mvccVersion, objectEntryId, ",
-				"externalReferenceCode) values (0, ", objectEntryId1,
-				", '", _OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
+				"externalReferenceCode) values (0, ", objectEntryId1, ", '",
+				_OVERSIZED_EXTERNAL_REFERENCE_CODE, "')"));
 
 		long objectEntryId2 = RandomTestUtil.nextLong();
 
 		_db.runSQL(
 			StringBundler.concat(
 				"insert into ObjectEntry (mvccVersion, objectEntryId, ",
-				"externalReferenceCode) values (0, ", objectEntryId2,
-				", '", _MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
+				"externalReferenceCode) values (0, ", objectEntryId2, ", '",
+				_MAX_LENGTH_EXTERNAL_REFERENCE_CODE, "')"));
 
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator, _CLASS_NAME);
@@ -86,10 +86,11 @@ public class ObjectEntryExternalReferenceCodeUpgradeProcessTest {
 			}
 
 			try (Connection connection = DataAccess.getConnection();
-				 PreparedStatement preparedStatement =
-					 connection.prepareStatement(
-						 "select externalReferenceCode from ObjectEntry " +
-							 "where objectEntryId = ?")) {
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"select externalReferenceCode from ObjectEntry where " +
+							"objectEntryId = ?")) {
 
 				preparedStatement.setLong(1, objectEntryId1);
 
@@ -114,8 +115,7 @@ public class ObjectEntryExternalReferenceCodeUpgradeProcessTest {
 			_db.runSQL(
 				StringBundler.concat(
 					"delete from ObjectEntry where objectEntryId in (",
-					objectEntryId1, ", ", objectEntryId2,
-					")"));
+					objectEntryId1, ", ", objectEntryId2, ")"));
 		}
 	}
 
@@ -126,8 +126,8 @@ public class ObjectEntryExternalReferenceCodeUpgradeProcessTest {
 	private static final String _MAX_LENGTH_EXTERNAL_REFERENCE_CODE =
 		"a".repeat(500);
 
-	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE =
-		"a".repeat(501);
+	private static final String _OVERSIZED_EXTERNAL_REFERENCE_CODE = "a".repeat(
+		501);
 
 	private static DB _db;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89588

## What is being fixed

SQL Server enforces a 1,700-byte limit on nonclustered index key length (warning 1945). The unique indexes on `externalReferenceCode` in `ChangesetEntry`, `OAuth2Application`, and `ObjectEntry` were defined as VARCHAR(1000), which maps to NVARCHAR(1000) = 2,000 bytes on SQL Server. Combined with the BIGINT columns in the same index, the total exceeded the limit.

## How it is being fixed

The `externalReferenceCode` column is narrowed from VARCHAR(1000) to VARCHAR(500) across all three affected tables. Each module registers an upgrade process that truncates any existing values longer than 500 characters, drops the oversized unique index, alters the column type to VARCHAR(500), and recreates the index at the correct width. The `indexes.sql` and `portlet-model-hints.xml` files are updated to keep future Service Builder regenerations in sync.