### PR TITLE
LPD-56169 Register collection providers for system object relationships

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -281,6 +281,19 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		List<ObjectField> objectFields, List<ObjectLayout> objectLayouts,
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap) {
 
+		List<ObjectRelationship> objectRelationships = null;
+
+		if (objectRelationshipsMap != null) {
+			objectRelationships = objectRelationshipsMap.getOrDefault(
+				objectDefinition.getObjectDefinitionId(),
+				Collections.emptyList());
+		}
+
+		_objectRelationshipLocalService.
+			registerObjectRelationshipsRelatedInfoCollectionProviders(
+				objectDefinition, _objectDefinitionLocalService,
+				objectRelationships);
+
 		if (objectDefinition.isUnmodifiableSystemObject()) {
 			return Collections.emptyList();
 		}
@@ -535,19 +548,6 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				registerObjectLayoutTabScreenNavigationCategories(
 					objectDefinition, objectLayout.getObjectLayoutTabs());
 		}
-
-		List<ObjectRelationship> objectRelationships = null;
-
-		if (objectRelationshipsMap != null) {
-			objectRelationships = objectRelationshipsMap.getOrDefault(
-				objectDefinition.getObjectDefinitionId(),
-				Collections.emptyList());
-		}
-
-		_objectRelationshipLocalService.
-			registerObjectRelationshipsRelatedInfoCollectionProviders(
-				objectDefinition, _objectDefinitionLocalService,
-				objectRelationships);
 
 		try {
 			if (ArrayUtil.isNotEmpty(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
@@ -13,13 +13,17 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -48,22 +52,57 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 		CollectionQuery collectionQuery) {
 
 		Object relatedItem = collectionQuery.getRelatedItem();
-
-		if (!(relatedItem instanceof ObjectEntry)) {
-			return InfoPage.of(
-				Collections.emptyList(), collectionQuery.getPagination(), 0);
-		}
+		Pagination pagination = collectionQuery.getPagination();
 
 		try {
-			return getCollectionInfoPage(
-				(ObjectEntry)relatedItem, collectionQuery.getPagination());
+			if (relatedItem instanceof ObjectEntry) {
+				ObjectEntry objectEntry = (ObjectEntry)relatedItem;
+
+				long primaryKey = objectEntry.getObjectEntryId();
+
+				if (_objectDefinition1.isSystem()) {
+					primaryKey = GetterUtil.getLong(
+						objectEntry.getValues(
+						).get(
+							_objectDefinition1.getPKObjectFieldName()
+						),
+						primaryKey);
+				}
+
+				return getCollectionInfoPage(
+					objectEntry.getGroupId(), primaryKey, pagination);
+			}
+			else if (relatedItem instanceof SystemObjectEntry) {
+				SystemObjectEntry systemObjectEntry =
+					(SystemObjectEntry)relatedItem;
+
+				return getCollectionInfoPage(
+					systemObjectEntry.getGroupId(),
+					systemObjectEntry.getClassPK(), pagination);
+			}
+			else if (_objectDefinition1.isSystem() &&
+					 (relatedItem instanceof BaseModel)) {
+
+				BaseModel<?> baseModel = (BaseModel<?>)relatedItem;
+
+				long groupId = 0L;
+
+				if (relatedItem instanceof GroupedModel) {
+					GroupedModel groupedModel = (GroupedModel)relatedItem;
+
+					groupId = groupedModel.getGroupId();
+				}
+
+				return getCollectionInfoPage(
+					groupId, GetterUtil.getLong(baseModel.getPrimaryKeyObj()),
+					pagination);
+			}
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);
 		}
 
-		return InfoPage.of(
-			Collections.emptyList(), collectionQuery.getPagination(), 0);
+		return InfoPage.of(Collections.emptyList(), pagination, 0);
 	}
 
 	@Override
@@ -110,7 +149,7 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	}
 
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, long primaryKey, Pagination pagination)
 		throws PortalException {
 
 		return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/BaseObjectRelationshipRelatedInfoCollectionProvider.java
@@ -25,8 +25,11 @@ import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.io.Serializable;
+
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Feliphe Marinho
@@ -61,31 +64,30 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 				long primaryKey = objectEntry.getObjectEntryId();
 
 				if (_objectDefinition1.isSystem()) {
+					Map<String, Serializable> values = objectEntry.getValues();
+
 					primaryKey = GetterUtil.getLong(
-						objectEntry.getValues(
-						).get(
-							_objectDefinition1.getPKObjectFieldName()
-						),
+						values.get(_objectDefinition1.getPKObjectFieldName()),
 						primaryKey);
 				}
 
 				return getCollectionInfoPage(
-					objectEntry.getGroupId(), primaryKey, pagination);
+					objectEntry.getGroupId(), pagination, primaryKey);
 			}
 			else if (relatedItem instanceof SystemObjectEntry) {
 				SystemObjectEntry systemObjectEntry =
 					(SystemObjectEntry)relatedItem;
 
 				return getCollectionInfoPage(
-					systemObjectEntry.getGroupId(),
-					systemObjectEntry.getClassPK(), pagination);
+					systemObjectEntry.getGroupId(), pagination,
+					systemObjectEntry.getClassPK());
 			}
 			else if (_objectDefinition1.isSystem() &&
 					 (relatedItem instanceof BaseModel)) {
 
 				BaseModel<?> baseModel = (BaseModel<?>)relatedItem;
 
-				long groupId = 0L;
+				long groupId = 0;
 
 				if (relatedItem instanceof GroupedModel) {
 					GroupedModel groupedModel = (GroupedModel)relatedItem;
@@ -94,8 +96,8 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 				}
 
 				return getCollectionInfoPage(
-					groupId, GetterUtil.getLong(baseModel.getPrimaryKeyObj()),
-					pagination);
+					groupId, pagination,
+					GetterUtil.getLong(baseModel.getPrimaryKeyObj()));
 			}
 		}
 		catch (PortalException portalException) {
@@ -149,7 +151,7 @@ public abstract class BaseObjectRelationshipRelatedInfoCollectionProvider
 	}
 
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			long groupId, long primaryKey, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,7 +33,7 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			long groupId, long primaryKey, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ManyToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,22 +33,18 @@ public class ManyToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, long primaryKey, Pagination pagination)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getManyToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null, pagination.getStart(),
-				pagination.getEnd()),
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null,
+				pagination.getStart(), pagination.getEnd()),
 			pagination,
 			objectEntryLocalService.getManyToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(),
-				objectEntry.getObjectEntryId(), true,
-				objectRelationship.isReverse(), null));
+				groupId, objectRelationship.getObjectRelationshipId(),
+				primaryKey, true, objectRelationship.isReverse(), null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,7 +33,7 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			long groupId, long primaryKey, Pagination pagination)
+			long groupId, Pagination pagination, long primaryKey)
 		throws PortalException {
 
 		return InfoPage.of(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/OneToManyObjectRelationshipRelatedInfoCollectionProvider.java
@@ -33,20 +33,18 @@ public class OneToManyObjectRelationshipRelatedInfoCollectionProvider
 
 	@Override
 	protected InfoPage<ObjectEntry> getCollectionInfoPage(
-			ObjectEntry objectEntry, Pagination pagination)
+			long groupId, long primaryKey, Pagination pagination)
 		throws PortalException {
 
 		return InfoPage.of(
 			objectEntryLocalService.getOneToManyObjectEntries(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null, false,
-				objectEntry.getObjectEntryId(), true, null,
-				pagination.getStart(), pagination.getEnd(), null),
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				false, primaryKey, true, null, pagination.getStart(),
+				pagination.getEnd(), null),
 			pagination,
 			objectEntryLocalService.getOneToManyObjectEntriesCount(
-				objectEntry.getGroupId(),
-				objectRelationship.getObjectRelationshipId(), null,
-				objectEntry.getObjectEntryId(), true, null));
+				groupId, objectRelationship.getObjectRelationshipId(), null,
+				primaryKey, true, null));
 	}
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/RelatedInfoCollectionProviderFactory.java
@@ -30,7 +30,7 @@ public class RelatedInfoCollectionProviderFactory {
 			ObjectRelationship objectRelationship)
 		throws PortalException {
 
-		if (objectDefinition1.isSystem() || objectDefinition2.isSystem()) {
+		if (objectDefinition2.isSystem()) {
 			return null;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -940,6 +940,35 @@ public class ObjectRelationshipLocalServiceImpl
 				_log.error(portalException);
 			}
 		}
+
+		for (ObjectRelationship objectRelationship :
+				objectRelationshipPersistence.findByObjectDefinitionId2(
+					objectDefinition1.getObjectDefinitionId())) {
+
+			String type = objectRelationship.getType();
+
+			if (!objectRelationship.isAllowedObjectRelationshipType(type) ||
+				Objects.equals(
+					type, ObjectRelationshipConstants.TYPE_MANY_TO_MANY) ||
+				Objects.equals(
+					type, ObjectRelationshipConstants.TYPE_ONE_TO_ONE)) {
+
+				continue;
+			}
+
+			try {
+				ObjectDefinition parentObjectDefinition =
+					objectDefinitionLocalService.getObjectDefinition(
+						objectRelationship.getObjectDefinitionId1());
+
+				_registerRelatedInfoItemCollectionProvider(
+					parentObjectDefinition, objectDefinition1,
+					objectRelationship);
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
+			}
+		}
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -10,7 +10,11 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
+import com.liferay.info.collection.provider.CollectionQuery;
 import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -56,6 +60,7 @@ import com.liferay.object.service.persistence.ObjectLayoutRowPersistence;
 import com.liferay.object.service.persistence.ObjectLayoutTabPersistence;
 import com.liferay.object.service.test.system.TestSystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectEntry;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.object.test.util.TreeTestUtil;
@@ -812,7 +817,355 @@ public class ObjectRelationshipLocalServiceTest {
 	}
 
 	@Test
-	public void testRegisterObjectRelationshipsRelatedInfoItemCollectionProviders()
+	public void testGetCollectionInfoPageWhenParentObjectDefinitionIsCustom()
+		throws Exception {
+
+		ObjectDefinition childObjectDefinition =
+			_addAndPublishCustomObjectDefinition();
+
+		ObjectDefinition parentObjectDefinition =
+			_addAndPublishCustomObjectDefinition();
+
+		String customObjectRelationshipName = StringUtil.randomId();
+
+		ObjectRelationship customObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				customObjectRelationshipName, false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			String customRelationshipFieldName =
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					parentObjectDefinition, customObjectRelationshipName);
+
+			ObjectEntry parentObjectEntry =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					parentObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null, Collections.emptyMap(),
+					ServiceContextTestUtil.getServiceContext());
+
+			ObjectEntry childObjectEntry1 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						customRelationshipFieldName,
+						parentObjectEntry.getObjectEntryId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			ObjectEntry childObjectEntry2 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						customRelationshipFieldName,
+						parentObjectEntry.getObjectEntryId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			RelatedInfoItemCollectionProvider
+				customRelatedInfoItemCollectionProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						RelatedInfoItemCollectionProvider.class,
+						parentObjectDefinition.getClassName());
+
+			CollectionQuery customCollectionQuery = new CollectionQuery();
+
+			customCollectionQuery.setPagination(Pagination.of(10, 0));
+			customCollectionQuery.setRelatedItemObject(parentObjectEntry);
+
+			InfoPage collectionInfoPage =
+				customRelatedInfoItemCollectionProvider.getCollectionInfoPage(
+					customCollectionQuery);
+
+			List<ObjectEntry> objectEntries =
+				(List<ObjectEntry>)collectionInfoPage.getPageItems();
+
+			Assert.assertEquals(
+				objectEntries.toString(), 2, objectEntries.size());
+			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
+			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
+
+			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				customObjectRelationship);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				parentObjectDefinition);
+		}
+	}
+
+	@Test
+	public void testGetCollectionInfoPageWhenParentObjectDefinitionIsSystem()
+		throws Exception {
+
+		ObjectDefinition childObjectDefinition =
+			_addAndPublishCustomObjectDefinition();
+
+		String systemObjectRelationshipName = StringUtil.randomId();
+
+		ObjectRelationship systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				systemObjectRelationshipName, false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			String systemRelationshipFieldName =
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					_systemObjectDefinition2, systemObjectRelationshipName);
+
+			long systemParentPK = RandomTestUtil.randomLong();
+
+			ObjectEntry childObjectEntry1 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName, systemParentPK
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			ObjectEntry childObjectEntry2 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName, systemParentPK
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			RelatedInfoItemCollectionProvider
+				relatedInfoItemCollectionProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						RelatedInfoItemCollectionProvider.class,
+						_systemObjectDefinition2.getClassName());
+
+			CollectionQuery collectionQuery = new CollectionQuery();
+
+			collectionQuery.setPagination(Pagination.of(10, 0));
+			collectionQuery.setRelatedItemObject(
+				new SystemObjectEntry(
+					systemParentPK, null, Collections.emptyMap()));
+
+			InfoPage collectionInfoPage =
+				relatedInfoItemCollectionProvider.getCollectionInfoPage(
+					collectionQuery);
+
+			List<ObjectEntry> objectEntries =
+				(List<ObjectEntry>)collectionInfoPage.getPageItems();
+
+			Assert.assertEquals(
+				objectEntries.toString(), 2, objectEntries.size());
+			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
+			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
+
+			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				systemObjectRelationship);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+		}
+
+		childObjectDefinition = _addAndPublishCustomObjectDefinition();
+
+		systemObjectRelationshipName = StringUtil.randomId();
+
+		systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				systemObjectRelationshipName, false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			String systemRelationshipFieldName =
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					_systemObjectDefinition2, systemObjectRelationshipName);
+
+			User user = TestPropsValues.getUser();
+
+			ObjectEntry childObjectEntry1 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName, user.getUserId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			ObjectEntry childObjectEntry2 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName, user.getUserId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			RelatedInfoItemCollectionProvider
+				relatedInfoItemCollectionProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						RelatedInfoItemCollectionProvider.class,
+						_systemObjectDefinition2.getClassName());
+
+			CollectionQuery collectionQuery = new CollectionQuery();
+
+			collectionQuery.setPagination(Pagination.of(10, 0));
+			collectionQuery.setRelatedItemObject(user);
+
+			InfoPage collectionInfoPage =
+				relatedInfoItemCollectionProvider.getCollectionInfoPage(
+					collectionQuery);
+
+			List<ObjectEntry> objectEntries =
+				(List<ObjectEntry>)collectionInfoPage.getPageItems();
+
+			Assert.assertEquals(
+				objectEntries.toString(), 2, objectEntries.size());
+			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
+			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
+
+			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				systemObjectRelationship);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+		}
+
+		childObjectDefinition = _addAndPublishCustomObjectDefinition();
+
+		systemObjectRelationshipName = StringUtil.randomId();
+
+		systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				systemObjectRelationshipName, false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		try {
+			String systemRelationshipFieldName =
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					_systemObjectDefinition2, systemObjectRelationshipName);
+
+			ObjectEntry childObjectEntry1 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName,
+						depotEntry.getDepotEntryId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			ObjectEntry childObjectEntry2 =
+				_objectEntryLocalService.addObjectEntry(
+					0, TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId(),
+					ObjectEntryFolderConstants.
+						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+					null,
+					HashMapBuilder.<String, Serializable>put(
+						systemRelationshipFieldName,
+						depotEntry.getDepotEntryId()
+					).build(),
+					ServiceContextTestUtil.getServiceContext());
+
+			RelatedInfoItemCollectionProvider
+				relatedInfoItemCollectionProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						RelatedInfoItemCollectionProvider.class,
+						_systemObjectDefinition2.getClassName());
+
+			CollectionQuery collectionQuery = new CollectionQuery();
+
+			collectionQuery.setPagination(Pagination.of(10, 0));
+			collectionQuery.setRelatedItemObject(depotEntry);
+
+			InfoPage collectionInfoPage =
+				relatedInfoItemCollectionProvider.getCollectionInfoPage(
+					collectionQuery);
+
+			List<ObjectEntry> objectEntries =
+				(List<ObjectEntry>)collectionInfoPage.getPageItems();
+
+			Assert.assertEquals(
+				objectEntries.toString(), 2, objectEntries.size());
+			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
+			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
+
+			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				systemObjectRelationship);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_depotEntryLocalService.deleteDepotEntry(
+				depotEntry.getDepotEntryId());
+		}
+	}
+
+	@Test
+	public void testRegisterObjectRelationshipsRelatedInfoCollectionProviders()
 		throws Exception {
 
 		ObjectDefinition objectDefinition1 =
@@ -874,6 +1227,114 @@ public class ObjectRelationshipLocalServiceTest {
 		Assert.assertEquals(
 			objectDefinition2.getClassName(),
 			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		ObjectRelationship systemObjectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				_objectDefinition1.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+			_systemObjectDefinition2.getClassName());
+
+		Assert.assertEquals(
+			_systemObjectDefinition2.getClassName(),
+			relatedInfoItemCollectionProvider.getSourceItemClassName());
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			systemObjectRelationship);
+
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_systemObjectDefinition2.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			Assert.assertNull(
+				serviceTrackerMap.getService(
+					_systemObjectDefinition2.getClassName()));
+
+			childObjectDefinition =
+				_objectDefinitionLocalService.publishCustomObjectDefinition(
+					TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId());
+
+			relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+				_systemObjectDefinition2.getClassName());
+
+			Assert.assertEquals(
+				_systemObjectDefinition2.getClassName(),
+				relatedInfoItemCollectionProvider.getSourceItemClassName());
+		}
+		finally {
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+		}
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			Assert.assertNull(
+				serviceTrackerMap.getService(
+					parentObjectDefinition.getClassName()));
+
+			parentObjectDefinition =
+				_objectDefinitionLocalService.publishCustomObjectDefinition(
+					TestPropsValues.getUserId(),
+					parentObjectDefinition.getObjectDefinitionId());
+
+			Assert.assertNull(
+				serviceTrackerMap.getService(
+					parentObjectDefinition.getClassName()));
+
+			childObjectDefinition =
+				_objectDefinitionLocalService.publishCustomObjectDefinition(
+					TestPropsValues.getUserId(),
+					childObjectDefinition.getObjectDefinitionId());
+
+			relatedInfoItemCollectionProvider = serviceTrackerMap.getService(
+				parentObjectDefinition.getClassName());
+
+			Assert.assertEquals(
+				parentObjectDefinition.getClassName(),
+				relatedInfoItemCollectionProvider.getSourceItemClassName());
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				parentObjectDefinition);
+		}
 
 		serviceTrackerMap.close();
 
@@ -1857,6 +2318,9 @@ public class ObjectRelationshipLocalServiceTest {
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
 
 	@DeleteAfterTestRun
 	private ObjectDefinition _modifiableSystemObjectDefinition;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -826,23 +826,15 @@ public class ObjectRelationshipLocalServiceTest {
 		ObjectDefinition parentObjectDefinition =
 			_addAndPublishCustomObjectDefinition();
 
-		String customObjectRelationshipName = StringUtil.randomId();
+		String name = StringUtil.randomId();
 
-		ObjectRelationship customObjectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				parentObjectDefinition.getObjectDefinitionId(),
-				childObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				customObjectRelationshipName, false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition,
+				childObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, name);
 
 		try {
-			String customRelationshipFieldName =
-				ObjectRelationshipUtil.getObjectRelationshipFieldName(
-					parentObjectDefinition, customObjectRelationshipName);
-
 			ObjectEntry parentObjectEntry =
 				_objectEntryLocalService.addObjectEntry(
 					0, TestPropsValues.getUserId(),
@@ -852,60 +844,22 @@ public class ObjectRelationshipLocalServiceTest {
 					null, Collections.emptyMap(),
 					ServiceContextTestUtil.getServiceContext());
 
-			ObjectEntry childObjectEntry1 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						customRelationshipFieldName,
-						parentObjectEntry.getObjectEntryId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
+			String relationshipFieldName =
+				ObjectRelationshipUtil.getObjectRelationshipFieldName(
+					parentObjectDefinition, name);
 
-			ObjectEntry childObjectEntry2 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						customRelationshipFieldName,
-						parentObjectEntry.getObjectEntryId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
-
-			RelatedInfoItemCollectionProvider
-				customRelatedInfoItemCollectionProvider =
-					_infoItemServiceRegistry.getFirstInfoItemService(
-						RelatedInfoItemCollectionProvider.class,
-						parentObjectDefinition.getClassName());
-
-			CollectionQuery customCollectionQuery = new CollectionQuery();
-
-			customCollectionQuery.setPagination(Pagination.of(10, 0));
-			customCollectionQuery.setRelatedItemObject(parentObjectEntry);
-
-			InfoPage collectionInfoPage =
-				customRelatedInfoItemCollectionProvider.getCollectionInfoPage(
-					customCollectionQuery);
-
-			List<ObjectEntry> objectEntries =
-				(List<ObjectEntry>)collectionInfoPage.getPageItems();
-
-			Assert.assertEquals(
-				objectEntries.toString(), 2, objectEntries.size());
-			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
-			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
-
-			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+			_assertCollectionInfoPage(
+				parentObjectDefinition, parentObjectEntry,
+				_addChildObjectEntry(
+					childObjectDefinition, parentObjectEntry.getObjectEntryId(),
+					relationshipFieldName),
+				_addChildObjectEntry(
+					childObjectDefinition, parentObjectEntry.getObjectEntryId(),
+					relationshipFieldName));
 		}
 		finally {
 			_objectRelationshipLocalService.deleteObjectRelationship(
-				customObjectRelationship);
+				objectRelationship);
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				childObjectDefinition);
 			_objectDefinitionLocalService.deleteObjectDefinition(
@@ -920,174 +874,6 @@ public class ObjectRelationshipLocalServiceTest {
 		ObjectDefinition childObjectDefinition =
 			_addAndPublishCustomObjectDefinition();
 
-		String systemObjectRelationshipName = StringUtil.randomId();
-
-		ObjectRelationship systemObjectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
-				childObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				systemObjectRelationshipName, false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
-
-		try {
-			String systemRelationshipFieldName =
-				ObjectRelationshipUtil.getObjectRelationshipFieldName(
-					_systemObjectDefinition2, systemObjectRelationshipName);
-
-			long systemParentPK = RandomTestUtil.randomLong();
-
-			ObjectEntry childObjectEntry1 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName, systemParentPK
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
-
-			ObjectEntry childObjectEntry2 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName, systemParentPK
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
-
-			RelatedInfoItemCollectionProvider
-				relatedInfoItemCollectionProvider =
-					_infoItemServiceRegistry.getFirstInfoItemService(
-						RelatedInfoItemCollectionProvider.class,
-						_systemObjectDefinition2.getClassName());
-
-			CollectionQuery collectionQuery = new CollectionQuery();
-
-			collectionQuery.setPagination(Pagination.of(10, 0));
-			collectionQuery.setRelatedItemObject(
-				new SystemObjectEntry(
-					systemParentPK, null, Collections.emptyMap()));
-
-			InfoPage collectionInfoPage =
-				relatedInfoItemCollectionProvider.getCollectionInfoPage(
-					collectionQuery);
-
-			List<ObjectEntry> objectEntries =
-				(List<ObjectEntry>)collectionInfoPage.getPageItems();
-
-			Assert.assertEquals(
-				objectEntries.toString(), 2, objectEntries.size());
-			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
-			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
-
-			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				systemObjectRelationship);
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				childObjectDefinition);
-		}
-
-		childObjectDefinition = _addAndPublishCustomObjectDefinition();
-
-		systemObjectRelationshipName = StringUtil.randomId();
-
-		systemObjectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
-				childObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				systemObjectRelationshipName, false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
-
-		try {
-			String systemRelationshipFieldName =
-				ObjectRelationshipUtil.getObjectRelationshipFieldName(
-					_systemObjectDefinition2, systemObjectRelationshipName);
-
-			User user = TestPropsValues.getUser();
-
-			ObjectEntry childObjectEntry1 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName, user.getUserId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
-
-			ObjectEntry childObjectEntry2 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName, user.getUserId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
-
-			RelatedInfoItemCollectionProvider
-				relatedInfoItemCollectionProvider =
-					_infoItemServiceRegistry.getFirstInfoItemService(
-						RelatedInfoItemCollectionProvider.class,
-						_systemObjectDefinition2.getClassName());
-
-			CollectionQuery collectionQuery = new CollectionQuery();
-
-			collectionQuery.setPagination(Pagination.of(10, 0));
-			collectionQuery.setRelatedItemObject(user);
-
-			InfoPage collectionInfoPage =
-				relatedInfoItemCollectionProvider.getCollectionInfoPage(
-					collectionQuery);
-
-			List<ObjectEntry> objectEntries =
-				(List<ObjectEntry>)collectionInfoPage.getPageItems();
-
-			Assert.assertEquals(
-				objectEntries.toString(), 2, objectEntries.size());
-			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
-			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
-
-			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
-		}
-		finally {
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				systemObjectRelationship);
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				childObjectDefinition);
-		}
-
-		childObjectDefinition = _addAndPublishCustomObjectDefinition();
-
-		systemObjectRelationshipName = StringUtil.randomId();
-
-		systemObjectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_systemObjectDefinition2.getObjectDefinitionId(),
-				childObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				systemObjectRelationshipName, false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
-
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
@@ -1098,65 +884,55 @@ public class ObjectRelationshipLocalServiceTest {
 			DepotConstants.TYPE_ASSET_LIBRARY,
 			ServiceContextTestUtil.getServiceContext());
 
+		String name = StringUtil.randomId();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _systemObjectDefinition2,
+				childObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, name);
+
 		try {
-			String systemRelationshipFieldName =
+			String relationshipFieldName =
 				ObjectRelationshipUtil.getObjectRelationshipFieldName(
-					_systemObjectDefinition2, systemObjectRelationshipName);
+					_systemObjectDefinition2, name);
 
-			ObjectEntry childObjectEntry1 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName,
-						depotEntry.getDepotEntryId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
+			_assertCollectionInfoPage(
+				_systemObjectDefinition2, depotEntry,
+				_addChildObjectEntry(
+					childObjectDefinition, depotEntry.getDepotEntryId(),
+					relationshipFieldName),
+				_addChildObjectEntry(
+					childObjectDefinition, depotEntry.getDepotEntryId(),
+					relationshipFieldName));
 
-			ObjectEntry childObjectEntry2 =
-				_objectEntryLocalService.addObjectEntry(
-					0, TestPropsValues.getUserId(),
-					childObjectDefinition.getObjectDefinitionId(),
-					ObjectEntryFolderConstants.
-						PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
-					null,
-					HashMapBuilder.<String, Serializable>put(
-						systemRelationshipFieldName,
-						depotEntry.getDepotEntryId()
-					).build(),
-					ServiceContextTestUtil.getServiceContext());
+			long systemParentPrimaryKey = RandomTestUtil.randomLong();
 
-			RelatedInfoItemCollectionProvider
-				relatedInfoItemCollectionProvider =
-					_infoItemServiceRegistry.getFirstInfoItemService(
-						RelatedInfoItemCollectionProvider.class,
-						_systemObjectDefinition2.getClassName());
+			_assertCollectionInfoPage(
+				_systemObjectDefinition2,
+				new SystemObjectEntry(
+					systemParentPrimaryKey, null, Collections.emptyMap()),
+				_addChildObjectEntry(
+					childObjectDefinition, systemParentPrimaryKey,
+					relationshipFieldName),
+				_addChildObjectEntry(
+					childObjectDefinition, systemParentPrimaryKey,
+					relationshipFieldName));
 
-			CollectionQuery collectionQuery = new CollectionQuery();
+			User user = TestPropsValues.getUser();
 
-			collectionQuery.setPagination(Pagination.of(10, 0));
-			collectionQuery.setRelatedItemObject(depotEntry);
-
-			InfoPage collectionInfoPage =
-				relatedInfoItemCollectionProvider.getCollectionInfoPage(
-					collectionQuery);
-
-			List<ObjectEntry> objectEntries =
-				(List<ObjectEntry>)collectionInfoPage.getPageItems();
-
-			Assert.assertEquals(
-				objectEntries.toString(), 2, objectEntries.size());
-			Assert.assertTrue(objectEntries.contains(childObjectEntry1));
-			Assert.assertTrue(objectEntries.contains(childObjectEntry2));
-
-			Assert.assertEquals(2, collectionInfoPage.getTotalCount());
+			_assertCollectionInfoPage(
+				_systemObjectDefinition2, user,
+				_addChildObjectEntry(
+					childObjectDefinition, user.getUserId(),
+					relationshipFieldName),
+				_addChildObjectEntry(
+					childObjectDefinition, user.getUserId(),
+					relationshipFieldName));
 		}
 		finally {
 			_objectRelationshipLocalService.deleteObjectRelationship(
-				systemObjectRelationship);
+				objectRelationship);
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				childObjectDefinition);
 			_depotEntryLocalService.deleteDepotEntry(
@@ -1831,6 +1607,22 @@ public class ObjectRelationshipLocalServiceTest {
 			modifiableSystemObjectDefinition.getObjectDefinitionId());
 	}
 
+	private ObjectEntry _addChildObjectEntry(
+			ObjectDefinition childObjectDefinition, long parentPrimaryKey,
+			String relationshipFieldName)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				relationshipFieldName, parentPrimaryKey
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
 	private ObjectLayoutBox _addObjectLayoutBox() throws Exception {
 		ObjectLayoutBox objectLayoutBox = _objectLayoutBoxPersistence.create(0);
 
@@ -1926,6 +1718,40 @@ public class ObjectRelationshipLocalServiceTest {
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 			StringUtil.randomId(), false,
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+	}
+
+	private void _assertCollectionInfoPage(
+			ObjectDefinition parentObjectDefinition, Object relatedItem,
+			ObjectEntry... expectedObjectEntries)
+		throws Exception {
+
+		RelatedInfoItemCollectionProvider relatedInfoItemCollectionProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				RelatedInfoItemCollectionProvider.class,
+				parentObjectDefinition.getClassName());
+
+		CollectionQuery collectionQuery = new CollectionQuery();
+
+		collectionQuery.setPagination(Pagination.of(10, 0));
+		collectionQuery.setRelatedItemObject(relatedItem);
+
+		InfoPage collectionInfoPage =
+			relatedInfoItemCollectionProvider.getCollectionInfoPage(
+				collectionQuery);
+
+		List<ObjectEntry> objectEntries =
+			(List<ObjectEntry>)collectionInfoPage.getPageItems();
+
+		Assert.assertEquals(
+			objectEntries.toString(), expectedObjectEntries.length,
+			objectEntries.size());
+
+		for (ObjectEntry expectedObjectEntry : expectedObjectEntries) {
+			Assert.assertTrue(objectEntries.contains(expectedObjectEntry));
+		}
+
+		Assert.assertEquals(
+			expectedObjectEntries.length, collectionInfoPage.getTotalCount());
 	}
 
 	private void _assertObjectLayoutTab(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56169

Resending because: https://github.com/brianchandotcom/liferay-portal/pull/175766

## What Is Being Fixed

When a system object definition (e.g. Depot, User) was on the "one" side of a one-to-many relationship with a custom object, the related info collection provider was never registered. This happened because `RelatedInfoCollectionProviderFactory` skipped any relationship where either side was a system object definition, and `registerObjectRelationshipsRelatedInfoCollectionProviders` only walked relationships where the system object was `objectDefinition2` (the child side), never where it was `objectDefinition1` (the parent side).

## How It Is Being Fixed

`RelatedInfoCollectionProviderFactory` is narrowed to skip only relationships where `objectDefinition2` is a system object (the child cannot be a custom entry in that case). The registration method in `ObjectRelationshipLocalServiceImpl` gains a second loop that walks `findByObjectDefinitionId2` — relationships where the given definition is the child — and registers a provider for each one-to-many relationship whose parent is a system object. `BaseObjectRelationshipRelatedInfoCollectionProvider` is extended to resolve the primary key from three relatedItem types: `ObjectEntry`, `SystemObjectEntry`, and any `BaseModel` (for portal entities such as `DepotEntry` or `User`). Integration tests cover all three scenarios plus the registration lifecycle for system-to-custom and custom-to-custom relationships.