### PR TITLE
LPD-91390 Pass page locale to data provider

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
@@ -108,8 +108,12 @@ public class DDMFormFieldOptionsFactoryImplTest {
 
 		_mockDDMDataProviderResponse(
 			ListUtil.fromArray(
-				new KeyValuePair("key1", "value1"),
-				new KeyValuePair("key2", "value2")));
+				new KeyValuePair(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new KeyValuePair(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString())));
 
 		_ddmFormFieldOptionsFactoryImpl.create(
 			_ddmFormField, _ddmFormFieldRenderingContext);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
@@ -34,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -60,6 +61,12 @@ public class DDMFormFieldOptionsFactoryImplTest {
 
 	@Test
 	public void testCreate() {
+		Mockito.when(
+			_ddmFormFieldRenderingContext.getLocale()
+		).thenReturn(
+			LocaleUtil.BRAZIL
+		);
+
 		_mockDDMDataProviderResponse(
 			ListUtil.fromArray(
 				new KeyValuePair("key1", "value1"),
@@ -75,6 +82,50 @@ public class DDMFormFieldOptionsFactoryImplTest {
 			"value2", _getString(ddmFormFieldOptions.getOptionLabels("key2")));
 		Assert.assertNull(ddmFormFieldOptions.getOptionReference("key1"));
 		Assert.assertNull(ddmFormFieldOptions.getOptionReference("key2"));
+
+		ArgumentCaptor<DDMDataProviderRequest> argumentCaptor =
+			ArgumentCaptor.forClass(DDMDataProviderRequest.class);
+
+		Mockito.verify(
+			_ddmDataProviderInvoker
+		).invoke(
+			argumentCaptor.capture()
+		);
+
+		DDMDataProviderRequest ddmDataProviderRequest =
+			argumentCaptor.getValue();
+
+		Assert.assertEquals(
+			LocaleUtil.BRAZIL, ddmDataProviderRequest.getLocale());
+
+		Mockito.clearInvocations(_ddmDataProviderInvoker);
+
+		Mockito.when(
+			_ddmFormFieldRenderingContext.getLocale()
+		).thenReturn(
+			LocaleUtil.SPAIN
+		);
+
+		_mockDDMDataProviderResponse(
+			ListUtil.fromArray(
+				new KeyValuePair("key1", "value1"),
+				new KeyValuePair("key2", "value2")));
+
+		_ddmFormFieldOptionsFactoryImpl.create(
+			_ddmFormField, _ddmFormFieldRenderingContext);
+
+		argumentCaptor = ArgumentCaptor.forClass(DDMDataProviderRequest.class);
+
+		Mockito.verify(
+			_ddmDataProviderInvoker
+		).invoke(
+			argumentCaptor.capture()
+		);
+
+		ddmDataProviderRequest = argumentCaptor.getValue();
+
+		Assert.assertEquals(
+			LocaleUtil.SPAIN, ddmDataProviderRequest.getLocale());
 
 		_mockDDMDataProviderResponse(null);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
@@ -147,7 +147,9 @@ public class DDMFormContextProviderServlet extends HttpServlet {
 
 		try {
 			Locale locale = LocaleUtil.fromLanguageId(
-				_language.getLanguageId(httpServletRequest));
+				ParamUtil.getString(
+					httpServletRequest, "languageId",
+					_language.getLanguageId(httpServletRequest)));
 
 			DDMFormRenderingContext ddmFormRenderingContext =
 				_createDDMFormRenderingContext(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -293,7 +293,8 @@ public class DDMFormDisplayContext {
 				ddmFormFieldRenderingContext.setHttpServletRequest(
 					_getHttpServletRequest());
 				ddmFormFieldRenderingContext.setLocale(
-					getLocale(_getHttpServletRequest(), ddmForm));
+					LocaleUtil.fromLanguageId(
+						LanguageUtil.getLanguageId(_getHttpServletRequest())));
 
 				ddmFormField.setDDMFormFieldOptions(
 					_ddmFormFieldOptionsFactory.create(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -399,8 +399,6 @@ public class DDMFormDisplayContextTest {
 		actualDDMFormFieldOptions =
 			(DDMFormFieldOptions)ddmFormField.getProperty("options");
 
-		Assert.assertFalse(
-			SetUtil.isEmpty(actualDDMFormFieldOptions.getOptionsValues()));
 		Assert.assertEquals(
 			expectedDDMFormFieldOptions, actualDDMFormFieldOptions);
 
@@ -579,9 +577,7 @@ public class DDMFormDisplayContextTest {
 
 	@Test
 	public void testGetRedirectURL() throws Exception {
-		String redirectURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/page";
+		String redirectURL = "http://localhost/page";
 
 		_mockDDMFormInstance(_mockDDMFormInstanceSettings(redirectURL));
 
@@ -857,8 +853,7 @@ public class DDMFormDisplayContextTest {
 	public void testIsShowSuccessPageWithRedirectURL() throws Exception {
 		_mockDDMFormInstance(
 			_mockDDMFormInstanceSettings(
-				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-					"/web/forms/shared/-/form/123"));
+				"http://localhost/web/forms/shared/-/form/123"));
 
 		RenderRequest renderRequest = _mockRenderRequest();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -92,6 +92,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -114,6 +115,7 @@ public class DDMFormDisplayContextTest {
 		_setUpJSONFactoryUtil();
 		_setUpLanguageUtil();
 		_setUpPortalUtil();
+		_renderRequest = _mockRenderRequest();
 		_setUpPrefsParamUtilMockedStatic();
 		_setUpResourceBundleUtil();
 	}
@@ -296,6 +298,12 @@ public class DDMFormDisplayContextTest {
 
 	@Test
 	public void testGetDDMFormContext() throws Exception {
+		Mockito.when(
+			_language.getLanguageId(Mockito.eq(_mockHttpServletRequest2))
+		).thenReturn(
+			"pt_BR"
+		);
+
 		ThemeDisplay themeDisplay = _mockThemeDisplay(false);
 
 		_mockHttpServletRequest2.setAttribute(
@@ -393,9 +401,23 @@ public class DDMFormDisplayContextTest {
 
 		Assert.assertFalse(
 			SetUtil.isEmpty(actualDDMFormFieldOptions.getOptionsValues()));
-
 		Assert.assertEquals(
 			expectedDDMFormFieldOptions, actualDDMFormFieldOptions);
+
+		ArgumentCaptor<DDMFormFieldRenderingContext> argumentCaptor =
+			ArgumentCaptor.forClass(DDMFormFieldRenderingContext.class);
+
+		Mockito.verify(
+			_ddmFormFieldOptionsFactory
+		).create(
+			Mockito.eq(ddmFormField), argumentCaptor.capture()
+		);
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			argumentCaptor.getValue();
+
+		Assert.assertEquals(
+			LocaleUtil.BRAZIL, ddmFormFieldRenderingContext.getLocale());
 	}
 
 	@Test
@@ -1161,8 +1183,7 @@ public class DDMFormDisplayContextTest {
 		Mockito.when(
 			themeDisplay.getURLCurrent()
 		).thenReturn(
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/web/forms/shared?form=123"
+			"http://localhost/web/forms/shared?form=123"
 		);
 
 		User user = Mockito.mock(User.class);
@@ -1360,7 +1381,7 @@ public class DDMFormDisplayContextTest {
 		_portletPermissionUtilMockedStatic;
 	private final MockedStatic<PrefsParamUtil> _prefsParamUtilMockedStatic =
 		Mockito.mockStatic(PrefsParamUtil.class);
-	private final RenderRequest _renderRequest = _mockRenderRequest();
+	private RenderRequest _renderRequest;
 	private final WorkflowDefinitionLinkLocalService
 		_workflowDefinitionLinkLocalService = Mockito.mock(
 			WorkflowDefinitionLinkLocalService.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91390

## What Is Being Fixed

When a user switches language on a form page containing a `SELECT` field backed by a Custom Data Provider, the data provider was not receiving the updated locale. Options were fetched using the form's configured locale rather than the active page language, so the wrong language options appeared after a language switch.

## How It Is Being Fixed

In `DDMFormDisplayContext.getDDMFormContext()`, the locale passed to the `DDMFormFieldRenderingContext` for data-provider-backed `SELECT` fields now comes directly from the HTTP request via `LocaleUtil.fromLanguageId(LanguageUtil.getLanguageId(httpServletRequest))` instead of the form's own `getLocale()` helper, which was returning the form's configured locale rather than the active page locale.

The same change is applied to `DDMFormContextProviderServlet`, which now reads the `languageId` request parameter (with the HTTP request's current language as fallback) so both the context provider and the display context use the same page locale.