### PR TITLE
LPD-91679 Recycle Bin object entries are not automatically deleted

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -505,7 +505,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				TrashHandler.class,
 				new ObjectEntryTrashHandler(
 					objectDefinition, _objectDefinitionLocalService,
-					_objectEntryService, _systemEventLocalService),
+					_objectEntryLocalService, _objectEntryService,
+					_systemEventLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"model.class.name", objectDefinition.getClassName()
 				).build()));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
@@ -31,7 +31,7 @@ public class ObjectEntryFolderTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryFolderService.deleteObjectEntryFolder(classPK);
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(classPK);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
@@ -8,6 +8,7 @@ package com.liferay.object.internal.trash;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
@@ -30,11 +31,13 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 	public ObjectEntryTrashHandler(
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
 		SystemEventLocalService systemEventLocalService) {
 
 		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
 		_systemEventLocalService = systemEventLocalService;
 	}
@@ -55,7 +58,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryService.deleteObjectEntry(classPK);
+		_objectEntryLocalService.deleteObjectEntry(classPK);
 	}
 
 	@Override
@@ -100,6 +103,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
 	private final SystemEventLocalService _systemEventLocalService;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.trash.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.test.util.ObjectEntryFolderTestUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryFolderTrashHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
+	}
+
+	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder();
+
+		_objectEntryFolderLocalService.moveObjectEntryFolderToTrash(
+			TestPropsValues.getUserId(), objectEntryFolder,
+			ServiceContextTestUtil.getServiceContext());
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return objectEntryFolder;
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -48,8 +48,8 @@ public class ObjectEntryFolderTrashHandlerTest {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -117,8 +117,8 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -20,8 +20,13 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.TrashedModel;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -29,14 +34,18 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.trash.TrashHelper;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
 import com.liferay.trash.test.util.BaseTrashHandlerTestCase;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -103,6 +112,13 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		_testAddDeletionSystemEvent(group.getGroupId(), (ObjectEntry)baseModel);
+	}
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
 	}
 
 	@Override
@@ -203,6 +219,27 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
+	private ObjectEntry _addExpiredTrashedObjectEntry() throws Exception {
+		baseModel = addBaseModel(
+			group,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		long primaryKey = (Long)baseModel.getPrimaryKeyObj();
+
+		moveBaseModelToTrash(primaryKey);
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			_objectDefinition.getClassName(), primaryKey);
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return (ObjectEntry)baseModel;
+	}
+
 	private void _testAddDeletionSystemEvent(
 			long groupId, ObjectEntry objectEntry)
 		throws Exception {
@@ -226,6 +263,42 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			systemEvent.getClassExternalReferenceCode());
 		Assert.assertEquals(
 			SystemEventConstants.TYPE_DELETE, systemEvent.getType());
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
 	}
 
 	private ObjectDefinition _objectDefinition;


### PR DESCRIPTION
This resends #6134 (LPD-91679) with one fix applied.

Original author: Alicia García, who is no longer at the company. The original PR fixed the Recycle Bin scheduler failing to purge expired ObjectEntry and ObjectEntryFolder entries: both TrashHandlers called the permission-aware *Service.delete* variant, which throws PrincipalException when checkEntries() runs system-wide with no PermissionChecker bound. The fix routes deleteTrashEntry through the *LocalService variant, consistent with every other TrashHandler.

Why the resend: the forward was rejected for a call-order issue in the tests. In both testCheckEntries() methods the helper calls ran WithPermissions before WithoutPermissions; case-insensitive ordering and the methods' own declaration order require WithoutPermissions first. This PR sorts the two calls accordingly. No other change from #6134.

The companion config LPD-91035 has landed on brianchandotcom/master, so this is no longer blocked.

Run the included automated tests to verify.
