### PR TITLE
LPD-92227 Use index when filtering by ERC

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 123.1.1
+Bundle-Version: 124.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsPredicateProvider.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/related/models/ObjectRelatedModelsPredicateProvider.java
@@ -19,7 +19,8 @@ public interface ObjectRelatedModelsPredicateProvider {
 	public String getObjectRelationshipType();
 
 	public Predicate getPredicate(
-			ObjectRelationship objectRelationship, Predicate predicate)
+			Long[] groupIds, ObjectRelationship objectRelationship,
+			Predicate predicate)
 		throws PortalException;
 
 }

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/related/models/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 12.0.0

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/filter/factory/BaseFilterFactory.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/filter/factory/BaseFilterFactory.java
@@ -38,6 +38,20 @@ public abstract class BaseFilterFactory<T> implements FilterFactory<T> {
 			entityModel,
 			objectDefinitionFilterParser.parse(
 				entityModel, filterString, objectDefinition),
+			null, objectDefinition);
+	}
+
+	@Override
+	public final T create(
+		Expression filterExpression, Long[] groupIds,
+		ObjectDefinition objectDefinition) {
+
+		if (filterExpression == null) {
+			return null;
+		}
+
+		return _create(
+			getEntityModel(objectDefinition), filterExpression, groupIds,
 			objectDefinition);
 	}
 
@@ -50,7 +64,7 @@ public abstract class BaseFilterFactory<T> implements FilterFactory<T> {
 		}
 
 		return _create(
-			getEntityModel(objectDefinition), filterExpression,
+			getEntityModel(objectDefinition), filterExpression, null,
 			objectDefinition);
 	}
 
@@ -71,6 +85,13 @@ public abstract class BaseFilterFactory<T> implements FilterFactory<T> {
 		}
 	}
 
+	public ExpressionVisitor<?> getExpressionVisitor(
+		EntityModel entityModel, Long[] groupIds,
+		ObjectDefinition objectDefinition) {
+
+		return getExpressionVisitor(entityModel, objectDefinition);
+	}
+
 	public abstract ExpressionVisitor<?> getExpressionVisitor(
 		EntityModel entityModel, ObjectDefinition objectDefinition);
 
@@ -88,12 +109,12 @@ public abstract class BaseFilterFactory<T> implements FilterFactory<T> {
 	protected ObjectFieldLocalService objectFieldLocalService;
 
 	private T _create(
-		EntityModel entityModel, Expression filterExpression,
+		EntityModel entityModel, Expression filterExpression, Long[] groupIds,
 		ObjectDefinition objectDefinition) {
 
 		try {
 			return (T)filterExpression.accept(
-				getExpressionVisitor(entityModel, objectDefinition));
+				getExpressionVisitor(entityModel, groupIds, objectDefinition));
 		}
 		catch (ExpressionVisitException expressionVisitException) {
 			throw new InvalidFilterException(

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/filter/factory/FilterFactory.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/filter/factory/FilterFactory.java
@@ -19,6 +19,10 @@ public interface FilterFactory<T> {
 		ObjectDefinition objectDefinition);
 
 	public T create(
+		Expression filterExpression, Long[] groupIds,
+		ObjectDefinition objectDefinition);
+
+	public T create(
 		Expression filterExpression, ObjectDefinition objectDefinition);
 
 	public T create(String filterString, ObjectDefinition objectDefinition);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/filter/factory/DefaultFilterFactoryImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/filter/factory/DefaultFilterFactoryImpl.java
@@ -39,6 +39,17 @@ public class DefaultFilterFactoryImpl
 
 	@Override
 	public ExpressionVisitor<Object> getExpressionVisitor(
+		EntityModel entityModel, Long[] groupIds,
+		ObjectDefinition objectDefinition) {
+
+		return new PredicateExpressionVisitorImpl(
+			entityModel, entityModelProvider, groupIds, objectDefinition,
+			_objectFieldBusinessTypeRegistry, _objectFieldLocalService,
+			_objectRelatedModelsPredicateProviderRegistry, _serviceTrackerMap);
+	}
+
+	@Override
+	public ExpressionVisitor<Object> getExpressionVisitor(
 		EntityModel entityModel, ObjectDefinition objectDefinition) {
 
 		return new PredicateExpressionVisitorImpl(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -786,7 +786,7 @@ public class DefaultObjectEntryManagerImpl
 		Long[] groupIds = groupIdsList.toArray(new Long[0]);
 
 		Predicate predicate = _filterFactory.create(
-			filterExpression, objectDefinition);
+			filterExpression, groupIds, objectDefinition);
 
 		int start = _getStartPosition(pagination);
 		int end = _getEndPosition(pagination);

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/filter/expression/PredicateExpressionVisitorImpl.java
@@ -77,6 +77,22 @@ public class PredicateExpressionVisitorImpl
 
 	public PredicateExpressionVisitorImpl(
 		EntityModel entityModel, EntityModelProvider entityModelProvider,
+		Long[] groupIds, ObjectDefinition objectDefinition,
+		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
+		ObjectFieldLocalService objectFieldLocalService,
+		ObjectRelatedModelsPredicateProviderRegistry
+			objectRelatedModelsPredicateProviderRegistry,
+		ServiceTrackerMap<String, FieldPredicateProvider> serviceTrackerMap) {
+
+		this(
+			entityModel, entityModelProvider, groupIds, new HashMap<>(),
+			objectDefinition, objectFieldBusinessTypeRegistry,
+			objectFieldLocalService,
+			objectRelatedModelsPredicateProviderRegistry, serviceTrackerMap);
+	}
+
+	public PredicateExpressionVisitorImpl(
+		EntityModel entityModel, EntityModelProvider entityModelProvider,
 		ObjectDefinition objectDefinition,
 		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		ObjectFieldLocalService objectFieldLocalService,
@@ -85,8 +101,9 @@ public class PredicateExpressionVisitorImpl
 		ServiceTrackerMap<String, FieldPredicateProvider> serviceTrackerMap) {
 
 		this(
-			entityModel, entityModelProvider, new HashMap<>(), objectDefinition,
-			objectFieldBusinessTypeRegistry, objectFieldLocalService,
+			entityModel, entityModelProvider, null, new HashMap<>(),
+			objectDefinition, objectFieldBusinessTypeRegistry,
+			objectFieldLocalService,
 			objectRelatedModelsPredicateProviderRegistry, serviceTrackerMap);
 	}
 
@@ -360,7 +377,7 @@ public class PredicateExpressionVisitorImpl
 
 	private PredicateExpressionVisitorImpl(
 		EntityModel entityModel, EntityModelProvider entityModelProvider,
-		Map<String, String> lambdaVariableExpressionFieldNames,
+		Long[] groupIds, Map<String, String> lambdaVariableExpressionFieldNames,
 		ObjectDefinition objectDefinition,
 		ObjectFieldBusinessTypeRegistry objectFieldBusinessTypeRegistry,
 		ObjectFieldLocalService objectFieldLocalService,
@@ -371,6 +388,7 @@ public class PredicateExpressionVisitorImpl
 		_entityModels.put(
 			objectDefinition.getObjectDefinitionId(), entityModel);
 		_entityModelProvider = entityModelProvider;
+		_groupIds = groupIds;
 		_lambdaVariableExpressionFieldNames =
 			lambdaVariableExpressionFieldNames;
 		_objectDefinition = objectDefinition;
@@ -579,7 +597,7 @@ public class PredicateExpressionVisitorImpl
 
 		if (objectValuePairs.isEmpty()) {
 			return objectRelatedModelsPredicateProvider.getPredicate(
-				objectRelationship, predicate);
+				_groupIds, objectRelationship, predicate);
 		}
 
 		ObjectValuePair<ObjectRelationship, ObjectDefinition> objectValuePair =
@@ -589,7 +607,7 @@ public class PredicateExpressionVisitorImpl
 			objectValuePair.getValue(), objectValuePairs,
 			objectValuePair.getKey(),
 			objectRelatedModelsPredicateProvider.getPredicate(
-				objectRelationship, predicate));
+				_groupIds, objectRelationship, predicate));
 	}
 
 	private List<ObjectValuePair<ObjectRelationship, ObjectDefinition>>
@@ -824,7 +842,7 @@ public class PredicateExpressionVisitorImpl
 		return (Predicate)lambdaFunctionExpression.accept(
 			new PredicateExpressionVisitorImpl(
 				_getObjectDefinitionEntityModel(objectDefinition),
-				_entityModelProvider,
+				_entityModelProvider, _groupIds,
 				Collections.singletonMap(
 					lambdaFunctionExpression.getVariableName(),
 					collectionPropertyExpression.getName()),
@@ -853,6 +871,7 @@ public class PredicateExpressionVisitorImpl
 
 	private final EntityModelProvider _entityModelProvider;
 	private final Map<Long, EntityModel> _entityModels = new HashMap<>();
+	private final Long[] _groupIds;
 	private final Map<String, String> _lambdaVariableExpressionFieldNames;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectFieldBusinessTypeRegistry

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/entry/util/ObjectEntrySearchUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.object.internal.entry.util;
 
 import com.liferay.document.library.kernel.model.DLFileEntryTable;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -120,6 +122,35 @@ public class ObjectEntrySearchUtil {
 			).eq(
 				(languageId == null) ? getLanguageId() : languageId
 			)
+		);
+	}
+
+	public static Predicate getObjectEntryIndexPredicate(
+		Long[] groupIds, ObjectDefinition objectDefinition,
+		Predicate predicate) {
+
+		return ObjectEntryTable.INSTANCE.companyId.eq(
+			objectDefinition.getCompanyId()
+		).and(
+			() -> {
+				if (StringUtil.equals(
+						objectDefinition.getScope(),
+						ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+					return ObjectEntryTable.INSTANCE.groupId.eq(0L);
+				}
+
+				if (ArrayUtil.isEmpty(groupIds)) {
+					return null;
+				}
+
+				return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
+			}
+		).and(
+			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+				objectDefinition.getObjectDefinitionId())
+		).and(
+			predicate
 		);
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/BaseObjectEntryObjectRelatedModelsPredicateProviderImpl.java
@@ -38,7 +38,8 @@ public abstract class BaseObjectEntryObjectRelatedModelsPredicateProviderImpl
 
 	@Override
 	public Predicate getPredicate(
-			ObjectRelationship objectRelationship, Predicate predicate)
+			Long[] groupIds, ObjectRelationship objectRelationship,
+			Predicate predicate)
 		throws PortalException {
 
 		ObjectDefinition relatedObjectDefinition =
@@ -51,12 +52,12 @@ public abstract class BaseObjectEntryObjectRelatedModelsPredicateProviderImpl
 		}
 
 		return getPredicate(
-			objectRelationship, predicate, relatedObjectDefinition);
+			groupIds, objectRelationship, predicate, relatedObjectDefinition);
 	}
 
 	public abstract Predicate getPredicate(
-			ObjectRelationship objectRelationship, Predicate predicate,
-			ObjectDefinition relatedObjectDefinition)
+			Long[] groupIds, ObjectRelationship objectRelationship,
+			Predicate predicate, ObjectDefinition relatedObjectDefinition)
 		throws PortalException;
 
 	protected DynamicObjectDefinitionTable getDynamicObjectDefinitionTable(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl.java
@@ -42,8 +42,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 
 	@Override
 	public Predicate getPredicate(
-			ObjectRelationship objectRelationship, Predicate predicate,
-			ObjectDefinition relatedObjectDefinition)
+			Long[] groupIds, ObjectRelationship objectRelationship,
+			Predicate predicate, ObjectDefinition relatedObjectDefinition)
 		throws PortalException {
 
 		ObjectDefinition objectDefinition1 = _getObjectDefinition1(
@@ -79,8 +79,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					objectDefinition2, objectFieldLocalService),
 				objectDefinition2DynamicObjectDefinitionTable,
 				objectDefinition2ExtensionDynamicObjectDefinitionTable,
-				DSLQueryFactoryUtil.select(objectRelationshipColumn),
-				predicate);
+				DSLQueryFactoryUtil.select(objectRelationshipColumn), groupIds,
+				objectDefinition2, predicate);
 		}
 
 		DynamicObjectDefinitionTable dynamicObjectDefinitionTable =
@@ -104,7 +104,7 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					DSLQueryFactoryUtil.select(
 						objectDefinition1DynamicObjectDefinitionTable.
 							getPrimaryKeyColumn()),
-					predicate)
+					groupIds, objectDefinition1, predicate)
 			));
 	}
 
@@ -163,7 +163,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 				dynamicObjectDefinitionLocalizationTable,
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			DynamicObjectDefinitionTable extensionDynamicObjectDefinitionTable,
-			FromStep fromStep, Predicate predicate)
+			FromStep fromStep, Long[] groupIds,
+			ObjectDefinition objectDefinition, Predicate predicate)
 		throws PortalException {
 
 		return column.in(
@@ -185,7 +186,8 @@ public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
 					dynamicObjectDefinitionLocalizationTable,
 					dynamicObjectDefinitionTable, null)
 			).where(
-				predicate
+				ObjectEntrySearchUtil.getObjectEntryIndexPredicate(
+					groupIds, objectDefinition, predicate)
 			));
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.object.internal.related.models;
 
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.internal.entry.util.ObjectEntrySearchUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectRelationship;
@@ -38,8 +39,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 
 	@Override
 	public Predicate getPredicate(
-			ObjectRelationship objectRelationship, Predicate predicate,
-			ObjectDefinition relatedObjectDefinition)
+			Long[] groupIds, ObjectRelationship objectRelationship,
+			Predicate predicate, ObjectDefinition relatedObjectDefinition)
 		throws PortalException {
 
 		Column<?, ?> dynamicObjectDefinitionTableColumn =
@@ -89,7 +90,8 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 								getPrimaryKeyColumn()
 						)
 					).where(
-						predicate
+						ObjectEntrySearchUtil.getObjectEntryIndexPredicate(
+							groupIds, relatedObjectDefinition, predicate)
 					))
 			));
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4746,8 +4746,26 @@ public class ObjectEntryLocalServiceImpl
 				dynamicObjectDefinitionLocalizationTable,
 				dynamicObjectDefinitionTable, null)
 		).where(
-			ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-				objectDefinition.getObjectDefinitionId()
+			ObjectEntryTable.INSTANCE.companyId.eq(
+				objectDefinition.getCompanyId()
+			).and(
+				() -> {
+					if (StringUtil.equals(
+							objectDefinition.getScope(),
+							ObjectDefinitionConstants.SCOPE_COMPANY)) {
+
+						return ObjectEntryTable.INSTANCE.groupId.eq(0L);
+					}
+
+					if (ArrayUtil.isEmpty(groupIds)) {
+						return null;
+					}
+
+					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
+				}
+			).and(
+				ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
+					objectDefinition.getObjectDefinitionId())
 			).and(
 				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
 					ObjectEntryTable.INSTANCE.objectEntryId
@@ -4757,14 +4775,6 @@ public class ObjectEntryLocalServiceImpl
 			).and(
 				ObjectEntryTable.INSTANCE.status.neq(
 					WorkflowConstants.STATUS_IN_TRASH)
-			).and(
-				() -> {
-					if (ArrayUtil.isEmpty(groupIds)) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
-				}
 			).and(
 				Predicate.withParentheses(
 					_fillPredicate(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4746,26 +4746,12 @@ public class ObjectEntryLocalServiceImpl
 				dynamicObjectDefinitionLocalizationTable,
 				dynamicObjectDefinitionTable, null)
 		).where(
-			ObjectEntryTable.INSTANCE.companyId.eq(
-				objectDefinition.getCompanyId()
-			).and(
-				() -> {
-					if (StringUtil.equals(
-							objectDefinition.getScope(),
-							ObjectDefinitionConstants.SCOPE_COMPANY)) {
-
-						return ObjectEntryTable.INSTANCE.groupId.eq(0L);
-					}
-
-					if (ArrayUtil.isEmpty(groupIds)) {
-						return null;
-					}
-
-					return ObjectEntryTable.INSTANCE.groupId.in(groupIds);
-				}
-			).and(
-				ObjectEntryTable.INSTANCE.objectDefinitionId.eq(
-					objectDefinition.getObjectDefinitionId())
+			ObjectEntrySearchUtil.getObjectEntryIndexPredicate(
+				groupIds, objectDefinition,
+				Predicate.withParentheses(
+					_fillPredicate(
+						objectDefinition.getObjectDefinitionId(), predicate,
+						search))
 			).and(
 				ObjectEntryTable.INSTANCE.rootObjectEntryId.eq(
 					ObjectEntryTable.INSTANCE.objectEntryId
@@ -4775,11 +4761,6 @@ public class ObjectEntryLocalServiceImpl
 			).and(
 				ObjectEntryTable.INSTANCE.status.neq(
 					WorkflowConstants.STATUS_IN_TRASH)
-			).and(
-				Predicate.withParentheses(
-					_fillPredicate(
-						objectDefinition.getObjectDefinitionId(), predicate,
-						search))
 			).and(
 				_getHeadObjectEntryPredicate(preferApproved)
 			).and(

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/BaseObjectRelatedModelsPredicateProviderImplTestCase.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/BaseObjectRelatedModelsPredicateProviderImplTestCase.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.related.models;
+
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.petra.string.StringBundler;
+
+import org.junit.Assert;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public abstract class BaseObjectRelatedModelsPredicateProviderImplTestCase {
+
+	protected void assertPredicateString(
+		String operator, String predicateString) {
+
+		Assert.assertTrue(
+			predicateString,
+			predicateString.contains("ObjectEntry.companyId = ?"));
+		Assert.assertTrue(
+			predicateString,
+			predicateString.contains("ObjectEntry.externalReferenceCode = ?"));
+		Assert.assertTrue(
+			predicateString,
+			predicateString.contains("ObjectEntry.groupId " + operator));
+		Assert.assertTrue(
+			predicateString,
+			predicateString.contains("ObjectEntry.objectDefinitionId = ?"));
+	}
+
+	protected ObjectDefinition mockObjectDefinition(
+		long companyId, long objectDefinitionId, String objectDefinitionName,
+		String scope) {
+
+		ObjectDefinition objectDefinition = Mockito.mock(
+			ObjectDefinition.class);
+
+		Mockito.when(
+			objectDefinition.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		String dbTableName = StringBundler.concat(
+			"O_", companyId, "_", objectDefinitionName);
+
+		Mockito.when(
+			objectDefinition.getDBTableName()
+		).thenReturn(
+			dbTableName
+		);
+
+		Mockito.when(
+			objectDefinition.getExtensionDBTableName()
+		).thenReturn(
+			dbTableName + "x"
+		);
+
+		Mockito.when(
+			objectDefinition.getObjectDefinitionId()
+		).thenReturn(
+			objectDefinitionId
+		);
+
+		String pkObjectFieldName = "c_" + objectDefinitionName + "Id";
+
+		Mockito.when(
+			objectDefinition.getPKObjectFieldDBColumnName()
+		).thenReturn(
+			pkObjectFieldName + "_"
+		);
+
+		Mockito.when(
+			objectDefinition.getPKObjectFieldName()
+		).thenReturn(
+			pkObjectFieldName
+		);
+
+		Mockito.when(
+			objectDefinition.getScope()
+		).thenReturn(
+			scope
+		);
+
+		return objectDefinition;
+	}
+
+	protected ObjectRelationship mockObjectRelationship(
+		long objectDefinitionId1, long objectDefinitionId2,
+		String objectRelationshipName) {
+
+		ObjectRelationship objectRelationship = Mockito.mock(
+			ObjectRelationship.class);
+
+		Mockito.when(
+			objectRelationship.getDBTableName()
+		).thenReturn(
+			"R_" + objectRelationshipName
+		);
+
+		Mockito.when(
+			objectRelationship.getName()
+		).thenReturn(
+			objectRelationshipName
+		);
+
+		Mockito.when(
+			objectRelationship.getObjectDefinitionId1()
+		).thenReturn(
+			objectDefinitionId1
+		);
+
+		Mockito.when(
+			objectRelationship.getObjectDefinitionId2()
+		).thenReturn(
+			objectDefinitionId2
+		);
+
+		Mockito.when(
+			objectRelationship.isReverse()
+		).thenReturn(
+			false
+		);
+
+		return objectRelationship;
+	}
+
+}

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntry1toMObjectRelatedModelsPredicateProviderImplTest.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.related.models;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class ObjectEntry1toMObjectRelatedModelsPredicateProviderImplTest
+	extends BaseObjectRelatedModelsPredicateProviderImplTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetPredicate() throws Exception {
+
+		// Company scope
+
+		long companyId = RandomTestUtil.randomLong();
+		long objectDefinitionId = RandomTestUtil.randomLong();
+
+		String objectDefinitionName = RandomTestUtil.randomString();
+		String objectRelationshipName = RandomTestUtil.randomString();
+
+		ObjectFieldLocalService objectFieldLocalService =
+			_mockObjectFieldLocalService(
+				StringBundler.concat(
+					"r_", objectRelationshipName, "_c_", objectDefinitionName,
+					"Id"),
+				objectDefinitionId);
+
+		ObjectRelationship objectRelationship = mockObjectRelationship(
+			objectDefinitionId, objectDefinitionId, objectRelationshipName);
+
+		assertPredicateString(
+			"= ?",
+			_getPredicateString(
+				new Long[] {RandomTestUtil.randomLong()},
+				mockObjectDefinition(
+					companyId, objectDefinitionId, objectDefinitionName,
+					ObjectDefinitionConstants.SCOPE_COMPANY),
+				objectFieldLocalService, objectRelationship));
+
+		// Depot scope with connected depot entries
+
+		assertPredicateString(
+			"in (?, ?, ?)",
+			_getPredicateString(
+				new Long[] {
+					RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+					RandomTestUtil.randomLong()
+				},
+				mockObjectDefinition(
+					companyId, objectDefinitionId, objectDefinitionName,
+					ObjectDefinitionConstants.SCOPE_DEPOT),
+				objectFieldLocalService, objectRelationship));
+
+		// Site scope
+
+		assertPredicateString(
+			"in (?)",
+			_getPredicateString(
+				new Long[] {RandomTestUtil.randomLong()},
+				mockObjectDefinition(
+					companyId, objectDefinitionId, objectDefinitionName,
+					ObjectDefinitionConstants.SCOPE_SITE),
+				objectFieldLocalService, objectRelationship));
+	}
+
+	private String _getPredicateString(
+			Long[] groupIds, ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
+			ObjectRelationship objectRelationship)
+		throws Exception {
+
+		ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl
+			objectEntry1toMObjectRelatedModelsPredicateProviderImpl =
+				new ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl(
+					objectDefinition, objectFieldLocalService);
+
+		return String.valueOf(
+			objectEntry1toMObjectRelatedModelsPredicateProviderImpl.
+				getPredicate(
+					groupIds, objectRelationship,
+					ObjectEntryTable.INSTANCE.externalReferenceCode.eq(
+						RandomTestUtil.randomString()),
+					objectDefinition));
+	}
+
+	private ObjectFieldLocalService _mockObjectFieldLocalService(
+		String dbColumnName, long objectDefinitionId) {
+
+		ObjectFieldLocalService objectFieldLocalService = Mockito.mock(
+			ObjectFieldLocalService.class);
+
+		Mockito.when(
+			objectFieldLocalService.getLocalizedObjectFields(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.compareBusinessType(
+				ObjectFieldConstants.BUSINESS_TYPE_AUTO_INCREMENT)
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectField.getDBColumnNames()
+		).thenReturn(
+			new String[] {dbColumnName}
+		);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			ObjectFieldConstants.DB_TYPE_LONG
+		);
+
+		Mockito.when(
+			objectField.hasInsertValues()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(
+				Mockito.eq(objectDefinitionId), Mockito.anyString())
+		).thenReturn(
+			List.of(objectField)
+		);
+
+		return objectFieldLocalService;
+	}
+
+}

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.related.models;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest
+	extends BaseObjectRelatedModelsPredicateProviderImplTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetPredicate() throws Exception {
+
+		// Company scope
+
+		long companyId = RandomTestUtil.randomLong();
+		long objectDefinitionId1 = RandomTestUtil.randomLong();
+
+		ObjectDefinition objectDefinition = mockObjectDefinition(
+			companyId, objectDefinitionId1, RandomTestUtil.randomString(),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		ObjectFieldLocalService objectFieldLocalService =
+			_mockObjectFieldLocalService();
+
+		long objectDefinitionId2 = RandomTestUtil.randomLong();
+
+		ObjectRelationship objectRelationship = mockObjectRelationship(
+			objectDefinitionId1, objectDefinitionId2,
+			RandomTestUtil.randomString());
+
+		String objectDefinitionName2 = RandomTestUtil.randomString();
+
+		assertPredicateString(
+			"= ?",
+			_getPredicateString(
+				new Long[] {RandomTestUtil.randomLong()}, objectDefinition,
+				objectFieldLocalService, objectRelationship,
+				mockObjectDefinition(
+					companyId, objectDefinitionId2, objectDefinitionName2,
+					ObjectDefinitionConstants.SCOPE_COMPANY)));
+
+		// Depot scope with connected depot entries
+
+		assertPredicateString(
+			"in (?, ?, ?)",
+			_getPredicateString(
+				new Long[] {
+					RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+					RandomTestUtil.randomLong()
+				},
+				objectDefinition, objectFieldLocalService, objectRelationship,
+				mockObjectDefinition(
+					companyId, objectDefinitionId2, objectDefinitionName2,
+					ObjectDefinitionConstants.SCOPE_DEPOT)));
+
+		// Site scope
+
+		assertPredicateString(
+			"in (?)",
+			_getPredicateString(
+				new Long[] {RandomTestUtil.randomLong()}, objectDefinition,
+				objectFieldLocalService, objectRelationship,
+				mockObjectDefinition(
+					companyId, objectDefinitionId2, objectDefinitionName2,
+					ObjectDefinitionConstants.SCOPE_SITE)));
+	}
+
+	private String _getPredicateString(
+			Long[] groupIds, ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
+			ObjectRelationship objectRelationship,
+			ObjectDefinition relatedObjectDefinition)
+		throws Exception {
+
+		ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
+			objectEntryMtoMObjectRelatedModelsPredicateProviderImpl =
+				new ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl(
+					objectDefinition, objectFieldLocalService);
+
+		return String.valueOf(
+			objectEntryMtoMObjectRelatedModelsPredicateProviderImpl.
+				getPredicate(
+					groupIds, objectRelationship,
+					ObjectEntryTable.INSTANCE.externalReferenceCode.eq(
+						RandomTestUtil.randomString()),
+					relatedObjectDefinition));
+	}
+
+	private ObjectFieldLocalService _mockObjectFieldLocalService() {
+		ObjectFieldLocalService objectFieldLocalService = Mockito.mock(
+			ObjectFieldLocalService.class);
+
+		Mockito.when(
+			objectFieldLocalService.getLocalizedObjectFields(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			objectFieldLocalService.getObjectFields(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		return objectFieldLocalService;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92227

## What Is Being Fixed

When object entries are queried by ERC, directly or through a 1:M / M:M relationship nested filter, the generated SQL omits `objectDefinitionId`, `groupId`, or `companyId`, preventing the database from using the composite index `IX_11E61545 (objectDefinitionId, groupId, companyId, externalReferenceCode)` and triggering a full table scan.

For depot-scoped object definitions, the relationship subquery additionally captured only the main depot, so entries in connected depots were silently excluded.

## How It Is Being Fixed

In `ObjectEntryLocalServiceImpl`, the direct ERC listing subquery now filters by `companyId`.

In the relationship predicate providers, the subquery WHERE clause now includes all four `IX_11E61545` columns. The API was refactored to thread `Long[] groupIds` explicitly from `DefaultObjectEntryManagerImpl` through `FilterFactory`, the `PredicateExpressionVisitorImpl`, and into the provider lambda, replacing the previous reliance on `GroupThreadLocal`. This lets depot-scoped queries pass both the main depot and the connected depots, so the resulting `groupId IN (...)` filter spans the depot federation.

Legacy callers of `FilterFactory.create(Expression, ObjectDefinition)` that do not pass groupIds preserve exact prior behavior, the lambda skips the groupId filter when none is provided.

Unit tests added for both relationship predicate provider implementations cover SCOPE_COMPANY, SCOPE_DEPOT (with connected depots), and SCOPE_SITE, asserting that the generated SQL includes all four index columns.