### PR TITLE
LPD-1457 Render the Default Value field for picklists without items

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BaseEntryFields/ListTypeEntryBaseField.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BaseEntryFields/ListTypeEntryBaseField.tsx
@@ -38,34 +38,29 @@ export function ListTypeEntryBaseField({
 	selectedPicklistItemKey,
 }: ListTypeEntryBaseFieldProps) {
 	return (
-		<>
-			{picklistItems.length ? (
-				<SingleSelect
-					error={error}
-					items={picklistItems.map((item) => ({
-						label: creationLanguageId
-							? getLocalizableLabel({
-									fallbackLanguageId: creationLanguageId,
-									labels: item.name_i18n,
-								})
-							: item.name,
-						value: item.key,
-					}))}
-					label={label}
-					onSelectionChange={(value) => {
-						onChange(
-							picklistItems.find((item) => item.key === value)
-						);
-					}}
-					placeholder={placeholder}
-					required={required}
-					selectedKey={
-						picklistItems.find(
-							(item) => item.key === selectedPicklistItemKey
-						)?.key
-					}
-				/>
-			) : null}
-		</>
+		<SingleSelect
+			error={error}
+			items={picklistItems.map((item) => ({
+				label: creationLanguageId
+					? getLocalizableLabel({
+							fallbackLanguageId: creationLanguageId,
+							labels: item.name_i18n,
+						})
+					: item.name,
+				value: item.key,
+			}))}
+			key={picklistItems.map((item) => item.id).join()}
+			label={label}
+			onSelectionChange={(value) => {
+				onChange(picklistItems.find((item) => item.key === value));
+			}}
+			placeholder={placeholder}
+			required={required}
+			selectedKey={
+				picklistItems.find(
+					(item) => item.key === selectedPicklistItemKey
+				)?.key
+			}
+		/>
 	);
 }

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/ListTypeEntryBaseField.spec.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/tests/ListTypeEntryBaseField.spec.tsx
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {ListTypeEntryBaseField} from '../components/BaseEntryFields/ListTypeEntryBaseField';
+
+const baseProps = {
+	creationLanguageId: 'en_US' as Liferay.Language.Locale,
+	label: 'default-value',
+	onChange: () => {},
+	placeholder: 'choose-an-option',
+	required: true,
+};
+
+const colorsPicklistItems = [
+	{
+		externalReferenceCode: 'blue-erc',
+		id: 11,
+		key: 'blue',
+		listTypeDefinitionId: 1,
+		name: 'Blue',
+		name_i18n: {en_US: 'Blue'},
+	},
+];
+
+const sizesPicklistItems = [
+	{
+		externalReferenceCode: 'small-erc',
+		id: 21,
+		key: 'small',
+		listTypeDefinitionId: 2,
+		name: 'Small',
+		name_i18n: {en_US: 'Small'},
+	},
+];
+
+describe('ListTypeEntryBaseField', () => {
+	it('clears the selected value when switching to a different picklist', () => {
+		const {rerender} = render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+
+		rerender(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={sizesPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('clears the selected value when the picklist items become empty', () => {
+		const {rerender} = render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+
+		rerender(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={[]}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('renders an empty select when the picklist has no items', () => {
+		render(<ListTypeEntryBaseField {...baseProps} picklistItems={[]} />);
+
+		expect(screen.getByRole('combobox')).toBeInTheDocument();
+		expect(screen.getByText('default-value')).toBeInTheDocument();
+	});
+
+	it('shows the selected value when the picklist has items', () => {
+		render(
+			<ListTypeEntryBaseField
+				{...baseProps}
+				picklistItems={colorsPicklistItems}
+				selectedPicklistItemKey="blue"
+			/>
+		);
+
+		expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+	});
+});

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.tsx
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {API, ListTypeEntryBaseField} from '@liferay/object-js-components-web';
-import React, {useEffect, useState} from 'react';
+import {ListTypeEntryBaseField} from '@liferay/object-js-components-web';
+import React from 'react';
 
 import {getUpdatedDefaultValueFieldSettings} from '../../../utils/defaultValues';
-import {fixLocaleKeys} from '../../ListTypeDefinition/utils';
 import {InputAsValueFieldComponentProps} from '../Tabs/Advanced/DefaultValueContainer';
+import {useListTypeEntries} from './useListTypeEntries';
 
 const ListTypeDefaultValueSelect: React.FC<
 	{children?: React.ReactNode | undefined} & InputAsValueFieldComponentProps
@@ -22,7 +22,7 @@ const ListTypeDefaultValueSelect: React.FC<
 	setValues,
 	values,
 }: InputAsValueFieldComponentProps) => {
-	const [listTypeEntries, setListTypeEntries] = useState<ListTypeEntry[]>();
+	const listTypeEntries = useListTypeEntries(values.listTypeDefinitionId);
 
 	const handleChange = (selected?: ListTypeEntry) => {
 		if (selected) {
@@ -45,38 +45,21 @@ const ListTypeDefaultValueSelect: React.FC<
 		}
 	};
 
-	useEffect(() => {
-		if (values.listTypeDefinitionId) {
-			API.getListTypeDefinitionListTypeEntries(
-				values.listTypeDefinitionId
-			).then((items) => {
-				if (items.length) {
-					setListTypeEntries(
-						items.map((item) => ({
-							...item,
-							name_i18n: fixLocaleKeys(item.name_i18n),
-						}))
-					);
-				}
-			});
-		}
-	}, [defaultValue, setValues, values, values.listTypeDefinitionId]);
+	if (!listTypeEntries || !values.listTypeDefinitionId) {
+		return null;
+	}
 
 	return (
-		<>
-			{listTypeEntries && values.listTypeDefinitionId && (
-				<ListTypeEntryBaseField
-					creationLanguageId={creationLanguageId}
-					error={error}
-					label={label}
-					onChange={handleChange}
-					picklistItems={listTypeEntries}
-					placeholder={Liferay.Language.get('choose-an-option')}
-					required={required}
-					selectedPicklistItemKey={defaultValue as string | undefined}
-				/>
-			)}
-		</>
+		<ListTypeEntryBaseField
+			creationLanguageId={creationLanguageId}
+			error={error}
+			label={label}
+			onChange={handleChange}
+			picklistItems={listTypeEntries}
+			placeholder={Liferay.Language.get('choose-an-option')}
+			required={required}
+			selectedPicklistItemKey={defaultValue as string | undefined}
+		/>
 	);
 };
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/useListTypeEntries.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/DefaultValueFields/useListTypeEntries.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {API} from '@liferay/object-js-components-web';
+import {useEffect, useState} from 'react';
+
+import {fixLocaleKeys} from '../../ListTypeDefinition/utils';
+
+export function useListTypeEntries(
+	listTypeDefinitionId?: number
+): ListTypeEntry[] | undefined {
+	const [listTypeEntries, setListTypeEntries] = useState<ListTypeEntry[]>();
+
+	useEffect(() => {
+		let discardResults = false;
+
+		setListTypeEntries(undefined);
+
+		if (listTypeDefinitionId) {
+			API.getListTypeDefinitionListTypeEntries(listTypeDefinitionId).then(
+				(items) => {
+					if (!discardResults) {
+						setListTypeEntries(
+							items.map((item) => ({
+								...item,
+								name_i18n: fixLocaleKeys(item.name_i18n),
+							}))
+						);
+					}
+				}
+			);
+		}
+
+		return () => {
+			discardResults = true;
+		};
+	}, [listTypeDefinitionId]);
+
+	return listTypeEntries;
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect.spec.tsx
@@ -1,0 +1,210 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {API} from '@liferay/object-js-components-web';
+
+import '@testing-library/jest-dom';
+import {act, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import ListTypeDefaultValueSelect from '../../../components/ObjectField/DefaultValueFields/ListTypeDefaultValueSelect';
+
+const baseProps = {
+	creationLanguageId: 'en_US' as Liferay.Language.Locale,
+	label: 'default-value',
+	onSubmit: () => {},
+	required: true,
+	setValues: () => {},
+};
+
+const colorsListTypeEntries = [
+	{
+		externalReferenceCode: 'blue-erc',
+		id: 11,
+		key: 'blue',
+		listTypeDefinitionId: 1,
+		name: 'Blue',
+		name_i18n: {en_US: 'Blue'},
+	},
+];
+
+const sizesListTypeEntries = [
+	{
+		externalReferenceCode: 'small-erc',
+		id: 21,
+		key: 'small',
+		listTypeDefinitionId: 2,
+		name: 'Small',
+		name_i18n: {en_US: 'Small'},
+	},
+];
+
+describe('ListTypeDefaultValueSelect', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('clears the previous default value when switching to a different picklist', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockImplementation((listTypeDefinitionId) =>
+			Promise.resolve(
+				(listTypeDefinitionId === 1
+					? colorsListTypeEntries
+					: sizesListTypeEntries) as any
+			)
+		);
+
+		const {rerender} = render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+
+		rerender(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 2}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		});
+
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('clears the previous default value when switching to a picklist without items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockImplementation((listTypeDefinitionId) =>
+			Promise.resolve(
+				(listTypeDefinitionId === 1 ? colorsListTypeEntries : []) as any
+			)
+		);
+
+		const {rerender} = render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+
+		rerender(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 2}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+		});
+
+		expect(screen.getByRole('combobox')).toHaveTextContent(
+			'choose-an-option'
+		);
+	});
+
+	it('discards results from a superseded picklist request', async () => {
+		let resolveColors!: (items: ListTypeEntry[]) => void;
+
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockImplementation((listTypeDefinitionId) =>
+			listTypeDefinitionId === 1
+				? (new Promise((resolve) => {
+						resolveColors = resolve;
+					}) as any)
+				: (Promise.resolve(sizesListTypeEntries) as any)
+		);
+
+		const {rerender} = render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		rerender(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 2}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toBeInTheDocument();
+		});
+
+		await act(async () => {
+			resolveColors(colorsListTypeEntries);
+		});
+
+		expect(screen.getByRole('combobox')).not.toHaveTextContent('Blue');
+	});
+
+	it('renders the required field and its error when the picklist has no items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockResolvedValue([]);
+
+		render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				error="this-field-is-required"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toBeInTheDocument();
+		});
+
+		expect(screen.getByText('default-value')).toBeInTheDocument();
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+	});
+
+	it('shows the selected default value when the picklist has items', async () => {
+		jest.spyOn(
+			API,
+			'getListTypeDefinitionListTypeEntries'
+		).mockResolvedValue(colorsListTypeEntries as any);
+
+		render(
+			<ListTypeDefaultValueSelect
+				{...baseProps}
+				defaultValue="blue"
+				values={{listTypeDefinitionId: 1}}
+			/>
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole('combobox')).toHaveTextContent('Blue');
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-1457

## What Is Being Fixed

When a Picklist object field is switched to a picklist that has no items, the Default Value field kept the previously selected picklist's value. The required Default Value field was also not rendered at all for an empty picklist, so saving failed with a required-field error and no field to correct.

## How It Is Being Fixed

`ListTypeEntryBaseField` now renders the select even when the picklist has no items, and keys the picker on its item ids so it remounts whenever the set of options changes, clearing a value selected for a previous picklist. The fetch moves into a `useListTypeEntries` hook that loads the entries, clears them while switching, ignores responses from a superseded request, and depends only on the picklist id. The Default Value field is rendered for empty picklists so the user sees there are no options and corrects themselves, with no extra prevention messaging.

## PR Check

**pr-check: PASS** — tested on `01cb82079536b6cef7d7528643f96d6605175a75`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "01cb82079536b6cef7d7528643f96d6605175a75"} -->