### PR TITLE
LPD-91697 Fix IDOR in workflow task assignment across virtual instances

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImpl.java
@@ -124,6 +124,13 @@ public class WorkflowTaskManagerImpl implements WorkflowTaskManager {
 				ActionKeys.VIEW);
 		}
 
+		User user = _userLocalService.fetchUser(assigneeUserId);
+
+		if ((user == null) || (user.getCompanyId() != companyId)) {
+			throw new PrincipalException.MustHavePermission(
+				userId, User.class.getName(), assigneeUserId, ActionKeys.VIEW);
+		}
+
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setCompanyId(companyId);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermission.java
@@ -65,6 +65,12 @@ public class KaleoTaskModelResourcePermission
 			KaleoTaskInstanceToken kaleoTaskInstanceToken, String actionId)
 		throws PortalException {
 
+		if (kaleoTaskInstanceToken.getCompanyId() !=
+				permissionChecker.getCompanyId()) {
+
+			return false;
+		}
+
 		WorkflowTask workflowTask = _kaleoWorkflowModelConverter.toWorkflowTask(
 			kaleoTaskInstanceToken,
 			WorkflowContextUtil.convert(

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowTaskManagerImplTest.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.runtime.TaskManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class WorkflowTaskManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_userLocalService = Mockito.mock(UserLocalService.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskManagerImpl, "_userLocalService", _userLocalService);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getUserId()
+		).thenReturn(
+			_USER_ID
+		);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+	}
+
+	@After
+	public void tearDown() {
+		PermissionThreadLocal.setPermissionChecker(null);
+	}
+
+	@Test
+	public void testAssignWorkflowTaskToUser() throws Exception {
+
+		// User from a different company
+
+		long assigneeUserId1 = RandomTestUtil.randomLong();
+
+		User assigneeUser1 = Mockito.mock(User.class);
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId1)
+		).thenReturn(
+			assigneeUser1
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			assigneeUser1.getCompanyId()
+		).thenReturn(
+			companyId + 1
+		);
+
+		try {
+			_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+				companyId, _USER_ID, RandomTestUtil.randomLong(),
+				assigneeUserId1, RandomTestUtil.randomString(), null, null);
+
+			Assert.fail();
+		}
+		catch (PrincipalException.MustHavePermission principalException) {
+			Assert.assertEquals(
+				User.class.getName(), principalException.resourceName);
+			Assert.assertEquals(assigneeUserId1, principalException.resourceId);
+		}
+
+		// User from the same company
+
+		ReflectionTestUtil.setFieldValue(
+			_workflowTaskManagerImpl, "_taskManager",
+			Mockito.mock(TaskManager.class));
+
+		long assigneeUserId2 = RandomTestUtil.randomLong();
+
+		User assigneeUser2 = Mockito.mock(User.class);
+
+		Mockito.when(
+			_userLocalService.fetchUser(assigneeUserId2)
+		).thenReturn(
+			assigneeUser2
+		);
+
+		Mockito.when(
+			assigneeUser2.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		_workflowTaskManagerImpl.assignWorkflowTaskToUser(
+			companyId, _USER_ID, RandomTestUtil.randomLong(), assigneeUserId2,
+			RandomTestUtil.randomString(), null, null);
+	}
+
+	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private UserLocalService _userLocalService;
+	private final WorkflowTaskManagerImpl _workflowTaskManagerImpl =
+		new WorkflowTaskManagerImpl();
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/KaleoTaskModelResourcePermissionTest.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.runtime.integration.internal.security.permission.resource;
+
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.workflow.kaleo.KaleoWorkflowModelConverter;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+import com.liferay.portal.workflow.security.permission.WorkflowTaskPermission;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Roselaine Marques
+ */
+public class KaleoTaskModelResourcePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testContains() throws Exception {
+
+		// Kaleo task instance token from a different company
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken1 = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			kaleoTaskInstanceToken1.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		PermissionChecker permissionChecker1 = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker1.getCompanyId()
+		).thenReturn(
+			companyId + 1
+		);
+
+		Assert.assertFalse(
+			_kaleoTaskModelResourcePermission.contains(
+				permissionChecker1, kaleoTaskInstanceToken1,
+				RandomTestUtil.randomString()));
+
+		// Kaleo task instance token from the same company
+
+		KaleoTaskInstanceToken kaleoTaskInstanceToken2 = Mockito.mock(
+			KaleoTaskInstanceToken.class);
+
+		Mockito.when(
+			kaleoTaskInstanceToken2.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		KaleoWorkflowModelConverter kaleoWorkflowModelConverter = Mockito.mock(
+			KaleoWorkflowModelConverter.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_kaleoTaskModelResourcePermission, "_kaleoWorkflowModelConverter",
+			kaleoWorkflowModelConverter);
+
+		WorkflowTask workflowTask = Mockito.mock(WorkflowTask.class);
+
+		Mockito.when(
+			kaleoWorkflowModelConverter.toWorkflowTask(
+				Mockito.eq(kaleoTaskInstanceToken2), Mockito.any())
+		).thenReturn(
+			workflowTask
+		);
+
+		WorkflowTaskPermission workflowTaskPermission = Mockito.mock(
+			WorkflowTaskPermission.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_kaleoTaskModelResourcePermission, "_workflowTaskPermission",
+			workflowTaskPermission);
+
+		Mockito.when(
+			workflowTaskPermission.contains(
+				Mockito.any(), Mockito.eq(workflowTask), Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		PermissionChecker permissionChecker2 = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker2.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Assert.assertTrue(
+			_kaleoTaskModelResourcePermission.contains(
+				permissionChecker2, kaleoTaskInstanceToken2,
+				RandomTestUtil.randomString()));
+	}
+
+	private final KaleoTaskModelResourcePermission
+		_kaleoTaskModelResourcePermission =
+			new KaleoTaskModelResourcePermission();
+
+}


### PR DESCRIPTION
Resent: https://github.com/brianchandotcom/liferay-portal/pull/175543

https://liferay.atlassian.net/browse/LPD-91697

## What Is Being Fixed

A cross-virtual-instance IDOR in workflow task assignment. Two specific vectors:

1. `KaleoTaskModelResourcePermission.contains` returned `true` for tasks belonging to a company other than the permission checker's, so an attacker in instance A could permission-check tasks owned by instance B.

2. `WorkflowTaskManagerImpl.assignWorkflowTaskToUser` did not validate that the assignee user belonged to the same company as the requester, so a task could be assigned to a foreign-instance user.

## How It Is Being Fixed

`KaleoTaskModelResourcePermission.contains` short-circuits with `false` at the top of the model-based `contains` when the token's `companyId` differs from `permissionChecker.getCompanyId()`. Because the primary-key overload and `check(...)` route through this same method, the guard covers every entry point.

`WorkflowTaskManagerImpl.assignWorkflowTaskToUser` fetches the assignee via `_userLocalService.fetchUser` and throws `PrincipalException.MustHavePermission` (naming `User` as the missing-VIEW resource) when the user is null or belongs to a different `companyId`.

Unit tests in `KaleoTaskModelResourcePermissionTest` (one `testContains` method with two `//` sections covering same-company vs different-company tokens) and `WorkflowTaskManagerImplTest` (one `testAssignWorkflowTaskToUser` method, try/catch asserting the exception's `resourceName` and `resourceId` to pin the failure to the assignee check) cover both branches.
