### PR TITLE
LPD-1457 Render the Default Value field for picklists without items

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BaseEntryFields/ListTypeEntryBaseField.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BaseEntryFields/ListTypeEntryBaseField.tsx
@@ -37,35 +37,35 @@ export function ListTypeEntryBaseField({
 	required,
 	selectedPicklistItemKey,
 }: ListTypeEntryBaseFieldProps) {
+
+	// Key the picker on the available item keys so it is remounted whenever the
+	// set of options changes, including when it becomes empty. Without the
+	// remount the picker keeps showing a value selected for a previous list.
+
 	return (
-		<>
-			{picklistItems.length ? (
-				<SingleSelect
-					error={error}
-					items={picklistItems.map((item) => ({
-						label: creationLanguageId
-							? getLocalizableLabel({
-									fallbackLanguageId: creationLanguageId,
-									labels: item.name_i18n,
-								})
-							: item.name,
-						value: item.key,
-					}))}
-					label={label}
-					onSelectionChange={(value) => {
-						onChange(
-							picklistItems.find((item) => item.key === value)
-						);
-					}}
-					placeholder={placeholder}
-					required={required}
-					selectedKey={
-						picklistItems.find(
-							(item) => item.key === selectedPicklistItemKey
-						)?.key
-					}
-				/>
-			) : null}
-		</>
+		<SingleSelect
+			error={error}
+			items={picklistItems.map((item) => ({
+				label: creationLanguageId
+					? getLocalizableLabel({
+							fallbackLanguageId: creationLanguageId,
+							labels: item.name_i18n,
+						})
+					: item.name,
+				value: item.key,
+			}))}
+			key={picklistItems.map((item) => item.key).join()}
+			label={label}
+			onSelectionChange={(value) => {
+				onChange(picklistItems.find((item) => item.key === value));
+			}}
+			placeholder={placeholder}
+			required={required}
+			selectedKey={
+				picklistItems.find(
+					(item) => item.key === selectedPicklistItemKey
+				)?.key
+			}
+		/>
 	);
 }

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/ListTypeEntryBaseField.spec.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/ListTypeEntryBaseField.spec.tsx
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {ListTypeEntryBaseField} from '../components/BaseEntryFields/ListTypeEntryBaseField';
+
+const baseProps = {
+	creationLanguageId: 'en_US' as Liferay.Language.Locale,
+	label: 'default-value',
+	onChange: () => {},
+	placeholder: 'choose-an-option',
+	required: true,
+};
+
+const colorsPicklistItems = [
+	{
+		externalReferenceCode: 'blue-erc',
+		id: 11,
+		key: 'blue',
+		listTypeDefinitionId: 1,
+		name: 'Blue',
+		name_i18n: {en_US: 'Blue'},
+	},
+];
+
+const sizesPicklistItems = [
+	{
+		externalReferenceCode: 'small-erc',
+		id: 21,
+		key: 'small',
+		listTypeDefinitionId: 2,
+		name: 'Small',
+		name_i18n: {en_US: 'Small'},
+	},
+];
+
+describe('ListTypeEntryBaseField', () => {
+	it('clears the selected value when switching to a different picklist', () => {
+		const {rerender} = render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+
+		rerender(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={sizesPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('clears the selected value when the picklist items become empty', () => {
+		const {rerender} = render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+
+		rerender(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={[]}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('renders an empty select when the picklist has no items', () => {
+		render(<ListTypeEntryBaseField {...baseProps} picklistItems={[]} />);
+
+		expect(screen.getByRole('combobox')).toBeInTheDocument();
+		expect(screen.getByText('default-value')).toBeInTheDocument();
+	});
+
+	it('shows the selected value when the picklist has items', () => {
+		render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.tsx
@@ -50,33 +50,31 @@ const ListTypeDefaultValueSelect: React.FC<
 			API.getListTypeDefinitionListTypeEntries(
 				values.listTypeDefinitionId
 			).then((items) => {
-				if (items.length) {
-					setListTypeEntries(
-						items.map((item) => ({
-							...item,
-							name_i18n: fixLocaleKeys(item.name_i18n),
-						}))
-					);
-				}
+				setListTypeEntries(
+					items.map((item) => ({
+						...item,
+						name_i18n: fixLocaleKeys(item.name_i18n),
+					}))
+				);
 			});
 		}
 	}, [defaultValue, setValues, values, values.listTypeDefinitionId]);
 
+	if (!listTypeEntries || !values.listTypeDefinitionId) {
+		return null;
+	}
+
 	return (
-		<>
-			{listTypeEntries && values.listTypeDefinitionId && (
-				<ListTypeEntryBaseField
-					creationLanguageId={creationLanguageId}
-					error={error}
-					label={label}
-					onChange={handleChange}
-					picklistItems={listTypeEntries}
-					placeholder={Liferay.Language.get('choose-an-option')}
-					required={required}
-					selectedPicklistItemKey={defaultValue as string | undefined}
-				/>
-			)}
-		</>
+		<ListTypeEntryBaseField
+			creationLanguageId={creationLanguageId}
+			error={error}
+			label={label}
+			onChange={handleChange}
+			picklistItems={listTypeEntries}
+			placeholder={Liferay.Language.get('choose-an-option')}
+			required={required}
+			selectedPicklistItemKey={defaultValue as string | undefined}
+		/>
 	);
 };
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {API} from '@liferay/object-js-components-web';
+
+import '@testing-library/jest-dom';
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import ListTypeDefaultValueSelect from '../../../components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect';
+
+const baseProps = {
+	creationLanguageId: 'en_US' as Liferay.Language.Locale,
+	label: 'default-value',
+	onSubmit: () => {},
+	required: true,
+	setValues: () => {},
+};
+
+const colorsListTypeEntries = [
+	{
+		externalReferenceCode: 'blue-erc',
+		id: 11,
+		key: 'blue',
+		listTypeDefinitionId: 1,
+		name: 'Blue',
+		name_i18n: {en_US: 'Blue'},
+	},
+];
+
+const sizesListTypeEntries = [
+	{
+		externalReferenceCode: 'small-erc',
+		id: 21,
+		key: 'small',
+		listTypeDefinitionId: 2,
+		name: 'Small',
+		name_i18n: {en_US: 'Small'},
+	},
+];
+
+describe('ListTypeDefaultValueSelect', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('clears the previous default value when switching to a different picklist', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockImplementation((listTypeDefinitionId) =>
+			Promise.resolve(
+				(listTypeDefinitionId === 1
+					? colorsListTypeEntries
+					: sizesListTypeEntries) as any
+			)
+		);
+
+		const {rerender} = render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+
+		rerender(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 2}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		});
+
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('clears the previous default value when switching to a picklist without items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockImplementation((listTypeDefinitionId) =>
+			Promise.resolve(
+				(listTypeDefinitionId === 1 ? colorsListTypeEntries : []) as any
+			)
+		);
+
+		const {rerender} = render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+
+		rerender(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 2}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		});
+
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('renders the required field and its error when the picklist has no items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockResolvedValue([]);
+
+		render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				error="this-field-is-required"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('default-value')).toBeInTheDocument();
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+	});
+
+	it('shows the selected default value when the picklist has items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockResolvedValue(colorsListTypeEntries as any);
+
+		render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+	});
+});


### PR DESCRIPTION
**Review notes**
- `ListTypeEntryBaseField` is keyed on its item keys so the Clay picker remounts when the option set changes; on its own the picker does not clear when the selection becomes invalid.
- Public API change in `object-js-components-web`: the field now renders an empty select instead of nothing. No in-repo consumer relied on the old behavior.
- Showing an empty dropdown rather than a custom message is intentional, per the LPD-1457 design discussion.

Unit tests in both modules cover the empty, populated, and picklist-switch cases.
