### PR TITLE
LPD-93214 Reserve "comments" as an object field name

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -2231,12 +2231,12 @@ public class ObjectFieldLocalServiceImpl
 	private final Set<String> _readOnlyObjectFieldNames = SetUtil.fromArray(
 		"createDate", "creator", "id", "modifiedDate", "status");
 	private final Set<String> _reservedNames = SetUtil.fromArray(
-		"actions", "companyid", "createdate", "creator", "currentdate",
-		"datecreated", "datemodified", "displaydate", "expirationdate",
-		"externalreferencecode", "groupid", "id", "keywords", "lastpublishdate",
-		"modifieddate", "reviewdate", "status", "statusbyuserid",
-		"statusbyusername", "statusdate", "taxonomycategoryids", "userid",
-		"username");
+		"actions", "comments", "companyid", "createdate", "creator",
+		"currentdate", "datecreated", "datemodified", "displaydate",
+		"expirationdate", "externalreferencecode", "groupid", "id", "keywords",
+		"lastpublishdate", "modifieddate", "reviewdate", "status",
+		"statusbyuserid", "statusbyusername", "statusdate",
+		"taxonomycategoryids", "userid", "username");
 
 	@Reference
 	private ResourceActions _resourceActions;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -558,11 +558,11 @@ public class ObjectFieldLocalServiceTest {
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition3);
 
 		String[] reservedNames = {
-			"actions", "companyId", "createDate", "creator", "dateCreated",
-			"dateModified", "externalReferenceCode", "groupId", "id",
-			"keywords", "lastPublishDate", "modifiedDate", "statusByUserId",
-			"statusByUserName", "statusDate", "taxonomycategoryids", "userId",
-			"userName"
+			"actions", "comments", "companyId", "createDate", "creator",
+			"dateCreated", "dateModified", "externalReferenceCode", "groupId",
+			"id", "keywords", "lastPublishDate", "modifiedDate",
+			"statusByUserId", "statusByUserName", "statusDate",
+			"taxonomycategoryids", "userId", "userName"
 		};
 
 		for (String reservedName : reservedNames) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93214

## What Is Being Fixed

Creating a custom object field named `comments` succeeds, but any write to an entry that sets that field fails with HTTP 400 `Unable to map JSON path: comments`. The `ObjectEntry` REST DTO already declares a built-in READ_WRITE property named `comments` (type `Comment[]`); when Jackson tries to bind a scalar value from the custom field to `Comment[]`, it throws, producing the 400.

## How It Is Being Fixed

`comments` is added to the `_reservedNames` set in `ObjectFieldLocalServiceImpl`, which `_validateName` checks at field-creation time. The name is now rejected with `ObjectFieldNameException.MustNotBeReserved` before a conflicting field can be published, consistent with `id`, `externalreferencecode`, and the other built-in property names already in the set. A matching entry is added to the reserved-names array in `ObjectFieldLocalServiceTest` so the existing coverage loop asserts the new rejection.