### PR TITLE
LPD-90520 Move the REST Builder test application off the /test base

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -107,6 +107,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -120,6 +121,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Brian Wing Shun Chan
@@ -141,14 +143,20 @@ public class ObjectRelationshipLocalServiceTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_systemObjectDefinition1 = _addSystemObjectDefinition(
+		_unmodifiableSystemObjectDefinition1 =
+			_addUnmodifiableSystemObjectDefinition();
+
+		_serviceRegistration1 = _registerTestSystemObjectDefinitionManager(
+			_unmodifiableSystemObjectDefinition1,
 			"/o/test-endpoint/rel/{relId}/entries");
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
+		_serviceRegistration1.unregister();
+
 		_objectDefinitionLocalService.deleteObjectDefinition(
-			_systemObjectDefinition1);
+			_unmodifiableSystemObjectDefinition1);
 	}
 
 	@Before
@@ -159,8 +167,19 @@ public class ObjectRelationshipLocalServiceTest {
 			"A" + StringUtil.randomString(40));
 		_objectDefinition2 = _addAndPublishCustomObjectDefinition();
 		_objectDefinition3 = _addAndPublishCustomObjectDefinition();
-		_systemObjectDefinition2 = _addSystemObjectDefinition(
-			"/o/test-endpoint/entries");
+
+		_unmodifiableSystemObjectDefinition2 =
+			_addUnmodifiableSystemObjectDefinition();
+
+		_serviceRegistration2 = _registerTestSystemObjectDefinitionManager(
+			_unmodifiableSystemObjectDefinition2, "/o/test-endpoint/entries");
+	}
+
+	@After
+	public void tearDown() {
+		if (_serviceRegistration2 != null) {
+			_serviceRegistration2.unregister();
+		}
 	}
 
 	@Test
@@ -630,7 +649,7 @@ public class ObjectRelationshipLocalServiceTest {
 			"Invalid type " + ObjectRelationshipConstants.TYPE_ONE_TO_ONE,
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -655,7 +674,7 @@ public class ObjectRelationshipLocalServiceTest {
 					" does not allow a parameter object field ID",
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				RandomTestUtil.randomLong(),
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
@@ -667,8 +686,8 @@ public class ObjectRelationshipLocalServiceTest {
 			"Relationships are not allowed between system objects",
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
-				_systemObjectDefinition2.getObjectDefinitionId(), 0,
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition2.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(), false,
@@ -676,16 +695,16 @@ public class ObjectRelationshipLocalServiceTest {
 
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			_objectDefinition1, _systemObjectDefinition2, false);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, false);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			_objectDefinition1, _systemObjectDefinition2, true);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, true);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
-			_objectDefinition1, _systemObjectDefinition2, false);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, false);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
-			_objectDefinition1, _systemObjectDefinition2, true);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, true);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
 			_modifiableSystemObjectDefinition, _objectDefinition1, false);
@@ -694,33 +713,33 @@ public class ObjectRelationshipLocalServiceTest {
 			_modifiableSystemObjectDefinition, _objectDefinition1, true);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-			_objectDefinition1, _systemObjectDefinition2, false);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, false);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-			_objectDefinition1, _systemObjectDefinition2, true);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, true);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-			_systemObjectDefinition2, _objectDefinition1, false);
+			_unmodifiableSystemObjectDefinition2, _objectDefinition1, false);
 		_testAddObjectRelationshipManyToMany(
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT,
-			_systemObjectDefinition2, _objectDefinition1, true);
+			_unmodifiableSystemObjectDefinition2, _objectDefinition1, true);
 		_testAddObjectRelationshipOneToMany(
 			_modifiableSystemObjectDefinition, _objectDefinition1, false);
 		_testAddObjectRelationshipOneToMany(
 			_modifiableSystemObjectDefinition, _objectDefinition1, true);
 		_testAddObjectRelationshipOneToMany(
-			_objectDefinition1, _systemObjectDefinition2, false);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, false);
 		_testAddObjectRelationshipOneToMany(
-			_objectDefinition1, _systemObjectDefinition2, true);
+			_objectDefinition1, _unmodifiableSystemObjectDefinition2, true);
 		_testAddObjectRelationshipOneToMany(
-			_systemObjectDefinition2, _objectDefinition1, false);
+			_unmodifiableSystemObjectDefinition2, _objectDefinition1, false);
 		_testAddObjectRelationshipOneToMany(
-			_systemObjectDefinition2, _objectDefinition1, true);
+			_unmodifiableSystemObjectDefinition2, _objectDefinition1, true);
 
 		_testCreateManyToManyObjectRelationshipTable(
-			_systemObjectDefinition2, false);
+			_unmodifiableSystemObjectDefinition2, false);
 		_testCreateManyToManyObjectRelationshipTable(
-			_systemObjectDefinition2, true);
+			_unmodifiableSystemObjectDefinition2, true);
 
 		_testSystemObjectRelationshipOneToMany();
 	}
@@ -1288,41 +1307,42 @@ public class ObjectRelationshipLocalServiceTest {
 			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
-	private static ObjectDefinition _addSystemObjectDefinition(
-			String restContextPath)
+	private static ObjectDefinition _addUnmodifiableSystemObjectDefinition()
 		throws Exception {
 
-		ObjectDefinition systemObjectDefinition =
-			ObjectDefinitionTestUtil.addUnmodifiableSystemObjectDefinition(
-				null, TestPropsValues.getUserId(),
-				RandomTestUtil.randomString(), null,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				ObjectDefinitionTestUtil.getRandomName(), null, null,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
-				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING,
-						RandomTestUtil.randomString(), StringUtil.randomId())));
+		return ObjectDefinitionTestUtil.addUnmodifiableSystemObjectDefinition(
+			null, TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionTestUtil.getRandomName(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+			Arrays.asList(
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING,
+					RandomTestUtil.randomString(), StringUtil.randomId())));
+	}
+
+	private static ServiceRegistration<SystemObjectDefinitionManager>
+		_registerTestSystemObjectDefinitionManager(
+			ObjectDefinition objectDefinition, String restContextPath) {
 
 		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
-				systemObjectDefinition.getCompanyId())) {
+				objectDefinition.getCompanyId())) {
 
 			Bundle bundle = FrameworkUtil.getBundle(
 				ObjectRelationshipLocalServiceTest.class);
 
 			BundleContext bundleContext = bundle.getBundleContext();
 
-			bundleContext.registerService(
+			return bundleContext.registerService(
 				SystemObjectDefinitionManager.class,
 				new TestSystemObjectDefinitionManager(
-					systemObjectDefinition.getModelClass(),
-					systemObjectDefinition.getName(), restContextPath),
+					objectDefinition.getModelClass(),
+					objectDefinition.getName(), restContextPath),
 				new HashMapDictionary<>());
 		}
-
-		return systemObjectDefinition;
 	}
 
 	private ObjectDefinition _addAndPublishCustomObjectDefinition()
@@ -1458,7 +1478,7 @@ public class ObjectRelationshipLocalServiceTest {
 
 		return _objectRelationshipLocalService.addObjectRelationship(
 			null, TestPropsValues.getUserId(),
-			_systemObjectDefinition1.getObjectDefinitionId(),
+			_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 			_objectDefinition2.getObjectDefinitionId(),
 			objectField.getObjectFieldId(),
 			ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
@@ -1777,11 +1797,12 @@ public class ObjectRelationshipLocalServiceTest {
 	private void _testSystemObjectRelationshipOneToMany() throws Exception {
 		AssertUtils.assertFailure(
 			ObjectRelationshipParameterObjectFieldIdException.class,
-			"Object definition " + _systemObjectDefinition1.getName() +
-				" requires a parameter object field ID",
+			"Object definition " +
+				_unmodifiableSystemObjectDefinition1.getName() +
+					" requires a parameter object field ID",
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -1796,7 +1817,7 @@ public class ObjectRelationshipLocalServiceTest {
 				" does not exist",
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				parameterObjectFieldId,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
@@ -1818,7 +1839,7 @@ public class ObjectRelationshipLocalServiceTest {
 				_objectDefinition1.getName()),
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				objectField1.getObjectFieldId(),
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
@@ -1837,7 +1858,7 @@ public class ObjectRelationshipLocalServiceTest {
 				" does not belong to a relationship object field",
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition1.getObjectDefinitionId(),
+				_unmodifiableSystemObjectDefinition1.getObjectDefinitionId(),
 				_objectDefinition1.getObjectDefinitionId(),
 				objectField2.getObjectFieldId(),
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
@@ -1853,7 +1874,9 @@ public class ObjectRelationshipLocalServiceTest {
 
 	private static final Pattern _pattern = Pattern.compile(
 		"R_[A-Z][0-9][A-Z][0-9]$");
-	private static ObjectDefinition _systemObjectDefinition1;
+	private static ServiceRegistration<SystemObjectDefinitionManager>
+		_serviceRegistration1;
+	private static ObjectDefinition _unmodifiableSystemObjectDefinition1;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
@@ -1904,8 +1927,11 @@ public class ObjectRelationshipLocalServiceTest {
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
+	private ServiceRegistration<SystemObjectDefinitionManager>
+		_serviceRegistration2;
+
 	@DeleteAfterTestRun
-	private ObjectDefinition _systemObjectDefinition2;
+	private ObjectDefinition _unmodifiableSystemObjectDefinition2;
 
 	@Inject
 	private WorkflowInstanceManager _workflowInstanceManager;

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/AssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/AssetLibraryTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -158,4 +158,4 @@ public interface AssetLibraryTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-298408198
+// LIFERAY-REST-BUILDER-HASH:104430706

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/BatchTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/BatchTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -172,4 +172,4 @@ public interface BatchTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:552264913
+// LIFERAY-REST-BUILDER-HASH:-802291559

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/CompanyTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/CompanyTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -197,4 +197,4 @@ public interface CompanyTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1286456241
+// LIFERAY-REST-BUILDER-HASH:342781753

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -195,4 +195,4 @@ public interface ERCAssetLibraryTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1641517204
+// LIFERAY-REST-BUILDER-HASH:-129258740

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCScopedTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCScopedTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -271,4 +271,4 @@ public interface ERCScopedTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1885832774
+// LIFERAY-REST-BUILDER-HASH:1112469634

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ERCSiteTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -192,4 +192,4 @@ public interface ERCSiteTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1830349064
+// LIFERAY-REST-BUILDER-HASH:1188632176

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity1Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity1Resource.java
@@ -38,7 +38,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -148,4 +148,4 @@ public interface EntityModelResourceTestEntity1Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1190084464
+// LIFERAY-REST-BUILDER-HASH:-265995752

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity2Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/EntityModelResourceTestEntity2Resource.java
@@ -35,7 +35,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -138,4 +138,4 @@ public interface EntityModelResourceTestEntity2Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1634864584
+// LIFERAY-REST-BUILDER-HASH:1525313680

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/FilterResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/FilterResource.java
@@ -38,7 +38,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -150,4 +150,4 @@ public interface FilterResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2029490126
+// LIFERAY-REST-BUILDER-HASH:-597509354

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/MultipartTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/MultipartTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -180,4 +180,4 @@ public interface MultipartTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1949339668
+// LIFERAY-REST-BUILDER-HASH:2117514204

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SchemaResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SchemaResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -151,4 +151,4 @@ public interface SchemaResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1651392007
+// LIFERAY-REST-BUILDER-HASH:1422331585

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ScopedTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/ScopedTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -217,4 +217,4 @@ public interface ScopedTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1444493566
+// LIFERAY-REST-BUILDER-HASH:-538852294

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SharedInternalModelBatchTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SharedInternalModelBatchTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -179,4 +179,4 @@ public interface SharedInternalModelBatchTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1720306882
+// LIFERAY-REST-BUILDER-HASH:-1351498694

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SiteTestEntityResource.java
@@ -39,7 +39,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -199,4 +199,4 @@ public interface SiteTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1778821628
+// LIFERAY-REST-BUILDER-HASH:1195318412

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SortResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/SortResource.java
@@ -38,7 +38,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -150,4 +150,4 @@ public interface SortResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-301354764
+// LIFERAY-REST-BUILDER-HASH:-1962092996

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityAddressResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityAddressResource.java
@@ -35,7 +35,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -136,4 +136,4 @@ public interface TestEntityAddressResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1810323473
+// LIFERAY-REST-BUILDER-HASH:2129511065

--- a/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-api/src/main/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/TestEntityResource.java
@@ -40,7 +40,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * To access this resource, run:
  *
- *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/test/v1.0
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/portal-tools-rest-builder-test/v1.0
  *
  * @author Alejandro Tardín
  * @generated
@@ -195,4 +195,4 @@ public interface TestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1779137957
+// LIFERAY-REST-BUILDER-HASH:634988717

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/AssetLibraryTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/AssetLibraryTestEntityAPI.ts
@@ -41,7 +41,7 @@ export class AssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -99,7 +99,7 @@ export class AssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/BatchTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/BatchTestEntityAPI.ts
@@ -40,7 +40,7 @@ export class BatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -91,7 +91,7 @@ export class BatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -139,7 +139,7 @@ export class BatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities/{batchTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities/{batchTestEntityId}"
 						.replace("{batchTestEntityId}",encodeURIComponent(batchTestEntityId))
 				;
 
@@ -192,7 +192,7 @@ export class BatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -266,7 +266,7 @@ export class BatchTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.batchTestEntity, "BatchTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -360,7 +360,7 @@ export class BatchTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.batchTestEntity, "BatchTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/CompanyTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/CompanyTestEntityAPI.ts
@@ -40,7 +40,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -91,7 +91,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -139,7 +139,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/{companyTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}"
 						.replace("{companyTestEntityId}",encodeURIComponent(companyTestEntityId))
 				;
 
@@ -192,7 +192,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -247,7 +247,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/{companyTestEntityId}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions"
 						.replace("{companyTestEntityId}",encodeURIComponent(companyTestEntityId))
 								;
 
@@ -327,7 +327,7 @@ export class CompanyTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.companyTestEntity, "CompanyTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/{companyTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}"
 						.replace("{companyTestEntityId}",encodeURIComponent(companyTestEntityId))
 				;
 
@@ -427,7 +427,7 @@ export class CompanyTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.companyTestEntity, "CompanyTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/company-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -521,7 +521,7 @@ export class CompanyTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.companyTestEntity, "CompanyTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/{companyTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}"
 						.replace("{companyTestEntityId}",encodeURIComponent(companyTestEntityId))
 				;
 
@@ -623,7 +623,7 @@ export class CompanyTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.companyTestEntity, "CompanyTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -702,7 +702,7 @@ export class CompanyTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/company-test-entities/{companyTestEntityId}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions"
 						.replace("{companyTestEntityId}",encodeURIComponent(companyTestEntityId))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCAssetLibraryTestEntityAPI.ts
@@ -42,7 +42,7 @@ export class ERCAssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
 				;
@@ -100,7 +100,7 @@ export class ERCAssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 				;
 
@@ -155,7 +155,7 @@ export class ERCAssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
 				;
@@ -221,7 +221,7 @@ export class ERCAssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
 																;
@@ -314,7 +314,7 @@ export class ERCAssetLibraryTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCAssetLibraryTestEntity, "ERCAssetLibraryTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 				;
 
@@ -418,7 +418,7 @@ export class ERCAssetLibraryTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCAssetLibraryTestEntity, "ERCAssetLibraryTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
 				;
@@ -507,7 +507,7 @@ export class ERCAssetLibraryTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercAssetLibraryTestEntityExternalReferenceCode}",encodeURIComponent(ercAssetLibraryTestEntityExternalReferenceCode))
 				;

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCScopedTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCScopedTestEntityAPI.ts
@@ -42,7 +42,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -100,7 +100,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
 
@@ -155,7 +155,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -213,7 +213,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 				;
 
@@ -268,7 +268,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -334,7 +334,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 																;
@@ -408,7 +408,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/erc-scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities"
 												;
 
 			const queryParameters: any = {};
@@ -474,7 +474,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 																;
 
@@ -539,7 +539,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 
@@ -594,7 +594,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -660,7 +660,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 																;
@@ -753,7 +753,7 @@ export class ERCScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCScopedTestEntity, "ERCScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 				;
 
@@ -855,7 +855,7 @@ export class ERCScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCScopedTestEntity, "ERCScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 
@@ -959,7 +959,7 @@ export class ERCScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCScopedTestEntity, "ERCScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -1048,7 +1048,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{assetLibraryExternalReferenceCode}",encodeURIComponent(assetLibraryExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -1106,7 +1106,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
 
@@ -1184,7 +1184,7 @@ export class ERCScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCScopedTestEntity, "ERCScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;
@@ -1273,7 +1273,7 @@ export class ERCScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercScopedTestEntityExternalReferenceCode}",encodeURIComponent(ercScopedTestEntityExternalReferenceCode))
 				;

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ERCSiteTestEntityAPI.ts
@@ -42,7 +42,7 @@ export class ERCSiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
 				;
@@ -100,7 +100,7 @@ export class ERCSiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 
@@ -155,7 +155,7 @@ export class ERCSiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
 				;
@@ -221,7 +221,7 @@ export class ERCSiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
 																;
@@ -314,7 +314,7 @@ export class ERCSiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCSiteTestEntity, "ERCSiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 
@@ -418,7 +418,7 @@ export class ERCSiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.eRCSiteTestEntity, "ERCSiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
 				;
@@ -507,7 +507,7 @@ export class ERCSiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 										.replace("{ercSiteTestEntityExternalReferenceCode}",encodeURIComponent(ercSiteTestEntityExternalReferenceCode))
 				;

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity1API.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity1API.ts
@@ -37,7 +37,7 @@ export class EntityModelResourceTestEntity1API {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/entity-model-resource-test-entities1"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities1"
 ;
 
 			const queryParameters: any = {};

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity2API.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/EntityModelResourceTestEntity2API.ts
@@ -39,7 +39,7 @@ export class EntityModelResourceTestEntity2API {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}"
 						.replace("{entityModelResourceTestEntity2Id}",encodeURIComponent(entityModelResourceTestEntity2Id))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/FilterAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/FilterAPI.ts
@@ -37,7 +37,7 @@ export class FilterAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/filters"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/filters"
 ;
 
 			const queryParameters: any = {};

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/MultipartTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/MultipartTestEntityAPI.ts
@@ -39,7 +39,7 @@ export class MultipartTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/multipart-test-entities/{multipartTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}"
 						.replace("{multipartTestEntityId}",encodeURIComponent(multipartTestEntityId))
 				;
 
@@ -92,7 +92,7 @@ export class MultipartTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 
@@ -168,7 +168,7 @@ export class MultipartTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.multipartTestEntity, "MultipartTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/multipart-test-entities/{multipartTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}"
 						.replace("{multipartTestEntityId}",encodeURIComponent(multipartTestEntityId))
 				;
 
@@ -280,7 +280,7 @@ export class MultipartTestEntityAPI {
 								body = formData;
 						}
 
-			const path = this._basePath + "/test/v1.0/multipart-test-entity"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/multipart-test-entity"
 ;
 
 			const queryParameters: any = {};
@@ -358,7 +358,7 @@ export class MultipartTestEntityAPI {
 								formData.append("multipartTestEntity", JSON.stringify(ObjectSerializer.serialize(multipartTestEntity, "MultipartTestEntity")));
 						body = formData;
 
-			const path = this._basePath + "/test/v1.0/multipart-test-entities/{multipartTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}"
 						.replace("{multipartTestEntityId}",encodeURIComponent(multipartTestEntityId))
 				;
 
@@ -418,7 +418,7 @@ export class MultipartTestEntityAPI {
 								formData.append("file", file);
 						body = formData;
 
-			const path = this._basePath + "/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity"
 						.replace("{siteExternalReferenceCode}",encodeURIComponent(siteExternalReferenceCode))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SchemaAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SchemaAPI.ts
@@ -37,7 +37,7 @@ export class SchemaAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/schemas"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/schemas"
 ;
 
 			const queryParameters: any = {};

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ScopedTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/ScopedTestEntityAPI.ts
@@ -42,7 +42,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -102,7 +102,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -160,7 +160,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 				;
 
@@ -215,7 +215,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -273,7 +273,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities"
 						.replace("{siteId}",encodeURIComponent(siteId))
 				;
 
@@ -328,7 +328,7 @@ export class ScopedTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -411,7 +411,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -523,7 +523,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -633,7 +633,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 				;
 
@@ -735,7 +735,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities"
 						.replace("{siteId}",encodeURIComponent(siteId))
 				;
 
@@ -839,7 +839,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{assetLibraryId}",encodeURIComponent(assetLibraryId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -951,7 +951,7 @@ export class ScopedTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.scopedTestEntity, "ScopedTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SharedInternalModelBatchTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SharedInternalModelBatchTestEntityAPI.ts
@@ -40,7 +40,7 @@ export class SharedInternalModelBatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -91,7 +91,7 @@ export class SharedInternalModelBatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/shared-internal-model-batch-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -139,7 +139,7 @@ export class SharedInternalModelBatchTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 
@@ -213,7 +213,7 @@ export class SharedInternalModelBatchTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.sharedInternalModelBatchTestEntity, "SharedInternalModelBatchTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/shared-internal-model-batch-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -307,7 +307,7 @@ export class SharedInternalModelBatchTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.sharedInternalModelBatchTestEntity, "SharedInternalModelBatchTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SiteTestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SiteTestEntityAPI.ts
@@ -42,7 +42,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -100,7 +100,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/site-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities"
 						.replace("{siteId}",encodeURIComponent(siteId))
 				;
 
@@ -155,7 +155,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -213,7 +213,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/site-test-entities/{siteTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}"
 						.replace("{siteTestEntityId}",encodeURIComponent(siteTestEntityId))
 				;
 
@@ -268,7 +268,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/site-test-entities/{siteTestEntityId}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions"
 						.replace("{siteTestEntityId}",encodeURIComponent(siteTestEntityId))
 								;
 
@@ -348,7 +348,7 @@ export class SiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.siteTestEntity, "SiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/site-test-entities/{siteTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}"
 						.replace("{siteTestEntityId}",encodeURIComponent(siteTestEntityId))
 				;
 
@@ -450,7 +450,7 @@ export class SiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.siteTestEntity, "SiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/site-test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities"
 						.replace("{siteId}",encodeURIComponent(siteId))
 				;
 
@@ -554,7 +554,7 @@ export class SiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.siteTestEntity, "SiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}"
 						.replace("{siteId}",encodeURIComponent(siteId))
 										.replace("{externalReferenceCode}",encodeURIComponent(externalReferenceCode))
 				;
@@ -664,7 +664,7 @@ export class SiteTestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.siteTestEntity, "SiteTestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/site-test-entities/{siteTestEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}"
 						.replace("{siteTestEntityId}",encodeURIComponent(siteTestEntityId))
 				;
 
@@ -743,7 +743,7 @@ export class SiteTestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/site-test-entities/{siteTestEntityId}/permissions"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions"
 						.replace("{siteTestEntityId}",encodeURIComponent(siteTestEntityId))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SortAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/SortAPI.ts
@@ -37,7 +37,7 @@ export class SortAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/sorts"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/sorts"
 ;
 
 			const queryParameters: any = {};

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAPI.ts
@@ -42,7 +42,7 @@ export class TestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 								;
 
@@ -96,7 +96,7 @@ export class TestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities"
 				;
 
 			const queryParameters: any = {};
@@ -148,7 +148,7 @@ export class TestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 				;
 
@@ -199,7 +199,7 @@ export class TestEntityAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/test-entities/count"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/count"
 ;
 
 			const queryParameters: any = {};
@@ -272,7 +272,7 @@ export class TestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.testEntity, "TestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 								;
 
@@ -379,7 +379,7 @@ export class TestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.body, "boolean"));
 						}
 
-			const path = this._basePath + "/test/v1.0/reserved-word"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/reserved-word"
 ;
 
 			const queryParameters: any = {};
@@ -468,7 +468,7 @@ export class TestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.testEntity, "TestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/test-entities"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities"
 ;
 
 			const queryParameters: any = {};
@@ -543,7 +543,7 @@ export class TestEntityAPI {
 								formData.append("testEntities", JSON.stringify(ObjectSerializer.serialize(testEntities, "Array<TestEntity>")));
 						body = formData;
 
-			const path = this._basePath + "/test/v1.0/test-entities/multipart/bulk"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/multipart/bulk"
 ;
 
 			const queryParameters: any = {};
@@ -596,7 +596,7 @@ export class TestEntityAPI {
 								formData.append("imageName", JSON.stringify(ObjectSerializer.serialize(imageName, "string")));
 						body = formData;
 
-			const path = this._basePath + "/test/v1.0/test-entities/multipart/image"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/multipart/image"
 ;
 
 			const queryParameters: any = {};
@@ -667,7 +667,7 @@ export class TestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.testEntity, "TestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 								;
 
@@ -776,7 +776,7 @@ export class TestEntityAPI {
 								body = JSON.stringify(ObjectSerializer.serialize(requestBody.parameters.testEntity, "TestEntity"));
 						}
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}/status"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/status"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAddressAPI.ts
+++ b/modules/util/portal-tools-rest-builder-test-client-js/src/apis/TestEntityAddressAPI.ts
@@ -39,7 +39,7 @@ export class TestEntityAddressAPI {
 			response: Response;
 		}> {
 
-			const path = this._basePath + "/test/v1.0/test-entities/{testEntityId}/test-entity-address"
+			const path = this._basePath + "/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/test-entity-address"
 						.replace("{testEntityId}",encodeURIComponent(testEntityId))
 				;
 

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/AssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/AssetLibraryTestEntityResource.java
@@ -268,7 +268,7 @@ public interface AssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -377,7 +377,7 @@ public interface AssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -492,7 +492,7 @@ public interface AssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/export-batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -516,4 +516,4 @@ public interface AssetLibraryTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1398748080
+// LIFERAY-REST-BUILDER-HASH:-1943511784

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/BatchTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/BatchTestEntityResource.java
@@ -300,7 +300,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -404,7 +404,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -507,7 +507,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/{batchTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/{batchTestEntityId}");
 
 			httpInvoker.path("batchTestEntityId", batchTestEntityId);
 
@@ -615,7 +615,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -728,7 +728,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -834,7 +834,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -933,7 +933,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1042,7 +1042,7 @@ public interface BatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -1066,4 +1066,4 @@ public interface BatchTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1826588345
+// LIFERAY-REST-BUILDER-HASH:427614455

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/CompanyTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/CompanyTestEntityResource.java
@@ -347,7 +347,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -451,7 +451,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -554,7 +554,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/{companyTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}");
 
 			httpInvoker.path("companyTestEntityId", companyTestEntityId);
 
@@ -662,7 +662,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -774,7 +774,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/{companyTestEntityId}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions");
 
 			httpInvoker.path("companyTestEntityId", companyTestEntityId);
 
@@ -883,7 +883,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/{companyTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}");
 
 			httpInvoker.path("companyTestEntityId", companyTestEntityId);
 
@@ -996,7 +996,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1102,7 +1102,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1202,7 +1202,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1309,7 +1309,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/{companyTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}");
 
 			httpInvoker.path("companyTestEntityId", companyTestEntityId);
 
@@ -1410,7 +1410,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1520,7 +1520,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -1636,7 +1636,7 @@ public interface CompanyTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/company-test-entities/{companyTestEntityId}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions");
 
 			httpInvoker.path("companyTestEntityId", companyTestEntityId);
 
@@ -1660,4 +1660,4 @@ public interface CompanyTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1870181878
+// LIFERAY-REST-BUILDER-HASH:1528613838

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCAssetLibraryTestEntityResource.java
@@ -350,7 +350,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -464,7 +464,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -578,7 +578,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -701,7 +701,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -822,7 +822,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/export-batch");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -939,7 +939,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1047,7 +1047,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1167,7 +1167,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1295,7 +1295,7 @@ public interface ERCAssetLibraryTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1324,4 +1324,4 @@ public interface ERCAssetLibraryTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:635046010
+// LIFERAY-REST-BUILDER-HASH:-818975822

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCScopedTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCScopedTestEntityResource.java
@@ -499,7 +499,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -611,7 +611,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"ercScopedTestEntityExternalReferenceCode",
@@ -716,7 +716,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -825,7 +825,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -938,7 +938,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1051,7 +1051,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1174,7 +1174,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1289,7 +1289,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1401,7 +1401,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"ercScopedTestEntityExternalReferenceCode",
@@ -1511,7 +1511,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1622,7 +1622,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1743,7 +1743,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1863,7 +1863,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/export-batch");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -1978,7 +1978,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -2086,7 +2086,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -2207,7 +2207,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -2321,7 +2321,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/export-batch");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -2434,7 +2434,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -2541,7 +2541,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -2659,7 +2659,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -2786,7 +2786,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"assetLibraryExternalReferenceCode",
@@ -2909,7 +2909,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"ercScopedTestEntityExternalReferenceCode",
@@ -3027,7 +3027,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -3152,7 +3152,7 @@ public interface ERCScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -3180,4 +3180,4 @@ public interface ERCScopedTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1593855401
+// LIFERAY-REST-BUILDER-HASH:-1090588537

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ERCSiteTestEntityResource.java
@@ -336,7 +336,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -448,7 +448,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -559,7 +559,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -679,7 +679,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -799,7 +799,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/export-batch");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -911,7 +911,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1018,7 +1018,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1133,7 +1133,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1258,7 +1258,7 @@ public interface ERCSiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1286,4 +1286,4 @@ public interface ERCSiteTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-554276145
+// LIFERAY-REST-BUILDER-HASH:1192255031

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity1Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity1Resource.java
@@ -245,7 +245,7 @@ public interface EntityModelResourceTestEntity1Resource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/entity-model-resource-test-entities1");
+						"/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities1");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -267,4 +267,4 @@ public interface EntityModelResourceTestEntity1Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2090173484
+// LIFERAY-REST-BUILDER-HASH:-2129223156

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity2Resource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/EntityModelResourceTestEntity2Resource.java
@@ -248,7 +248,7 @@ public interface EntityModelResourceTestEntity2Resource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}");
+						"/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}");
 
 			httpInvoker.path(
 				"entityModelResourceTestEntity2Id",
@@ -274,4 +274,4 @@ public interface EntityModelResourceTestEntity2Resource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:927501084
+// LIFERAY-REST-BUILDER-HASH:846905044

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/FilterResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/FilterResource.java
@@ -244,7 +244,7 @@ public interface FilterResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/filters");
+						"/o/portal-tools-rest-builder-test/v1.0/filters");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -354,7 +354,7 @@ public interface FilterResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/filters/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/filters/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -376,4 +376,4 @@ public interface FilterResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:733572798
+// LIFERAY-REST-BUILDER-HASH:-1593210450

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/MultipartTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/MultipartTestEntityResource.java
@@ -317,7 +317,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}");
 
 			httpInvoker.path("multipartTestEntityId", multipartTestEntityId);
 
@@ -412,7 +412,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -525,7 +525,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}");
 
 			httpInvoker.path("multipartTestEntityId", multipartTestEntityId);
 
@@ -634,7 +634,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entity");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -752,7 +752,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entity");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -853,7 +853,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entity/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -972,7 +972,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}");
 
 			httpInvoker.path("multipartTestEntityId", multipartTestEntityId);
 
@@ -1079,7 +1079,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/multipart-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1199,7 +1199,7 @@ public interface MultipartTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity");
 
 			httpInvoker.path(
 				"siteExternalReferenceCode", siteExternalReferenceCode);
@@ -1224,4 +1224,4 @@ public interface MultipartTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1007171414
+// LIFERAY-REST-BUILDER-HASH:1886289598

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SchemaResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SchemaResource.java
@@ -244,7 +244,7 @@ public interface SchemaResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/schemas");
+						"/o/portal-tools-rest-builder-test/v1.0/schemas");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -354,7 +354,7 @@ public interface SchemaResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/schemas/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/schemas/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -376,4 +376,4 @@ public interface SchemaResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-738278795
+// LIFERAY-REST-BUILDER-HASH:-1245580699

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ScopedTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/ScopedTestEntityResource.java
@@ -393,7 +393,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -502,7 +502,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -611,7 +611,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -720,7 +720,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -826,7 +826,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -934,7 +934,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1048,7 +1048,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1162,7 +1162,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1278,7 +1278,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/export-batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -1388,7 +1388,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -1492,7 +1492,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 
@@ -1607,7 +1607,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/export-batch");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1715,7 +1715,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1819,7 +1819,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/batch");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1932,7 +1932,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -2045,7 +2045,7 @@ public interface ScopedTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -2070,4 +2070,4 @@ public interface ScopedTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-898383980
+// LIFERAY-REST-BUILDER-HASH:-1435323372

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SharedInternalModelBatchTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SharedInternalModelBatchTestEntityResource.java
@@ -310,7 +310,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -417,7 +417,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -524,7 +524,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -637,7 +637,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -750,7 +750,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -852,7 +852,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -967,7 +967,7 @@ public interface SharedInternalModelBatchTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -993,4 +993,4 @@ public interface SharedInternalModelBatchTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1894856671
+// LIFERAY-REST-BUILDER-HASH:1407866103

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SiteTestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SiteTestEntityResource.java
@@ -352,7 +352,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -458,7 +458,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -566,7 +566,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -672,7 +672,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/{siteTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}");
 
 			httpInvoker.path("siteTestEntityId", siteTestEntityId);
 
@@ -784,7 +784,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/{siteTestEntityId}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions");
 
 			httpInvoker.path("siteTestEntityId", siteTestEntityId);
 
@@ -893,7 +893,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/{siteTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}");
 
 			httpInvoker.path("siteTestEntityId", siteTestEntityId);
 
@@ -1008,7 +1008,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/export-batch");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1116,7 +1116,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1219,7 +1219,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/batch");
 
 			httpInvoker.path("siteId", siteId);
 
@@ -1331,7 +1331,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
+						"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1440,7 +1440,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/{siteTestEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}");
 
 			httpInvoker.path("siteTestEntityId", siteTestEntityId);
 
@@ -1541,7 +1541,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1655,7 +1655,7 @@ public interface SiteTestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/site-test-entities/{siteTestEntityId}/permissions");
+						"/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions");
 
 			httpInvoker.path("siteTestEntityId", siteTestEntityId);
 
@@ -1679,4 +1679,4 @@ public interface SiteTestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:330120503
+// LIFERAY-REST-BUILDER-HASH:2114559247

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SortResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/SortResource.java
@@ -242,7 +242,7 @@ public interface SortResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sorts");
+						"/o/portal-tools-rest-builder-test/v1.0/sorts");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -352,7 +352,7 @@ public interface SortResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/sorts/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/sorts/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -374,4 +374,4 @@ public interface SortResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-558063848
+// LIFERAY-REST-BUILDER-HASH:487642120

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityAddressResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityAddressResource.java
@@ -242,7 +242,7 @@ public interface TestEntityAddressResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}/test-entity-address");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/test-entity-address");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -266,4 +266,4 @@ public interface TestEntityAddressResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1720555500
+// LIFERAY-REST-BUILDER-HASH:-1126401380

--- a/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityResource.java
+++ b/modules/util/portal-tools-rest-builder-test-client/src/main/java/com/liferay/portal/tools/rest/builder/test/client/resource/v1_0/TestEntityResource.java
@@ -338,7 +338,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -445,7 +445,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -552,7 +552,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -653,7 +653,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -755,7 +755,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/count");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/count");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -868,7 +868,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -962,7 +962,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/reserved-word");
+						"/o/portal-tools-rest-builder-test/v1.0/reserved-word");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1079,7 +1079,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/export-batch");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/export-batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1184,7 +1184,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1283,7 +1283,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1385,7 +1385,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/multipart/bulk");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/multipart/bulk");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1488,7 +1488,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/multipart/image");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/multipart/image");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1601,7 +1601,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -1709,7 +1709,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/batch");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/batch");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1815,7 +1815,7 @@ public interface TestEntityResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
-						"/o/test/v1.0/test-entities/{testEntityId}/status");
+						"/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/status");
 
 			httpInvoker.path("testEntityId", testEntityId);
 
@@ -1839,4 +1839,4 @@ public interface TestEntityResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-956455216
+// LIFERAY-REST-BUILDER-HASH:-708346312

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
@@ -1,7 +1,7 @@
 apiDir: ../portal-tools-rest-builder-test-api/src/main/java
 apiPackagePath: com.liferay.portal.tools.rest.builder.test
 application:
-    baseURI: /test
+    baseURI: /portal-tools-rest-builder-test
     className: PortalToolsRESTBuilderTestApplication
     name: Liferay.Portal.Tools.REST.Builder.Test
 author: Alejandro Tardín

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -144,7 +144,7 @@ public class ServletDataImpl implements ServletData {
 
 	@Override
 	public String getPath() {
-		return "/test-graphql/v1_0";
+		return "/portal-tools-rest-builder-test-graphql/v1_0";
 	}
 
 	@Override
@@ -940,4 +940,4 @@ public class ServletDataImpl implements ServletData {
 		_testEntityAddressResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2106682717
+// LIFERAY-REST-BUILDER-HASH:129083861

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/jaxrs/application/PortalToolsRESTBuilderTestApplication.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/jaxrs/application/PortalToolsRESTBuilderTestApplication.java
@@ -17,7 +17,8 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"liferay.jackson=false", "osgi.jaxrs.application.base=/test",
+		"liferay.jackson=false",
+		"osgi.jaxrs.application.base=/portal-tools-rest-builder-test",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
 		"osgi.jaxrs.name=Liferay.Portal.Tools.REST.Builder.Test"
 	},
@@ -26,4 +27,4 @@ import org.osgi.service.component.annotations.Component;
 @Generated("")
 public class PortalToolsRESTBuilderTestApplication extends Application {
 }
-// LIFERAY-REST-BUILDER-HASH:725900772
+// LIFERAY-REST-BUILDER-HASH:2006009564

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseAssetLibraryTestEntityResourceImpl.java
@@ -73,7 +73,7 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -115,7 +115,7 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -152,7 +152,7 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/asset-library-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -457,7 +457,7 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -925,4 +925,4 @@ public abstract class BaseAssetLibraryTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseAssetLibraryTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2065653968
+// LIFERAY-REST-BUILDER-HASH:1794662384

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseBatchTestEntityResourceImpl.java
@@ -76,7 +76,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -108,7 +108,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/batch-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -126,7 +126,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/batch-test-entities/{batchTestEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/{batchTestEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -158,7 +158,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -192,7 +192,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/batch-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -255,7 +255,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -276,7 +276,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/batch-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -322,7 +322,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"acceptAllLanguages": ___, "customFields": ___, "externalReferenceCode": ___, "name": ___, "nestedField": ___, "relatedCompanyTestEntity": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -623,7 +623,7 @@ public abstract class BaseBatchTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1090,4 +1090,4 @@ public abstract class BaseBatchTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseBatchTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1318516220
+// LIFERAY-REST-BUILDER-HASH:-579560020

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseCompanyTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseCompanyTestEntityResourceImpl.java
@@ -93,7 +93,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -128,7 +128,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/company-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -174,7 +174,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/company-test-entities/{companyTestEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -229,7 +229,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -282,7 +282,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/company-test-entities/{companyTestEntityId}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -345,7 +345,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/company-test-entities/{companyTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -410,7 +410,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/company-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -477,7 +477,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/company-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -521,7 +521,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/company-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -571,7 +571,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/company-test-entities/{companyTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -627,7 +627,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/company-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -679,7 +679,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -738,7 +738,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/company-test-entities/{companyTestEntityId}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/company-test-entities/{companyTestEntityId}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1324,7 +1324,7 @@ public abstract class BaseCompanyTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1796,4 +1796,4 @@ public abstract class BaseCompanyTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseCompanyTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:861441775
+// LIFERAY-REST-BUILDER-HASH:-1601141409

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCAssetLibraryTestEntityResourceImpl.java
@@ -89,7 +89,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -138,7 +138,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -207,7 +207,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -277,7 +277,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -365,7 +365,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -446,7 +446,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -510,7 +510,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -576,7 +576,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -652,7 +652,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/{ercAssetLibraryTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1241,7 +1241,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1709,4 +1709,4 @@ public abstract class BaseERCAssetLibraryTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseERCAssetLibraryTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1080528993
+// LIFERAY-REST-BUILDER-HASH:510421569

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCScopedTestEntityResourceImpl.java
@@ -89,7 +89,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -131,7 +131,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -165,7 +165,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -213,7 +213,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -260,7 +260,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -326,7 +326,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -391,7 +391,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -480,7 +480,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -544,7 +544,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -623,7 +623,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -687,7 +687,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -752,7 +752,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -836,7 +836,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -917,7 +917,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -979,7 +979,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1037,7 +1037,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1109,7 +1109,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1189,7 +1189,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1251,7 +1251,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1315,7 +1315,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1386,7 +1386,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1495,7 +1495,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1600,7 +1600,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}' -d $'{"assetLibraryExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "id": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1671,7 +1671,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/{ercScopedTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -2293,7 +2293,7 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -2760,4 +2760,4 @@ public abstract class BaseERCScopedTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseERCScopedTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1006858949
+// LIFERAY-REST-BUILDER-HASH:-1856318307

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseERCSiteTestEntityResourceImpl.java
@@ -89,7 +89,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -133,7 +133,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -196,7 +196,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -258,7 +258,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -338,7 +338,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -416,7 +416,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -476,7 +476,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -538,7 +538,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -607,7 +607,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/{ercSiteTestEntityExternalReferenceCode}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1160,7 +1160,7 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1627,4 +1627,4 @@ public abstract class BaseERCSiteTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseERCSiteTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1556804269
+// LIFERAY-REST-BUILDER-HASH:1972619955

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity1ResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity1ResourceImpl.java
@@ -72,7 +72,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/entity-model-resource-test-entities1'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities1'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Retrieve all EntityModelResourceTestEntity1 items."
@@ -294,7 +294,7 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -764,4 +764,4 @@ public abstract class BaseEntityModelResourceTestEntity1ResourceImpl
 			BaseEntityModelResourceTestEntity1ResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1392235090
+// LIFERAY-REST-BUILDER-HASH:-1060220654

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity2ResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseEntityModelResourceTestEntity2ResourceImpl.java
@@ -46,7 +46,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/entity-model-resource-test-entities2/{entityModelResourceTestEntity2Id}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Retrieve a EntityModelResourceTestEntity2 item. (EntityModelResource and VulcanBatchEngineTaskItemDelegate interfaces will not be implemented automatically)"
@@ -154,7 +154,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	protected Map<String, String> addAction(
@@ -529,4 +529,4 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceImpl
 			BaseEntityModelResourceTestEntity2ResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:227065456
+// LIFERAY-REST-BUILDER-HASH:507882112

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseFilterResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseFilterResourceImpl.java
@@ -71,7 +71,7 @@ public abstract class BaseFilterResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/filters'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/filters'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Filter")}
@@ -87,7 +87,7 @@ public abstract class BaseFilterResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/filters/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/filters/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -332,7 +332,7 @@ public abstract class BaseFilterResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -797,4 +797,4 @@ public abstract class BaseFilterResourceImpl
 		LogFactoryUtil.getLog(BaseFilterResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-946518602
+// LIFERAY-REST-BUILDER-HASH:874512942

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseMultipartTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseMultipartTestEntityResourceImpl.java
@@ -78,7 +78,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -112,7 +112,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -150,7 +150,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}' -d $'{"externalReferenceCode": ___, "id": ___, "name": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}' -d $'{"externalReferenceCode": ___, "id": ___, "name": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -186,7 +186,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/multipart-test-entity' -d $'{"externalReferenceCode": ___, "id": ___, "name": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity' -d $'{"externalReferenceCode": ___, "id": ___, "name": ___, "siteExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -210,7 +210,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/multipart-test-entity'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -234,7 +234,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/multipart-test-entity/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entity/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -282,7 +282,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/multipart-test-entities/{multipartTestEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/{multipartTestEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -318,7 +318,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/multipart-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/multipart-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -367,7 +367,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/multipart-test-entity'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PutSiteMultipartTestEntityRequestBody.class)))
@@ -675,7 +675,7 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1151,4 +1151,4 @@ public abstract class BaseMultipartTestEntityResourceImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1188083795
+// LIFERAY-REST-BUILDER-HASH:775561261

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSchemaResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSchemaResourceImpl.java
@@ -72,7 +72,7 @@ public abstract class BaseSchemaResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/schemas'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/schemas'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Schema")}
@@ -88,7 +88,7 @@ public abstract class BaseSchemaResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/schemas/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/schemas/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -333,7 +333,7 @@ public abstract class BaseSchemaResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -798,4 +798,4 @@ public abstract class BaseSchemaResourceImpl
 		LogFactoryUtil.getLog(BaseSchemaResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-497577694
+// LIFERAY-REST-BUILDER-HASH:358085210

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseScopedTestEntityResourceImpl.java
@@ -74,7 +74,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -114,7 +114,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -154,7 +154,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -188,7 +188,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -231,7 +231,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -263,7 +263,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -305,7 +305,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -382,7 +382,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -458,7 +458,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -531,7 +531,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -567,7 +567,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -623,7 +623,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -694,7 +694,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -728,7 +728,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -782,7 +782,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -827,7 +827,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1177,7 +1177,7 @@ public abstract class BaseScopedTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1649,4 +1649,4 @@ public abstract class BaseScopedTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseScopedTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1296743086
+// LIFERAY-REST-BUILDER-HASH:-250991322

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSharedInternalModelBatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSharedInternalModelBatchTestEntityResourceImpl.java
@@ -75,7 +75,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -109,7 +109,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -132,7 +132,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -169,7 +169,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -236,7 +236,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities' -d $'{"externalReferenceCode": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities' -d $'{"externalReferenceCode": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
@@ -262,7 +262,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -311,7 +311,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/shared-internal-model-batch-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"externalReferenceCode": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -641,7 +641,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1111,4 +1111,4 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceImpl
 			BaseSharedInternalModelBatchTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:753696642
+// LIFERAY-REST-BUILDER-HASH:-1284374206

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSiteTestEntityResourceImpl.java
@@ -93,7 +93,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -137,7 +137,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -194,7 +194,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -258,7 +258,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/site-test-entities/{siteTestEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -308,7 +308,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/site-test-entities/{siteTestEntityId}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -369,7 +369,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/site-test-entities/{siteTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -436,7 +436,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -511,7 +511,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -566,7 +566,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -626,7 +626,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -696,7 +696,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/site-test-entities/{siteTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "permissions": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -751,7 +751,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/site-test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -797,7 +797,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/site-test-entities/{siteTestEntityId}/permissions'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/site-test-entities/{siteTestEntityId}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1414,7 +1414,7 @@ public abstract class BaseSiteTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1884,4 +1884,4 @@ public abstract class BaseSiteTestEntityResourceImpl
 		LogFactoryUtil.getLog(BaseSiteTestEntityResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1475242337
+// LIFERAY-REST-BUILDER-HASH:1874194609

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSortResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseSortResourceImpl.java
@@ -71,7 +71,7 @@ public abstract class BaseSortResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/sorts'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sorts'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Sort")}
@@ -87,7 +87,7 @@ public abstract class BaseSortResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/sorts/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/sorts/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -332,7 +332,7 @@ public abstract class BaseSortResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -797,4 +797,4 @@ public abstract class BaseSortResourceImpl
 		LogFactoryUtil.getLog(BaseSortResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:573914602
+// LIFERAY-REST-BUILDER-HASH:-1282947102

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityAddressResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityAddressResourceImpl.java
@@ -46,7 +46,7 @@ public abstract class BaseTestEntityAddressResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}/test-entity-address'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/test-entity-address'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -146,7 +146,7 @@ public abstract class BaseTestEntityAddressResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	protected Map<String, String> addAction(
@@ -520,4 +520,4 @@ public abstract class BaseTestEntityAddressResourceImpl
 		LogFactoryUtil.getLog(BaseTestEntityAddressResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1588449122
+// LIFERAY-REST-BUILDER-HASH:1989630754

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BaseTestEntityResourceImpl.java
@@ -78,7 +78,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -117,7 +117,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -169,7 +169,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -197,7 +197,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -227,7 +227,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/test/v1.0/test-entities/count'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/count'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Retrieves the count."
@@ -246,7 +246,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -322,7 +322,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/reserved-word'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/reserved-word'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "TestEntity")}
@@ -340,7 +340,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities/export-batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/export-batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -407,7 +407,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "TestEntity")}
@@ -424,7 +424,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -468,7 +468,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities/multipart/bulk'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/multipart/bulk'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostTestEntityMultipartBulkRequestBody.class)))
@@ -491,7 +491,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/test/v1.0/test-entities/multipart/image'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/multipart/image'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostTestEntityMultipartImageRequestBody.class)))
@@ -514,7 +514,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -553,7 +553,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/batch'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -604,7 +604,7 @@ public abstract class BaseTestEntityResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/test/v1.0/test-entities/{testEntityId}/status' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/portal-tools-rest-builder-test/v1.0/test-entities/{testEntityId}/status' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "jsonProperty": ___, "name": ___, "nestedTestEntity": ___, "self": ___, "stringTestEntities": ___, "stringTestEntity": ___, "testEntities": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -930,7 +930,7 @@ public abstract class BaseTestEntityResourceImpl
 	}
 
 	protected String getApplicationPath() {
-		return "test";
+		return "portal-tools-rest-builder-test";
 	}
 
 	public void setVulcanBatchEngineExportTaskResource(
@@ -1417,4 +1417,4 @@ public abstract class BaseTestEntityResourceImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1078977656
+// LIFERAY-REST-BUILDER-HASH:607706328

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/CompanyTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/CompanyTestEntityResourceImpl.java
@@ -109,7 +109,8 @@ public class CompanyTestEntityResourceImpl
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
-						"/o/test/v1.0/company-test-entities/batch")
+						"/o/portal-tools-rest-builder-test/v1.0",
+						"/company-test-entities/batch")
 				).put(
 					"method", "POST"
 				).build()

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ScopedTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/ScopedTestEntityResourceImpl.java
@@ -82,8 +82,8 @@ public class ScopedTestEntityResourceImpl
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
-						"/o/test/v1.0/asset-libraries/",
-						depotEntry.getDepotEntryId(),
+						"/o/portal-tools-rest-builder-test/v1.0",
+						"/asset-libraries/", depotEntry.getDepotEntryId(),
 						"/scoped-test-entities/batch")
 				).put(
 					"method", "POST"
@@ -129,7 +129,7 @@ public class ScopedTestEntityResourceImpl
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
-						"/o/test/v1.0/sites/", siteId,
+						"/o/portal-tools-rest-builder-test/v1.0/sites/", siteId,
 						"/scoped-test-entities/batch")
 				).put(
 					"method", "POST"

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/SiteTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/SiteTestEntityResourceImpl.java
@@ -118,7 +118,7 @@ public class SiteTestEntityResourceImpl extends BaseSiteTestEntityResourceImpl {
 					StringBundler.concat(
 						"http://localhost:",
 						PortalUtil.getPortalServerPort(false),
-						"/o/test/v1.0/sites/", siteId,
+						"/o/portal-tools-rest-builder-test/v1.0/sites/", siteId,
 						"/site-test-entities/batch")
 				).put(
 					"method", "POST"

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/AssetLibraryTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/AssetLibraryTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/AssetLibraryTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/AssetLibraryTestEntity",
 	service = AssetLibraryTestEntityResource.Factory.class
 )
 @Generated("")
@@ -338,4 +338,4 @@ public class AssetLibraryTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1486521182
+// LIFERAY-REST-BUILDER-HASH:-77759590

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/BatchTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/BatchTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/BatchTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/BatchTestEntity",
 	service = BatchTestEntityResource.Factory.class
 )
 @Generated("")
@@ -332,4 +332,4 @@ public class BatchTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:236593801
+// LIFERAY-REST-BUILDER-HASH:-1233518911

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/CompanyTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/CompanyTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/CompanyTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/CompanyTestEntity",
 	service = CompanyTestEntityResource.Factory.class
 )
 @Generated("")
@@ -333,4 +333,4 @@ public class CompanyTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-17475736
+// LIFERAY-REST-BUILDER-HASH:-2087786016

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCAssetLibraryTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCAssetLibraryTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/ERCAssetLibraryTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/ERCAssetLibraryTestEntity",
 	service = ERCAssetLibraryTestEntityResource.Factory.class
 )
 @Generated("")
@@ -342,4 +342,4 @@ public class ERCAssetLibraryTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-765694628
+// LIFERAY-REST-BUILDER-HASH:-1122579756

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCScopedTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCScopedTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/ERCScopedTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/ERCScopedTestEntity",
 	service = ERCScopedTestEntityResource.Factory.class
 )
 @Generated("")
@@ -335,4 +335,4 @@ public class ERCScopedTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:432905413
+// LIFERAY-REST-BUILDER-HASH:761846269

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCSiteTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ERCSiteTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/ERCSiteTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/ERCSiteTestEntity",
 	service = ERCSiteTestEntityResource.Factory.class
 )
 @Generated("")
@@ -333,4 +333,4 @@ public class ERCSiteTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-739339864
+// LIFERAY-REST-BUILDER-HASH:-1804266464

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/EntityModelResourceTestEntity1ResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/EntityModelResourceTestEntity1ResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/EntityModelResourceTestEntity1",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/EntityModelResourceTestEntity1",
 	service = EntityModelResourceTestEntity1Resource.Factory.class
 )
 @Generated("")
@@ -347,4 +347,4 @@ public class EntityModelResourceTestEntity1ResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1131266886
+// LIFERAY-REST-BUILDER-HASH:1290215858

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/EntityModelResourceTestEntity2ResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/EntityModelResourceTestEntity2ResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/EntityModelResourceTestEntity2",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/EntityModelResourceTestEntity2",
 	service = EntityModelResourceTestEntity2Resource.Factory.class
 )
 @Generated("")
@@ -347,4 +347,4 @@ public class EntityModelResourceTestEntity2ResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1485984971
+// LIFERAY-REST-BUILDER-HASH:-299417363

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/FilterResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/FilterResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/Filter",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/Filter",
 	service = FilterResource.Factory.class
 )
 @Generated("")
@@ -324,4 +324,4 @@ public class FilterResourceFactoryImpl implements FilterResource.Factory {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1194584854
+// LIFERAY-REST-BUILDER-HASH:-314001950

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/MultipartTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/MultipartTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/MultipartTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/MultipartTestEntity",
 	service = MultipartTestEntityResource.Factory.class
 )
 @Generated("")
@@ -335,4 +335,4 @@ public class MultipartTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:635033763
+// LIFERAY-REST-BUILDER-HASH:-276770213

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SchemaResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SchemaResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/Schema",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/Schema",
 	service = SchemaResource.Factory.class
 )
 @Generated("")
@@ -324,4 +324,4 @@ public class SchemaResourceFactoryImpl implements SchemaResource.Factory {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:243623837
+// LIFERAY-REST-BUILDER-HASH:-608413867

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ScopedTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/ScopedTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/ScopedTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/ScopedTestEntity",
 	service = ScopedTestEntityResource.Factory.class
 )
 @Generated("")
@@ -332,4 +332,4 @@ public class ScopedTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:436545065
+// LIFERAY-REST-BUILDER-HASH:2117268705

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SharedInternalModelBatchTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SharedInternalModelBatchTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/SharedInternalModelBatchTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/SharedInternalModelBatchTestEntity",
 	service = SharedInternalModelBatchTestEntityResource.Factory.class
 )
 @Generated("")
@@ -349,4 +349,4 @@ public class SharedInternalModelBatchTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1524138682
+// LIFERAY-REST-BUILDER-HASH:-1590865998

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SiteTestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SiteTestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/SiteTestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/SiteTestEntity",
 	service = SiteTestEntityResource.Factory.class
 )
 @Generated("")
@@ -330,4 +330,4 @@ public class SiteTestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2080659862
+// LIFERAY-REST-BUILDER-HASH:-891961970

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SortResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/SortResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/Sort",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/Sort",
 	service = SortResource.Factory.class
 )
 @Generated("")
@@ -323,4 +323,4 @@ public class SortResourceFactoryImpl implements SortResource.Factory {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1305936596
+// LIFERAY-REST-BUILDER-HASH:-1624209756

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityAddressResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityAddressResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/TestEntityAddress",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/TestEntityAddress",
 	service = TestEntityAddressResource.Factory.class
 )
 @Generated("")
@@ -333,4 +333,4 @@ public class TestEntityAddressResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:918799450
+// LIFERAY-REST-BUILDER-HASH:870236498

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/factory/TestEntityResourceFactoryImpl.java
@@ -55,7 +55,7 @@ import org.osgi.service.component.annotations.ReferenceScope;
  * @generated
  */
 @Component(
-	property = "resource.locator.key=/test/v1.0/TestEntity",
+	property = "resource.locator.key=/portal-tools-rest-builder-test/v1.0/TestEntity",
 	service = TestEntityResource.Factory.class
 )
 @Generated("")
@@ -329,4 +329,4 @@ public class TestEntityResourceFactoryImpl
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2057392232
+// LIFERAY-REST-BUILDER-HASH:1047551376

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/vulcan/openapi/contributor/TestExtensionOpenAPIContributor.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/vulcan/openapi/contributor/TestExtensionOpenAPIContributor.java
@@ -26,7 +26,9 @@ public class TestExtensionOpenAPIContributor implements OpenAPIContributor {
 	@Override
 	public void contribute(OpenAPI openAPI, OpenAPIContext openAPIContext) {
 		if ((openAPIContext == null) ||
-			!Objects.equals(openAPIContext.getPath(), "/o/test/")) {
+			!Objects.equals(
+				openAPIContext.getPath(),
+				"/o/portal-tools-rest-builder-test/")) {
 
 			return;
 		}

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
@@ -4,6 +4,6 @@
 
 api.version=v1.0
 openapi.resource=true
-openapi.resource.path=/test
+openapi.resource.path=/portal-tools-rest-builder-test
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Tools.REST.Builder.Test)
 osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseAssetLibraryTestEntityResourceTestCase.java
@@ -299,7 +299,7 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 				"JSONObject/data",
 				"Object/deleteAssetLibraryAssetLibraryTestEntityByExternalReferenceCode"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AssetLibraryTestEntity assetLibraryTestEntity2 =
@@ -309,7 +309,7 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteAssetLibraryAssetLibraryTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -327,7 +327,7 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteAssetLibraryAssetLibraryTestEntityByExternalReferenceCode"));
 	}
 
@@ -1441,4 +1441,4 @@ public abstract class BaseAssetLibraryTestEntityResourceTestCase {
 		AssetLibraryTestEntityResource _assetLibraryTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:650238122
+// LIFERAY-REST-BUILDER-HASH:-817688699

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
@@ -303,7 +303,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		BatchTestEntity batchTestEntity2 =
@@ -313,7 +313,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteBatchTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -326,13 +326,13 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteBatchTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"batchTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -445,11 +445,12 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 				BatchTestEntitySerDes.toDTOs(
 					batchTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		batchTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/batchTestEntities");
 
 		Assert.assertEquals(
@@ -711,7 +712,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/batchTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -720,7 +721,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"batchTestEntity",
 									new HashMap<String, Object>() {
@@ -731,7 +732,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/batchTestEntity"))));
 	}
 
@@ -758,14 +759,14 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"batchTestEntity",
 							new HashMap<String, Object>() {
@@ -840,7 +841,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/batchTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -849,7 +850,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"batchTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -863,7 +864,7 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/batchTestEntityByExternalReferenceCode"))));
 	}
 
@@ -893,14 +894,14 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"batchTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -2130,4 +2131,4 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1171780144
+// LIFERAY-REST-BUILDER-HASH:-1993247939

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
@@ -321,7 +321,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CompanyTestEntity companyTestEntity2 =
@@ -331,7 +331,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteCompanyTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -344,13 +344,13 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteCompanyTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"companyTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -477,11 +477,12 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 				CompanyTestEntitySerDes.toDTOs(
 					companyTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		companyTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/companyTestEntities");
 
 		Assert.assertEquals(
@@ -753,7 +754,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/companyTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -762,7 +763,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"companyTestEntity",
 									new HashMap<String, Object>() {
@@ -773,7 +774,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/companyTestEntity"))));
 	}
 
@@ -800,14 +801,14 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"companyTestEntity",
 							new HashMap<String, Object>() {
@@ -893,7 +894,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/companyTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -902,7 +903,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"companyTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -916,7 +917,7 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/companyTestEntityByExternalReferenceCode"))));
 	}
 
@@ -946,14 +947,14 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"companyTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -2421,4 +2422,4 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2045761476
+// LIFERAY-REST-BUILDER-HASH:-1675477083

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -361,7 +361,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ERCAssetLibraryTestEntity ercAssetLibraryTestEntity2 =
@@ -371,7 +371,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteAssetLibraryERCAssetLibraryTestEntity",
 							new HashMap<String, Object>() {
@@ -390,13 +390,13 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteAssetLibraryERCAssetLibraryTestEntity"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"assetLibraryERCAssetLibraryTestEntity",
 						new HashMap<String, Object>() {
@@ -523,7 +523,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-asset-library-test-entities/batch").
 					replace(
 						"{assetLibraryExternalReferenceCode}",
 						String.valueOf(assetLibraryExternalReferenceCode)));
@@ -621,12 +621,13 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 					assetLibraryERCAssetLibraryTestEntitiesJSONObject.getString(
 						"items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		assetLibraryERCAssetLibraryTestEntitiesJSONObject =
 			JSONUtil.getValueAsJSONObject(
-				invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				invokeGraphQLQuery(
+					new GraphQLField("portalTools_v1_0", graphQLField)),
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"JSONObject/assetLibraryERCAssetLibraryTestEntities");
 
 		Assert.assertEquals(
@@ -725,7 +726,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/assetLibraryERCAssetLibraryTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -734,7 +735,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"assetLibraryERCAssetLibraryTestEntity",
 									new HashMap<String, Object>() {
@@ -754,7 +755,7 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/assetLibraryERCAssetLibraryTestEntity"))));
 	}
 
@@ -789,14 +790,14 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"assetLibraryERCAssetLibraryTestEntity",
 							new HashMap<String, Object>() {
@@ -2294,4 +2295,4 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		ERCAssetLibraryTestEntityResource _ercAssetLibraryTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1218758217
+// LIFERAY-REST-BUILDER-HASH:-2019162337

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
@@ -348,7 +348,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ERCScopedTestEntity ercScopedTestEntity2 =
@@ -358,7 +358,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteAssetLibraryERCScopedTestEntity",
 							new HashMap<String, Object>() {
@@ -377,13 +377,13 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteAssetLibraryERCScopedTestEntity"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"assetLibraryERCScopedTestEntity",
 						new HashMap<String, Object>() {
@@ -459,7 +459,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 						})),
 				"JSONObject/data", "Object/deleteERCScopedTestEntity"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ERCScopedTestEntity ercScopedTestEntity2 =
@@ -469,7 +469,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteERCScopedTestEntity",
 							new HashMap<String, Object>() {
@@ -482,7 +482,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteERCScopedTestEntity"));
 	}
 
@@ -617,7 +617,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ERCScopedTestEntity ercScopedTestEntity2 =
@@ -627,7 +627,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteSiteERCScopedTestEntity",
 							new HashMap<String, Object>() {
@@ -646,13 +646,13 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteSiteERCScopedTestEntity"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"eRCScopedTestEntity",
 						new HashMap<String, Object>() {
@@ -777,7 +777,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryExternalReferenceCode}/erc-scoped-test-entities/batch").
 					replace(
 						"{assetLibraryExternalReferenceCode}",
 						String.valueOf(assetLibraryExternalReferenceCode)));
@@ -870,12 +870,13 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 					assetLibraryERCScopedTestEntitiesJSONObject.getString(
 						"items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		assetLibraryERCScopedTestEntitiesJSONObject =
 			JSONUtil.getValueAsJSONObject(
-				invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				invokeGraphQLQuery(
+					new GraphQLField("portalTools_v1_0", graphQLField)),
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"JSONObject/assetLibraryERCScopedTestEntities");
 
 		Assert.assertEquals(
@@ -967,7 +968,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/assetLibraryERCScopedTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -976,7 +977,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"assetLibraryERCScopedTestEntity",
 									new HashMap<String, Object>() {
@@ -996,7 +997,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/assetLibraryERCScopedTestEntity"))));
 	}
 
@@ -1031,14 +1032,14 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"assetLibraryERCScopedTestEntity",
 							new HashMap<String, Object>() {
@@ -1249,11 +1250,12 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 				ERCScopedTestEntitySerDes.toDTOs(
 					eRCScopedTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		eRCScopedTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/eRCScopedTestEntities");
 
 		Assert.assertEquals(
@@ -1425,7 +1427,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-scoped-test-entities/batch").
 					replace(
 						"{siteExternalReferenceCode}",
 						String.valueOf(siteExternalReferenceCode)));
@@ -1513,11 +1515,12 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 				ERCScopedTestEntitySerDes.toDTOs(
 					siteERCScopedTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		siteERCScopedTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/siteERCScopedTestEntities");
 
 		Assert.assertEquals(
@@ -1601,7 +1604,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/eRCScopedTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -1610,7 +1613,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"eRCScopedTestEntity",
 									new HashMap<String, Object>() {
@@ -1630,7 +1633,7 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/eRCScopedTestEntity"))));
 	}
 
@@ -1665,14 +1668,14 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"eRCScopedTestEntity",
 							new HashMap<String, Object>() {
@@ -3587,4 +3590,4 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		ERCScopedTestEntityResource _ercScopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:830812406
+// LIFERAY-REST-BUILDER-HASH:-1660322624

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -306,7 +306,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ERCSiteTestEntity ercSiteTestEntity2 =
@@ -316,7 +316,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteSiteERCSiteTestEntity",
 							new HashMap<String, Object>() {
@@ -335,13 +335,13 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteSiteERCSiteTestEntity"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"eRCSiteTestEntity",
 						new HashMap<String, Object>() {
@@ -452,7 +452,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/sites/{siteExternalReferenceCode}/erc-site-test-entities/batch").
 					replace(
 						"{siteExternalReferenceCode}",
 						String.valueOf(siteExternalReferenceCode)));
@@ -539,11 +539,12 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 				ERCSiteTestEntitySerDes.toDTOs(
 					eRCSiteTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		eRCSiteTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/eRCSiteTestEntities");
 
 		Assert.assertEquals(
@@ -627,7 +628,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/eRCSiteTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -636,7 +637,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"eRCSiteTestEntity",
 									new HashMap<String, Object>() {
@@ -656,7 +657,7 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/eRCSiteTestEntity"))));
 	}
 
@@ -689,14 +690,14 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"eRCSiteTestEntity",
 							new HashMap<String, Object>() {
@@ -2103,4 +2104,4 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		ERCSiteTestEntityResource _ercSiteTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-592228869
+// LIFERAY-REST-BUILDER-HASH:996020699

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseEntityModelResourceTestEntity2ResourceTestCase.java
@@ -246,7 +246,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 						"JSONObject/data",
 						"Object/entityModelResourceTestEntities2EntityModelResourceTestEntity2"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -255,7 +255,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
 									new HashMap<String, Object>() {
@@ -267,7 +267,7 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/entityModelResourceTestEntities2EntityModelResourceTestEntity2"))));
 	}
 
@@ -297,14 +297,14 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"entityModelResourceTestEntities2EntityModelResourceTestEntity2",
 							new HashMap<String, Object>() {
@@ -1046,4 +1046,4 @@ public abstract class BaseEntityModelResourceTestEntity2ResourceTestCase {
 			_entityModelResourceTestEntity2Resource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:769910531
+// LIFERAY-REST-BUILDER-HASH:-403321362

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseMultipartTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseMultipartTestEntityResourceTestCase.java
@@ -461,7 +461,7 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/multipartTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -470,7 +470,7 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"multipartTestEntity",
 									new HashMap<String, Object>() {
@@ -481,7 +481,7 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/multipartTestEntity"))));
 	}
 
@@ -508,14 +508,14 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"multipartTestEntity",
 							new HashMap<String, Object>() {
@@ -1712,4 +1712,4 @@ public abstract class BaseMultipartTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-201179494
+// LIFERAY-REST-BUILDER-HASH:516592327

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
@@ -331,7 +331,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ScopedTestEntity scopedTestEntity2 =
@@ -341,7 +341,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteAssetLibraryScopedTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -359,13 +359,13 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteAssetLibraryScopedTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"assetLibraryScopedTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -490,7 +490,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		ScopedTestEntity scopedTestEntity2 =
@@ -500,7 +500,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteSiteScopedTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -517,13 +517,13 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteSiteScopedTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"scopedTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -621,7 +621,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/asset-libraries/{assetLibraryId}/scoped-test-entities/batch").
 					replace(
 						"{assetLibraryId}", String.valueOf(assetLibraryId)));
 
@@ -709,12 +709,13 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 					assetLibraryScopedTestEntitiesJSONObject.getString(
 						"items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		assetLibraryScopedTestEntitiesJSONObject =
 			JSONUtil.getValueAsJSONObject(
-				invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				invokeGraphQLQuery(
+					new GraphQLField("portalTools_v1_0", graphQLField)),
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"JSONObject/assetLibraryScopedTestEntities");
 
 		Assert.assertEquals(
@@ -803,7 +804,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/assetLibraryScopedTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -812,7 +813,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"assetLibraryScopedTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -831,7 +832,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/assetLibraryScopedTestEntityByExternalReferenceCode"))));
 	}
 
@@ -873,14 +874,14 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"assetLibraryScopedTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -968,7 +969,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/sites/{siteId}/scoped-test-entities/batch").
+				"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/scoped-test-entities/batch").
 					replace("{siteId}", String.valueOf(siteId)));
 
 		expectedActions.put("createBatch", createBatchAction);
@@ -1045,11 +1046,12 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 				ScopedTestEntitySerDes.toDTOs(
 					scopedTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		scopedTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/scopedTestEntities");
 
 		Assert.assertEquals(
@@ -1128,7 +1130,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/scopedTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -1137,7 +1139,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"scopedTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -1156,7 +1158,7 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/scopedTestEntityByExternalReferenceCode"))));
 	}
 
@@ -1189,14 +1191,14 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"scopedTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -2729,4 +2731,4 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		ScopedTestEntityResource _scopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1389067384
+// LIFERAY-REST-BUILDER-HASH:-1522530996

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
@@ -296,7 +296,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		SharedInternalModelBatchTestEntity sharedInternalModelBatchTestEntity2 =
@@ -306,7 +306,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteSharedInternalModelBatchTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -319,13 +319,13 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteSharedInternalModelBatchTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"sharedInternalModelBatchTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -459,12 +459,13 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 					sharedInternalModelBatchTestEntitiesJSONObject.getString(
 						"items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		sharedInternalModelBatchTestEntitiesJSONObject =
 			JSONUtil.getValueAsJSONObject(
-				invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				invokeGraphQLQuery(
+					new GraphQLField("portalTools_v1_0", graphQLField)),
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"JSONObject/sharedInternalModelBatchTestEntities");
 
 		Assert.assertEquals(
@@ -546,7 +547,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/sharedInternalModelBatchTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -555,7 +556,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"sharedInternalModelBatchTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -569,7 +570,7 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/sharedInternalModelBatchTestEntityByExternalReferenceCode"))));
 	}
 
@@ -599,14 +600,14 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"sharedInternalModelBatchTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -1743,4 +1744,4 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 			_sharedInternalModelBatchTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:88348890
+// LIFERAY-REST-BUILDER-HASH:1365181772

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
@@ -327,7 +327,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		SiteTestEntity siteTestEntity2 =
@@ -337,7 +337,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteSiteSiteTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -354,13 +354,13 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 													"\"");
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteSiteSiteTestEntityByExternalReferenceCode"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"siteTestEntityByExternalReferenceCode",
 						new HashMap<String, Object>() {
@@ -458,8 +458,8 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 		createBatchAction.put(
 			"href",
 			("http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/o/test/v1.0/sites/{siteId}/site-test-entities/batch").replace(
-					"{siteId}", String.valueOf(siteId)));
+				"/o/portal-tools-rest-builder-test/v1.0/sites/{siteId}/site-test-entities/batch").
+					replace("{siteId}", String.valueOf(siteId)));
 
 		expectedActions.put("createBatch", createBatchAction);
 
@@ -534,11 +534,12 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 				SiteTestEntitySerDes.toDTOs(
 					siteTestEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		siteTestEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/siteTestEntities");
 
 		Assert.assertEquals(
@@ -625,7 +626,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 						"JSONObject/data",
 						"Object/siteTestEntityByExternalReferenceCode"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -634,7 +635,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"siteTestEntityByExternalReferenceCode",
 									new HashMap<String, Object>() {
@@ -653,7 +654,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/siteTestEntityByExternalReferenceCode"))));
 	}
 
@@ -686,14 +687,14 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"siteTestEntityByExternalReferenceCode",
 							new HashMap<String, Object>() {
@@ -970,7 +971,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/testEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -979,7 +980,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"testEntity",
 									new HashMap<String, Object>() {
@@ -990,7 +991,7 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/testEntity"))));
 	}
 
@@ -1017,14 +1018,14 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"testEntity",
 							new HashMap<String, Object>() {
@@ -2530,4 +2531,4 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1907069435
+// LIFERAY-REST-BUILDER-HASH:-431871166

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityAddressResourceTestCase.java
@@ -238,7 +238,7 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 						"JSONObject/data",
 						"Object/testEntityTestEntityAddress"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -247,7 +247,7 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"testEntityTestEntityAddress",
 									new HashMap<String, Object>() {
@@ -258,7 +258,7 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/testEntityTestEntityAddress"))));
 	}
 
@@ -292,14 +292,14 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"testEntityTestEntityAddress",
 							new HashMap<String, Object>() {
@@ -1254,4 +1254,4 @@ public abstract class BaseTestEntityAddressResourceTestCase {
 		TestEntityAddressResource _testEntityAddressResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1820051977
+// LIFERAY-REST-BUILDER-HASH:185615214

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
@@ -289,7 +289,7 @@ public abstract class BaseTestEntityResourceTestCase {
 
 		Assert.assertTrue(errorsJSONArray1.length() > 0);
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		TestEntity testEntity2 = testGraphQLDeleteTestEntity_addTestEntity();
@@ -298,7 +298,7 @@ public abstract class BaseTestEntityResourceTestCase {
 			JSONUtil.getValueAsBoolean(
 				invokeGraphQLMutation(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"deleteTestEntity",
 							new HashMap<String, Object>() {
@@ -306,13 +306,13 @@ public abstract class BaseTestEntityResourceTestCase {
 									put("testEntityId", testEntity2.getId());
 								}
 							}))),
-				"JSONObject/data", "JSONObject/test_v1_0",
+				"JSONObject/data", "JSONObject/portalTools_v1_0",
 				"Object/deleteTestEntity"));
 
 		JSONArray errorsJSONArray2 = JSONUtil.getValueAsJSONArray(
 			invokeGraphQLQuery(
 				new GraphQLField(
-					"test_v1_0",
+					"portalTools_v1_0",
 					new GraphQLField(
 						"testEntity",
 						new HashMap<String, Object>() {
@@ -537,11 +537,12 @@ public abstract class BaseTestEntityResourceTestCase {
 				TestEntitySerDes.toDTOs(
 					testEntitiesJSONObject.getString("items"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		testEntitiesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(new GraphQLField("test_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/test_v1_0",
+			invokeGraphQLQuery(
+				new GraphQLField("portalTools_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/portalTools_v1_0",
 			"JSONObject/testEntities");
 
 		Assert.assertEquals(
@@ -792,7 +793,7 @@ public abstract class BaseTestEntityResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data", "Object/testEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -801,7 +802,7 @@ public abstract class BaseTestEntityResourceTestCase {
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"testEntity",
 									new HashMap<String, Object>() {
@@ -812,7 +813,7 @@ public abstract class BaseTestEntityResourceTestCase {
 										}
 									},
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/testEntity"))));
 	}
 
@@ -837,14 +838,14 @@ public abstract class BaseTestEntityResourceTestCase {
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"testEntity",
 							new HashMap<String, Object>() {
@@ -2509,4 +2510,4 @@ public abstract class BaseTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:670798875
+// LIFERAY-REST-BUILDER-HASH:-1918766857

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/OpenAPIResourceTest.java
@@ -134,7 +134,8 @@ public class OpenAPIResourceTest {
 										)))))))
 			).toString(),
 			HTTPTestUtil.invokeToJSONObject(
-				null, "test/v1.0/openapi.json", Http.Method.GET
+				null, "portal-tools-rest-builder-test/v1.0/openapi.json",
+				Http.Method.GET
 			).toString(),
 			false);
 	}

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/SiteTestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/SiteTestEntityResourceTest.java
@@ -141,7 +141,7 @@ public class SiteTestEntityResourceTest
 								getGraphQLFields())),
 						"JSONObject/data", "Object/siteTestEntity"))));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertTrue(
 			equals(
@@ -150,7 +150,7 @@ public class SiteTestEntityResourceTest
 					JSONUtil.getValueAsString(
 						invokeGraphQLQuery(
 							new GraphQLField(
-								"test_v1_0",
+								"portalTools_v1_0",
 								new GraphQLField(
 									"siteTestEntity",
 									HashMapBuilder.<String, Object>put(
@@ -158,7 +158,7 @@ public class SiteTestEntityResourceTest
 										siteTestEntity.getId()
 									).build(),
 									getGraphQLFields()))),
-						"JSONObject/data", "JSONObject/test_v1_0",
+						"JSONObject/data", "JSONObject/portalTools_v1_0",
 						"Object/siteTestEntity"))));
 	}
 
@@ -182,14 +182,14 @@ public class SiteTestEntityResourceTest
 				"JSONArray/errors", "Object/0", "JSONObject/extensions",
 				"Object/code"));
 
-		// Using the namespace test_v1_0
+		// Using the namespace portalTools_v1_0
 
 		Assert.assertEquals(
 			"Not Found",
 			JSONUtil.getValueAsString(
 				invokeGraphQLQuery(
 					new GraphQLField(
-						"test_v1_0",
+						"portalTools_v1_0",
 						new GraphQLField(
 							"siteTestEntity",
 							HashMapBuilder.<String, Object>put(
@@ -226,7 +226,9 @@ public class SiteTestEntityResourceTest
 		throws Exception {
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
-			null, "test/v1.0/sites/" + siteId + "/site-test-entities",
+			null,
+			"portal-tools-rest-builder-test/v1.0/sites/" + siteId +
+				"/site-test-entities",
 			Http.Method.GET);
 
 		Assert.assertEquals(totalCount, jsonObject.getInt("totalCount"));

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/TestEntityResourceTest.java
@@ -224,7 +224,8 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 			).put(
 				"type", invalidTypeId
 			).toString(),
-			"test/v1.0/test-entities", Http.Method.POST);
+			"portal-tools-rest-builder-test/v1.0/test-entities",
+			Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 		Assert.assertTrue(
@@ -238,7 +239,8 @@ public class TestEntityResourceTest extends BaseTestEntityResourceTestCase {
 			JSONUtil.put(
 				"name", StringUtil.toLowerCase(RandomTestUtil.randomString())
 			).toString(),
-			"test/v1.0/test-entities", Http.Method.POST);
+			"portal-tools-rest-builder-test/v1.0/test-entities",
+			Http.Method.POST);
 
 		Assert.assertEquals("BAD_REQUEST", jsonObject.getString("status"));
 		Assert.assertTrue(


### PR DESCRIPTION
Supersedes #6161 — Marcela's commit is included here (authorship preserved).

## Why

`portal-tools-rest-builder-test` registers its JAX-RS application at the base URI `/test` (`osgi.jaxrs.application.base=/test`), i.e. `/o/test/v1.0/...`. `/test` is a short, generic path that other code legitimately uses, so a dedicated internal test application occupying it competes for a shared namespace.

This surfaced through two independent root causes, and this PR addresses both:

1. **A leaked OSGi stub (#6161).** `ObjectRelationshipLocalServiceTest` registered a `TestSystemObjectDefinitionManager` and discarded the returned `ServiceRegistration`, leaking it into the JVM for the rest of the run. The leaked stub then intercepted `/test/{pk}` requests issued by later test classes (notably `ObjectEntryRelatedObjectsResourceTest`), returning the stub's null/0 defaults — CI failures that did not reproduce locally because no other class polluted the registry. Fixed by capturing and unregistering the service in `@After`/`@AfterClass`.

2. **The application statically squatting `/test`.** Even with the leak fixed, the rest-builder test application itself owns `/test`, so anything else resolving to `/test` in the same runtime is shadowed. Concretely, in test mode the Object framework maps modifiable system object definitions named `Test` to the REST context path `/test`; with the rest-builder app deployed, those requests hit the wrong application. **This only manifests on CI**: the `portal-tools-rest-builder-test` application is deployed there as part of the test run, whereas a typical local bundle does not have it deployed — so the clash (and the resulting failures below) does not appear locally unless the app is deployed by hand.

### Evidence

With the rest-builder app deployed on `/test` (i.e. #6161 alone), `ObjectEntryRelatedObjectsResourceTest` still fails:

| Test | Failure |
| --- | --- |
| `testDeleteObjectEntryWithHierarchy` | `expected:<204> but was:<404>` |
| `testGetRelatedObjectEntriesWithHierarchy` | `NullPointerException: jsonArray is null` |
| `testPostRelatedObjectEntryWithHierarchy` | `expected:<0> but was:<null>` |

Moving the application to a unique base makes all 24 pass. (Reproduced locally by deploying the test app to mirror CI.)

## What

- `rest-config.yaml`: `baseURI` `/test` → `/portal-tools-rest-builder-test`.
- `buildREST` regeneration of all generated artifacts (api / client / client-js / impl / test).
- Updated the hand-written test classes the generator does not own: old endpoint literals (`test/v1.0/...` → `portal-tools-rest-builder-test/v1.0/...`) and the derived GraphQL namespace (`test_v1_0` → `portalTools_v1_0`).

## Validation (local)

- `ObjectEntryRelatedObjectsResourceTest`: 24/24 pass (3 failing on `/test`).
- `portal-tools-rest-builder-test` integration tests (TestEntity, SiteTestEntity, OpenAPI, ...): pass.
- Playwright `portal-tools-rest-builder-test-impl.main`: pass.
