### PR TITLE
LPD-88016 Proceed on conflicts for workflow metrics update by query

### DIFF
--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/UpdateByQueryDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/document/UpdateByQueryDocumentRequestExecutor.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Conflicts;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
 import co.elastic.clients.elasticsearch.core.UpdateByQueryResponse;
@@ -70,6 +71,10 @@ public class UpdateByQueryDocumentRequestExecutor {
 				new Query(
 					ElasticsearchQueryVisitor.INSTANCE.translate(
 						updateByQueryDocumentRequest.getQuery())));
+		}
+
+		if (updateByQueryDocumentRequest.isProceedOnConflicts()) {
+			builder.conflicts(Conflicts.Proceed);
 		}
 
 		if (updateByQueryDocumentRequest.isRefresh()) {

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -55,9 +55,15 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -489,6 +495,59 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 	}
 
 	@Test
+	public void testExecuteUpdateByQueryDocumentRequestProceedsOnConflicts()
+		throws Exception {
+
+		for (int i = 0; i < _DOCUMENT_COUNT; i++) {
+			_indexDocument(
+				String.valueOf(i),
+				JsonData.of(
+					HashMapBuilder.<String, Object>put(
+						_FIELD_NAME, Boolean.TRUE
+					).build()));
+		}
+
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			_THREAD_COUNT);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		List<Throwable> throwables = new CopyOnWriteArrayList<>();
+
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+
+			for (int i = 0; i < _THREAD_COUNT; i++) {
+				futures.add(
+					executorService.submit(
+						() -> {
+							try {
+								countDownLatch.await();
+
+								for (int j = 0; j < _ITERATION_COUNT; j++) {
+									_updateByQueryProceedOnConflicts();
+								}
+							}
+							catch (Throwable throwable) {
+								throwables.add(throwable);
+							}
+						}));
+			}
+
+			countDownLatch.countDown();
+
+			for (Future<?> future : futures) {
+				future.get();
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+
+		Assert.assertTrue(throwables.toString(), throwables.isEmpty());
+	}
+
+	@Test
 	public void testExecuteUpdateDocumentRequest() throws Exception {
 		Map<String, Object> documentFields = HashMapBuilder.<String, Object>put(
 			_FIELD_NAME, Boolean.TRUE
@@ -684,6 +743,20 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		}
 	}
 
+	private void _updateByQueryProceedOnConflicts() {
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
+
+		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
+			new UpdateByQueryDocumentRequest(
+				booleanQuery, null, new String[] {_INDEX_NAME});
+
+		updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		_searchEngineAdapter.execute(updateByQueryDocumentRequest);
+	}
+
 	private GetResponse _getDocument(String id) {
 		try {
 			return _elasticsearchClient.get(
@@ -770,9 +843,15 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
 
+	private static final int _DOCUMENT_COUNT = 50;
+
 	private static final String _FIELD_NAME = "matchDocument";
 
 	private static final String _INDEX_NAME = "test_request_index";
+
+	private static final int _ITERATION_COUNT = 30;
+
+	private static final int _THREAD_COUNT = 6;
 
 	private static ElasticsearchFixture _elasticsearchFixture;
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -367,12 +367,13 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 					_FIELD_NAME, Boolean.FALSE
 				).build()));
 
-		BooleanQuery query = new BooleanQuery();
+		BooleanQuery booleanQuery = new BooleanQuery();
 
-		query.addExactTerm(_FIELD_NAME, true);
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
 
 		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
-			new DeleteByQueryDocumentRequest(query, new String[] {_INDEX_NAME});
+			new DeleteByQueryDocumentRequest(
+				booleanQuery, new String[] {_INDEX_NAME});
 
 		DeleteByQueryDocumentResponse deleteByQueryDocumentResponse =
 			_searchEngineAdapter.execute(deleteByQueryDocumentRequest);
@@ -480,13 +481,13 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 					_FIELD_NAME, Boolean.TRUE
 				).build()));
 
-		BooleanQuery query = new BooleanQuery();
+		BooleanQuery booleanQuery = new BooleanQuery();
 
-		query.addExactTerm(_FIELD_NAME, true);
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
 
 		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
 			new UpdateByQueryDocumentRequest(
-				query, null, new String[] {_INDEX_NAME});
+				booleanQuery, null, new String[] {_INDEX_NAME});
 
 		UpdateByQueryDocumentResponse updateByQueryDocumentResponse =
 			_searchEngineAdapter.execute(updateByQueryDocumentRequest);
@@ -743,20 +744,6 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		}
 	}
 
-	private void _updateByQueryProceedOnConflicts() {
-		BooleanQuery booleanQuery = new BooleanQuery();
-
-		booleanQuery.addExactTerm(_FIELD_NAME, true);
-
-		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
-			new UpdateByQueryDocumentRequest(
-				booleanQuery, null, new String[] {_INDEX_NAME});
-
-		updateByQueryDocumentRequest.setProceedOnConflicts(true);
-
-		_searchEngineAdapter.execute(updateByQueryDocumentRequest);
-	}
-
 	private GetResponse _getDocument(String id) {
 		try {
 			return _elasticsearchClient.get(
@@ -816,6 +803,20 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 			IndexMappingsConstants.LIFERAY_DOCUMENT_TYPE);
 
 		return _searchEngineAdapter.execute(indexDocumentRequest);
+	}
+
+	private void _updateByQueryProceedOnConflicts() {
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
+
+		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
+			new UpdateByQueryDocumentRequest(
+				booleanQuery, null, new String[] {_INDEX_NAME});
+
+		updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		_searchEngineAdapter.execute(updateByQueryDocumentRequest);
 	}
 
 	private UpdateDocumentResponse _updateDocumentWithAdapter(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/search/engine/adapter/ElasticsearchSearchEngineAdapterDocumentRequestTest.java
@@ -496,10 +496,10 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 	}
 
 	@Test
-	public void testExecuteUpdateByQueryDocumentRequestProceedsOnConflicts()
+	public void testExecuteUpdateByQueryDocumentRequestProceedOnConflicts()
 		throws Exception {
 
-		for (int i = 0; i < _DOCUMENT_COUNT; i++) {
+		for (int i = 0; i < 50; i++) {
 			_indexDocument(
 				String.valueOf(i),
 				JsonData.of(
@@ -508,10 +508,10 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 					).build()));
 		}
 
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
 		ExecutorService executorService = Executors.newFixedThreadPool(
 			_THREAD_COUNT);
-
-		CountDownLatch countDownLatch = new CountDownLatch(1);
 
 		List<Throwable> throwables = new CopyOnWriteArrayList<>();
 
@@ -525,7 +525,7 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 							try {
 								countDownLatch.await();
 
-								for (int j = 0; j < _ITERATION_COUNT; j++) {
+								for (int j = 0; j < 30; j++) {
 									_updateByQueryProceedOnConflicts();
 								}
 							}
@@ -844,13 +844,9 @@ public class ElasticsearchSearchEngineAdapterDocumentRequestTest {
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
 
-	private static final int _DOCUMENT_COUNT = 50;
-
 	private static final String _FIELD_NAME = "matchDocument";
 
 	private static final String _INDEX_NAME = "test_request_index";
-
-	private static final int _ITERATION_COUNT = 30;
 
 	private static final int _THREAD_COUNT = 6;
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/UpdateByQueryDocumentRequestExecutor.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/document/UpdateByQueryDocumentRequestExecutor.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.UpdateByQueryRequest;
 import org.opensearch.client.opensearch.core.UpdateByQueryResponse;
@@ -70,6 +71,10 @@ public class UpdateByQueryDocumentRequestExecutor {
 				new Query(
 					OpenSearchQueryVisitor.INSTANCE.translate(
 						updateByQueryDocumentRequest.getQuery())));
+		}
+
+		if (updateByQueryDocumentRequest.isProceedOnConflicts()) {
+			builder.conflicts(Conflicts.Proceed);
 		}
 
 		if (updateByQueryDocumentRequest.isRefresh()) {

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
@@ -448,10 +448,10 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 	}
 
 	@Test
-	public void testExecuteUpdateByQueryDocumentRequestProceedsOnConflicts()
+	public void testExecuteUpdateByQueryDocumentRequestProceedOnConflicts()
 		throws Exception {
 
-		for (int i = 0; i < _DOCUMENT_COUNT; i++) {
+		for (int i = 0; i < 50; i++) {
 			_indexDocument(
 				String.valueOf(i),
 				JsonData.of(
@@ -460,10 +460,10 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 					).build()));
 		}
 
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
 		ExecutorService executorService = Executors.newFixedThreadPool(
 			_THREAD_COUNT);
-
-		CountDownLatch countDownLatch = new CountDownLatch(1);
 
 		List<Throwable> throwables = new CopyOnWriteArrayList<>();
 
@@ -477,7 +477,7 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 							try {
 								countDownLatch.await();
 
-								for (int j = 0; j < _ITERATION_COUNT; j++) {
+								for (int j = 0; j < 30; j++) {
 									_updateByQueryProceedOnConflicts();
 								}
 							}
@@ -789,11 +789,7 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
 
-	private static final int _DOCUMENT_COUNT = 50;
-
 	private static final String _FIELD_NAME = "matchDocument";
-
-	private static final int _ITERATION_COUNT = 30;
 
 	private static final int _THREAD_COUNT = 6;
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/search/engine/adapter/OpenSearchSearchEngineAdapterDocumentRequestTest.java
@@ -43,9 +43,15 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -316,13 +322,13 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 					_FIELD_NAME, Boolean.FALSE
 				).build()));
 
-		BooleanQuery query = new BooleanQuery();
+		BooleanQuery booleanQuery = new BooleanQuery();
 
-		query.addExactTerm(_FIELD_NAME, true);
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
 
 		DeleteByQueryDocumentRequest deleteByQueryDocumentRequest =
 			new DeleteByQueryDocumentRequest(
-				query, new String[] {TEST_INDEX_NAME});
+				booleanQuery, new String[] {TEST_INDEX_NAME});
 
 		DeleteByQueryDocumentResponse deleteByQueryDocumentResponse =
 			_searchEngineAdapter.execute(deleteByQueryDocumentRequest);
@@ -427,18 +433,71 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 					_FIELD_NAME, Boolean.TRUE
 				).build()));
 
-		BooleanQuery query = new BooleanQuery();
+		BooleanQuery booleanQuery = new BooleanQuery();
 
-		query.addExactTerm(_FIELD_NAME, true);
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
 
 		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
 			new UpdateByQueryDocumentRequest(
-				query, null, new String[] {TEST_INDEX_NAME});
+				booleanQuery, null, new String[] {TEST_INDEX_NAME});
 
 		UpdateByQueryDocumentResponse updateByQueryDocumentResponse =
 			_searchEngineAdapter.execute(updateByQueryDocumentRequest);
 
 		Assert.assertEquals(1, updateByQueryDocumentResponse.getUpdated());
+	}
+
+	@Test
+	public void testExecuteUpdateByQueryDocumentRequestProceedsOnConflicts()
+		throws Exception {
+
+		for (int i = 0; i < _DOCUMENT_COUNT; i++) {
+			_indexDocument(
+				String.valueOf(i),
+				JsonData.of(
+					HashMapBuilder.<String, Object>put(
+						_FIELD_NAME, Boolean.TRUE
+					).build()));
+		}
+
+		ExecutorService executorService = Executors.newFixedThreadPool(
+			_THREAD_COUNT);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		List<Throwable> throwables = new CopyOnWriteArrayList<>();
+
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+
+			for (int i = 0; i < _THREAD_COUNT; i++) {
+				futures.add(
+					executorService.submit(
+						() -> {
+							try {
+								countDownLatch.await();
+
+								for (int j = 0; j < _ITERATION_COUNT; j++) {
+									_updateByQueryProceedOnConflicts();
+								}
+							}
+							catch (Throwable throwable) {
+								throwables.add(throwable);
+							}
+						}));
+			}
+
+			countDownLatch.countDown();
+
+			for (Future<?> future : futures) {
+				future.get();
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
+
+		Assert.assertTrue(throwables.toString(), throwables.isEmpty());
 	}
 
 	@Test
@@ -698,6 +757,20 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 			new IndexDocumentRequest(TEST_INDEX_NAME, uid, document));
 	}
 
+	private void _updateByQueryProceedOnConflicts() {
+		BooleanQuery booleanQuery = new BooleanQuery();
+
+		booleanQuery.addExactTerm(_FIELD_NAME, true);
+
+		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
+			new UpdateByQueryDocumentRequest(
+				booleanQuery, null, new String[] {TEST_INDEX_NAME});
+
+		updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		_searchEngineAdapter.execute(updateByQueryDocumentRequest);
+	}
+
 	private UpdateDocumentResponse _updateDocumentWithAdapter(
 		Document document, String uid) {
 
@@ -716,7 +789,13 @@ public class OpenSearchSearchEngineAdapterDocumentRequestTest
 		return _searchEngineAdapter.execute(updateDocumentRequest);
 	}
 
+	private static final int _DOCUMENT_COUNT = 50;
+
 	private static final String _FIELD_NAME = "matchDocument";
+
+	private static final int _ITERATION_COUNT = 30;
+
+	private static final int _THREAD_COUNT = 6;
 
 	private final DocumentFixture _documentFixture = new DocumentFixture();
 	private OpenSearchClient _openSearchClient;

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/UpdateByQueryDocumentRequest.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/UpdateByQueryDocumentRequest.java
@@ -78,12 +78,20 @@ public class UpdateByQueryDocumentRequest
 		return _scriptJSONObject;
 	}
 
+	public boolean isProceedOnConflicts() {
+		return _proceedOnConflicts;
+	}
+
 	public boolean isRefresh() {
 		return _refresh;
 	}
 
 	public boolean isWaitForCompletion() {
 		return _waitForCompletion;
+	}
+
+	public void setProceedOnConflicts(boolean proceedOnConflicts) {
+		_proceedOnConflicts = proceedOnConflicts;
 	}
 
 	public void setRefresh(boolean refresh) {
@@ -96,6 +104,7 @@ public class UpdateByQueryDocumentRequest
 
 	private final String[] _indexNames;
 	private final Query _portalSearchQuery;
+	private boolean _proceedOnConflicts;
 	private final com.liferay.portal.kernel.search.Query _query;
 	private boolean _refresh;
 	private final Script _script;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsSLAProcessBackgroundTaskExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsSLAProcessBackgroundTaskExecutor.java
@@ -711,6 +711,8 @@ public class WorkflowMetricsSLAProcessBackgroundTaskExecutor
 						")")),
 				indexName + WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE);
 
+		updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
 		if (PortalRunMode.isTestMode()) {
 			updateByQueryDocumentRequest.setRefresh(true);
 		}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/TaskWorkflowMetricsIndexerImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/search/index/TaskWorkflowMetricsIndexerImpl.java
@@ -411,6 +411,8 @@ public class TaskWorkflowMetricsIndexerImpl
 							WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
 							updateTaskRequest.getCompanyId()));
 
+				updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
 				updateByQueryDocumentRequest.setRefresh(true);
 
 				searchEngineAdapter.execute(updateByQueryDocumentRequest);
@@ -426,7 +428,7 @@ public class TaskWorkflowMetricsIndexerImpl
 
 		ScriptBuilder scriptBuilder = Scripts.INSTANCE.builder();
 
-		searchEngineAdapter.execute(
+		UpdateByQueryDocumentRequest updateByQueryDocumentRequest =
 			new UpdateByQueryDocumentRequest(
 				QueriesUtil.nested(
 					"tasks", QueriesUtil.term("tasks.taskId", taskId)),
@@ -445,7 +447,11 @@ public class TaskWorkflowMetricsIndexerImpl
 				WorkflowMetricsIndex.getIndexName(
 					_indexNameBuilder,
 					WorkflowMetricsIndexNameConstants.SUFFIX_INSTANCE,
-					companyId)));
+					companyId));
+
+		updateByQueryDocumentRequest.setProceedOnConflicts(true);
+
+		searchEngineAdapter.execute(updateByQueryDocumentRequest);
 	}
 
 	private String _getAssigneeName(List<Assignment> assignments) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88016

## What Is Being Fixed

Approving a workflow task triggers update-by-query operations against the workflow-metrics indexes. When several of these run concurrently they collide on the same documents, and the search engine aborts the conflicting updates and logs `version_conflict_engine_exception` against the workflow-metrics-instances index.

## How It Is Being Fixed

A `proceedOnConflicts` option is added to `UpdateByQueryDocumentRequest`. Both the Elasticsearch and OpenSearch request executors translate it to `Conflicts.Proceed` on the underlying update-by-query request, so the engine skips past conflicting documents and retries them instead of failing the whole operation. The workflow-metrics indexers that issue these updates (`TaskWorkflowMetricsIndexerImpl` for task instances and `WorkflowMetricsSLAProcessBackgroundTaskExecutor` for SLA process instances) set the option on their requests. Concurrency tests added to both the Elasticsearch and OpenSearch adapter test suites fire many update-by-query operations from multiple threads and assert that none throw.

## Why a New PR

This is a resend of `liferay-bpm/liferay-portal#6208`, which was forwarded to `brianchandotcom/liferay-portal#176264` and flagged by the review bot. Three findings on the new concurrent test method addressed in commit `2912fd0`:

1. Local variable declarations grouped before the `try` block are now alphabetical (`countDownLatch`, `executorService`, `throwables`) instead of insertion-driven.
2. `_DOCUMENT_COUNT` and `_ITERATION_COUNT` were each referenced exactly once and are now inlined (50 and 30). `_THREAD_COUNT` is referenced twice (the executor pool size has to match the submit loop bound) and stays as a constant.
3. Test method renamed from `testExecuteUpdateByQueryDocumentRequestProceedsOnConflicts` to `testExecuteUpdateByQueryDocumentRequestProceedOnConflicts` so the qualifier mirrors `setProceedOnConflicts` / `isProceedOnConflicts` on the API.

Applied symmetrically to both `ElasticsearchSearchEngineAdapterDocumentRequestTest` and `OpenSearchSearchEngineAdapterDocumentRequestTest`.

## PR Check

**pr-check: SKIPPED** — `ci:test:sf` will validate format-source on this HEAD. Locally `formatSource` was run on both `portal-search-elasticsearch8-impl` and `portal-search-opensearch2-impl` and passed with no changes after the manual edits.
