### PR TITLE
LPD-93833 Fix Workflow Metrics counts returning 0 on Elasticsearch 8

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/helper/ResourceHelper.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/helper/ResourceHelper.java
@@ -337,7 +337,8 @@ public class ResourceHelper {
 				filterAggregationResult.getChildAggregationResult(
 					"breachedInstanceCount");
 
-		return GetterUtil.getLong(scriptedMetricAggregationResult.getValue());
+		return getScriptedMetricAggregationResultValue(
+			scriptedMetricAggregationResult);
 	}
 
 	public double getBreachedInstancePercentage(Bucket bucket) {
@@ -413,7 +414,8 @@ public class ResourceHelper {
 				filterAggregationResult.getChildAggregationResult(
 					"instanceCount");
 
-		return GetterUtil.getLong(scriptedMetricAggregationResult.getValue());
+		return getScriptedMetricAggregationResultValue(
+			scriptedMetricAggregationResult);
 	}
 
 	public long getOnTimeTaskCount(Bucket bucket) {
@@ -428,7 +430,8 @@ public class ResourceHelper {
 			(ScriptedMetricAggregationResult)
 				filterAggregationResult.getChildAggregationResult("taskCount");
 
-		return GetterUtil.getLong(scriptedMetricAggregationResult.getValue());
+		return getScriptedMetricAggregationResultValue(
+			scriptedMetricAggregationResult);
 	}
 
 	public long getOverdueInstanceCount(Bucket bucket) {
@@ -441,7 +444,8 @@ public class ResourceHelper {
 				filterAggregationResult.getChildAggregationResult(
 					"instanceCount");
 
-		return GetterUtil.getLong(scriptedMetricAggregationResult.getValue());
+		return getScriptedMetricAggregationResultValue(
+			scriptedMetricAggregationResult);
 	}
 
 	public long getOverdueTaskCount(Bucket bucket) {
@@ -457,7 +461,19 @@ public class ResourceHelper {
 			(ScriptedMetricAggregationResult)
 				filterAggregationResult.getChildAggregationResult("taskCount");
 
-		return GetterUtil.getLong(scriptedMetricAggregationResult.getValue());
+		return getScriptedMetricAggregationResultValue(
+			scriptedMetricAggregationResult);
+	}
+
+	public long getScriptedMetricAggregationResultValue(
+		ScriptedMetricAggregationResult scriptedMetricAggregationResult) {
+
+		if (scriptedMetricAggregationResult == null) {
+			return 0;
+		}
+
+		return GetterUtil.getLong(
+			String.valueOf(scriptedMetricAggregationResult.getValue()));
 	}
 
 	@Activate

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/ProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/ProcessMetricResourceImpl.java
@@ -611,8 +611,8 @@ public class ProcessMetricResourceImpl extends BaseProcessMetricResourceImpl {
 					bucket.getChildAggregationResult("instanceCount");
 
 			processMetric.setInstanceCount(
-				() -> GetterUtil.getLong(
-					scriptedMetricAggregationResult.getValue()));
+				() -> _resourceHelper.getScriptedMetricAggregationResultValue(
+					scriptedMetricAggregationResult));
 		}
 	}
 


### PR DESCRIPTION
[LPD-93833](https://liferay.atlassian.net/browse/LPD-93833)

This bug fixes test ProcessMetricResourceTest

**What is being fixed:** On Elasticsearch 8 the Workflow Metrics process dashboard summary card showed 0 instances, on time, overdue, and untracked, even though the instance list correctly listed the overdue items. Reproduced on master and 2026.Q1.1, originating from customer ticket LPP-64273.

**How it is being fixed:** The Elasticsearch 8 client returns a scripted metric aggregation value as a `JsonData` object rather than the already-deserialized number returned under Elasticsearch 7. `GetterUtil` only reads `String`/`Number` values, so every scripted metric count resolved to 0. The value is now rendered to its JSON scalar before parsing, centralized in a single `ResourceHelper.getScriptedMetricAggregationResultValue` method that the count readers (and `ProcessMetricResourceImpl`) share, so there is one place to revise when the underlying connector is fixed. The existing `ProcessMetricResourceTest` already covers this path. Note the deeper root cause lives in the shared `portal-search-elasticsearch8` connector, which does not unwrap `JsonData`; that affects every scripted-metric consumer and should be addressed separately.

[LPD-93833]: https://liferay.atlassian.net/browse/LPD-93833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ