### PR TITLE
LPD-93154 LPD-93156 Restore the active tasks tab and refresh on switch

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
@@ -18,6 +18,7 @@ import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {styleActions, styleBulkActions} from '../../utils/actionStyles';
+import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
 import {WORKFLOW_TASK_ACTION_LINK_ID} from '../../utils/constants';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {
@@ -67,6 +68,8 @@ export default function AllTasksFDSPropsTransformer({
 		default: false,
 		initialPaginationDelta: 20,
 	}));
+
+	installCMPTabPersistence();
 
 	return {
 		...otherProps,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
@@ -18,7 +18,10 @@ import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {styleActions, styleBulkActions} from '../../utils/actionStyles';
-import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
+import {
+	installCMPTabPersistence,
+	registerTabFDS,
+} from '../../utils/cmpTabPersistence';
 import {WORKFLOW_TASK_ACTION_LINK_ID} from '../../utils/constants';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {
@@ -69,6 +72,7 @@ export default function AllTasksFDSPropsTransformer({
 		initialPaginationDelta: 20,
 	}));
 
+	registerTabFDS(id, 0);
 	installCMPTabPersistence();
 
 	return {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -19,6 +19,7 @@ import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {styleActions, styleBulkActions} from '../../utils/actionStyles';
+import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {ProjectTaskItemData, TaskAction} from '../../utils/types';
 import StateLabel from '../StateLabel';
@@ -55,6 +56,8 @@ export default function ProjectTasksFDSPropsTransformer({
 		default: false,
 		initialPaginationDelta: 20,
 	}));
+
+	installCMPTabPersistence();
 
 	const calendarView: IView = {
 		component: (props: any) => CalendarView(props),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -19,7 +19,10 @@ import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {styleActions, styleBulkActions} from '../../utils/actionStyles';
-import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
+import {
+	installCMPTabPersistence,
+	registerTabFDS,
+} from '../../utils/cmpTabPersistence';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {ProjectTaskItemData, TaskAction} from '../../utils/types';
 import StateLabel from '../StateLabel';
@@ -57,6 +60,7 @@ export default function ProjectTasksFDSPropsTransformer({
 		initialPaginationDelta: 20,
 	}));
 
+	registerTabFDS(id, 1);
 	installCMPTabPersistence();
 
 	const calendarView: IView = {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/WorkflowTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/WorkflowTasksFDSPropsTransformer.tsx
@@ -12,7 +12,10 @@ import {addOnClickToCreationMenuItems} from '@liferay/site-cms-site-initializer'
 import React from 'react';
 
 import {styleActions} from '../../utils/actionStyles';
-import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
+import {
+	installCMPTabPersistence,
+	registerTabFDS,
+} from '../../utils/cmpTabPersistence';
 import {WORKFLOW_TASK_ACTION_LINK_ID} from '../../utils/constants';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {TaskAction, WorkflowTaskItemData} from '../../utils/types';
@@ -41,6 +44,7 @@ export default function WorkflowTasksFDSPropsTransformer({
 		initialPaginationDelta: 20,
 	}));
 
+	registerTabFDS(id, 2);
 	installCMPTabPersistence();
 
 	return {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/WorkflowTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/WorkflowTasksFDSPropsTransformer.tsx
@@ -12,6 +12,7 @@ import {addOnClickToCreationMenuItems} from '@liferay/site-cms-site-initializer'
 import React from 'react';
 
 import {styleActions} from '../../utils/actionStyles';
+import {installCMPTabPersistence} from '../../utils/cmpTabPersistence';
 import {WORKFLOW_TASK_ACTION_LINK_ID} from '../../utils/constants';
 import {openCMPModal} from '../../utils/openCMPModal';
 import {TaskAction, WorkflowTaskItemData} from '../../utils/types';
@@ -39,6 +40,8 @@ export default function WorkflowTasksFDSPropsTransformer({
 		default: false,
 		initialPaginationDelta: 20,
 	}));
+
+	installCMPTabPersistence();
 
 	return {
 		...otherProps,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/cmpTabPersistence.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/cmpTabPersistence.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {COOKIE_TYPES, sessionStorage} from 'frontend-js-web';
+
+export const STORAGE_KEY = 'cmpGlobalTasksActiveTab';
+
+let installed = false;
+
+function findTabsContainer(): HTMLElement | null {
+	const tabsContainers = Array.from(
+		document.querySelectorAll<HTMLElement>('.component-tabs')
+	);
+
+	const container = tabsContainers.find((tabs) => {
+		const panels = getTabPanelItems(tabs);
+
+		return (
+			panels.length === 3 &&
+			panels.every((panel) => panel.querySelector('.cms-section'))
+		);
+	});
+
+	return container || null;
+}
+
+function getTabNavItems(container: HTMLElement): HTMLElement[] {
+	return Array.from(
+		container.querySelectorAll<HTMLElement>('.nav-link')
+	).filter((navLink) => !navLink.closest('.tab-panel-item'));
+}
+
+function getTabPanelItems(container: HTMLElement): HTMLElement[] {
+	return Array.from(
+		container.querySelectorAll<HTMLElement>('.tab-panel-item')
+	).filter((panel) => !panel.parentElement?.closest('.tab-panel-item'));
+}
+
+function restoreActiveTab() {
+	const stored = sessionStorage.getItem(STORAGE_KEY, COOKIE_TYPES.NECESSARY);
+
+	if (stored === null) {
+		return;
+	}
+
+	const index = Number(stored);
+
+	if (!Number.isInteger(index) || index <= 0) {
+		return;
+	}
+
+	const container = findTabsContainer();
+
+	if (!container) {
+		return;
+	}
+
+	const tabs = getTabNavItems(container);
+
+	if (tabs[index] && !tabs[index].classList.contains('active')) {
+		tabs[index].click();
+	}
+}
+
+function handleActivePanel(event: {panel: HTMLElement}) {
+	const container = findTabsContainer();
+
+	if (!container || !container.contains(event.panel)) {
+		return;
+	}
+
+	const index = getTabPanelItems(container).indexOf(event.panel);
+
+	if (index < 0) {
+		return;
+	}
+
+	sessionStorage.setItem(STORAGE_KEY, String(index), COOKIE_TYPES.NECESSARY);
+}
+
+export function installCMPTabPersistence() {
+	if (!installed) {
+		installed = true;
+
+		Liferay.on('tabsFragment:activePanel', handleActivePanel);
+	}
+
+	restoreActiveTab();
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/cmpTabPersistence.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/cmpTabPersistence.ts
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {FDS_EVENT} from '@liferay/frontend-data-set-web';
 import {COOKIE_TYPES, sessionStorage} from 'frontend-js-web';
 
 export const STORAGE_KEY = 'cmpGlobalTasksActiveTab';
 
 let installed = false;
+
+const tabIndexToFDSId = new Map<number, string>();
 
 function findTabsContainer(): HTMLElement | null {
 	const tabsContainers = Array.from(
@@ -78,6 +81,16 @@ function handleActivePanel(event: {panel: HTMLElement}) {
 	}
 
 	sessionStorage.setItem(STORAGE_KEY, String(index), COOKIE_TYPES.NECESSARY);
+
+	const fdsId = tabIndexToFDSId.get(index);
+
+	if (fdsId) {
+		Liferay.fire(FDS_EVENT.UPDATE_DISPLAY, {id: fdsId});
+	}
+}
+
+export function registerTabFDS(fdsId: string, tabIndex: number) {
+	tabIndexToFDSId.set(tabIndex, fdsId);
 }
 
 export function installCMPTabPersistence() {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/cmpTabPersistence.spec.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/cmpTabPersistence.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+jest.mock('@liferay/frontend-data-set-web', () => ({
+	FDS_EVENT: {
+		UPDATE_DISPLAY: 'fds-update-display',
+	},
+}));
+
+const mockFire = jest.fn();
+const mockOn = jest.fn();
+const tabClickSpies: jest.Mock[] = [];
+
+function buildTabsContainer(activeIndex = 0) {
+	const container = document.createElement('div');
+
+	container.className = 'component-tabs';
+
+	tabClickSpies.length = 0;
+
+	['All Tasks', 'Project Tasks', 'Workflow'].forEach((label, index) => {
+		const tab = document.createElement('a');
+
+		tab.className = 'nav-link';
+		tab.textContent = label;
+
+		if (index === activeIndex) {
+			tab.classList.add('active');
+		}
+
+		const clickSpy = jest.fn();
+
+		tab.addEventListener('click', clickSpy);
+		tabClickSpies.push(clickSpy);
+
+		container.appendChild(tab);
+	});
+
+	['allTasksPanel', 'projectTasksPanel', 'workflowTasksPanel'].forEach(
+		(id) => {
+			const panel = document.createElement('div');
+
+			panel.className = 'tab-panel-item';
+			panel.id = id;
+
+			const section = document.createElement('div');
+
+			section.className = 'cms-section';
+
+			panel.appendChild(section);
+
+			container.appendChild(panel);
+		}
+	);
+
+	document.body.appendChild(container);
+
+	return container;
+}
+
+function loadModule() {
+	let exports: any;
+
+	jest.isolateModules(() => {
+		exports = require('../../js/utils/cmpTabPersistence');
+	});
+
+	return exports;
+}
+
+beforeEach(() => {
+	mockFire.mockReset();
+	mockOn.mockReset();
+	document.body.innerHTML = '';
+	window.sessionStorage.clear();
+
+	(globalThis as any).Liferay = {
+		...(globalThis as any).Liferay,
+		fire: mockFire,
+		on: mockOn,
+	};
+});
+
+describe('cmpTabPersistence', () => {
+	describe('restore tab on page load', () => {
+		it('clicks the persisted tab when sessionStorage has a non-zero index', () => {
+			buildTabsContainer(0);
+
+			const {STORAGE_KEY, installCMPTabPersistence} = loadModule();
+
+			window.sessionStorage.setItem(STORAGE_KEY, '1');
+
+			installCMPTabPersistence();
+
+			expect(tabClickSpies[1]).toHaveBeenCalledTimes(1);
+			expect(tabClickSpies[0]).not.toHaveBeenCalled();
+			expect(tabClickSpies[2]).not.toHaveBeenCalled();
+		});
+
+		it('registers the activePanel listener only once', () => {
+			buildTabsContainer(0);
+
+			const {installCMPTabPersistence} = loadModule();
+
+			installCMPTabPersistence();
+			installCMPTabPersistence();
+			installCMPTabPersistence();
+
+			expect(mockOn).toHaveBeenCalledTimes(1);
+			expect(mockOn).toHaveBeenCalledWith(
+				'tabsFragment:activePanel',
+				expect.any(Function)
+			);
+		});
+
+		it('restores the tab on each install so SPA re-entry re-applies it', () => {
+			const {STORAGE_KEY, installCMPTabPersistence} = loadModule();
+
+			window.sessionStorage.setItem(STORAGE_KEY, '1');
+
+			buildTabsContainer(0);
+
+			installCMPTabPersistence();
+
+			expect(tabClickSpies[1]).toHaveBeenCalledTimes(1);
+
+			document.body.innerHTML = '';
+
+			buildTabsContainer(0);
+
+			installCMPTabPersistence();
+
+			expect(tabClickSpies[1]).toHaveBeenCalledTimes(1);
+			expect(mockOn).toHaveBeenCalledTimes(1);
+		});
+
+		it('skips restore when sessionStorage is empty', () => {
+			buildTabsContainer(0);
+
+			const {installCMPTabPersistence} = loadModule();
+
+			installCMPTabPersistence();
+
+			tabClickSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+		});
+
+		it('skips restore when the persisted tab is already active', () => {
+			buildTabsContainer(2);
+
+			const {STORAGE_KEY, installCMPTabPersistence} = loadModule();
+
+			window.sessionStorage.setItem(STORAGE_KEY, '2');
+
+			installCMPTabPersistence();
+
+			tabClickSpies.forEach((spy) => expect(spy).not.toHaveBeenCalled());
+		});
+	});
+});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/cmpTabPersistence.spec.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/cmpTabPersistence.spec.ts
@@ -84,6 +84,74 @@ beforeEach(() => {
 });
 
 describe('cmpTabPersistence', () => {
+	describe('refresh FDS on tab switch', () => {
+		it('ignores activePanel events for panels outside the CMP tabs container', () => {
+			buildTabsContainer(0);
+
+			const {STORAGE_KEY, installCMPTabPersistence, registerTabFDS} =
+				loadModule();
+
+			registerTabFDS('allTasksFDS', 0);
+
+			installCMPTabPersistence();
+
+			const handleActivePanel = mockOn.mock.calls[0][1];
+			const otherPanel = document.createElement('div');
+
+			document.body.appendChild(otherPanel);
+
+			handleActivePanel({panel: otherPanel});
+
+			expect(mockFire).not.toHaveBeenCalled();
+			expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it('skips FDS refresh when the activated tab has no registered FDS id', () => {
+			const container = buildTabsContainer(0);
+
+			const {STORAGE_KEY, installCMPTabPersistence} = loadModule();
+
+			installCMPTabPersistence();
+
+			const handleActivePanel = mockOn.mock.calls[0][1];
+			const projectTasksPanel = container.querySelectorAll(
+				'.tab-panel-item'
+			)[1] as HTMLElement;
+
+			handleActivePanel({panel: projectTasksPanel});
+
+			expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+
+			expect(mockFire).not.toHaveBeenCalled();
+		});
+
+		it('writes the new tab index to sessionStorage and fires FDS refresh', () => {
+			const container = buildTabsContainer(0);
+
+			const {STORAGE_KEY, installCMPTabPersistence, registerTabFDS} =
+				loadModule();
+
+			registerTabFDS('allTasksFDS', 0);
+			registerTabFDS('projectTasksFDS', 1);
+			registerTabFDS('workflowTasksFDS', 2);
+
+			installCMPTabPersistence();
+
+			const handleActivePanel = mockOn.mock.calls[0][1];
+			const projectTasksPanel = container.querySelectorAll(
+				'.tab-panel-item'
+			)[1] as HTMLElement;
+
+			handleActivePanel({panel: projectTasksPanel});
+
+			expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1');
+
+			expect(mockFire).toHaveBeenCalledWith('fds-update-display', {
+				id: 'projectTasksFDS',
+			});
+		});
+	});
+
 	describe('restore tab on page load', () => {
 		it('clicks the persisted tab when sessionStorage has a non-zero index', () => {
 			buildTabsContainer(0);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93154

## What Is Being Fixed

After creating or editing a task from the "Project Tasks" or "Workflow" tab, the user was redirected back to the "All Tasks" tab instead of the tab they were working on. The shared tabs fragment persists the active tab through Liferay.Util.SessionStorage with the PERSONALIZATION type, which silently no-ops when the user has not consented to personalization cookies, so on the post-save reload the tab always fell back to "All Tasks".

## How It Is Being Fixed

A small cmpTabPersistence utility mirrors the active tasks tab in native sessionStorage, which requires no cookie consent, and restores it on page load before the user notices the wrong tab. Each tasks data set registers itself by tab index, so switching tabs both records the new active tab and refreshes that tab's data set to keep the list current. The three tasks props transformers (All Tasks, Project Tasks, Workflow) install the utility and register their data set IDs.