### PR TITLE
LPD-92808 Prevent cross-instance access to form entries via record ID

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
@@ -16,7 +16,7 @@ import com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFor
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecordVersion;
-import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
@@ -53,9 +53,9 @@ public class DDMFormAssetRenderer
 
 	public DDMFormAssetRenderer(
 		DDMFormInstanceRecord ddmFormInstanceRecord,
-		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService,
 		ModelResourcePermission<DDMFormInstanceRecord>
 			ddmFormInstanceRecordModelResourcePermission,
+		DDMFormInstanceRecordService ddmFormInstanceRecordService,
 		DDMFormInstanceRecordVersion ddmFormInstanceRecordVersion,
 		DDMFormInstanceVersionLocalService ddmFormInstanceVersionLocalService,
 		DDMFormRenderer ddmFormRenderer,
@@ -63,9 +63,9 @@ public class DDMFormAssetRenderer
 		DDMFormValuesMerger ddmFormValuesMerger, Portal portal) {
 
 		_ddmFormInstanceRecord = ddmFormInstanceRecord;
-		_ddmFormInstanceRecordLocalService = ddmFormInstanceRecordLocalService;
 		_ddmFormInstanceRecordModelResourcePermission =
 			ddmFormInstanceRecordModelResourcePermission;
+		_ddmFormInstanceRecordService = ddmFormInstanceRecordService;
 		_ddmFormInstanceRecordVersion = ddmFormInstanceRecordVersion;
 		_ddmFormInstanceVersionLocalService =
 			ddmFormInstanceVersionLocalService;
@@ -270,7 +270,7 @@ public class DDMFormAssetRenderer
 			ddmFormViewFormInstanceRecordDisplayContext =
 				new DDMFormViewFormInstanceRecordDisplayContext(
 					httpServletRequest, httpServletResponse,
-					_ddmFormInstanceRecordLocalService,
+					_ddmFormInstanceRecordService,
 					_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
 					_ddmFormValuesFactory, _ddmFormValuesMerger);
 
@@ -286,10 +286,9 @@ public class DDMFormAssetRenderer
 
 	private final DDMFormInstance _ddmFormInstance;
 	private final DDMFormInstanceRecord _ddmFormInstanceRecord;
-	private final DDMFormInstanceRecordLocalService
-		_ddmFormInstanceRecordLocalService;
 	private final ModelResourcePermission<DDMFormInstanceRecord>
 		_ddmFormInstanceRecordModelResourcePermission;
+	private final DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 	private final DDMFormInstanceRecordVersion _ddmFormInstanceRecordVersion;
 	private final DDMFormInstanceVersionLocalService
 		_ddmFormInstanceVersionLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRendererFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRendererFactory.java
@@ -15,6 +15,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecordVersion;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
@@ -121,11 +122,10 @@ public class DDMFormAssetRendererFactory
 		DDMFormInstanceRecordVersion formInstanceRecordVersion, int type) {
 
 		DDMFormAssetRenderer ddmFormAssetRenderer = new DDMFormAssetRenderer(
-			formInstanceRecord, _ddmFormInstanceRecordLocalService,
-			_ddmFormInstanceRecordModelResourcePermission,
-			formInstanceRecordVersion, _ddmFormInstanceVersionLocalService,
-			_ddmFormRenderer, _ddmFormValuesFactory, _ddmFormValuesMerger,
-			_portal);
+			formInstanceRecord, _ddmFormInstanceRecordModelResourcePermission,
+			_ddmFormInstanceRecordService, formInstanceRecordVersion,
+			_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
+			_ddmFormValuesFactory, _ddmFormValuesMerger, _portal);
 
 		ddmFormAssetRenderer.setAssetRendererType(type);
 		ddmFormAssetRenderer.setServletContext(_servletContext);
@@ -148,6 +148,9 @@ public class DDMFormAssetRendererFactory
 	)
 	private ModelResourcePermission<DDMFormInstanceRecord>
 		_ddmFormInstanceRecordModelResourcePermission;
+
+	@Reference
+	private DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 
 	@Reference
 	private DDMFormInstanceRecordVersionLocalService

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -45,6 +45,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -148,6 +149,7 @@ public class DDMFormAdminDisplayContext {
 		DDMFormFieldTypesSerializer ddmFormFieldTypesSerializer,
 		DDMFormInstanceLocalService ddmFormInstanceLocalService,
 		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService,
+		DDMFormInstanceRecordService ddmFormInstanceRecordService,
 		DDMFormInstanceRecordWriterRegistry ddmFormInstanceRecordWriterRegistry,
 		DDMFormInstanceService ddmFormInstanceService,
 		DDMFormInstanceVersionLocalService ddmFormInstanceVersionLocalService,
@@ -170,6 +172,7 @@ public class DDMFormAdminDisplayContext {
 		_ddmFormFieldTypesSerializer = ddmFormFieldTypesSerializer;
 		_ddmFormInstanceLocalService = ddmFormInstanceLocalService;
 		_ddmFormInstanceRecordLocalService = ddmFormInstanceRecordLocalService;
+		_ddmFormInstanceRecordService = ddmFormInstanceRecordService;
 		_ddmFormInstanceRecordWriterRegistry =
 			ddmFormInstanceRecordWriterRegistry;
 		_ddmFormInstanceService = ddmFormInstanceService;
@@ -521,9 +524,8 @@ public class DDMFormAdminDisplayContext {
 		return new DDMFormViewFormInstanceRecordDisplayContext(
 			ddmFormAdminRequestHelper.getRequest(),
 			PortalUtil.getHttpServletResponse(renderResponse),
-			_ddmFormInstanceRecordLocalService,
-			_ddmFormInstanceVersionLocalService, ddmFormRenderer,
-			_ddmFormValuesFactory, _ddmFormValuesMerger);
+			_ddmFormInstanceRecordService, _ddmFormInstanceVersionLocalService,
+			ddmFormRenderer, _ddmFormValuesFactory, _ddmFormValuesMerger);
 	}
 
 	public DDMFormViewFormInstanceRecordsDisplayContext
@@ -1788,6 +1790,7 @@ public class DDMFormAdminDisplayContext {
 	private final DDMFormInstanceLocalService _ddmFormInstanceLocalService;
 	private final DDMFormInstanceRecordLocalService
 		_ddmFormInstanceRecordLocalService;
+	private final DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 	private final DDMFormInstanceRecordWriterRegistry
 		_ddmFormInstanceRecordWriterRegistry;
 	private final DDMFormInstanceService _ddmFormInstanceService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminFieldSetDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminFieldSetDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -90,6 +91,7 @@ public class DDMFormAdminFieldSetDisplayContext
 		DDMFormFieldTypesSerializer ddmFormFieldTypesSerializer,
 		DDMFormInstanceLocalService ddmFormInstanceLocalService,
 		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService,
+		DDMFormInstanceRecordService ddmFormInstanceRecordService,
 		DDMFormInstanceRecordWriterRegistry ddmFormInstanceRecordWriterRegistry,
 		DDMFormInstanceService ddmFormInstanceService,
 		DDMFormInstanceVersionLocalService ddmFormInstanceVersionLocalService,
@@ -110,10 +112,10 @@ public class DDMFormAdminFieldSetDisplayContext
 			ddmFormBuilderSettingsRetriever, ddmFormContextToDDMFormValues,
 			ddmFormFieldTypeServicesRegistry, ddmFormFieldTypesSerializer,
 			ddmFormInstanceLocalService, ddmFormInstanceRecordLocalService,
-			ddmFormInstanceRecordWriterRegistry, ddmFormInstanceService,
-			ddmFormInstanceVersionLocalService, ddmFormRenderer,
-			ddmFormTemplateContextFactory, ddmFormValuesFactory,
-			ddmFormValuesMerger, ddmFormWebConfiguration,
+			ddmFormInstanceRecordService, ddmFormInstanceRecordWriterRegistry,
+			ddmFormInstanceService, ddmFormInstanceVersionLocalService,
+			ddmFormRenderer, ddmFormTemplateContextFactory,
+			ddmFormValuesFactory, ddmFormValuesMerger, ddmFormWebConfiguration,
 			ddmStorageAdapterRegistry, ddmStructureLocalService,
 			ddmStructureService, jsonFactory, npmResolver,
 			objectDefinitionLocalService, portal);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContext.java
@@ -21,7 +21,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceVersion;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
-import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
@@ -50,14 +50,14 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 	public DDMFormViewFormInstanceRecordDisplayContext(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse,
-		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService,
+		DDMFormInstanceRecordService ddmFormInstanceRecordService,
 		DDMFormInstanceVersionLocalService ddmFormInstanceVersionLocalService,
 		DDMFormRenderer ddmFormRenderer,
 		DDMFormValuesFactory ddmFormValuesFactory,
 		DDMFormValuesMerger ddmFormValuesMerger) {
 
 		_httpServletResponse = httpServletResponse;
-		_ddmFormInstanceRecordLocalService = ddmFormInstanceRecordLocalService;
+		_ddmFormInstanceRecordService = ddmFormInstanceRecordService;
 		_ddmFormInstanceVersionLocalService =
 			ddmFormInstanceVersionLocalService;
 		_ddmFormRenderer = ddmFormRenderer;
@@ -207,7 +207,7 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 			httpServletRequest, "formInstanceRecordId");
 
 		if (formInstanceRecordId > 0) {
-			return _ddmFormInstanceRecordLocalService.fetchFormInstanceRecord(
+			return _ddmFormInstanceRecordService.getFormInstanceRecord(
 				formInstanceRecordId);
 		}
 
@@ -262,8 +262,7 @@ public class DDMFormViewFormInstanceRecordDisplayContext {
 	}
 
 	private final DDMFormAdminRequestHelper _ddmFormAdminRequestHelper;
-	private final DDMFormInstanceRecordLocalService
-		_ddmFormInstanceRecordLocalService;
+	private final DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 	private final DDMFormInstanceVersionLocalService
 		_ddmFormInstanceVersionLocalService;
 	private final DDMFormRenderer _ddmFormRenderer;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/DDMFormAdminPortlet.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -154,6 +155,7 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 					_ddmFormFieldTypeServicesRegistry,
 					_ddmFormFieldTypesSerializer, _ddmFormInstanceLocalService,
 					_ddmFormInstanceRecordLocalService,
+					_ddmFormInstanceRecordService,
 					_ddmFormInstanceRecordWriterRegistry,
 					_ddmFormInstanceService,
 					_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
@@ -176,6 +178,7 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 					_ddmFormFieldTypeServicesRegistry,
 					_ddmFormFieldTypesSerializer, _ddmFormInstanceLocalService,
 					_ddmFormInstanceRecordLocalService,
+					_ddmFormInstanceRecordService,
 					_ddmFormInstanceRecordWriterRegistry,
 					_ddmFormInstanceService,
 					_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
@@ -216,6 +219,9 @@ public class DDMFormAdminPortlet extends MVCPortlet {
 	@Reference
 	private DDMFormInstanceRecordLocalService
 		_ddmFormInstanceRecordLocalService;
+
+	@Reference
+	private DDMFormInstanceRecordService _ddmFormInstanceRecordService;
 
 	@Reference
 	private DDMFormInstanceRecordWriterRegistry

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
@@ -20,6 +20,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceSettings;
 import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -362,6 +363,7 @@ public class DDMFormAdminDisplayContextTest {
 			Mockito.mock(DDMFormFieldTypesSerializer.class),
 			Mockito.mock(DDMFormInstanceLocalService.class),
 			Mockito.mock(DDMFormInstanceRecordLocalService.class),
+			Mockito.mock(DDMFormInstanceRecordService.class),
 			Mockito.mock(DDMFormInstanceRecordWriterRegistry.class),
 			_mockDDMFormInstanceService(),
 			Mockito.mock(DDMFormInstanceVersionLocalService.class),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormViewFormInstanceRecordDisplayContextTest.java
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.form.web.internal.display.context;
+
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
+import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
+import com.liferay.dynamic.data.mapping.model.DDMFormInstanceVersion;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.RenderRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Alberto Sousa
+ */
+public class DDMFormViewFormInstanceRecordDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_setUpDDMFormInstanceRecordService();
+		_setUpDDMFormInstanceVersionLocalService();
+		_setUpDDMFormRenderer();
+		_setUpDDMFormValuesMerger();
+		_setUpHttpServletRequest();
+		_setUpPortalUtil();
+	}
+
+	@Test
+	public void testGetDDMFormContext() throws Exception {
+		DDMFormViewFormInstanceRecordDisplayContext
+			ddmFormViewFormInstanceRecordDisplayContext =
+				new DDMFormViewFormInstanceRecordDisplayContext(
+					_httpServletRequest,
+					Mockito.mock(HttpServletResponse.class),
+					_ddmFormInstanceRecordService,
+					_ddmFormInstanceVersionLocalService, _ddmFormRenderer,
+					Mockito.mock(DDMFormValuesFactory.class),
+					_ddmFormValuesMerger);
+
+		ddmFormViewFormInstanceRecordDisplayContext.getDDMFormContext(
+			_renderRequest);
+
+		Mockito.verify(
+			_ddmFormInstanceRecordService
+		).getFormInstanceRecord(
+			_FORM_INSTANCE_RECORD_ID
+		);
+	}
+
+	private DDMFormInstance _mockDDMFormInstance() throws Exception {
+		DDMFormInstance ddmFormInstance = Mockito.mock(DDMFormInstance.class);
+
+		Mockito.when(
+			ddmFormInstance.getFormInstanceVersion(Mockito.anyString())
+		).thenReturn(
+			_ddmFormInstanceVersion
+		);
+
+		return ddmFormInstance;
+	}
+
+	private DDMFormInstanceRecord _mockDDMFormInstanceRecord()
+		throws Exception {
+
+		DDMFormInstanceRecord ddmFormInstanceRecord = Mockito.mock(
+			DDMFormInstanceRecord.class);
+
+		DDMFormValues ddmFormValues = _mockDDMFormValues();
+
+		Mockito.when(
+			ddmFormInstanceRecord.getDDMFormValues()
+		).thenReturn(
+			ddmFormValues
+		);
+
+		DDMFormInstance ddmFormInstance = _mockDDMFormInstance();
+
+		Mockito.when(
+			ddmFormInstanceRecord.getFormInstance()
+		).thenReturn(
+			ddmFormInstance
+		);
+
+		Mockito.when(
+			ddmFormInstanceRecord.getFormInstanceVersion()
+		).thenReturn(
+			"1.0"
+		);
+
+		return ddmFormInstanceRecord;
+	}
+
+	private DDMFormValues _mockDDMFormValues() {
+		DDMFormValues ddmFormValues = Mockito.mock(DDMFormValues.class);
+
+		Mockito.when(
+			ddmFormValues.getAvailableLocales()
+		).thenReturn(
+			Collections.singleton(LocaleUtil.US)
+		);
+
+		Mockito.when(
+			ddmFormValues.getDefaultLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		return ddmFormValues;
+	}
+
+	private void _setUpDDMFormInstanceRecordService() throws Exception {
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			_mockDDMFormInstanceRecord();
+
+		Mockito.when(
+			_ddmFormInstanceRecordService.getFormInstanceRecord(
+				_FORM_INSTANCE_RECORD_ID)
+		).thenReturn(
+			ddmFormInstanceRecord
+		);
+	}
+
+	private void _setUpDDMFormInstanceVersionLocalService() throws Exception {
+		DDMStructureVersion ddmStructureVersion = Mockito.mock(
+			DDMStructureVersion.class);
+
+		Mockito.when(
+			ddmStructureVersion.getDDMForm()
+		).thenReturn(
+			Mockito.mock(DDMForm.class)
+		);
+
+		Mockito.when(
+			ddmStructureVersion.getDDMFormLayout()
+		).thenReturn(
+			Mockito.mock(DDMFormLayout.class)
+		);
+
+		Mockito.when(
+			_ddmFormInstanceVersion.getStructureVersion()
+		).thenReturn(
+			ddmStructureVersion
+		);
+
+		Mockito.when(
+			_ddmFormInstanceVersionLocalService.getLatestFormInstanceVersion(
+				Mockito.anyLong(), Mockito.anyInt())
+		).thenReturn(
+			_ddmFormInstanceVersion
+		);
+	}
+
+	private void _setUpDDMFormRenderer() throws Exception {
+		Mockito.when(
+			_ddmFormRenderer.getDDMFormTemplateContext(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.emptyMap()
+		);
+	}
+
+	private void _setUpDDMFormValuesMerger() {
+		DDMFormValues mergedDDMFormValues = Mockito.mock(DDMFormValues.class);
+
+		Mockito.when(
+			mergedDDMFormValues.getDefaultLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		Mockito.when(
+			_ddmFormValuesMerger.merge(Mockito.any(), Mockito.any())
+		).thenReturn(
+			mergedDDMFormValues
+		);
+	}
+
+	private void _setUpHttpServletRequest() {
+		Mockito.when(
+			_httpServletRequest.getParameter("formInstanceRecordId")
+		).thenReturn(
+			String.valueOf(_FORM_INSTANCE_RECORD_ID)
+		);
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(Mockito.mock(Portal.class));
+	}
+
+	private static final long _FORM_INSTANCE_RECORD_ID =
+		RandomTestUtil.randomLong();
+
+	private final DDMFormInstanceRecordService _ddmFormInstanceRecordService =
+		Mockito.mock(DDMFormInstanceRecordService.class);
+	private final DDMFormInstanceVersion _ddmFormInstanceVersion = Mockito.mock(
+		DDMFormInstanceVersion.class);
+	private final DDMFormInstanceVersionLocalService
+		_ddmFormInstanceVersionLocalService = Mockito.mock(
+			DDMFormInstanceVersionLocalService.class);
+	private final DDMFormRenderer _ddmFormRenderer = Mockito.mock(
+		DDMFormRenderer.class);
+	private final DDMFormValuesMerger _ddmFormValuesMerger = Mockito.mock(
+		DDMFormValuesMerger.class);
+	private final HttpServletRequest _httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	private final RenderRequest _renderRequest = Mockito.mock(
+		RenderRequest.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92808

**What is being fixed:** An insecure direct object reference (IDOR) in the Forms admin let a user read form entries belonging to a different virtual instance. The form entry view loaded the record straight from its formInstanceRecordId without any permission check, so keeping a form instance the user legitimately owns and changing only the formInstanceRecordId to one from another instance returned that other instance's submitted data. Because instance Administrator roles are scoped per company, this crossed the instance boundary the permission model is meant to enforce.

**How it is being fixed:** DDMFormViewFormInstanceRecordDisplayContext now retrieves the record through the permission-checked DDMFormInstanceRecordService.getFormInstanceRecord rather than DDMFormInstanceRecordLocalService.fetchFormInstanceRecord. The service runs a VIEW permission check on the record itself, so a cross-instance request throws a PrincipalException instead of disclosing the entry, while the owner's own entries render unchanged. The permission-checked service is threaded in from the callers — the portlet reference into DDMFormAdminDisplayContext and its field-set subclass, and the asset renderer and its factory. A unit test asserts the display context delegates the record lookup to the service; the permission logic itself stays covered at the service layer.