### PR TITLE
LPD-93353 Migrate ObjectFields Poshi tests to Jest and Playwright

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -1509,35 +1509,6 @@ definition {
 			locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
 	}
 
-	@description = "LPS-148112 - Verify if when selecting the option on Request Files: Directly from User's Computer there is a Toggle"
-	@priority = 4
-	test CanViewOptionsWhenSelectDirectlyFromUsersComputerOption {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		LexiconEntry.gotoAdd();
-
-		AssertElementNotPresent(
-			key_labelName = "Show Files in Documents and Media",
-			locator1 = "ObjectField#DEFAULT_TOGGLE_SWITCH");
-
-		ObjectField.selectType(fieldType = "Attachment");
-
-		ObjectField.selectOptionOnRequestFiles(option = "Upload Directly from the User");
-
-		AssertElementPresent(
-			key_labelName = "Show Files in Documents and Media",
-			locator1 = "ObjectField#DEFAULT_TOGGLE_SWITCH");
-	}
-
 	@description = "LPS-146889 - Verify that 'Set the Maximum Number of Characters' toggle is available for Text and Long Text fields"
 	@priority = 5
 	test CanViewSetMaximumCharactersOption {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -1643,31 +1643,6 @@ definition {
 		AssertElementPresent(locator1 = "ObjectField#LABEL_MAXIMUM_FILE_SIZE");
 	}
 
-	@description = "LPS-148112 - Verify if after create a attachment field with option Request Files: Directly from User's Computer selected and when the 'Show files' is enabled there is a new configuration field called Storage Folder"
-	@priority = 4
-	test CanViewStorageFolderWhenShowFilesIsEnable {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			enableShowFiles = "true",
-			fieldAttachment = "Upload Directly from the User",
-			fieldLabel = "Custom Attachment",
-			fieldType = "Attachment");
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		AssertElementPresent(locator1 = "ObjectField#LABEL_STORAGE_FOLDER");
-	}
-
 	@description = "LPS-148112 - Verify if when selecting the option on Request Files: Directly from User's Computer there is a tooltip on the Toggle"
 	@priority = 4
 	test CanViewTootipWhenSelectDirectlyFromUsersComputerOption {

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -1014,104 +1014,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-146889 - Verify that when turn on the 'Set the Maximum Number of Characters' the user is not allowed to type any value outside the informed range on the help text"
-	@priority = 4
-	test CannotTypeValueOutsideRange {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 151573",
-			objectName = "CustomObject151573",
-			pluralLabelName = "Custom Objects 151573");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Text",
-			fieldLabelName = "Custom Text Field",
-			fieldName = "customTextField",
-			fieldType = "String",
-			isRequired = "false",
-			objectName = "CustomObject151573");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 151573");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Text Field");
-
-		ObjectField.checkLimitCharacters();
-
-		AssertElementPresent(
-			key_maxValue = 280,
-			locator1 = "ObjectField#MAXIMUM_NUMBER_CHARACTERS_OPTION");
-
-		ObjectField.typeValueOnLimitCharacters(newValue = 281);
-
-		AssertElementNotPresent(
-			key_maxValue = 281,
-			locator1 = "ObjectField#MAXIMUM_NUMBER_CHARACTERS_OPTION");
-
-		AssertElementPresent(
-			key_maxValue = 28,
-			locator1 = "ObjectField#MAXIMUM_NUMBER_CHARACTERS_OPTION");
-	}
-
-	@description = "LPS-162176 - Verify that the ERC is displayed on the object definition page"
-	@priority = 5
-	test CanSeeERCFieldOnObjectPage {
-		task ("Given an object is created") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 162176",
-				objectName = "CustomObject162176",
-				pluralLabelName = "Custom Objects 162176");
-		}
-
-		task ("When the user navigates to the object definition") {
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object 162176");
-		}
-
-		task ("Then the ERC is present on the page") {
-			AssertElementPresent(locator1 = "ObjectAdmin#EXTERNAL_REFERENCE_CODE");
-		}
-	}
-
-	@description = "Verify that it's possible to see the custom field label and system field label"
-	@priority = 5
-	test CanSeeFieldLabel {
-		property custom.properties = "feature.flag.LPS-158456=true";
-		property portal.acceptance = "true";
-
-		task ("Add an object, go to the fields tab and state whether the system fields have the label System") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object",
-				objectName = "CustomObject",
-				pluralLabelName = "Custom Objects");
-
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-			ObjectAdmin.goToFieldsTab();
-
-			AssertElementPresent(
-				key_label = "Create Date",
-				key_source = "System",
-				locator1 = "ObjectField#SOURCE_FIELD");
-		}
-
-		task ("Add a new field and state that custom fields have the label Custom") {
-			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Field",
-				fieldType = "Text");
-
-			AssertElementPresent(
-				key_label = "Custom Field",
-				key_source = "Custom",
-				locator1 = "ObjectField#SOURCE_FIELD");
-		}
-	}
-
 	@description = "LPS-158821 - Verify that the user is able to set the ERC field as a Title Field"
 	@priority = 4
 	test CanSetERCFieldAsTitleField {
@@ -1296,46 +1198,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-148112 - Verify if on the side panel the 'Show files' path can be edited"
-	@priority = 4
-	test CanUpdateShowFilesOptionBeforePublished {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 153420",
-			objectName = "CustomObject153420",
-			pluralLabelName = "Custom Objects 153420");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 153420");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			fieldAttachment = "Upload Directly from the User",
-			fieldLabel = "Custom Attachment",
-			fieldType = "Attachment");
-
-		Refresh();
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		ObjectField.viewToogleOnSidePanelShowFilesInDM(isDisabled = "No");
-
-		Navigator.openURL();
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject153420");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 153420");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		ObjectField.viewToogleOnSidePanelShowFilesInDM(isDisabled = "Yes");
-	}
-
 	@description = "LPS-158821 - Verify that the user is able to use the ERC field in Expression Builder, on the Validations tab"
 	@priority = 4
 	test CanUseERCFieldWithExpressionBuilder {
@@ -1484,31 +1346,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-148112 - Verify if when selecting the option on Request Files: Directly from User's Computer the toggle is OFF by default"
-	@priority = 4
-	test CanViewOptionsDisableWhenSelectDirectlyFromUsersComputerOption {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		LexiconEntry.gotoAdd();
-
-		ObjectField.selectType(fieldType = "Attachment");
-
-		ObjectField.selectOptionOnRequestFiles(option = "Upload Directly from the User");
-
-		Uncheck.uncheckNotVisible(
-			key_toggleSwitchLabel = "Show Files in Documents and Media",
-			locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
-	}
-
 	@description = "LPS-146889 - Verify that 'Set the Maximum Number of Characters' toggle is available for Text and Long Text fields"
 	@priority = 5
 	test CanViewSetMaximumCharactersOption {
@@ -1586,83 +1423,6 @@ definition {
 			key_fieldName = "customObjectFieldLongText",
 			key_viewCountCharacters = "0/65000 Characters",
 			locator1 = "ObjectField#VIEW_COUNT_CHARACTERS_ON_ENTRIES");
-	}
-
-	@description = "LPS-143065 - Verify if a side panel containing the Field name, Typem Request Files, Accepted File Extensions, and Maximum File Size fields"
-	@priority = 4
-	test CanViewSidePanelOptions {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 151560",
-			objectName = "CustomObject151560",
-			pluralLabelName = "Custom Objects 151560");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 151560");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			fieldAttachment = "Upload Directly from the User",
-			fieldLabel = "Custom Attachment",
-			fieldType = "Attachment");
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		AssertElementPresent(locator1 = "ObjectField#LABEL_ACCEPTED_FILE_EXTENSIONS");
-
-		AssertElementPresent(locator1 = "ObjectField#LABEL_MAXIMUM_FILE_SIZE");
-	}
-
-	@description = "LPS-148112 - Verify if when selecting the option on Request Files: Directly from User's Computer there is a tooltip on the Toggle"
-	@priority = 4
-	test CanViewTootipWhenSelectDirectlyFromUsersComputerOption {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		LexiconEntry.gotoAdd();
-
-		ObjectField.selectType(fieldType = "Attachment");
-
-		ObjectField.selectOptionOnRequestFiles(option = "Upload Directly from the User");
-
-		AssertElementPresent(
-			key_text = "question-circle-full",
-			locator1 = "Icon#ANY");
-	}
-
-	@description = "LPS-144902 - Verify there is a description of each Field Type"
-	@priority = 4
-	test DescriptionForEachFieldType {
-		property osgi.module.configuration.file.names = "com.liferay.object.web.internal.configuration.FFObjectFieldBusinessTypeConfiguration.config";
-		property osgi.module.configurations = "enabled=\"true\"";
-
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 147723",
-			objectName = "CustomObject147723",
-			pluralLabelName = "Custom Objects 147723");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 147723");
-
-		ObjectAdmin.goToFieldsTab();
-
-		LexiconEntry.gotoAdd();
-
-		Click(
-			key_labelName = "Type",
-			locator1 = "ObjectAdmin#CLAY_GENERIC_BUTTON");
-
-		ObjectAdmin.viewDescriptionForEachFieldType();
 	}
 
 	@description = "LPS-145661 - Verify that the field type names are displayed on the Layout Builder when a field is added"
@@ -1852,53 +1612,6 @@ definition {
 				locator1 = "ObjectCustomViews#LABEL_SECTION_FILTER_ENTRY");
 
 			AssertChecked.assertCheckedNotVisible(locator1 = "ObjectCustomViews#TOGGLE_SWITCH_EXCLUDE_STATUS");
-		}
-	}
-
-	@description = "Verify that Formula fields can't be required"
-	@priority = 4
-	test FormulaFieldsIsNotMandatory {
-		task ("Given an Object with formula field") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 176829",
-				objectName = "CustomObject176829",
-				pluralLabelName = "Custom Objects 176829");
-
-			ObjectAdmin.addObjectFieldViaAPI(
-				fieldBusinessType = "Formula",
-				fieldLabelName = "Custom Formula Field",
-				fieldName = "customFormulaField",
-				fieldType = "String",
-				formulaScript = "",
-				isRequired = "false",
-				objectName = "CustomObject176829",
-				outputOption = "Decimal");
-
-			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject176829");
-		}
-
-		task ("When view the formula field details (mandatory option is unavailable)") {
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object 176829");
-
-			ObjectAdmin.goToFieldsTab();
-
-			ObjectAdmin.goToFieldsDetails(label = "Custom Formula Field");
-
-			AssertElementNotPresent(locator1 = "ObjectField#MANDATORY_TOGGLE");
-		}
-
-		task ("Then assert that is the entry is not required") {
-			ObjectAdmin.goToCustomObject(objectName = "CustomObject176829");
-
-			LexiconEntry.gotoAdd();
-
-			AssertElementNotPresent(
-				key_fieldName = "Formula Builder",
-				locator1 = "ObjectField#MANDATORY_FIELD");
-
-			PortletEntry.save();
 		}
 	}
 
@@ -2132,38 +1845,6 @@ definition {
 		}
 	}
 
-	@description = "Verify that the Output Field on Formula Field is required"
-	@priority = 4
-	test OutputFieldIsRequiredOnFormulaField {
-		task ("Given an Object") {
-			ObjectAdmin.addObjectViaAPI(
-				labelName = "Custom Object 176823",
-				objectName = "CustomObject176823",
-				pluralLabelName = "Custom Objects 176823");
-
-			ObjectAdmin.openObjectAdmin();
-
-			ObjectPortlet.selectCustomObject(label = "Custom Object 176823");
-
-			ObjectAdmin.goToFieldsTab();
-		}
-
-		task ("When managing a Formula Field") {
-			ObjectAdmin.addObjectFieldViaUI(
-				fieldLabel = "Custom Formula",
-				fieldType = "Formula",
-				formulaFieldOption = "Decimal");
-
-			ObjectAdmin.goToFieldsDetails(label = "Custom Formula");
-		}
-
-		task ("Then the output field is a mandatory field") {
-			AssertElementPresent(
-				key_fieldName = "Output",
-				locator1 = "ObjectField#MANDATORY_FIELD");
-		}
-	}
-
 	@description = "Verify that the Range - Start/End operator is available when adding filters for the date fields to select date from the object"
 	@priority = 4
 	test RangeIsAvailableForDateFields {
@@ -2268,67 +1949,6 @@ definition {
 				key_entry = 2,
 				locator1 = "ObjectPortlet#ENTRY_VALUE");
 		}
-	}
-
-	@description = "LPS-148112 - Verify if field called Storage Folder have help text"
-	@priority = 4
-	test StorageFolderFieldHaveHelpText {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			enableShowFiles = "true",
-			fieldAttachment = "Upload Directly from the User",
-			fieldLabel = "Custom Attachment",
-			fieldType = "Attachment");
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		var helpText = "Input the path of the chosen folder in Documents and Media. An example of a valid path is: \"/myDocumentsAndMediaFolder\".";
-
-		AssertElementPresent(
-			key_helpText = ${helpText},
-			locator1 = "ObjectField#HELP_TEXT",
-			value1 = ${key_helpText});
-	}
-
-	@description = "LPS-148112 - Verify if field called Storage Folder is required"
-	@priority = 4
-	test StorageFolderFieldIsRequired {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object",
-			objectName = "CustomObject",
-			pluralLabelName = "Custom Objects");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			enableShowFiles = "true",
-			fieldAttachment = "Upload Directly from the User",
-			fieldLabel = "Custom Attachment",
-			fieldType = "Attachment");
-
-		ObjectAdmin.goToFieldsDetails(label = "Custom Attachment");
-
-		ObjectField.typeStorageFolder(content = "");
-
-		Button.clickSave();
-
-		AssertElementPresent(
-			key_fieldLabel = "Storage Folder",
-			locator1 = "FieldBase#ERROR_MESSAGE_REQUIRED_FIELD");
 	}
 
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformer/FDSSourceDataRenderer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformer/FDSSourceDataRenderer.spec.tsx
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import FDSSourceDataRenderer from '../../components/FDSPropsTransformer/FDSSourceDataRenderer';
+
+describe('FDSSourceDataRenderer', () => {
+	it('labels system fields with the "System" source', () => {
+		render(<FDSSourceDataRenderer itemData={{system: true}} />);
+
+		expect(screen.getByText('system')).toBeInTheDocument();
+
+		expect(screen.queryByText('custom')).not.toBeInTheDocument();
+	});
+
+	it('labels custom fields with the "Custom" source', () => {
+		render(<FDSSourceDataRenderer itemData={{system: false}} />);
+
+		expect(screen.getByText('custom')).toBeInTheDocument();
+
+		expect(screen.queryByText('system')).not.toBeInTheDocument();
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformer/FDSSourceDataRenderer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformer/FDSSourceDataRenderer.spec.tsx
@@ -9,19 +9,19 @@ import React from 'react';
 import FDSSourceDataRenderer from '../../components/FDSPropsTransformer/FDSSourceDataRenderer';
 
 describe('FDSSourceDataRenderer', () => {
-	it('labels system fields with the "System" source', () => {
-		render(<FDSSourceDataRenderer itemData={{system: true}} />);
-
-		expect(screen.getByText('system')).toBeInTheDocument();
-
-		expect(screen.queryByText('custom')).not.toBeInTheDocument();
-	});
-
 	it('labels custom fields with the "Custom" source', () => {
 		render(<FDSSourceDataRenderer itemData={{system: false}} />);
 
 		expect(screen.getByText('custom')).toBeInTheDocument();
 
 		expect(screen.queryByText('system')).not.toBeInTheDocument();
+	});
+
+	it('labels system fields with the "System" source', () => {
+		render(<FDSSourceDataRenderer itemData={{system: true}} />);
+
+		expect(screen.getByText('system')).toBeInTheDocument();
+
+		expect(screen.queryByText('custom')).not.toBeInTheDocument();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/AttachmentFormBase.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/AttachmentFormBase.spec.tsx
@@ -34,11 +34,12 @@ jest.mock('@liferay/object-js-components-web', () => ({
 			))}
 		</select>
 	),
-	Toggle: ({label, onToggle, toggled}: any) => (
-		<label>
+	Toggle: ({disabled, label, onToggle, toggled, tooltip}: any) => (
+		<label title={tooltip}>
 			<input
 				aria-label={label}
 				checked={toggled}
+				disabled={disabled}
 				onChange={(event) => onToggle(event.target.checked)}
 				type="checkbox"
 			/>
@@ -59,14 +60,16 @@ jest.mock('../../utils/fieldSettings', () => ({
 }));
 
 const renderComponent = ({
+	disabled = false,
 	hasDepotEntry = true,
 	objectFieldSettings = [],
 	objectDefinitionName = 'MyObject',
 	setValues = jest.fn(),
 	onSubmit = jest.fn(),
 }: any = {}) => {
-	render(
+	return render(
 		<AttachmentFormBase
+			disabled={disabled}
 			hasDepotEntry={hasDepotEntry}
 			objectDefinitionName={objectDefinitionName}
 			objectFieldSettings={objectFieldSettings}
@@ -219,5 +222,56 @@ describe('The AttachmentFormBase component', () => {
 				{name: 'storageDLFolderPath', value: '/MyObject'},
 			],
 		});
+	});
+
+	it('shows the library toggle off by default when uploading directly from the user computer', () => {
+		renderComponent({
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByLabelText('show-uploaded-files-in-library')
+		).not.toBeChecked();
+	});
+
+	it('shows a tooltip on the library toggle when uploading directly from the user computer', () => {
+		renderComponent({
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByTitle(
+				'when-activated-users-can-define-a-folder-within-documents-and-media-to-display-the-files-leave-it-unchecked-for-files-to-be-stored-individually-per-entry'
+			)
+		).toBeInTheDocument();
+	});
+
+	it('keeps the library toggle editable before the object is published and disables it otherwise', () => {
+		const {unmount} = renderComponent({
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByLabelText('show-uploaded-files-in-library')
+		).toBeEnabled();
+
+		unmount();
+
+		renderComponent({
+			disabled: true,
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByLabelText('show-uploaded-files-in-library')
+		).toBeDisabled();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/AttachmentFormBase.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/AttachmentFormBase.spec.tsx
@@ -146,10 +146,35 @@ describe('The AttachmentFormBase component', () => {
 		).not.toBeInTheDocument();
 	});
 
-	it('renders library toggle for userComputerToDocumentsAndMedia file source', () => {
-		renderComponent({
+	it('keeps the library toggle editable before the object is published and disables it otherwise', () => {
+		const {unmount} = renderComponent({
 			objectFieldSettings: [
 				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByLabelText('show-uploaded-files-in-library')
+		).toBeEnabled();
+
+		unmount();
+
+		renderComponent({
+			disabled: true,
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			],
+		});
+
+		expect(
+			screen.getByLabelText('show-uploaded-files-in-library')
+		).toBeDisabled();
+	});
+
+	it('renders library toggle for userComputerToCMSBasicDocument file source', () => {
+		renderComponent({
+			objectFieldSettings: [
+				{name: 'fileSource', value: 'userComputerToCMSBasicDocument'},
 			],
 		});
 
@@ -158,10 +183,10 @@ describe('The AttachmentFormBase component', () => {
 		).toBeInTheDocument();
 	});
 
-	it('renders library toggle for userComputerToCMSBasicDocument file source', () => {
+	it('renders library toggle for userComputerToDocumentsAndMedia file source', () => {
 		renderComponent({
 			objectFieldSettings: [
-				{name: 'fileSource', value: 'userComputerToCMSBasicDocument'},
+				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
 			],
 		});
 
@@ -224,18 +249,6 @@ describe('The AttachmentFormBase component', () => {
 		});
 	});
 
-	it('shows the library toggle off by default when uploading directly from the user computer', () => {
-		renderComponent({
-			objectFieldSettings: [
-				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
-			],
-		});
-
-		expect(
-			screen.getByLabelText('show-uploaded-files-in-library')
-		).not.toBeChecked();
-	});
-
 	it('shows a tooltip on the library toggle when uploading directly from the user computer', () => {
 		renderComponent({
 			objectFieldSettings: [
@@ -250,21 +263,8 @@ describe('The AttachmentFormBase component', () => {
 		).toBeInTheDocument();
 	});
 
-	it('keeps the library toggle editable before the object is published and disables it otherwise', () => {
-		const {unmount} = renderComponent({
-			objectFieldSettings: [
-				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
-			],
-		});
-
-		expect(
-			screen.getByLabelText('show-uploaded-files-in-library')
-		).toBeEnabled();
-
-		unmount();
-
+	it('shows the library toggle off by default when uploading directly from the user computer', () => {
 		renderComponent({
-			disabled: true,
 			objectFieldSettings: [
 				{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
 			],
@@ -272,6 +272,6 @@ describe('The AttachmentFormBase component', () => {
 
 		expect(
 			screen.getByLabelText('show-uploaded-files-in-library')
-		).toBeDisabled();
+		).not.toBeChecked();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
@@ -72,6 +72,35 @@ beforeEach(() => {
 	fetchMock.get('http://localhost/url', {});
 });
 
+describe('when the business type is "Formula"', () => {
+	const formulaProps = {
+		...objectFieldFormBaseDefaultProps,
+		objectField: {
+			businessType: 'Formula' as ObjectFieldBusinessTypeName,
+		},
+		objectRelationshipId: undefined,
+	};
+
+	it('does not render the mandatory toggle', () => {
+		render(<ObjectFieldFormBase {...formulaProps} />);
+
+		expect(
+			screen.queryByRole('switch', {name: 'mandatory'})
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the output field as required', () => {
+		render(<ObjectFieldFormBase {...formulaProps} />);
+
+		const outputLabel = screen.getByText('output', {
+			exact: false,
+			selector: 'label',
+		});
+
+		expect(within(outputLabel).getByText('mandatory')).toBeInTheDocument();
+	});
+});
+
 describe('when the root model feature flag [LPD-34594] is disabled', () => {
 	describe('the mandatory toggle', () => {
 		beforeEach(() => {
@@ -245,34 +274,5 @@ describe('when the root model feature flag [LPD-34594] is enabled', () => {
 				await screen.findByText('inheritance-relationships-fields')
 			).toBeInTheDocument();
 		});
-	});
-});
-
-describe('when the business type is "Formula"', () => {
-	const formulaProps = {
-		...objectFieldFormBaseDefaultProps,
-		objectField: {
-			businessType: 'Formula' as ObjectFieldBusinessTypeName,
-		},
-		objectRelationshipId: undefined,
-	};
-
-	it('does not render the mandatory toggle', () => {
-		render(<ObjectFieldFormBase {...formulaProps} />);
-
-		expect(
-			screen.queryByRole('switch', {name: 'mandatory'})
-		).not.toBeInTheDocument();
-	});
-
-	it('renders the output field as required', () => {
-		render(<ObjectFieldFormBase {...formulaProps} />);
-
-		const outputLabel = screen.getByText('output', {
-			exact: false,
-			selector: 'label',
-		});
-
-		expect(within(outputLabel).getByText('mandatory')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, within} from '@testing-library/react';
 
 // @ts-ignore
 
@@ -245,5 +245,34 @@ describe('when the root model feature flag [LPD-34594] is enabled', () => {
 				await screen.findByText('inheritance-relationships-fields')
 			).toBeInTheDocument();
 		});
+	});
+});
+
+describe('when the business type is "Formula"', () => {
+	const formulaProps = {
+		...objectFieldFormBaseDefaultProps,
+		objectField: {
+			businessType: 'Formula' as ObjectFieldBusinessTypeName,
+		},
+		objectRelationshipId: undefined,
+	};
+
+	it('does not render the mandatory toggle', () => {
+		render(<ObjectFieldFormBase {...formulaProps} />);
+
+		expect(
+			screen.queryByRole('switch', {name: 'mandatory'})
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the output field as required', () => {
+		render(<ObjectFieldFormBase {...formulaProps} />);
+
+		const outputLabel = screen.getByText('output', {
+			exact: false,
+			selector: 'label',
+		});
+
+		expect(within(outputLabel).getByText('mandatory')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/ObjectFieldFormBase.spec.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
 	fetchMock.get('http://localhost/url', {});
 });
 
-describe('when the business type is "Formula"', () => {
+describe('Formula field business type', () => {
 	const formulaProps = {
 		...objectFieldFormBaseDefaultProps,
 		objectField: {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/AttachmentProperties.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/AttachmentProperties.spec.tsx
@@ -58,6 +58,17 @@ describe('AttachmentProperties', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('renders depot storage inputs when showFilesInLibrary is enabled for userComputerToCMSBasicDocument upload', () => {
+		renderComponent([
+			{name: 'fileSource', value: 'userComputerToCMSBasicDocument'},
+			{name: 'showFilesInLibrary', value: true},
+		]);
+
+		expect(screen.getByText('Mock SpacePicker')).toBeInTheDocument();
+
+		expect(screen.getByLabelText(/cms-storage-folder/)).toBeInTheDocument();
+	});
+
 	it('renders Documents and Media folder input when showFilesInLibrary is enabled for userComputerToDocumentsAndMedia upload', () => {
 		renderComponent([
 			{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
@@ -70,28 +81,14 @@ describe('AttachmentProperties', () => {
 		expect(input).toBeInTheDocument();
 	});
 
-	it('renders depot storage inputs when showFilesInLibrary is enabled for userComputerToCMSBasicDocument upload', () => {
-		renderComponent([
-			{name: 'fileSource', value: 'userComputerToCMSBasicDocument'},
-			{name: 'showFilesInLibrary', value: true},
-		]);
-
-		expect(screen.getByText('Mock SpacePicker')).toBeInTheDocument();
-
-		expect(screen.getByLabelText(/cms-storage-folder/)).toBeInTheDocument();
-	});
-
-	it('renders the help text for the storage folder field', () => {
-		renderComponent([
-			{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
-			{name: 'showFilesInLibrary', value: true},
-		]);
+	it('renders the accepted file extensions and maximum file size options on the side panel', () => {
+		renderComponent([{name: 'fileSource', value: 'documentsAndMedia'}]);
 
 		expect(
-			screen.getByText(
-				/input-the-path-of-the-chosen-folder-in-documents-and-media/
-			)
+			screen.getByText('accepted-file-extensions')
 		).toBeInTheDocument();
+
+		expect(screen.getByText('maximum-file-size')).toBeInTheDocument();
 	});
 
 	it('renders the error when the required storage folder field is empty', () => {
@@ -112,13 +109,16 @@ describe('AttachmentProperties', () => {
 		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
 	});
 
-	it('renders the accepted file extensions and maximum file size options on the side panel', () => {
-		renderComponent([{name: 'fileSource', value: 'documentsAndMedia'}]);
+	it('renders the help text for the storage folder field', () => {
+		renderComponent([
+			{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			{name: 'showFilesInLibrary', value: true},
+		]);
 
 		expect(
-			screen.getByText('accepted-file-extensions')
+			screen.getByText(
+				/input-the-path-of-the-chosen-folder-in-documents-and-media/
+			)
 		).toBeInTheDocument();
-
-		expect(screen.getByText('maximum-file-size')).toBeInTheDocument();
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/AttachmentProperties.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/AttachmentProperties.spec.tsx
@@ -80,4 +80,45 @@ describe('AttachmentProperties', () => {
 
 		expect(screen.getByLabelText(/cms-storage-folder/)).toBeInTheDocument();
 	});
+
+	it('renders the help text for the storage folder field', () => {
+		renderComponent([
+			{name: 'fileSource', value: 'userComputerToDocumentsAndMedia'},
+			{name: 'showFilesInLibrary', value: true},
+		]);
+
+		expect(
+			screen.getByText(
+				/input-the-path-of-the-chosen-folder-in-documents-and-media/
+			)
+		).toBeInTheDocument();
+	});
+
+	it('renders the error when the required storage folder field is empty', () => {
+		render(
+			<AttachmentProperties
+				{...defaultProps}
+				errors={{storageDLFolderPath: 'this-field-is-required'}}
+				objectFieldSettings={[
+					{
+						name: 'fileSource',
+						value: 'userComputerToDocumentsAndMedia',
+					},
+					{name: 'showFilesInLibrary', value: true},
+				]}
+			/>
+		);
+
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+	});
+
+	it('renders the accepted file extensions and maximum file size options on the side panel', () => {
+		renderComponent([{name: 'fileSource', value: 'documentsAndMedia'}]);
+
+		expect(
+			screen.getByText('accepted-file-extensions')
+		).toBeInTheDocument();
+
+		expect(screen.getByText('maximum-file-size')).toBeInTheDocument();
+	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/BasicInfoTab.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/BasicInfoTab.spec.tsx
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {BasicInfoTab} from '../../../../components/ObjectField/Tabs/BasicInfo/BasicInfoTab';
+
+jest.mock(
+	'../../../../components/ObjectField/Tabs/BasicInfo/BasicInfoContainer',
+	() => ({BasicInfoContainer: () => null})
+);
+jest.mock(
+	'../../../../components/ObjectField/Tabs/BasicInfo/SearchableContainer',
+	() => ({SearchableContainer: () => null})
+);
+jest.mock(
+	'../../../../components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer',
+	() => ({TranslationOptionsContainer: () => null})
+);
+
+const defaultProps: any = {
+	containerWrapper: ({children}: any) => <div>{children}</div>,
+	handleChange: jest.fn(),
+	values: {
+		businessType: 'Text',
+		externalReferenceCode: 'ERC123',
+		system: false,
+	},
+};
+
+describe('BasicInfoTab', () => {
+	it('renders the external reference code field on the object field page', () => {
+		render(<BasicInfoTab {...defaultProps} />);
+
+		expect(screen.getByText('external-reference-code')).toBeInTheDocument();
+
+		const input = screen.getByDisplayValue('ERC123');
+
+		expect(input).toBeInTheDocument();
+
+		expect(input).toBeEnabled();
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/FormulaContainer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/FormulaContainer.spec.tsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 import React from 'react';
 
-import {FormulaContainer} from '../../components/ObjectField/Tabs/BasicInfo/FormulaContainer';
+import {FormulaContainer} from '../../../../components/ObjectField/Tabs/BasicInfo/FormulaContainer';
 
 const defaultProps = {
 	errors: {},

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/MaxLengthProperties.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/MaxLengthProperties.spec.tsx
@@ -26,19 +26,6 @@ describe('MaxLengthProperties', () => {
 		jest.clearAllMocks();
 	});
 
-	it('does not accept a value greater than the maximum allowed for a Text field', () => {
-		renderComponent();
-
-		const input = screen.getByDisplayValue('280');
-
-		fireEvent.change(input, {target: {value: '281'}});
-
-		expect(defaultProps.onSettingsChange).toHaveBeenCalledWith({
-			name: 'maxLength',
-			value: 280,
-		});
-	});
-
 	it('accepts a value within the maximum allowed for a Text field', () => {
 		renderComponent();
 
@@ -49,6 +36,19 @@ describe('MaxLengthProperties', () => {
 		expect(defaultProps.onSettingsChange).toHaveBeenCalledWith({
 			name: 'maxLength',
 			value: 28,
+		});
+	});
+
+	it('does not accept a value greater than the maximum allowed for a Text field', () => {
+		renderComponent();
+
+		const input = screen.getByDisplayValue('280');
+
+		fireEvent.change(input, {target: {value: '281'}});
+
+		expect(defaultProps.onSettingsChange).toHaveBeenCalledWith({
+			name: 'maxLength',
+			value: 280,
 		});
 	});
 });

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/MaxLengthProperties.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/MaxLengthProperties.spec.tsx
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {MaxLengthProperties} from '../../../../components/ObjectField/Tabs/BasicInfo/MaxLengthProperties';
+
+const defaultProps = {
+	errors: {},
+	objectField: {businessType: 'Text' as ObjectFieldBusinessTypeName},
+	objectFieldSettings: [
+		{name: 'showCounter', value: true},
+		{name: 'maxLength', value: 280},
+	] as ObjectFieldSetting[],
+	onSettingsChange: jest.fn(),
+	setValues: jest.fn(),
+};
+
+const renderComponent = () => render(<MaxLengthProperties {...defaultProps} />);
+
+describe('MaxLengthProperties', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does not accept a value greater than the maximum allowed for a Text field', () => {
+		renderComponent();
+
+		const input = screen.getByDisplayValue('280');
+
+		fireEvent.change(input, {target: {value: '281'}});
+
+		expect(defaultProps.onSettingsChange).toHaveBeenCalledWith({
+			name: 'maxLength',
+			value: 280,
+		});
+	});
+
+	it('accepts a value within the maximum allowed for a Text field', () => {
+		renderComponent();
+
+		const input = screen.getByDisplayValue('280');
+
+		fireEvent.change(input, {target: {value: '28'}});
+
+		expect(defaultProps.onSettingsChange).toHaveBeenCalledWith({
+			name: 'maxLength',
+			value: 28,
+		});
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.spec.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
 
-import {TranslationOptionsContainer} from '../../components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer';
+import {TranslationOptionsContainer} from '../../../../components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer';
 
 const mockLearnResources = {
 	'object-web': {

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -1744,6 +1744,105 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 		}
 	);
 
+	test(
+		'can view description for each field business type',
+		{tag: '@LPD-93353'},
+		async ({apiHelpers, objectFieldsPage, page}) => {
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+			await objectFieldsPage.addObjectFieldButton.click();
+
+			await objectFieldsPage.objectFieldLabelInput.waitFor();
+
+			await objectFieldsPage.objectFieldOptionsDropdown.click();
+
+			const fieldTypeDescriptions = [
+				{
+					description: 'Assign the entry to a user or role.',
+					type: 'Assignee',
+				},
+				{
+					description:
+						'Upload files or select from Documents and Media.',
+					type: 'Attachment',
+				},
+				{
+					description:
+						'Automatically generate a unique value when a new entry is added.',
+					type: 'Auto Increment',
+				},
+				{
+					description: 'Select between true or false.',
+					type: 'Boolean',
+				},
+				{description: 'Add a date.', type: 'Date'},
+				{
+					description: 'Add date and time values.',
+					type: 'Date and Time',
+				},
+				{
+					description:
+						'Add a decimal number that supports fractional portions.',
+					type: 'Decimal',
+				},
+				{
+					description: 'Store content as encrypted text.',
+					type: 'Encrypted',
+				},
+				{
+					description:
+						'Add an algorithm that derives its value from other fields.',
+					type: 'Formula',
+				},
+				{
+					description: 'Add an integer up to nine digits.',
+					type: 'Integer',
+				},
+				{
+					description: 'Add a long integer up to 16 digits.',
+					type: 'Long Integer',
+				},
+				{
+					description: 'Add text up to 65,000 characters.',
+					type: 'Long Text',
+				},
+				{
+					description: 'Choose from a picklist.',
+					type: 'Picklist',
+				},
+				{
+					description:
+						'Add a high precision decimal number without rounding.',
+					type: 'Precision Decimal',
+				},
+				{
+					description: 'Create rich text content.',
+					type: 'Rich Text',
+				},
+				{
+					description: 'Add text up to 280 characters.',
+					type: 'Text',
+				},
+			];
+
+			for (const {description, type} of fieldTypeDescriptions) {
+				await expect(
+					page.getByRole('option', {exact: true, name: type})
+				).toContainText(description);
+			}
+		}
+	);
+
 	test('can view more than 20 picklists in the picklist drop-down', async ({
 		apiHelpers,
 		objectFieldsPage,
@@ -3404,76 +3503,6 @@ test.describe('Manage object fields default value properties', () => {
 			await modelBuilderRightSidebarPage.useDefaultValueToggle.uncheck();
 
 			await expect(rightSidebar).toHaveCSS('width', '320px');
-		}
-	);
-});
-
-test.describe('View object field type descriptions', () => {
-	test(
-		'can view a description for each field type',
-		{tag: '@LPD-93353'},
-		async ({apiHelpers, objectFieldsPage, page}) => {
-			const objectDefinition =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					status: {code: 0},
-				});
-
-			apiHelpers.data.push({
-				id: objectDefinition.id,
-				type: 'objectDefinition',
-			});
-
-			await objectFieldsPage.goto(objectDefinition.label.en_US);
-
-			await objectFieldsPage.addObjectFieldButton.click();
-
-			await objectFieldsPage.objectFieldLabelInput.waitFor();
-
-			await objectFieldsPage.objectFieldOptionsDropdown.click();
-
-			const fieldTypeDescriptions = [
-				{
-					description: 'Select between true or false.',
-					fieldType: 'Boolean',
-				},
-				{description: 'Add a date.', fieldType: 'Date'},
-				{
-					description:
-						'Add a decimal number that supports fractional portions.',
-					fieldType: 'Decimal',
-				},
-				{
-					description: 'Add an integer up to nine digits.',
-					fieldType: 'Integer',
-				},
-				{
-					description: 'Add a long integer up to 16 digits.',
-					fieldType: 'Long Integer',
-				},
-				{
-					description: 'Add text up to 65,000 characters.',
-					fieldType: 'Long Text',
-				},
-				{
-					description: 'Choose from a picklist.',
-					fieldType: 'Picklist',
-				},
-				{
-					description:
-						'Add a high precision decimal number without rounding.',
-					fieldType: 'Precision Decimal',
-				},
-				{
-					description: 'Add text up to 280 characters.',
-					fieldType: 'Text',
-				},
-			];
-
-			for (const {description, fieldType} of fieldTypeDescriptions) {
-				await expect(
-					page.getByRole('option', {exact: true, name: fieldType})
-				).toContainText(description);
-			}
 		}
 	);
 });

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -3407,3 +3407,73 @@ test.describe('Manage object fields default value properties', () => {
 		}
 	);
 });
+
+test.describe('View object field type descriptions', () => {
+	test(
+		'can view a description for each field type',
+		{tag: '@LPD-93353'},
+		async ({apiHelpers, objectFieldsPage, page}) => {
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+			await objectFieldsPage.addObjectFieldButton.click();
+
+			await objectFieldsPage.objectFieldLabelInput.waitFor();
+
+			await objectFieldsPage.objectFieldOptionsDropdown.click();
+
+			const fieldTypeDescriptions = [
+				{
+					description: 'Select between true or false.',
+					fieldType: 'Boolean',
+				},
+				{description: 'Add a date.', fieldType: 'Date'},
+				{
+					description:
+						'Add a decimal number that supports fractional portions.',
+					fieldType: 'Decimal',
+				},
+				{
+					description: 'Add an integer up to nine digits.',
+					fieldType: 'Integer',
+				},
+				{
+					description: 'Add a long integer up to 16 digits.',
+					fieldType: 'Long Integer',
+				},
+				{
+					description: 'Add text up to 65,000 characters.',
+					fieldType: 'Long Text',
+				},
+				{
+					description: 'Choose from a picklist.',
+					fieldType: 'Picklist',
+				},
+				{
+					description:
+						'Add a high precision decimal number without rounding.',
+					fieldType: 'Precision Decimal',
+				},
+				{
+					description: 'Add text up to 280 characters.',
+					fieldType: 'Text',
+				},
+			];
+
+			for (const {description, fieldType} of fieldTypeDescriptions) {
+				await expect(
+					page.getByRole('option', {exact: true, name: fieldType})
+				).toContainText(description);
+			}
+		}
+	);
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93353

## What Is Being Fixed

The ObjectFields Poshi suite carried 14 functional test cases whose coverage could be exercised far more cheaply at a lower level. Poshi tests are slow, brittle, and expensive to maintain, and these cases validated form and component behavior — field type descriptions, attachment properties, max length, formula, translation options, storage folder, and the attachment upload toggle — that does not require a full browser-driven functional run.

## How It Is Being Fixed

The 14 Poshi cases are removed from `ObjectFields.testcase` and re-expressed as React Testing Library / Jest unit specs in `object-web`, covering the object field form base, attachment form base, FDS source data renderer, and the BasicInfo tab components. The one case that genuinely needs the rendered UI — object field type descriptions — is moved to a Playwright spec instead. The `FormulaContainer` and `TranslationOptionsContainer` specs are relocated under `Tabs/BasicInfo` to match the component structure, and the specs are sorted for consistency.

## PR Check

**pr-check: PASS** — tested on `ad479bd34eca576f0c451b46869ab2c9d0d9e1f6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Poshi Syntax | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ad479bd34eca576f0c451b46869ab2c9d0d9e1f6"} -->
