### PR TITLE
LPD-92351 Move ColumnsDiplayCorrectInfo from Poshi to Playwright

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/tests/WorkflowMetricsAllItemsList.testcase
@@ -602,33 +602,6 @@ definition {
 		AssertElementPresent(locator1 = "WorkflowAllItems#DETAIL_PAGE_TITLE");
 	}
 
-	@description = "LPS-86652 - Verify that every column displays the correct info for a item"
-	@priority = 5
-	test ColumnsDiplayCorrectInfo {
-		Workflow.openWorkflowListView();
-
-		Navigator.gotoNavItem(navItem = "Configuration");
-
-		Workflow.configureWorkflow(
-			workflowDefinition = "Single Approver",
-			workflowResourceValue = "Blogs Entry");
-
-		JSONBlog.addEntry(
-			entryContent = "Blogs Content",
-			entryTitle = "Blogs Title 1");
-
-		WorkflowMetrics.goToWorkflowProcessMetrics(workflowProcessName = "Single Approver");
-
-		Click(locator1 = "WorkflowMetrics#DASHBOARD_TOTAL_PENDING_ITEMS_TITLE");
-
-		Workflow.assertInfoItem(
-			key_assignee = "Unassigned",
-			key_createdBy = "Test Test",
-			key_dueDate = "-",
-			key_itemSubject = "Blogs Entry: Blogs Title 1",
-			key_processStep = "Review");
-	}
-
 	@description = "LPS-130218 - Verify that once the order/sorting is made by the user, this definition should be preserved when the user change pagination number"
 	@priority = 3
 	test CreatedBySortIsPreservedWhenChangesPagination {

--- a/modules/test/playwright/tests/portal-workflow-metrics-web/main/metrics.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-metrics-web/main/metrics.spec.ts
@@ -343,3 +343,46 @@ test('Can search assignees and steps in Performance by Assignee and Step views',
 		).toBeVisible();
 	});
 });
+
+test('Columns on the All Items page display correct info for a pending instance', async ({
+	apiHelpers,
+	metricsPage,
+	page,
+	site,
+	workflowPage,
+}) => {
+	await workflowPage.goto(site.friendlyUrlPath);
+
+	await workflowPage.changeWorkflow('Blogs Entry', 'Single Approver');
+
+	const blogTitle = getRandomString();
+
+	await apiHelpers.headlessDelivery.postBlog(site.id, {
+		articleBody: 'Blogs Content',
+		headline: blogTitle,
+	});
+
+	await metricsPage.goTo(site.friendlyUrlPath);
+
+	await metricsPage.chooseProcess('Single Approver');
+
+	await metricsPage.viewAllPendingItems();
+
+	const row = page
+		.getByRole('row')
+		.filter({hasText: `Blogs Entry: ${blogTitle}`});
+
+	await expect(
+		row.getByRole('cell', {exact: true, name: 'Review'})
+	).toBeVisible();
+
+	await expect(
+		row.getByRole('cell', {exact: true, name: 'Unassigned'})
+	).toBeVisible();
+
+	await expect(
+		row.getByRole('cell', {exact: true, name: 'Test Test'})
+	).toBeVisible();
+
+	await expect(row.getByRole('cell', {exact: true, name: '-'})).toBeVisible();
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92351

## What Is Being Fixed

The ColumnsDiplayCorrectInfo test in WorkflowMetricsAllItemsList.testcase has been flaky in Poshi. It verifies that the All Items workflow metrics page shows the correct columns for a pending instance.

## How It Is Being Fixed

Ported the test to Playwright. The new spec assigns Single Approver to Blogs Entry on an isolated site, posts a blog via the headless-delivery REST API, opens the All Items table from Total Pending, and asserts the Item Subject, Process Step, Assignee, Created By, and Due Date cells. The original Poshi test is removed.