### PR TITLE
LPD-93484 Compare friendly URL separators at slash boundaries

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -3232,7 +3232,27 @@ public class ObjectDefinitionLocalServiceTest {
 			FriendlyURLResolverConstants.URL_SEPARATOR_Y_OBJECT_ENTRY,
 			objectDefinition2.getFriendlyURLSeparator());
 
+		String name = "Test" + RandomTestUtil.randomString();
+
 		ObjectDefinition objectDefinition3 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				name,
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				TestPropsValues.getUserId());
+
+		Assert.assertEquals(
+			StringUtil.toLowerCase("c_" + name),
+			objectDefinition3.getFriendlyURLSeparator());
+
+		ObjectDefinition objectDefinition4 =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				"Test",
 				Collections.singletonList(
@@ -3247,9 +3267,9 @@ public class ObjectDefinitionLocalServiceTest {
 				TestPropsValues.getUserId());
 
 		Assert.assertEquals(
-			"c_test", objectDefinition3.getFriendlyURLSeparator());
+			"c_test", objectDefinition4.getFriendlyURLSeparator());
 
-		ObjectDefinition objectDefinition4 =
+		ObjectDefinition objectDefinition5 =
 			_objectDefinitionLocalService.addCustomObjectDefinition(
 				null, TestPropsValues.getUserId(), 0, null, true, false, true,
 				true, true, false, false, false, false, "api",
@@ -3271,12 +3291,13 @@ public class ObjectDefinitionLocalServiceTest {
 			"Other asset types may use this prefix.",
 			() -> _objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
-				objectDefinition4.getObjectDefinitionId()));
+				objectDefinition5.getObjectDefinitionId()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition3);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition4);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition5);
 	}
 
 	@FeatureFlag("LPD-17564")

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -470,9 +470,7 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 			String urlSeparator = friendlyURLResolver.getURLSeparator();
 
-			if (urlSeparator.contains(friendlyURL) ||
-				friendlyURL.startsWith(urlSeparator)) {
-
+			if (_isConflictingFriendlyURLSeparator(friendlyURL, urlSeparator)) {
 				keywordConflict = urlSeparator;
 			}
 
@@ -481,8 +479,8 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 			if (Validator.isNull(keywordConflict) &&
 				friendlyURLResolver.isURLSeparatorConfigurable() &&
-				(defaultURLSeparator.contains(friendlyURL) ||
-				 friendlyURL.startsWith(defaultURLSeparator))) {
+				_isConflictingFriendlyURLSeparator(
+					friendlyURL, defaultURLSeparator)) {
 
 				keywordConflict = defaultURLSeparator;
 			}
@@ -729,6 +727,20 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 	@BeanReference(type = ResourcePermissionLocalService.class)
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
+
+	private boolean _isConflictingFriendlyURLSeparator(
+		String friendlyURL, String urlSeparator) {
+
+		String friendlyURLPath = friendlyURL + StringPool.SLASH;
+
+		if (urlSeparator.startsWith(friendlyURLPath) ||
+			friendlyURLPath.startsWith(urlSeparator)) {
+
+			return true;
+		}
+
+		return false;
+	}
 
 	private boolean _isDraftLayout(
 		long classNameId, long classPK, String type) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93484

## What Is Being Fixed

Publishing a custom object definition failed with "Other asset types may use this prefix" (HTTP 400) when its auto-generated friendly URL separator was a string prefix of an already-published definition's separator. For example, with UniversityClass (separator c_universityclass) published first, publishing University (separator c_university) failed — even though /c_university/ and /c_universityclass/ are distinct path namespaces that never collide at request time. The failure was order-dependent: publishing the shorter name first worked.

## How It Is Being Fixed

LayoutLocalServiceHelper.validateFriendlyURLKeyword compared the candidate keyword against each registered resolver's separator with a bare substring test (urlSeparator.contains(friendlyURL)), so "/c_universityclass/".contains("/c_university") returned true and raised a spurious keyword conflict. The check now compares at a path-segment (slash) boundary via a new helper, _isConflictingFriendlyURLSeparator, which appends a trailing slash to the keyword and tests the prefix relationship in both directions. This matches how the friendly-URL servlet actually resolves requests (startsWith on slash-terminated separators), so genuine conflicts (a layout named /b when /b/ is reserved) are still rejected while prefix-only overlaps are allowed. Both substring checks in the method — the configured and the default separator — were updated.

## PR Check

**pr-check: PASS** — tested on `a732261`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a732261a1570364b40a9abd00fc67a68ad9cf997"} -->
