### PR TITLE
LPD-89977 Attribute Modified By to the actor of the move/edit

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalService.java
@@ -57,7 +57,8 @@ public interface ObjectEntryVersionLocalService
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the object entry version local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link ObjectEntryVersionLocalServiceUtil} if injection and service tracking are not available.
 	 */
-	public ObjectEntryVersion addObjectEntryVersion(ObjectEntry objectEntry)
+	public ObjectEntryVersion addObjectEntryVersion(
+			long userId, ObjectEntry objectEntry)
 		throws PortalException;
 
 	/**
@@ -229,6 +230,9 @@ public interface ObjectEntryVersionLocalService
 		OrderByComparator<ObjectEntryVersion> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ObjectEntryVersion fetchLatestObjectEntryVersion(long objectEntryId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId);
 
@@ -343,7 +347,7 @@ public interface ObjectEntryVersionLocalService
 		throws PortalException;
 
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
-			ObjectEntry objectEntry)
+			long userId, ObjectEntry objectEntry)
 		throws PortalException;
 
 	public ObjectEntryVersion updateLatestObjectEntryVersionModifiedDate(
@@ -365,4 +369,4 @@ public interface ObjectEntryVersionLocalService
 		ObjectEntryVersion objectEntryVersion);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1964991365
+// LIFERAY-SERVICE-BUILDER-HASH:-1048908681

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceUtil.java
@@ -37,10 +37,10 @@ public class ObjectEntryVersionLocalServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.object.service.impl.ObjectEntryVersionLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static ObjectEntryVersion addObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			long userId, com.liferay.object.model.ObjectEntry objectEntry)
 		throws PortalException {
 
-		return getService().addObjectEntryVersion(objectEntry);
+		return getService().addObjectEntryVersion(userId, objectEntry);
 	}
 
 	/**
@@ -269,6 +269,12 @@ public class ObjectEntryVersionLocalServiceUtil {
 			objectEntryId, orderByComparator);
 	}
 
+	public static ObjectEntryVersion fetchLatestObjectEntryVersion(
+		long objectEntryId) {
+
+		return getService().fetchLatestObjectEntryVersion(objectEntryId);
+	}
+
 	public static ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId) {
 
@@ -429,10 +435,10 @@ public class ObjectEntryVersionLocalServiceUtil {
 	}
 
 	public static ObjectEntryVersion updateLatestObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			long userId, com.liferay.object.model.ObjectEntry objectEntry)
 		throws PortalException {
 
-		return getService().updateLatestObjectEntryVersion(objectEntry);
+		return getService().updateLatestObjectEntryVersion(userId, objectEntry);
 	}
 
 	public static ObjectEntryVersion updateLatestObjectEntryVersionModifiedDate(
@@ -469,4 +475,4 @@ public class ObjectEntryVersionLocalServiceUtil {
 			ObjectEntryVersionLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1715928762
+// LIFERAY-SERVICE-BUILDER-HASH:-1918791706

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectEntryVersionLocalServiceWrapper.java
@@ -31,11 +31,11 @@ public class ObjectEntryVersionLocalServiceWrapper
 
 	@Override
 	public com.liferay.object.model.ObjectEntryVersion addObjectEntryVersion(
-			com.liferay.object.model.ObjectEntry objectEntry)
+			long userId, com.liferay.object.model.ObjectEntry objectEntry)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryVersionLocalService.addObjectEntryVersion(
-			objectEntry);
+			userId, objectEntry);
 	}
 
 	/**
@@ -310,6 +310,14 @@ public class ObjectEntryVersionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.object.model.ObjectEntryVersion
+		fetchLatestObjectEntryVersion(long objectEntryId) {
+
+		return _objectEntryVersionLocalService.fetchLatestObjectEntryVersion(
+			objectEntryId);
+	}
+
+	@Override
 	public com.liferay.object.model.ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryVersionId) {
 
@@ -502,11 +510,11 @@ public class ObjectEntryVersionLocalServiceWrapper
 	@Override
 	public com.liferay.object.model.ObjectEntryVersion
 			updateLatestObjectEntryVersion(
-				com.liferay.object.model.ObjectEntry objectEntry)
+				long userId, com.liferay.object.model.ObjectEntry objectEntry)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _objectEntryVersionLocalService.updateLatestObjectEntryVersion(
-			objectEntry);
+			userId, objectEntry);
 	}
 
 	@Override
@@ -558,4 +566,4 @@ public class ObjectEntryVersionLocalServiceWrapper
 	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1136742427
+// LIFERAY-SERVICE-BUILDER-HASH:-1552720536

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/service/packageinfo
@@ -1,1 +1,1 @@
-version 85.1.0
+version 86.0.0

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -660,6 +660,48 @@ public class ObjectEntry implements Serializable {
 	private Supplier<String[]> _keywordsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Creator getModifiedBy() {
+		if (_modifiedBySupplier != null) {
+			modifiedBy = _modifiedBySupplier.get();
+
+			_modifiedBySupplier = null;
+		}
+
+		return modifiedBy;
+	}
+
+	public void setModifiedBy(Creator modifiedBy) {
+		this.modifiedBy = modifiedBy;
+
+		_modifiedBySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setModifiedBy(
+		UnsafeSupplier<Creator, Exception> modifiedByUnsafeSupplier) {
+
+		_modifiedBySupplier = () -> {
+			try {
+				return modifiedByUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Creator modifiedBy;
+
+	@JsonIgnore
+	private Supplier<Creator> _modifiedBySupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
 	public String getObjectEntryFolderExternalReferenceCode() {
 		if (_objectEntryFolderExternalReferenceCodeSupplier != null) {
 			objectEntryFolderExternalReferenceCode =
@@ -1314,6 +1356,9 @@ public class ObjectEntry implements Serializable {
 		else if (Objects.equals(propertyName, "keywords")) {
 			return getKeywords();
 		}
+		else if (Objects.equals(propertyName, "modifiedBy")) {
+			return getModifiedBy();
+		}
 		else if (Objects.equals(
 					propertyName, "objectEntryFolderExternalReferenceCode")) {
 
@@ -1417,6 +1462,9 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "keywords")) {
 			setKeywords((String[])propertyValue);
+		}
+		else if (Objects.equals(propertyName, "modifiedBy")) {
+			setModifiedBy((Creator)propertyValue);
 		}
 		else if (Objects.equals(
 					propertyName, "objectEntryFolderExternalReferenceCode")) {
@@ -1735,6 +1783,18 @@ public class ObjectEntry implements Serializable {
 			sb.append("]");
 		}
 
+		Creator modifiedBy = getModifiedBy();
+
+		if (modifiedBy != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"modifiedBy\": ");
+
+			sb.append(modifiedBy);
+		}
+
 		String objectEntryFolderExternalReferenceCode =
 			getObjectEntryFolderExternalReferenceCode();
 
@@ -2041,4 +2101,4 @@ public class ObjectEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1306455185
+// LIFERAY-REST-BUILDER-HASH:1395753834

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -229,6 +229,9 @@ components:
                     items:
                         type: string
                     type: array
+                modifiedBy:
+                    $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator
+                    readOnly: true
                 objectEntryFolderExternalReferenceCode:
                     type: string
                 objectEntryFolderId:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -338,11 +338,19 @@ public class ObjectEntryDTOConverter
 			() -> NestedFieldsSupplier.supply(
 				"modifiedBy",
 				nestedFieldNames -> {
+
+					if (objectEntryVersion != null) {
+						return CreatorUtil.toCreator(
+							_portal, dtoConverterContext.getUriInfo(),
+							_userLocalService.fetchUser(
+								objectEntryVersion.getUserId()));
+					}
+
 					ObjectEntryVersion latestObjectEntryVersion =
 						_fetchLatestObjectEntryVersion(
 							objectDefinition,
-							serviceBuilderObjectEntry.getObjectEntryId(),
-							objectEntryVersion);
+							serviceBuilderObjectEntry.getObjectEntryId()
+						);
 
 					if (latestObjectEntryVersion == null) {
 						return null;
@@ -672,12 +680,7 @@ public class ObjectEntryDTOConverter
 	}
 
 	private ObjectEntryVersion _fetchLatestObjectEntryVersion(
-		ObjectDefinition objectDefinition, long objectEntryId,
-		ObjectEntryVersion objectEntryVersion) {
-
-		if (objectEntryVersion != null) {
-			return objectEntryVersion;
-		}
+		ObjectDefinition objectDefinition, long objectEntryId) {
 
 		if (!objectDefinition.isEnableObjectEntryVersioning()) {
 			return null;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -338,7 +338,6 @@ public class ObjectEntryDTOConverter
 			() -> NestedFieldsSupplier.supply(
 				"modifiedBy",
 				nestedFieldNames -> {
-
 					if (objectEntryVersion != null) {
 						return CreatorUtil.toCreator(
 							_portal, dtoConverterContext.getUriInfo(),
@@ -346,11 +345,14 @@ public class ObjectEntryDTOConverter
 								objectEntryVersion.getUserId()));
 					}
 
+					if (!objectDefinition.isEnableObjectEntryVersioning()) {
+						return null;
+					}
+
 					ObjectEntryVersion latestObjectEntryVersion =
-						_fetchLatestObjectEntryVersion(
-							objectDefinition,
-							serviceBuilderObjectEntry.getObjectEntryId()
-						);
+						_objectEntryVersionLocalService.
+							fetchLatestObjectEntryVersion(
+								serviceBuilderObjectEntry.getObjectEntryId());
 
 					if (latestObjectEntryVersion == null) {
 						return null;
@@ -677,17 +679,6 @@ public class ObjectEntryDTOConverter
 				unsafeSuppliers.put(manyToOneRelationshipName, entry::getValue);
 			}
 		}
-	}
-
-	private ObjectEntryVersion _fetchLatestObjectEntryVersion(
-		ObjectDefinition objectDefinition, long objectEntryId) {
-
-		if (!objectDefinition.isEnableObjectEntryVersioning()) {
-			return null;
-		}
-
-		return _objectEntryVersionLocalService.fetchLatestObjectEntryVersion(
-			objectEntryId);
 	}
 
 	private <T> T _getAttribute(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -48,6 +48,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
+import com.liferay.object.service.ObjectEntryVersionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.system.SystemObjectDefinitionManager;
@@ -333,6 +334,25 @@ public class ObjectEntryDTOConverter
 						serviceBuilderObjectEntry.getObjectEntryId()),
 					AssetTag.NAME_ACCESSOR);
 			});
+		objectEntry.setModifiedBy(
+			() -> NestedFieldsSupplier.supply(
+				"modifiedBy",
+				nestedFieldNames -> {
+					ObjectEntryVersion latestObjectEntryVersion =
+						_fetchLatestObjectEntryVersion(
+							objectDefinition,
+							serviceBuilderObjectEntry.getObjectEntryId(),
+							objectEntryVersion);
+
+					if (latestObjectEntryVersion == null) {
+						return null;
+					}
+
+					return CreatorUtil.toCreator(
+						_portal, dtoConverterContext.getUriInfo(),
+						_userLocalService.fetchUser(
+							latestObjectEntryVersion.getUserId()));
+				}));
 		objectEntry.setObjectEntryFolderExternalReferenceCode(
 			() -> {
 				ObjectEntryFolder objectEntryFolder =
@@ -649,6 +669,22 @@ public class ObjectEntryDTOConverter
 				unsafeSuppliers.put(manyToOneRelationshipName, entry::getValue);
 			}
 		}
+	}
+
+	private ObjectEntryVersion _fetchLatestObjectEntryVersion(
+		ObjectDefinition objectDefinition, long objectEntryId,
+		ObjectEntryVersion objectEntryVersion) {
+
+		if (objectEntryVersion != null) {
+			return objectEntryVersion;
+		}
+
+		if (!objectDefinition.isEnableObjectEntryVersioning()) {
+			return null;
+		}
+
+		return _objectEntryVersionLocalService.fetchLatestObjectEntryVersion(
+			objectEntryId);
 	}
 
 	private <T> T _getAttribute(
@@ -1378,6 +1414,9 @@ public class ObjectEntryDTOConverter
 
 	@Reference
 	private ObjectEntryService _objectEntryService;
+
+	@Reference
+	private ObjectEntryVersionLocalService _objectEntryVersionLocalService;
 
 	@Reference
 	private ObjectFieldBusinessTypeRegistry _objectFieldBusinessTypeRegistry;

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -50,6 +50,7 @@ import com.liferay.exportimport.report.exception.NoSuchExportImportReportEntryEx
 import com.liferay.exportimport.report.model.ExportImportReportEntry;
 import com.liferay.exportimport.report.service.ExportImportReportEntryLocalService;
 import com.liferay.exportimport.test.util.ExportImportConfigurationTemporarySwapper;
+import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.list.type.entry.util.ListTypeEntryUtil;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
@@ -7631,6 +7632,7 @@ public class DefaultObjectEntryManagerImplTest
 
 	@FeatureFlag("LPD-17564")
 	@Test
+	@TestInfo("LPD-89977")
 	public void testMoveObjectEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry();
 
@@ -7681,6 +7683,7 @@ public class DefaultObjectEntryManagerImplTest
 
 		_testMoveObjectEntryGroup(
 			depotEntry.getGroupId(), objectDefinitionSetting);
+		_testMoveObjectEntryWithDifferentUser(depotEntry.getGroupId());
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -10837,6 +10840,25 @@ public class DefaultObjectEntryManagerImplTest
 				expectedStatus, objectEntryVersion.getStatus()));
 	}
 
+	private void _assertObjectEntryVersionUser(
+			User creatorUser, long objectEntryId, User user)
+		throws Exception {
+
+		com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry =
+			_objectEntryLocalService.getObjectEntry(objectEntryId);
+
+		Assert.assertEquals(
+			creatorUser.getUserId(), serviceBuilderObjectEntry.getUserId());
+
+		ObjectEntryVersion objectEntryVersion =
+			_objectEntryVersionLocalService.getObjectEntryVersion(
+				objectEntryId, serviceBuilderObjectEntry.getVersion());
+
+		Assert.assertEquals(user.getUserId(), objectEntryVersion.getUserId());
+		Assert.assertEquals(
+			user.getFullName(), objectEntryVersion.getUserName());
+	}
+
 	private void _assertObjectEntryWithPicklistObjectField(
 		String expectedPicklistObjectFieldValue, ObjectEntry objectEntry) {
 
@@ -12851,6 +12873,69 @@ public class DefaultObjectEntryManagerImplTest
 			String.valueOf(
 				destinationObjectEntryFolder.getObjectEntryFolderId()),
 			String.valueOf(objectEntry2.getObjectEntryFolderId()));
+	}
+
+	private void _testMoveObjectEntryWithDifferentUser(long groupId)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder(
+				groupId, adminUser.getUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT);
+
+		PrincipalThreadLocal.setName(adminUser.getUserId());
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(adminUser));
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition7,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			String.valueOf(groupId), 1);
+
+		_assertObjectEntryVersionUser(
+			adminUser, objectEntry.getId(), adminUser);
+
+		User user = UserTestUtil.addOmniadminUser();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		objectEntry = _defaultObjectEntryManager.moveObjectEntry(
+			_createDTOConverterContext(user), objectEntry.getId(),
+			objectEntryFolder.getObjectEntryFolderId(), false);
+
+		_assertObjectEntryVersionUser(adminUser, objectEntry.getId(), user);
+
+		NestedFieldsContext originalNestedFieldsContext =
+			NestedFieldsContextThreadLocal.getNestedFieldsContext();
+
+		try {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				new NestedFieldsContext(
+					1, null, Arrays.asList("modifiedBy"), null, null, null));
+
+			objectEntry = _defaultObjectEntryManager.getObjectEntry(
+				_createDTOConverterContext(adminUser), _objectDefinition7,
+				objectEntry.getId());
+
+			Creator modifiedBy = objectEntry.getModifiedBy();
+
+			Assert.assertEquals(user.getFullName(), modifiedBy.getName());
+
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(null);
+
+			objectEntry = _defaultObjectEntryManager.getObjectEntry(
+				_createDTOConverterContext(adminUser), _objectDefinition7,
+				objectEntry.getId());
+
+			Assert.assertNull(objectEntry.getModifiedBy());
+		}
+		finally {
+			NestedFieldsContextThreadLocal.setNestedFieldsContext(
+				originalNestedFieldsContext);
+		}
 	}
 
 	private void _testUpdateObjectEntryWithAccountEntryRestricted2(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -9671,6 +9671,50 @@ public class DefaultObjectEntryManagerImplTest
 		PrincipalThreadLocal.setName(_originalName);
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-89977")
+	public void testUpdateObjectEntryWithDifferentUser() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry();
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			_objectDefinition7.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+			String.valueOf(depotEntry.getGroupId()));
+
+		PrincipalThreadLocal.setName(adminUser.getUserId());
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(adminUser));
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			_objectDefinition7,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			String.valueOf(depotEntry.getGroupId()), 1);
+
+		_assertObjectEntryVersionUser(
+			adminUser, objectEntry.getId(), adminUser);
+
+		User user = UserTestUtil.addOmniadminUser();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(user));
+
+		objectEntry = _defaultObjectEntryManager.updateObjectEntry(
+			_createDTOConverterContext(user), _objectDefinition7,
+			objectEntry.getId(),
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.<String, Object>put(
+						"textObjectFieldName", RandomTestUtil.randomString()
+					).build();
+				}
+			});
+
+		_assertObjectEntryVersionUser(adminUser, objectEntry.getId(), user);
+	}
+
 	@Test
 	public void testUpdateObjectEntryWithObjectEntryFolder() throws Exception {
 		ObjectEntryFolder objectEntryFolder =

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -616,6 +616,9 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},
@@ -1426,6 +1429,9 @@
 						},
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
+					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
 					},
 					"multiselectPicklistField": {
 						"items": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -644,6 +644,9 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -656,6 +656,9 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -456,6 +456,9 @@
 						"type": "integer",
 						"x-parent-map": "properties"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -617,6 +617,9 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},
@@ -1427,6 +1430,9 @@
 						},
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
+					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
 					},
 					"multiselectPicklistField": {
 						"items": {
@@ -2372,6 +2378,9 @@
 						},
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
+					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
 					},
 					"multiselectPicklistField": {
 						"items": {

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -465,6 +465,9 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
+					"modifiedBy": {
+						"$ref": "#/components/schemas/Creator"
+					},
 					"objectEntryFolderExternalReferenceCode": {
 						"type": "string"
 					},

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -550,7 +550,8 @@ public class ObjectEntryLocalServiceImpl
 			_deleteTempFileEntries(dlFileEntriesMap);
 		}
 
-		objectEntry = _addObjectEntryVersion(objectDefinition, objectEntry);
+		objectEntry = _addObjectEntryVersion(
+			userId, objectDefinition, objectEntry);
 
 		boolean clearObjectEntryIdsMap =
 			ObjectActionThreadLocal.isClearObjectEntryIdsMap();
@@ -2446,11 +2447,13 @@ public class ObjectEntryLocalServiceImpl
 					objectEntry.getObjectEntryId());
 
 			if (count > 0) {
-				_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+				_updateLatestObjectEntryVersion(
+					userId, objectDefinition, objectEntry);
 			}
 		}
 		else if (!objectEntry.isInTrash() && !originalObjectEntry.isInTrash()) {
-			objectEntry = _addObjectEntryVersion(objectDefinition, objectEntry);
+			objectEntry = _addObjectEntryVersion(
+				userId, objectDefinition, objectEntry);
 		}
 
 		if (objectDefinition.isRootNode()) {
@@ -2905,7 +2908,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private ObjectEntry _addObjectEntryVersion(
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+			long userId, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
 		throws PortalException {
 
 		if (!objectDefinition.isEnableObjectEntryVersioning()) {
@@ -2913,7 +2917,8 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		ObjectEntryVersion objectEntryVersion =
-			_objectEntryVersionLocalService.addObjectEntryVersion(objectEntry);
+			_objectEntryVersionLocalService.addObjectEntryVersion(
+				userId, objectEntry);
 
 		objectEntry.setVersion(objectEntryVersion.getVersion());
 
@@ -6948,7 +6953,8 @@ public class ObjectEntryLocalServiceImpl
 	}
 
 	private void _updateLatestObjectEntryVersion(
-			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+			long userId, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry)
 		throws PortalException {
 
 		if (!objectDefinition.isEnableObjectEntryVersioning()) {
@@ -6956,7 +6962,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 
 		_objectEntryVersionLocalService.updateLatestObjectEntryVersion(
-			objectEntry);
+			userId, objectEntry);
 	}
 
 	private ObjectEntry _updateObjectEntry(
@@ -7076,6 +7082,9 @@ public class ObjectEntryLocalServiceImpl
 			serviceContext.getAssetPriority(), serviceContext);
 
 		if (move) {
+			_updateLatestObjectEntryVersion(
+				userId, objectDefinition, objectEntry);
+
 			return objectEntry;
 		}
 
@@ -7107,11 +7116,12 @@ public class ObjectEntryLocalServiceImpl
 			if (objectEntry.isPending() || originalObjectEntry.isDraft() ||
 				originalObjectEntry.isExpired()) {
 
-				_updateLatestObjectEntryVersion(objectDefinition, objectEntry);
+				_updateLatestObjectEntryVersion(
+					userId, objectDefinition, objectEntry);
 			}
 			else {
 				objectEntry = _addObjectEntryVersion(
-					objectDefinition, objectEntry);
+					userId, objectDefinition, objectEntry);
 			}
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -53,14 +53,15 @@ public class ObjectEntryVersionLocalServiceImpl
 	extends ObjectEntryVersionLocalServiceBaseImpl {
 
 	@Override
-	public ObjectEntryVersion addObjectEntryVersion(ObjectEntry objectEntry)
+	public ObjectEntryVersion addObjectEntryVersion(
+			long userId, ObjectEntry objectEntry)
 		throws PortalException {
 
 		ObjectEntryVersion objectEntryVersion = _updateObjectEntryVersion(
 			objectEntry,
 			objectEntryVersionPersistence.create(
 				counterLocalService.increment()),
-			objectEntry.getVersion() + 1);
+			userId, objectEntry.getVersion() + 1);
 
 		if (_exceedsMaximumVersions(objectEntry.getObjectEntryId())) {
 			ObjectEntryVersion oldestObjectEntryVersion =
@@ -291,7 +292,7 @@ public class ObjectEntryVersionLocalServiceImpl
 
 	@Override
 	public ObjectEntryVersion updateLatestObjectEntryVersion(
-			ObjectEntry objectEntry)
+			long userId, ObjectEntry objectEntry)
 		throws PortalException {
 
 		return _updateObjectEntryVersion(
@@ -299,7 +300,7 @@ public class ObjectEntryVersionLocalServiceImpl
 			objectEntryVersionPersistence.fetchByObjectEntryId_First(
 				objectEntry.getObjectEntryId(),
 				ObjectEntryVersionVersionComparator.getInstance(false)),
-			objectEntry.getVersion());
+			userId, objectEntry.getVersion());
 	}
 
 	@Override
@@ -390,10 +391,10 @@ public class ObjectEntryVersionLocalServiceImpl
 
 	private ObjectEntryVersion _updateObjectEntryVersion(
 			ObjectEntry objectEntry, ObjectEntryVersion objectEntryVersion,
-			int version)
+			long userId, int version)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(objectEntry.getUserId());
+		User user = _userLocalService.getUser(userId);
 
 		objectEntryVersion.setUserId(user.getUserId());
 		objectEntryVersion.setUserName(user.getFullName());

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -232,6 +232,15 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	@Override
+	public ObjectEntryVersion fetchLatestObjectEntryVersion(
+		long objectEntryId) {
+
+		return objectEntryVersionPersistence.fetchByObjectEntryId_First(
+			objectEntryId,
+			ObjectEntryVersionVersionComparator.getInstance(false));
+	}
+
+	@Override
 	public ObjectEntryVersion fetchObjectEntryVersion(
 		long objectEntryId, int version) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryVersionLocalServiceImpl.java
@@ -58,10 +58,10 @@ public class ObjectEntryVersionLocalServiceImpl
 		throws PortalException {
 
 		ObjectEntryVersion objectEntryVersion = _updateObjectEntryVersion(
-			objectEntry,
+			userId, objectEntry,
 			objectEntryVersionPersistence.create(
 				counterLocalService.increment()),
-			userId, objectEntry.getVersion() + 1);
+			objectEntry.getVersion() + 1);
 
 		if (_exceedsMaximumVersions(objectEntry.getObjectEntryId())) {
 			ObjectEntryVersion oldestObjectEntryVersion =
@@ -296,11 +296,11 @@ public class ObjectEntryVersionLocalServiceImpl
 		throws PortalException {
 
 		return _updateObjectEntryVersion(
-			objectEntry,
+			userId, objectEntry,
 			objectEntryVersionPersistence.fetchByObjectEntryId_First(
 				objectEntry.getObjectEntryId(),
 				ObjectEntryVersionVersionComparator.getInstance(false)),
-			userId, objectEntry.getVersion());
+			objectEntry.getVersion());
 	}
 
 	@Override
@@ -390,8 +390,8 @@ public class ObjectEntryVersionLocalServiceImpl
 	}
 
 	private ObjectEntryVersion _updateObjectEntryVersion(
-			ObjectEntry objectEntry, ObjectEntryVersion objectEntryVersion,
-			long userId, int version)
+			long userId, ObjectEntry objectEntry,
+			ObjectEntryVersion objectEntryVersion, int version)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -117,7 +117,7 @@ public class SectionDisplayContextUtil {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(12);
+		StringBundler sb = new StringBundler(13);
 
 		sb.append("emptySearch=true&filter=");
 
@@ -143,7 +143,8 @@ public class SectionDisplayContextUtil {
 
 		sb.append("&nestedFields=embedded,embeddedTaxonomyCategory,");
 		sb.append("file.metadata,file.previewURL,file.thumbnailURL,");
-		sb.append("numberOfObjectEntries,numberOfObjectEntryFolders,");
+		sb.append("modifiedBy,numberOfObjectEntries,");
+		sb.append("numberOfObjectEntryFolders,");
 		sb.append("systemProperties.collaboratorBrief,");
 		sb.append("systemProperties.objectDefinitionBrief");
 		sb.append("&sort=dateModified:desc");

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer.tsx
@@ -114,7 +114,8 @@ export default function AssetRenderer({
 					{sub(
 						Liferay.Language.get('modified-at-x-by-x'),
 						formatDate(itemData.dateModified),
-						itemData.embedded.creator.name
+						itemData.embedded?.modifiedBy?.name ??
+							itemData.embedded?.creator?.name
 					)}
 				</div>
 			</div>

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/AssetRenderer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/props_transformer/cell_renderers/AssetRenderer.test.tsx
@@ -12,6 +12,16 @@ import React from 'react';
 
 import AssetRenderer from '../../../../../src/main/resources/META-INF/resources/js/main_view/props_transformer/cell_renderers/AssetRenderer';
 
+jest.mock('frontend-js-web', () => ({
+	...(jest.requireActual('frontend-js-web') as Record<string, unknown>),
+	sub: (str: string, ...params: string[]) =>
+		params.reduce(
+			(result, param, index) =>
+				result.replace(new RegExp(`\\{${index}\\}`, 'g'), param),
+			str
+		),
+}));
+
 const testActionBase = {
 	data: {id: 'update'},
 	href: 'http://localhost:8080/o/cms/blogs/12345',
@@ -155,5 +165,44 @@ describe('AssetRenderer. Show metadata and icons.', () => {
 		expect(screen.getByRole('presentation', {name: ''})).toHaveClass(
 			'lexicon-icon-blogs'
 		);
+	});
+});
+
+describe('AssetRenderer. Modified by user name.', () => {
+	beforeAll(() => {
+		jest.spyOn(Liferay.Language, 'get').mockImplementation((key) => {
+			if (key === 'modified-at-x-by-x') {
+				return 'Modified at {0} by {1}';
+			}
+
+			return key;
+		});
+	});
+
+	afterAll(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('falls back to the creator name when modifiedBy is missing', () => {
+		render(<AssetRenderer {...testBaseProps} />);
+
+		expect(screen.getByText(/by Test Test$/)).toBeInTheDocument();
+	});
+
+	it('shows modifiedBy name when it is provided', () => {
+		render(
+			<AssetRenderer
+				{...testBaseProps}
+				itemData={{
+					...testBaseProps.itemData,
+					embedded: {
+						...testBaseProps.itemData.embedded,
+						modifiedBy: {name: 'Admin Moved'},
+					},
+				}}
+			/>
+		);
+
+		expect(screen.getByText(/by Admin Moved$/)).toBeInTheDocument();
 	});
 });

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -17,6 +17,7 @@ import performLogin, {
 	performLoginViaApi,
 	performLogout,
 	performUserSwitch,
+	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';
 import {SITE_CMS_SPACE_EXTERNAL_REFERENCE_CODE} from '../../setup/site-cms-site/constants/space';
@@ -1057,5 +1058,120 @@ test(
 		await expect(
 			page.getByRole('heading', {name: `Welcome, ${user.givenName}!`})
 		).toBeVisible();
+	}
+);
+
+test(
+	'Recent Assets shows the editor as "Modified by" after another user moves the content',
+	{tag: '@LPD-89977'},
+	async ({apiHelpers, assetsPage, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const contentTitle = `Content ${getRandomString()}`;
+		const destinationFolderName = `Folder ${getRandomString()}`;
+		const destinationSpaceName = `Destination ${getRandomString()}`;
+
+		const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+		const editorFullName = `${spaceAdminUser.givenName} ${spaceAdminUser.familyName}`;
+
+		const destinationSpace =
+			await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+				name: destinationSpaceName,
+				settings: {},
+				type: 'Space',
+			});
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccount(
+			destinationSpace.externalReferenceCode,
+			spaceAdminUser.externalReferenceCode
+		);
+
+		await apiHelpers.headlessAssetLibrary.putAssetLibraryUserAccountRoles(
+			destinationSpace.externalReferenceCode,
+			spaceAdminUser.externalReferenceCode,
+			['Asset Library Administrator']
+		);
+
+		await apiHelpers.objectFolder.createObjectEntryFolder({
+			parentObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+			scopeKey: destinationSpaceName,
+			title: destinationFolderName,
+		});
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			applicationName,
+			'Default'
+		);
+
+		await test.step('Sign in as the Space Administrator and move the content to the destination Space', async () => {
+			await performUserSwitchViaApi(page, spaceAdminUser.alternateName);
+
+			await assetsPage.gotoAll();
+
+			await assetsPage.moveTo({
+				destinationFolder: destinationFolderName,
+				destinationSpace: destinationSpaceName,
+				itemTitle: contentTitle,
+			});
+		});
+
+		await test.step('Recent Assets attributes the modification to the Space Administrator', async () => {
+			await homePage.goto();
+
+			const row = dataSetFragmentPage.getRow(contentTitle);
+
+			await expect(
+				row.getByText(new RegExp(`by ${editorFullName}$`))
+			).toBeVisible();
+		});
+
+		await performUserSwitchViaApi(page, 'test');
+	}
+);
+
+test(
+	'Recent Assets shows the editor as "Modified by" after another user edits the content',
+	{tag: '@LPD-89977'},
+	async ({apiHelpers, homePage, page}) => {
+		const applicationName = 'cms/basic-web-contents';
+		const contentTitle = `Content ${getRandomString()}`;
+		const updatedTitle = `Updated ${getRandomString()}`;
+
+		const dataSetFragmentPage: DataSetPage = new DataSetPage(page);
+		const editorFullName = `${spaceAdminUser.givenName} ${spaceAdminUser.familyName}`;
+
+		const contentEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+				title: contentTitle,
+			},
+			applicationName,
+			'Default'
+		);
+
+		await performUserSwitchViaApi(page, spaceAdminUser.alternateName);
+
+		await apiHelpers.objectEntry.patchObjectEntry(
+			{
+				title_i18n: {
+					en_US: updatedTitle,
+				},
+			},
+			applicationName,
+			contentEntry.id
+		);
+
+		await homePage.goto();
+
+		const row = dataSetFragmentPage.getRow(updatedTitle);
+
+		await expect(
+			row.getByText(new RegExp(`by ${editorFullName}$`))
+		).toBeVisible();
+
+		await performUserSwitchViaApi(page, 'test');
 	}
 );


### PR DESCRIPTION
Validate branch + pr check have passed in my local env

Comming from https://github.com/liferay-content-management/liferay-portal/pull/8368

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-89977

When a CMS Admin moves a content entry from one Space to another, the Recent Assets fragment and the underlying headless DTO still attribute "Modified By" to the original content creator. The same gap shows up on plain edits: the latest `ObjectEntryVersion` row carries the creator's `userId` instead of the actor who performed the update.

The `ObjectEntry` model has two userId fields with distinct semantics — `ObjectEntry.userId` is the immutable creator, and `ObjectEntryVersion.userId` is intended to track who authored each version row. The version-update helpers derived `userId` from `ObjectEntry.getUserId()`, so every new version inherited the creator and the modifier signal was lost. The move path additionally short-circuited before the version refresh, so moves did not update the version's metadata at all.

# How am I fixing it?

`addObjectEntryVersion` and `updateLatestObjectEntryVersion` now take the actor's `userId` as an explicit parameter, and every callsite in `ObjectEntryLocalServiceImpl` (add, edit, and the move branch in particular) passes it through. The move path no longer returns before refreshing the version row.

On the read side, the headless `ObjectEntry` DTO exposes a new `modifiedBy: Creator` field — symmetric with the existing `creator` and `removedBy` references on the same DTO — populated opt-in via `NestedFieldsSupplier` from the latest `ObjectEntryVersion.userId`. `modifiedBy: Creator` (instead of a bare `modifiedByUserName: String`) keeps the schema consistent with the rest of the user references in the DTO and gives the frontend access to `id`, `image`, `profileURL`, etc. without a follow-up change. The CMS Recent Assets fragment requests the field in `nestedFields` and falls back to `creator.name` when it is absent (non-versioned object definitions).

# How can you verify that it works?

Run the included automated tests.