### PR TITLE
LPD-94193 Convert dynamic-data-mapping SCSS to atlas tokens

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,8 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-ddm-edit-data-provider .has-success .form-control {
-	background-color: #f1f2f5;
-	border: 0.0625rem solid #e7e7ed;
+	background-color: $gray-200;
+	border: 0.0625rem solid $gray-300;
 }
 
 .portlet-dynamic-data-mapping-data-provider {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/components/_field-options.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/components/_field-options.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 $c: '.ddm-field-options';
 
@@ -12,8 +12,8 @@ $c: '.ddm-field-options';
 	padding: 16px 22px 16px 15px;
 
 	&.dragging {
-		background: #fff;
-		box-shadow: 0 1px 50px rgba(0, 0, 0, 0.35);
+		background: $white;
+		box-shadow: 0 1px 50px unquote('hsl(from #{$black} h s l / 0.35)');
 		height: 65px;
 		position: absolute;
 		width: 300px;
@@ -89,7 +89,7 @@ $c: '.ddm-field-options';
 	}
 
 	.lexicon-icon-drag {
-		color: #a7a9bc;
+		color: $gray-500;
 		font-size: 16px;
 		margin-left: -8px;
 		margin-top: 4px;
@@ -106,8 +106,8 @@ $c: '.ddm-field-options';
 }
 
 .ddm-options-target {
-	background: #f1f5ff;
-	border: solid 2px #82aaf8;
+	background: $blue-l5;
+	border: solid 2px $blue-l2;
 	height: 10px;
 	margin: 6px 0;
 	opacity: 0;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/config/_variables.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/config/_variables.scss
@@ -1,11 +1,13 @@
+@import 'atlas-custom-properties/_variables';
+
 // Measures
 $baseline: 1rem;
 
 // Colors
-$active-blue: #0b5fff;
-$dark-blue: rgba(179, 205, 255, 0.3);
-$light-blue: #80acff;
-$strong-blue: #2e5aac;
+$active-blue: $primary;
+$dark-blue: unquote('hsl(from #{$blue-l3} h s l / 0.3)');
+$light-blue: $blue-l2;
+$strong-blue: $blue-d3;
 
-$light-400: #dee4e9;
-$light-blue-100: #f0f5ff;
+$light-400: $gray-300;
+$light-blue-100: $blue-l5;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_actionable.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_actionable.scss
@@ -3,7 +3,7 @@
 	border: 2px solid $active-blue;
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
-	color: #fff;
+	color: $white;
 	display: flex;
 	font-weight: 600;
 	height: 28px;
@@ -26,8 +26,8 @@
 	}
 
 	&.ddm-fieldset {
-		background-color: #5aca75;
-		border-color: #5aca75;
+		background-color: $success;
+		border-color: $success;
 	}
 
 	.actions-label {
@@ -36,7 +36,7 @@
 	}
 
 	.dropdown-action button {
-		color: #fff;
+		color: $white;
 		margin-right: -8px;
 		margin-top: -4px;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_field-settings.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_field-settings.scss
@@ -22,12 +22,12 @@ $c: '.ddm-field-settings';
 
 		.has-error {
 			.ddm-field-text {
-				background-color: #f1f2f5;
-				border-color: #e7e7ed;
+				background-color: $gray-200;
+				border-color: $gray-300;
 			}
 
 			.key-value-editor .key-value-reference-input {
-				color: #da1414;
+				color: $danger;
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_field-types-panel.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_field-types-panel.scss
@@ -5,7 +5,7 @@ $c: '.ddm-field-types-panel';
 		padding-left: 17px;
 
 		&:hover {
-			background-color: #f0f5ff;
+			background-color: $blue-l5;
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_form-builder.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_form-builder.scss
@@ -38,7 +38,7 @@ $c: '.ddm-form-builder';
 			border-color: $active-blue;
 
 			&.ddm-fieldset {
-				border-color: #5aca75;
+				border-color: $success;
 			}
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_form-pagination.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_form-pagination.scss
@@ -65,7 +65,7 @@ $c: '.ddm-form-pagination';
 }
 
 .horizontal-line {
-	background-color: #cdced9;
+	background-color: $gray-400;
 	height: 1px;
 	margin-bottom: 40px;
 	margin-top: 40px;
@@ -87,7 +87,7 @@ $c: '.ddm-form-pagination';
 		}
 
 		.horizontal-line {
-			background-color: #cdced9;
+			background-color: $gray-400;
 			height: 1px;
 			margin: 4px 0;
 			padding: 0;
@@ -96,7 +96,7 @@ $c: '.ddm-form-pagination';
 	}
 
 	.h5.pagination {
-		color: #a7a9bc;
+		color: $gray-500;
 		font-size: 10px;
 		text-transform: uppercase;
 	}
@@ -107,12 +107,12 @@ $c: '.ddm-form-pagination';
 
 		button.dropdown-toggle {
 			border-width: 0;
-			color: #6b6c7e;
+			color: $gray-600;
 
 			&:hover {
-				background-color: #f7f8f9;
-				border-color: #cdced9;
-				color: #272833;
+				background-color: $gray-100;
+				border-color: $gray-400;
+				color: $gray-900;
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_moveable.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_moveable.scss
@@ -13,7 +13,7 @@ $c: '.ddm-form-builder';
 	}
 
 	.ddm-drag {
-		background-color: #fff;
+		background-color: $white;
 		padding: 1rem 0;
 		width: 100%;
 
@@ -32,7 +32,7 @@ $c: '.ddm-form-builder';
 
 	.ddm-drag.dragging {
 		border-radius: 4px;
-		box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2);
+		box-shadow: 0 0 3px 0 unquote('hsl(from #{$black} h s l / 0.2)');
 		cursor: grabbing;
 		opacity: 0.7;
 		position: absolute;
@@ -46,17 +46,17 @@ $c: '.ddm-form-builder';
 	}
 
 	.ddm-drag-item.dragging {
-		box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
+		box-shadow: 0 8px 16px 0 unquote('hsl(from #{$black} h s l / 0.2)');
 		cursor: grabbing;
 		z-index: 20;
 	}
 
 	.col.col-empty.lfr-initial-col .ddm-target,
 	.dragging {
-		background-color: #f7f8f9;
-		border: 2px dashed #a7a9bc;
+		background-color: $gray-100;
+		border: 2px dashed $gray-500;
 		border-radius: 4px;
-		color: #a7a9bc;
+		color: $gray-500;
 	}
 
 	.col.col-empty {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_resizeable.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_resizeable.scss
@@ -18,7 +18,7 @@ $c: '.ddm-form-builder';
 
 		.ddm-resize-handle-left,
 		.ddm-resize-handle-right {
-			background-color: #ccc;
+			background-color: $gray-400;
 			cursor: inherit;
 			opacity: 0;
 		}
@@ -37,7 +37,7 @@ $c: '.ddm-form-builder';
 		&.selected {
 			> .ddm-resize-handle-left,
 			> .ddm-resize-handle-right {
-				background-color: #1c67fb;
+				background-color: $primary;
 				cursor: col-resize;
 				opacity: 1;
 			}
@@ -48,7 +48,7 @@ $c: '.ddm-form-builder';
 			&.selected {
 				> .ddm-resize-handle-left,
 				> .ddm-resize-handle-right {
-					background-color: #5aca75;
+					background-color: $success;
 				}
 			}
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/main.scss
@@ -128,7 +128,7 @@
 }
 
 .form-builder-select-field .option-selected-placeholder {
-	color: #6a6c7d;
+	color: $gray-600;
 }
 
 .form-builder-select-field .dropdown-menu {
@@ -146,11 +146,11 @@
 }
 
 .form-builder-select-field .dropdown-menu .placeholder-dropdown-item {
-	color: #a7a9bc;
+	color: $gray-500;
 }
 
 .form-builder-select-field .dropdown-menu .placeholder-dropdown-item:hover {
-	color: #a7a9bc;
+	color: $gray-500;
 }
 
 .form-builder-select-field .dropdown-menu .custom-control {
@@ -158,11 +158,11 @@
 }
 
 .form-builder-select-field .select-arrow-down-container {
-	color: #6b6c7e;
+	color: $gray-600;
 }
 
 .form-builder-select-field .search-chosen {
-	border-bottom: 1px solid #e4e9ec;
+	border-bottom: 1px solid $gray-300;
 	position: relative;
 }
 
@@ -173,11 +173,11 @@
 }
 
 .form-builder-select-field .select-search-container a {
-	color: #869cad;
+	color: $gray-500;
 }
 
 .form-builder-select-field.active .select-field-trigger {
-	border-bottom: 2px solid #65b6f0;
+	border-bottom: 2px solid $blue-l1;
 }
 
 .form-builder-select-field
@@ -188,7 +188,7 @@
 }
 
 .form-builder-select-field .form-control[disabled]:focus {
-	border-bottom: 2px solid #869cad;
+	border-bottom: 2px solid $gray-500;
 	text-decoration: none;
 }
 
@@ -201,9 +201,9 @@
 }
 
 .form-builder-select-field .drop-chosen {
-	background-color: #fff;
+	background-color: $white;
 	border-radius: 0 0 4px 4px;
-	box-shadow: 0 2px 14px 0 rgba(58, 75, 87, 0.1);
+	box-shadow: 0 2px 14px 0 unquote('hsl(from #{$gray-800} h s l / 0.1)');
 	left: 0;
 	position: absolute;
 	right: 0;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/OptionFieldKeyValue/OptionFieldKeyValue.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/OptionFieldKeyValue/OptionFieldKeyValue.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .collapsable-option-body {
 	.tooltip-icon {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Options/Options.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Options/Options.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .add-option-button {
 	border-color: $light-d2;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Validation/StartEndDate.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Validation/StartEndDate.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .ddm__validation-date-start-end {
 	margin-bottom: 24px;
 
@@ -6,7 +8,7 @@
 		gap: 5px;
 
 		.ddm__validation-date-start-end-icon {
-			color: #a7a9bc;
+			color: $gray-500;
 		}
 	}
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/FieldBase.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/FieldBase.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .ddm-field-types-base {
 	&__nested {
 		margin-top: 15px;
@@ -42,7 +44,7 @@
 }
 
 .lfr-ddm-legend {
-	color: #272833;
+	color: $gray-900;
 	font-size: 0.875rem;
 	font-weight: 600;
 	margin-bottom: 0.25rem;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -442,7 +442,7 @@ div.lfr-de__partial-results--background {
 	margin-bottom: 42px !important;
 
 	&:before {
-		background-color: $gray-500;
+		background-color: $gray-400;
 		content: '';
 		display: block;
 		height: 12px;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -69,7 +69,7 @@ td.lfr-name-column {
 .ddm-form-settings-modal,
 .publish-modal-container {
 	.modal-body {
-		background-color: #fff;
+		background-color: $white;
 	}
 }
 
@@ -136,7 +136,7 @@ td.lfr-name-column {
 
 .ddm-icon-check {
 	.sticker {
-		color: #287d3c;
+		color: $success-d1;
 	}
 }
 
@@ -251,7 +251,7 @@ div.lfr-de__partial-results--background {
 	}
 
 	.input-group-container .input-group-addon {
-		background-color: #e7e7ed;
+		background-color: $gray-300;
 	}
 
 	.liferay-ddm-form-field-editor .form-control-feedback {
@@ -358,8 +358,8 @@ div.lfr-de__partial-results--background {
 
 		.form-builder-content,
 		.lfr-ddm-form-content {
-			background: #fff;
-			border-color: #e7e7ed;
+			background: $white;
+			border-color: $gray-300;
 			border-radius: 4px;
 			margin: 0 auto;
 			width: auto;
@@ -400,7 +400,7 @@ div.lfr-de__partial-results--background {
 
 	.taglib-workflow-status {
 		.workflow-version {
-			color: #6b6c7e;
+			color: $gray-600;
 		}
 	}
 }
@@ -408,12 +408,12 @@ div.lfr-de__partial-results--background {
 .portlet-forms-admin {
 	#formsNavigationBar .nav-item {
 		.nav-link {
-			color: #cdced9;
+			color: $gray-400;
 			cursor: pointer;
 
 			&.active,
 			&:hover {
-				color: #fff;
+				color: $white;
 			}
 		}
 	}
@@ -442,7 +442,7 @@ div.lfr-de__partial-results--background {
 	margin-bottom: 42px !important;
 
 	&:before {
-		background-color: #cad3db;
+		background-color: $gray-500;
 		content: '';
 		display: block;
 		height: 12px;
@@ -480,20 +480,20 @@ div.lfr-de__partial-results--background {
 				font-weight: 600;
 
 				&::placeholder {
-					color: #b0b4bb;
+					color: $gray-500;
 					font-weight: 500;
 				}
 			}
 
 			&.ddm-form-description {
-				color: #000;
+				color: $black;
 				font-size: 14px;
 				font-weight: 400;
 				height: auto;
 				padding-top: 0;
 
 				&::placeholder {
-					color: #b0b4bb;
+					color: $gray-500;
 				}
 			}
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -26,7 +26,7 @@
 }
 
 .error-icon {
-	color: #da1414;
+	color: $danger;
 	margin-right: 5px;
 }
 
@@ -54,7 +54,7 @@
 	}
 
 	.autosave-feedback {
-		color: #6b6c7e;
+		color: $gray-600;
 		display: block;
 		font-style: italic;
 		padding-bottom: 18.071px;
@@ -77,19 +77,19 @@
 	}
 
 	.publish-icon {
-		color: #879dae;
+		color: $gray-500;
 		cursor: pointer;
 		float: right;
 
 		&.disabled {
-			background-color: #fff;
-			border-color: #cdced9;
+			background-color: $white;
+			border-color: $gray-400;
 			cursor: not-allowed;
 			opacity: 0.26;
 		}
 
 		&:hover:not(.disabled) {
-			color: #65b3f0;
+			color: $blue-l1;
 		}
 	}
 
@@ -115,7 +115,7 @@
 		padding: 16px 10px;
 
 		&:hover {
-			background-color: #f0f8fe;
+			background-color: $blue-l5;
 			cursor: pointer;
 		}
 	}
@@ -156,7 +156,7 @@
 	}
 
 	.form-builder-field-list-add-button-label {
-		color: #4a90e2;
+		color: $blue-l2;
 	}
 
 	.form-builder-field-list-add-button-large
@@ -316,7 +316,7 @@
 	}
 
 	.form-builder-page-manager-content {
-		border-top: 1px solid #dce0e3;
+		border-top: 1px solid $gray-300;
 
 		.form-builder-controls-trigger {
 			margin: 0;
@@ -371,7 +371,7 @@
 	input[type='checkbox'],
 	input[type='radio'] {
 		background-color: transparent;
-		border-color: #869cad;
+		border-color: $gray-500;
 		color: initial;
 		cursor: default;
 	}
@@ -396,8 +396,8 @@
 	}
 
 	.layout-builder-remove-row-button {
-		background: #fff;
-		border: 1px solid #65b6f0;
+		background: $white;
+		border: 1px solid $blue-l1;
 		height: auto;
 		padding: 0;
 		top: -22px;
@@ -405,15 +405,15 @@
 		z-index: 9;
 
 		.lexicon-icon {
-			color: #65b6f0;
+			color: $blue-l1;
 			margin: 10px;
 		}
 
 		&:hover {
-			background: #65b6f0;
+			background: $blue-l1;
 
 			.lexicon-icon {
-				color: #fff;
+				color: $white;
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -156,7 +156,7 @@
 	}
 
 	.form-builder-field-list-add-button-label {
-		color: $blue-l2;
+		color: $primary;
 	}
 
 	.form-builder-field-list-add-button-large

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms.scss
@@ -38,7 +38,7 @@
 	.ddm-form-basic-info {
 		.ddm-form-name,
 		.ddm-form-description {
-			color: #6b6c7e;
+			color: $gray-600;
 			margin: 0;
 			word-wrap: break-word;
 		}
@@ -102,7 +102,7 @@
 	}
 
 	.horizontal-line {
-		background-color: #cdced9;
+		background-color: $gray-400;
 		height: 1px;
 		margin-bottom: 40px;
 		margin-top: 40px;
@@ -147,7 +147,7 @@
 	}
 
 	.management-bar {
-		border-bottom: 1px solid #e7e7ed;
+		border-bottom: 1px solid $gray-300;
 	}
 
 	.checkbox-multiple-options .checkbox-multiple-switcher-inline {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_variables.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_variables.scss
@@ -2,8 +2,8 @@ $baseline: 8px;
 $horizontal-spacing: 35px;
 $transition-time: 0.5s;
 
-$form-header-placeholder-color: #c0ccd3;
-$form-header-text-color: #869cad;
+$form-header-placeholder-color: $gray-500;
+$form-header-text-color: $gray-500;
 
 $form-management-bar-height: 63px;
 $form-navigation-bar-height: 48px;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_variables.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_variables.scss
@@ -2,7 +2,7 @@ $baseline: 8px;
 $horizontal-spacing: 35px;
 $transition-time: 0.5s;
 
-$form-header-placeholder-color: $gray-500;
+$form-header-placeholder-color: $gray-400;
 $form-header-text-color: $gray-500;
 
 $form-management-bar-height: 63px;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/main.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @import 'atlas-variables';
 
 @import 'variables';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/DefaultPage.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/DefaultPage.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-ddm__default-page {
 	margin-top: 2rem;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/DefaultPageHeader.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/components/DefaultPageHeader.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-ddm__default-page-header {
 	margin-bottom: 2rem;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/Report.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/Report.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 #wrapper .portlet-layout .portlet-body {
 	.lfr-ddm__form-report__header,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @import 'atlas-variables';
 
 .color-cell-editor-hidden {
@@ -291,7 +293,7 @@
 	}
 
 	.lfr-ddm-small-image-content {
-		background-color: #f5f5f5;
+		background-color: $gray-100;
 		padding: 5px;
 
 		th {
@@ -408,10 +410,10 @@
 }
 
 .tab-selected .tab-content {
-	color: #272833;
+	color: $gray-900;
 
 	&::after {
-		background-color: #80acff;
+		background-color: $blue-l2;
 		content: '';
 		height: 0.125rem;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94193

## What Is Being Fixed

Several SCSS files across the dynamic-data-mapping modules carried hardcoded hex colors (and a handful of `lighten()`/`darken()` derivations) instead of the shared atlas design tokens. This bypassed the centralized palette, made dark mode and theming changes harder to apply consistently, and produced visual drift between dynamic-data-mapping and the rest of the product.

## How It Is Being Fixed

The change rewrites the affected SCSS in five modules — `dynamic-data-mapping-data-provider-web`, `dynamic-data-mapping-form-builder`, `dynamic-data-mapping-form-field-type`, `dynamic-data-mapping-form-web`, and `dynamic-data-mapping-web` — to use atlas-custom-properties variables in place of raw hex values. Where a module already declared a local semantic alias (for example `$border-color`), that alias is reused; otherwise the closest atlas token is picked, accepting small visual drift over leaving the literal in place. Each file imports `atlas-custom-properties/_variables` and references tokens through `#{}` interpolation when a CSS custom property is the target.

## Why Are There No Tests?

This is a CSS-only token refactor: the SCSS color values are mapped onto atlas-custom-properties without changing component behavior. There is no runtime logic to cover, and the visual result is verified against the existing form builder, form editor, and form viewer screens.

## PR Check

**pr-check: PASS** — tested on `8ec6cd49ce219336aa126a68608d7c9fa740e454`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "8ec6cd49ce219336aa126a68608d7c9fa740e454"} -->