### PR TITLE
LPD-91390 Pass page locale to Custom Data Provider

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImpl.java
@@ -138,7 +138,7 @@ public class DDMFormFieldOptionsFactoryImpl
 				).withGroupId(
 					_getGroupId(httpServletRequest)
 				).withLocale(
-					ddmFormFieldRenderingContext.getLocale()
+					portal.getLocale(httpServletRequest)
 				).withParameter(
 					"filterParameterValue",
 					HtmlUtil.escapeURL(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImplTest.java
@@ -34,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -60,6 +61,30 @@ public class DDMFormFieldOptionsFactoryImplTest {
 
 	@Test
 	public void testCreate() {
+		Mockito.when(
+			_portal.getLocale(_httpServletRequest)
+		).thenReturn(
+			LocaleUtil.BRAZIL
+		);
+
+		_ddmFormFieldOptionsFactoryImpl.create(
+			_ddmFormField, _ddmFormFieldRenderingContext);
+
+		ArgumentCaptor<DDMDataProviderRequest> argumentCaptor =
+			ArgumentCaptor.forClass(DDMDataProviderRequest.class);
+
+		Mockito.verify(
+			_ddmDataProviderInvoker
+		).invoke(
+			argumentCaptor.capture()
+		);
+
+		DDMDataProviderRequest ddmDataProviderRequest =
+			argumentCaptor.getValue();
+
+		Assert.assertEquals(
+			LocaleUtil.BRAZIL, ddmDataProviderRequest.getLocale());
+
 		_mockDDMDataProviderResponse(
 			ListUtil.fromArray(
 				new KeyValuePair("key1", "value1"),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91390

## What Is Being Fixed

When a Liferay Forms page is in a language not included in the form's available locales, Custom Data Providers always receive the form's default locale instead of the user's actual page locale. This causes the data provider to return options in the wrong language.

## How It Is Being Fixed

In `DDMFormFieldOptionsFactoryImpl._createDDMFormFieldOptionsFromDataProvider()`, the locale passed to the data provider request is now taken from `portal.getLocale(httpServletRequest)` — the actual page locale — instead of `ddmFormFieldRenderingContext.getLocale()`, which is bounded to the form's available locales. This allows the data provider to receive and return options in the user's language even when the form has not been translated into that language.

## PR Check

**pr-check: PASS** — tested on `c357569def91afd2fbae90dd6168235abf0226b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c357569def91afd2fbae90dd6168235abf0226b6"} -->