### PR TITLE
LPD-93539 Hide child portlet widget when standalone is disabled

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -194,6 +194,8 @@ import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.sharing.security.permission.SharingEntryAction;
 import com.liferay.sharing.service.SharingEntryLocalService;
 
+import jakarta.portlet.Portlet;
+
 import java.io.Serializable;
 
 import java.sql.Connection;
@@ -216,6 +218,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -4306,6 +4313,28 @@ public class ObjectDefinitionLocalServiceTest {
 			));
 	}
 
+	private String _getPortletDisplayCategory(ObjectDefinition objectDefinition)
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			ObjectDefinitionLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		for (ServiceReference<Portlet> serviceReference :
+				bundleContext.getServiceReferences(
+					Portlet.class,
+					"(jakarta.portlet.name=" + objectDefinition.getPortletId() +
+						")")) {
+
+			return String.valueOf(
+				serviceReference.getProperty(
+					"com.liferay.portlet.display-category"));
+		}
+
+		return null;
+	}
+
 	private int _getSharingEntriesCount(ObjectDefinition objectDefinition) {
 		return _sharingEntryLocalService.getCompanySharingEntriesCount(
 			objectDefinition.getCompanyId(),
@@ -5051,8 +5080,8 @@ public class ObjectDefinitionLocalServiceTest {
 
 		Assert.assertFalse(objectDefinition.isAllowStandaloneObjectEntry());
 
-		// Panel app is not visible when the allow standalone object entry
-		// setting is disabled
+		// Panel app is not visible and the portlet is not selectable as a page
+		// widget when the allow standalone object entry setting is disabled
 
 		objectDefinition.setPanelCategoryKey(RandomTestUtil.randomString());
 
@@ -5068,9 +5097,11 @@ public class ObjectDefinitionLocalServiceTest {
 				).build()));
 
 		Assert.assertFalse(_isPanelAppRegistered(objectDefinition));
+		Assert.assertEquals(
+			"category.hidden", _getPortletDisplayCategory(objectDefinition));
 
-		// Panel app is visible when the allow standalone object entry setting
-		// is enabled
+		// Panel app is visible and the portlet is selectable as a page widget
+		// when the allow standalone object entry setting is enabled
 
 		objectDefinition = _updateCustomObjectDefinition(
 			objectDefinition.getClassName(), objectDefinition,
@@ -5084,6 +5115,8 @@ public class ObjectDefinitionLocalServiceTest {
 				).build()));
 
 		Assert.assertTrue(_isPanelAppRegistered(objectDefinition));
+		Assert.assertEquals(
+			"category.object", _getPortletDisplayCategory(objectDefinition));
 	}
 
 	private ObjectDefinition _updateCustomObjectDefinition(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -527,6 +527,13 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				).put(
 					"com.liferay.portlet.display-category",
 					() -> {
+						if (FeatureFlagManagerUtil.isEnabled(
+								objectDefinition.getCompanyId(), "LPD-69877") &&
+							!objectDefinition.isAllowStandaloneObjectEntry()) {
+
+							return "category.hidden";
+						}
+
 						if (objectDefinition.isPortlet()) {
 							return "category.object";
 						}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93539

## What Is Being Fixed

When a child object definition has "Allow Standalone Entries" disabled, its portlet is correctly removed from the Control Panel, but it still appears in the page Widget selector and can be added to a page. This lets users create standalone entries that the setting is meant to forbid.

## How It Is Being Fixed

The portlet's `com.liferay.portlet.display-category` property in `ObjectDefinitionDeployerImpl` was derived solely from `isPortlet()`, so it always resolved to `category.object` and the portlet stayed visible in the widget picker. The deployer now returns `category.hidden` when the `LPD-69877` feature flag is enabled and the definition does not allow standalone entries, mirroring the same condition already used a few lines below to blank `panel.category.key`. The value is re-evaluated on the redeploy that already runs when the setting is toggled, so the widget picker reflects the new state immediately.

## PR Check

**pr-check: PASS** — tested on `41a5a5c820289746718379cfa0996a071a9c177c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "41a5a5c820289746718379cfa0996a071a9c177c"} -->