### PR TITLE
LPD-90742 Headless Commerce API returns empty values for Commerce Product custom object fields

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/object/system/CPDefinitionSystemObjectDefinitionManager.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -266,6 +267,14 @@ public class CPDefinitionSystemObjectDefinitionManager
 
 		return productResource.getProductsPage(
 			search, filter, pagination, sorts);
+	}
+
+	@Override
+	public PersistedModel getPersistedModel(long primaryKey)
+		throws PortalException {
+
+		return _cpDefinitionLocalService.getCPDefinitionByCProductId(
+			primaryKey);
 	}
 
 	@Override

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
@@ -14,11 +14,14 @@ import com.liferay.petra.sql.dsl.Table;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.ObjectMapperUtil;
@@ -107,6 +110,16 @@ public interface SystemObjectDefinitionManager {
 		throws Exception {
 
 		return null;
+	}
+
+	public default PersistedModel getPersistedModel(long primaryKey)
+		throws PortalException {
+
+		PersistedModelLocalService persistedModelLocalService =
+			PersistedModelLocalServiceRegistryUtil.
+				getPersistedModelLocalService(getModelClassName());
+
+		return persistedModelLocalService.getPersistedModel(primaryKey);
 	}
 
 	public Map<Locale, String> getPluralLabelMap();

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -3002,13 +3002,8 @@ public class DefaultObjectEntryManagerImpl
 			_systemObjectDefinitionManagerRegistry.
 				getSystemObjectDefinitionManager(objectDefinition.getName());
 
-		PersistedModelLocalService persistedModelLocalService =
-			PersistedModelLocalServiceRegistryUtil.
-				getPersistedModelLocalService(
-					systemObjectDefinitionManager.getModelClassName());
-
 		PersistedModel persistedModel =
-			persistedModelLocalService.getPersistedModel(objectEntryId);
+			systemObjectDefinitionManager.getPersistedModel(objectEntryId);
 
 		if (Objects.equals(
 				systemObjectDefinitionManager.getScope(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/BaseObjectExtensionProvider.java
@@ -7,8 +7,12 @@ package com.liferay.object.rest.internal.vulcan.extension.v1_0;
 
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOMapper;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
 
@@ -64,14 +68,38 @@ public abstract class BaseObjectExtensionProvider implements ExtensionProvider {
 			companyId, internalDTOClassName);
 	}
 
-	protected long getPrimaryKey(Object entity) throws Exception {
+	protected long getPrimaryKey(
+			Object entity, ObjectDefinition objectDefinition)
+		throws Exception {
+
+		String idPropertyName = "id";
+
+		if ((objectDefinition != null) &&
+			objectDefinition.isUnmodifiableSystemObject()) {
+
+			SystemObjectDefinitionManager systemObjectDefinitionManager =
+				systemObjectDefinitionManagerRegistry.
+					getSystemObjectDefinitionManager(
+						objectDefinition.getName());
+
+			if (systemObjectDefinitionManager != null) {
+				String restDTOIdPropertyName =
+					systemObjectDefinitionManager.getRESTDTOIdPropertyName();
+
+				if (Validator.isNotNull(restDTOIdPropertyName)) {
+					idPropertyName = restDTOIdPropertyName;
+				}
+			}
+		}
+
 		if (entity instanceof Map) {
-			return MapUtil.getLong((Map<String, Object>)entity, "id");
+			return MapUtil.getLong((Map<String, Object>)entity, idPropertyName);
 		}
 
 		Class<?> clazz = entity.getClass();
 
-		Method method = clazz.getMethod("getId");
+		Method method = clazz.getMethod(
+			"get" + StringUtil.upperCaseFirstLetter(idPropertyName));
 
 		return GetterUtil.getLong(method.invoke(entity));
 	}
@@ -81,5 +109,9 @@ public abstract class BaseObjectExtensionProvider implements ExtensionProvider {
 
 	@Reference
 	protected ObjectDefinitionLocalService objectDefinitionLocalService;
+
+	@Reference
+	protected SystemObjectDefinitionManagerRegistry
+		systemObjectDefinitionManagerRegistry;
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectEntryExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectEntryExtensionProvider.java
@@ -49,7 +49,7 @@ public class ObjectEntryExtensionProvider extends BaseObjectExtensionProvider {
 
 			return _objectEntryLocalService.
 				getExtensionDynamicObjectDefinitionTableValues(
-					objectDefinition, getPrimaryKey(entity));
+					objectDefinition, getPrimaryKey(entity, objectDefinition));
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -148,8 +148,8 @@ public class ObjectEntryExtensionProvider extends BaseObjectExtensionProvider {
 
 			_objectEntryLocalService.
 				addOrUpdateExtensionDynamicObjectDefinitionTableValues(
-					userId, objectDefinition, getPrimaryKey(entity),
-					extendedProperties,
+					userId, objectDefinition,
+					getPrimaryKey(entity, objectDefinition), extendedProperties,
 					new ServiceContext() {
 						{
 							setCompanyId(companyId);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/ObjectRelationshipExtensionProvider.java
@@ -95,7 +95,7 @@ public class ObjectRelationshipExtensionProvider
 					return null;
 				}
 
-				long primaryKey = getPrimaryKey(entity);
+				long primaryKey = getPrimaryKey(entity, objectDefinition);
 
 				if (_isManyToOneObjectRelationship(
 						objectDefinition, objectRelationship,
@@ -198,7 +198,7 @@ public class ObjectRelationshipExtensionProvider
 				"No object definition exists with class name " + className);
 		}
 
-		long primaryKey = getPrimaryKey(entity);
+		long primaryKey = getPrimaryKey(entity, objectDefinition);
 
 		for (Map.Entry<String, Serializable> entry :
 				extendedProperties.entrySet()) {

--- a/modules/apps/object/object-rest-test/build.gradle
+++ b/modules/apps/object/object-rest-test/build.gradle
@@ -10,6 +10,10 @@ dependencies {
 	testIntegrationImplementation group: "org.yaml", name: "snakeyaml", version: "2.3"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:asset:asset-entry-rel-api")
+	testIntegrationImplementation project(":apps:commerce:commerce-product-api")
+	testIntegrationImplementation project(":apps:commerce:commerce-product-test-util")
+	testIntegrationImplementation project(":apps:commerce:commerce-product-type-simple")
+	testIntegrationImplementation project(":apps:commerce:headless:headless-commerce:headless-commerce-admin-catalog-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-test-util")

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -25,6 +25,10 @@ import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.model.CommerceCatalog;
+import com.liferay.commerce.product.test.util.CPTestUtil;
+import com.liferay.commerce.product.type.simple.constants.SimpleCPTypeConstants;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
@@ -163,6 +167,7 @@ import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -210,6 +215,7 @@ import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
 import com.liferay.portal.search.searcher.Searcher;
 import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -7220,6 +7226,81 @@ public class DefaultObjectEntryManagerImplTest
 
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA1.getId());
 		_objectEntryLocalService.deleteObjectEntry(objectEntryAA2.getId());
+	}
+
+	@Test
+	public void testGetRelatedObjectEntriesWithCommerceProduct()
+		throws Exception {
+
+		ObjectDefinition childObjectDefinition = _addObjectDefinition(
+			Arrays.asList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"textObjectFieldName"
+				).build()));
+
+		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
+			TestPropsValues.getCompanyId());
+
+		ObjectDefinition cpDefinitionObjectDefinition =
+			objectDefinitionLocalService.fetchSystemObjectDefinition(
+				companyId, "CPDefinition");
+
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, adminUser.getUserId(),
+				cpDefinitionObjectDefinition.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			ObjectField objectField = objectFieldLocalService.getObjectField(
+				objectRelationship.getObjectFieldId2());
+
+			_defaultObjectEntryManager.addObjectEntry(
+				_simpleDTOConverterContext, childObjectDefinition,
+				new ObjectEntry() {
+					{
+						properties = HashMapBuilder.<String, Object>put(
+							objectField.getName(), cpDefinition.getCProductId()
+						).build();
+					}
+				},
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+			Page<ObjectEntry> page =
+				_defaultObjectEntryManager.getRelatedObjectEntries(
+					_simpleDTOConverterContext, cpDefinition.getCProductId(),
+					objectRelationship, null);
+
+			Collection<ObjectEntry> objectEntries = page.getItems();
+
+			Assert.assertEquals(
+				objectEntries.toString(), 1, objectEntries.size());
+		}
+		finally {
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(CPDefinition.class.getName());
+
+			persistedModelLocalService.deletePersistedModel(cpDefinition);
+
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+		}
 	}
 
 	@Test

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -7245,13 +7245,13 @@ public class DefaultObjectEntryManagerImplTest
 		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
 			TestPropsValues.getCompanyId());
 
-		ObjectDefinition cpDefinitionObjectDefinition =
-			objectDefinitionLocalService.fetchSystemObjectDefinition(
-				companyId, "CPDefinition");
-
 		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
 			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
 			true);
+
+		ObjectDefinition cpDefinitionObjectDefinition =
+			objectDefinitionLocalService.fetchSystemObjectDefinition(
+				companyId, "CPDefinition");
 
 		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.addObjectRelationship(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
@@ -254,15 +254,15 @@ public class ObjectEntryExtensionProviderTest {
 		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
 			TestPropsValues.getCompanyId());
 
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
 		ObjectDefinition cpDefinitionObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
 				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
 
 		String customFieldName = "x" + RandomTestUtil.randomString();
-
-		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
-			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
-			true);
 
 		ObjectField objectField = ObjectFieldUtil.addCustomObjectField(
 			new TextObjectFieldBuilder(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectEntryExtensionProviderTest.java
@@ -6,20 +6,28 @@
 package com.liferay.object.rest.internal.vulcan.extension.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.model.CommerceCatalog;
+import com.liferay.commerce.product.test.util.CPTestUtil;
+import com.liferay.commerce.product.type.simple.constants.SimpleCPTypeConstants;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.builder.BooleanObjectFieldBuilder;
 import com.liferay.object.field.builder.DateObjectFieldBuilder;
 import com.liferay.object.field.builder.DecimalObjectFieldBuilder;
 import com.liferay.object.field.builder.PrecisionDecimalObjectFieldBuilder;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -28,6 +36,7 @@ import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
@@ -201,6 +210,105 @@ public class ObjectEntryExtensionProviderTest {
 
 	@Test
 	public void testSetAndGetExtendedProperties() throws Exception {
+		_testSetAndGetExtendedPropertiesWithCommerceProduct();
+		_testSetAndGetExtendedPropertiesWithUserAccount();
+	}
+
+	private void _assertPropertyDefinition(
+		String expectedPropertyName,
+		PropertyDefinition.PropertyType expectedPropertyType,
+		boolean expectedRequired, PropertyDefinition propertyDefinition) {
+
+		Assert.assertEquals(
+			expectedPropertyName, propertyDefinition.getPropertyName());
+		Assert.assertEquals(
+			expectedPropertyType, propertyDefinition.getPropertyType());
+		Assert.assertEquals(expectedRequired, propertyDefinition.isRequired());
+	}
+
+	private void _assertSetAndGetExtendedPropertiesWithCommerceProduct(
+			String customFieldName, Object entity)
+		throws Exception {
+
+		String customFieldValue = RandomTestUtil.randomString();
+
+		_extensionProvider.setExtendedProperties(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			Product.class.getName(), entity,
+			HashMapBuilder.<String, Serializable>put(
+				customFieldName, customFieldValue
+			).build());
+
+		Map<String, Serializable> extendedProperties =
+			_extensionProvider.getExtendedProperties(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				Product.class.getName(), entity);
+
+		Assert.assertEquals(
+			customFieldValue, extendedProperties.get(customFieldName));
+	}
+
+	private void _testSetAndGetExtendedPropertiesWithCommerceProduct()
+		throws Exception {
+
+		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
+			TestPropsValues.getCompanyId());
+
+		ObjectDefinition cpDefinitionObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
+
+		String customFieldName = "x" + RandomTestUtil.randomString();
+
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
+		ObjectField objectField = ObjectFieldUtil.addCustomObjectField(
+			new TextObjectFieldBuilder(
+			).userId(
+				TestPropsValues.getUserId()
+			).objectDefinitionId(
+				cpDefinitionObjectDefinition.getObjectDefinitionId()
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				customFieldName
+			).build());
+
+		try {
+			Product product = new Product() {
+				{
+					id = cpDefinition.getCPDefinitionId();
+					productId = cpDefinition.getCProductId();
+				}
+			};
+
+			_assertSetAndGetExtendedPropertiesWithCommerceProduct(
+				customFieldName, product);
+
+			_assertSetAndGetExtendedPropertiesWithCommerceProduct(
+				customFieldName,
+				HashMapBuilder.<String, Object>put(
+					"id", cpDefinition.getCPDefinitionId()
+				).put(
+					"productId", cpDefinition.getCProductId()
+				).build());
+		}
+		finally {
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(CPDefinition.class.getName());
+
+			persistedModelLocalService.deletePersistedModel(cpDefinition);
+
+			_objectFieldLocalService.deleteObjectField(objectField);
+		}
+	}
+
+	private void _testSetAndGetExtendedPropertiesWithUserAccount()
+		throws Exception {
+
 		UserAccount userAccount = new UserAccount() {
 			{
 				id = _user.getUserId();
@@ -229,18 +337,6 @@ public class ObjectEntryExtensionProviderTest {
 			).put(
 				"precisionDecimal", 20.55
 			).build());
-	}
-
-	private void _assertPropertyDefinition(
-		String expectedPropertyName,
-		PropertyDefinition.PropertyType expectedPropertyType,
-		boolean expectedRequired, PropertyDefinition propertyDefinition) {
-
-		Assert.assertEquals(
-			expectedPropertyName, propertyDefinition.getPropertyName());
-		Assert.assertEquals(
-			expectedPropertyType, propertyDefinition.getPropertyType());
-		Assert.assertEquals(expectedRequired, propertyDefinition.isRequired());
 	}
 
 	private void _testSetExtendedProperties(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -6,7 +6,12 @@
 package com.liferay.object.rest.internal.vulcan.extension.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.commerce.product.model.CPDefinition;
+import com.liferay.commerce.product.model.CommerceCatalog;
+import com.liferay.commerce.product.test.util.CPTestUtil;
+import com.liferay.commerce.product.type.simple.constants.SimpleCPTypeConstants;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
@@ -23,6 +28,7 @@ import com.liferay.object.system.SystemObjectDefinitionManager;
 import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -30,6 +36,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -127,41 +134,8 @@ public class ObjectRelationshipExtensionProviderTest {
 
 	@Test
 	public void testGetExtendedProperties() throws Exception {
-		UserAccount userAccount = new UserAccount() {
-			{
-				id = _user.getUserId();
-			}
-		};
-
-		NestedFieldsContextThreadLocal.setNestedFieldsContext(null);
-
-		Map<String, Serializable> extendedProperties =
-			_extensionProvider.getExtendedProperties(
-				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				UserAccount.class.getName(), userAccount);
-
-		Assert.assertNull(extendedProperties);
-
-		NestedFieldsContextThreadLocal.setNestedFieldsContext(
-			_getNestedFieldsContext(RandomTestUtil.randomString()));
-
-		extendedProperties = _extensionProvider.getExtendedProperties(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			UserAccount.class.getName(), userAccount);
-
-		Assert.assertTrue(extendedProperties.isEmpty());
-
-		NestedFieldsContextThreadLocal.setNestedFieldsContext(
-			_getNestedFieldsContext(_objectRelationship.getName()));
-
-		extendedProperties = _extensionProvider.getExtendedProperties(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			UserAccount.class.getName(), userAccount);
-
-		Assert.assertEquals(
-			extendedProperties.toString(), 1, extendedProperties.size());
-		Assert.assertNotNull(
-			extendedProperties.get(_objectRelationship.getName()));
+		_testGetExtendedPropertiesWithCommerceProduct();
+		_testGetExtendedPropertiesWithUserAccount();
 	}
 
 	@Test
@@ -238,6 +212,138 @@ public class ObjectRelationshipExtensionProviderTest {
 		return _objectDefinitionLocalService.publishCustomObjectDefinition(
 			TestPropsValues.getUserId(),
 			objectDefinition.getObjectDefinitionId());
+	}
+
+	private void _testGetExtendedPropertiesWithCommerceProduct()
+		throws Exception {
+
+		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
+			TestPropsValues.getCompanyId());
+
+		ObjectDefinition cpDefinitionObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			Collections.singletonList(
+				ObjectFieldUtil.createObjectField(
+					"Text", "String", true, true, null,
+					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
+
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
+		ObjectEntry objectEntry = ObjectEntryLocalServiceUtil.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, _OBJECT_FIELD_VALUE
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipLocalServiceUtil.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				cpDefinitionObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, null);
+
+		ObjectRelationshipLocalServiceUtil.
+			addObjectRelationshipMappingTableValues(
+				TestPropsValues.getUserId(),
+				objectRelationship.getObjectRelationshipId(),
+				objectEntry.getPrimaryKey(), cpDefinition.getCProductId(),
+				ServiceContextTestUtil.getServiceContext());
+
+		NestedFieldsContext originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		try {
+			Product product = new Product() {
+				{
+					id = cpDefinition.getCPDefinitionId();
+					productId = cpDefinition.getCProductId();
+				}
+			};
+
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				_getNestedFieldsContext(objectRelationship.getName()));
+
+			Map<String, Serializable> extendedProperties =
+				_extensionProvider.getExtendedProperties(
+					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+					Product.class.getName(), product);
+
+			Assert.assertEquals(
+				extendedProperties.toString(), 1, extendedProperties.size());
+			Assert.assertNotNull(
+				extendedProperties.get(objectRelationship.getName()));
+		}
+		finally {
+			ObjectRelationshipLocalServiceUtil.
+				deleteObjectRelationshipMappingTableValues(
+					objectRelationship.getObjectRelationshipId(),
+					objectEntry.getPrimaryKey(), cpDefinition.getCProductId());
+
+			ObjectRelationshipLocalServiceUtil.deleteObjectRelationship(
+				objectRelationship);
+
+			PersistedModelLocalService persistedModelLocalService =
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalService(CPDefinition.class.getName());
+
+			persistedModelLocalService.deletePersistedModel(cpDefinition);
+
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				originalNestedFieldsContext);
+		}
+	}
+
+	private void _testGetExtendedPropertiesWithUserAccount() throws Exception {
+		UserAccount userAccount = new UserAccount() {
+			{
+				id = _user.getUserId();
+			}
+		};
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(null);
+
+		Map<String, Serializable> extendedProperties =
+			_extensionProvider.getExtendedProperties(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				UserAccount.class.getName(), userAccount);
+
+		Assert.assertNull(extendedProperties);
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			_getNestedFieldsContext(RandomTestUtil.randomString()));
+
+		extendedProperties = _extensionProvider.getExtendedProperties(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			UserAccount.class.getName(), userAccount);
+
+		Assert.assertTrue(extendedProperties.isEmpty());
+
+		NestedFieldsContextThreadLocal.setNestedFieldsContext(
+			_getNestedFieldsContext(_objectRelationship.getName()));
+
+		extendedProperties = _extensionProvider.getExtendedProperties(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			UserAccount.class.getName(), userAccount);
+
+		Assert.assertEquals(
+			extendedProperties.toString(), 1, extendedProperties.size());
+		Assert.assertNotNull(
+			extendedProperties.get(_objectRelationship.getName()));
 	}
 
 	private static final String _OBJECT_FIELD_NAME =

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/vulcan/extension/v1_0/test/ObjectRelationshipExtensionProviderTest.java
@@ -220,6 +220,10 @@ public class ObjectRelationshipExtensionProviderTest {
 		CommerceCatalog commerceCatalog = CPTestUtil.getSystemCommerceCatalog(
 			TestPropsValues.getCompanyId());
 
+		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
+			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
+			true);
+
 		ObjectDefinition cpDefinitionObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
 				TestPropsValues.getCompanyId(), CPDefinition.class.getName());
@@ -229,10 +233,6 @@ public class ObjectRelationshipExtensionProviderTest {
 				ObjectFieldUtil.createObjectField(
 					"Text", "String", true, true, null,
 					RandomTestUtil.randomString(), _OBJECT_FIELD_NAME, false)));
-
-		CPDefinition cpDefinition = CPTestUtil.addCPDefinitionFromCatalog(
-			commerceCatalog.getGroupId(), SimpleCPTypeConstants.NAME, true,
-			true);
 
 		ObjectEntry objectEntry = ObjectEntryLocalServiceUtil.addObjectEntry(
 			0, TestPropsValues.getUserId(),
@@ -254,6 +254,9 @@ public class ObjectRelationshipExtensionProviderTest {
 				StringUtil.randomId(), false,
 				ObjectRelationshipConstants.TYPE_MANY_TO_MANY, null);
 
+		NestedFieldsContext originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
 		ObjectRelationshipLocalServiceUtil.
 			addObjectRelationshipMappingTableValues(
 				TestPropsValues.getUserId(),
@@ -261,19 +264,16 @@ public class ObjectRelationshipExtensionProviderTest {
 				objectEntry.getPrimaryKey(), cpDefinition.getCProductId(),
 				ServiceContextTestUtil.getServiceContext());
 
-		NestedFieldsContext originalNestedFieldsContext =
-			NestedFieldsContextThreadLocal.getNestedFieldsContext();
-
 		try {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				_getNestedFieldsContext(objectRelationship.getName()));
+
 			Product product = new Product() {
 				{
 					id = cpDefinition.getCPDefinitionId();
 					productId = cpDefinition.getCProductId();
 				}
 			};
-
-			NestedFieldsContextThreadLocal.setNestedFieldsContext(
-				_getNestedFieldsContext(objectRelationship.getName()));
 
 			Map<String, Serializable> extendedProperties =
 				_extensionProvider.getExtendedProperties(


### PR DESCRIPTION
> **Resent from liferay-bpm/liferay-portal#6141.** The previous forward to brianchandotcom/liferay-portal#175874 was rejected by Brian directly for variable-ordering: "var declarations in `_testGetExtendedPropertiesWithCommerceProduct` are still random. They're not alphabetical or as used." The 3 Commerce Product test helpers now follow strict case-sensitive ASCII order across the whole declaration block, with data dependencies respected at their alphabetical position (no grouping by independent-vs-dependent). Folded into the `LPD-90742 SF` commit on top of @Shakir-Shamim's original three commits.

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-90742

Custom extension fields and relationships added to Commerce Product via Liferay Objects do not round-trip through the REST API. After a `POST /products` with extension field values or related objects, a subsequent `GET` returns those fields as empty and those relationships as unresolved. Relationship navigation also throws `NoSuchCPDefinitionException` under certain configurations.

Related context (Commerce Product identity transition from `CPDefinition` to `CProduct`):
- https://liferay.atlassian.net/browse/PTR-8273
- https://liferay.atlassian.net/browse/LPD-78392

# How am I fixing it?

The root cause is that `BaseObjectExtensionProvider#getPrimaryKey` hardcoded `entity.getId()`, which on the Product DTO returns the `CPDefinitionId` (the version-row identifier). However, the extension dynamic table and relationship mapping tables for Commerce Product are keyed by `CProductId`, the stable identifier declared by `CPDefinitionSystemObjectDefinitionManager#getPrimaryKeyColumn` and `getRESTDTOIdPropertyName`. Writes landed under one key while reads filtered by another, so the join never matched.

The fix has two parts:

### 1. Primary key resolution

`BaseObjectExtensionProvider#getPrimaryKey` now consults `SystemObjectDefinitionManager#getRESTDTOIdPropertyName` and reflects the corresponding getter on the entity.

- For Commerce Product, this resolves to `getProductId()` (CProductId).
- For every other system object, it falls back to the default `"id"` and behaves identically to before.

### 2. PersistedModel resolution

Once `getPrimaryKey` returns the manager-declared logical key, downstream code that loads the persisted model via `PersistedModelLocalService#getPersistedModel` fails for Commerce Product because that service expects the table primary key (`CPDefinitionId`).

- Added a polymorphic `SystemObjectDefinitionManager#getPersistedModel` hook with a default delegating to the existing local service.
- `CPDefinitionSystemObjectDefinitionManager` overrides it to translate `CProductId` to `CPDefinition` via `CPDefinitionLocalService#getCPDefinitionByCProductId`.
- `DefaultObjectEntryManagerImpl#_getSystemObjectRelatedObjectEntries` is updated to route through this new method.

For every other system object whose DTO `id` already matches the table primary key (Account, Order, User, etc.), behavior is unchanged because the default `getRESTDTOIdPropertyName` resolves to `"id"` and the default `getPersistedModel` delegates to the original service call.

# How can you verify that it works?

```bash
cd modules/apps/object/object-rest-test

./gradlew testIntegration \
    --tests "ObjectEntryExtensionProviderTest.testSetAndGetExtendedProperties" \
    --tests "ObjectRelationshipExtensionProviderTest.testGetExtendedProperties" \
    --tests "*DefaultObjectEntryManagerImplTest.testGetRelatedObjectEntriesWithCommerceProduct"
```

- `ObjectEntryExtensionProviderTest.testSetAndGetExtendedProperties` extended to also round-trip a custom field on CPDefinition keyed by CProductId.
- `ObjectRelationshipExtensionProviderTest.testGetExtendedProperties` extended to also resolve a many-to-many relationship from a Commerce Product keyed by CProductId.
- `DefaultObjectEntryManagerImplTest.testGetRelatedObjectEntriesWithCommerceProduct` end-to-end test of getRelatedObjectEntries for a system object, exercising `SystemObjectDefinitionManager.getPersistedModel(cProductId)`.
