### PR TITLE
LPD-94131 Cast CLOB column to fix picklist upgrade on Oracle

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_1_1/ObjectEntryPicklistDefaultValueUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v12_1_1/ObjectEntryPicklistDefaultValueUpgradeProcess.java
@@ -41,8 +41,8 @@ public class ObjectEntryPicklistDefaultValueUpgradeProcess
 						"= [$TRUE$] and ObjectFieldSetting.value is not null ",
 						"and not exists (select 1 from ObjectFieldSetting ofs ",
 						"where ofs.objectFieldId = ObjectField.objectFieldId ",
-						"and ofs.name = 'defaultValueType' and ofs.value != ",
-						"'inputAsValue')")))) {
+						"and ofs.name = 'defaultValueType' and ",
+						"CAST_CLOB_TEXT(ofs.value) != 'inputAsValue')")))) {
 
 			preparedStatement1.setInt(1, WorkflowConstants.STATUS_APPROVED);
 			preparedStatement1.setString(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94131

## What Is Being Fixed

The com.liferay.object.service upgrade from 12.1.0 to 12.1.1 failed on Oracle during ObjectEntryPicklistDefaultValueUpgradeProcess. Its query compared the CLOB column ObjectFieldSetting.value with != inside a not-exists subquery, and Oracle rejects comparison operators on CLOB columns with ORA-22848 (cannot use CLOB type as comparison key). The exception aborted the upgrade process, which then surfaced downstream as "Unsatisfied components prevent upgrade processes to be registered". It hit Oracle customers during U150 validation; other databases compare TEXT columns without issue, so it went unnoticed until then.

## How It Is Being Fixed

The comparison now wraps the CLOB column in CAST_CLOB_TEXT(...), the SQL token Liferay's SQLTransformer already rewrites per database. On Oracle it becomes DBMS_LOB.SUBSTR(value, 4000, 1), a valid comparison key; on every other supported database it is a no-op or a plain cast, so the query semantics are unchanged. The statement already runs through SQLTransformer.transform(...), so no other wiring was needed.

## Why Are There No Tests?

The existing ObjectEntryPicklistDefaultValueUpgradeProcessTest already exercises this exact query: every picklist field it creates has defaultValueType = inputAsValue, so the CAST_CLOB_TEXT(ofs.value) != 'inputAsValue' comparison is evaluated on each selected row — precisely the statement that threw ORA-22848 before the fix. It is therefore the regression guard once run on Oracle. The fix was validated by reproducing ORA-22848 against the reported customer database, then running this test green on both MySQL and a clean Oracle 19c instance. The one branch the test does not cover (defaultValueType != inputAsValue) is unreachable for valid data: picklist state fields — the only fields the upgrade selects — cannot be assigned a non-inputAsValue default value type through the service layer.

## PR Check

**pr-check: PASS** — tested on `190293f37f7ad96b83c8530135b41cad97428604`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "190293f37f7ad96b83c8530135b41cad97428604"} -->
