### PR TITLE
LPD-93358 Delete redundant formula field Poshi test

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -1232,64 +1232,6 @@ definition {
 		}
 	}
 
-	@description = "Verify that is possible to use Formula Field on System Object related with Custom Object"
-	@priority = 4
-	test CanSystemAndCustomObjectRelatedWithFormulaField {
-		task ("Given add a custom object with a custom field, and create a one-to-many relationship with the User object") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 176852",
-				objectName = "CustomObject176852",
-				pluralLabelName = "Custom Objects 176852");
-
-			ObjectAdmin.addObjectRelationshipViaAPI(
-				objectName_1 = "User",
-				objectName_2 = "CustomObject176852",
-				relationshipLabel = "Relationship",
-				relationshipName = "relationship",
-				relationshipType = "oneToMany");
-
-			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject176852");
-		}
-
-		task ("And given add a Formula field to the User object with a title field on the object") {
-			ObjectAdmin.addObjectFieldViaAPI(
-				fieldBusinessType = "Formula",
-				fieldLabelName = "Custom Formula Field",
-				fieldName = "customFormulaField",
-				fieldType = "String",
-				formulaScript = "concat(id)",
-				isRequired = "false",
-				objectName = "CustomObject176852",
-				outputOption = "Integer");
-
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectSystemObject(label = "User");
-
-			CreateObject.selectTitleField(fieldLabel = "ID");
-
-			CreateObject.saveObject();
-		}
-
-		task ("When go to Custom Object and add the relationship field entry") {
-			var userId = JSONUserAPI._getUserIds();
-
-			ObjectAdmin.goToCustomObject(objectName = "CustomObject176852");
-
-			LexiconEntry.gotoAdd();
-
-			ObjectPortlet.selectRelationshipFieldEntry(
-				entry = "",
-				newEntry = ${userId});
-		}
-
-		task ("Then assert the custom object entry is added") {
-			ObjectAdmin.goToCustomObject(objectName = "CustomObject176852");
-
-			ObjectPortlet.viewEntry(entry = ${userId});
-		}
-	}
-
 	@description = "LPS-162190 - Verify that it's possible to update the layout of a System Object"
 	@priority = 5
 	test CanUpdateLayoutInSystemObject {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93358

## What Is Being Fixed

The Poshi functional test `CanSystemAndCustomObjectRelatedWithFormulaField` in
`ObjectFields.testcase` is redundant — its formula-field-on-system-object
coverage is already provided elsewhere.

## How It Is Being Fixed

The redundant test block is removed from `ObjectFields.testcase`. No other tests
reference it, and Poshi syntax validation passes.

## Why Are There No Tests?

This change only deletes a redundant Poshi functional test; the scenario remains
covered elsewhere, so no new tests are warranted.