### PR TITLE
LPD-91697 Fix testIsNotifiableUser regression caused by wrong company

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -969,7 +969,7 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 
 	@Test
 	public void testIsNotifiableUser() throws Exception {
-		User user = UserTestUtil.addUser(RandomTestUtil.randomString());
+		User user = UserTestUtil.addUser(_company);
 
 		_activateSingleApproverWorkflow(BlogsEntry.class.getName(), 0, 0);
 


### PR DESCRIPTION
Hi team, please see the fix found on the backport to 2026.q2:
UserTestUtil.addUser(screenName) defaults to TestPropsValues.getCompanyId() (the portal default company), not the test virtual instance created by CompanyTestUtil.addCompany(). The new cross-company guard correctly rejected the assignment because the assignee belonged to a different company. Fix uses UserTestUtil.addUser(_company) consistent with every other addUser call in the file.