### PR TITLE
LPD-93665 Resolve attachment download permission from the file entry

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectDLFileEntryModelResourcePermissionConfigurator.java
@@ -7,17 +7,20 @@ package com.liferay.object.internal.security.permission.resource;
 
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionFactory;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
@@ -25,12 +28,16 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.io.Serializable;
+
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.osgi.service.component.annotations.Component;
@@ -65,14 +72,16 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 					ServiceContextThreadLocal.getServiceContext();
 
 				if (serviceContext == null) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
 				HttpServletRequest httpServletRequest =
 					serviceContext.getRequest();
 
 				if (httpServletRequest == null) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
 				boolean download = ParamUtil.getBoolean(
@@ -93,7 +102,8 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 							companyId);
 
 				if (objectDefinition == null) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
 				long groupId = ObjectDefinitionConstants.GROUP_ID_DEFAULT;
@@ -116,14 +126,16 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 						groupId, objectDefinition.getObjectDefinitionId());
 
 				if (objectEntry == null) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
 				String objectFieldExternalReferenceCode = ParamUtil.getString(
 					httpServletRequest, "objectFieldExternalReferenceCode");
 
 				if (Validator.isNull(objectFieldExternalReferenceCode)) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
 				ObjectField objectField =
@@ -132,31 +144,40 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 						objectDefinition.getObjectDefinitionId());
 
 				if (objectField == null) {
-					return _validateObjectDefinitionClassName(dlFileEntry);
+					return _hasDownloadPermission(
+						dlFileEntry, permissionChecker);
 				}
 
-				ModelResourcePermission<?> objectEntryModelResourcePermission =
-					ModelResourcePermissionRegistryUtil.
-						getModelResourcePermission(
-							objectDefinition.getClassName());
-
-				if ((objectEntryModelResourcePermission == null) ||
-					(objectEntryModelResourcePermission.contains(
-						permissionChecker, objectEntry.getObjectEntryId(),
-						ActionKeys.VIEW) &&
-					 objectEntryModelResourcePermission.contains(
-						 permissionChecker, objectEntry.getObjectEntryId(),
-						 objectField.getAttachmentDownloadActionKey()))) {
-
-					return null;
-				}
-
-				return false;
+				return _hasDownloadPermission(
+					objectDefinition, objectEntry, objectField,
+					permissionChecker);
 			});
 	}
 
-	private Boolean _validateObjectDefinitionClassName(
-		DLFileEntry dlFileEntry) {
+	private ObjectField _getAttachmentObjectField(
+		long fileEntryId, ObjectDefinition objectDefinition,
+		ObjectEntry objectEntry) {
+
+		Map<String, Serializable> values = objectEntry.getValues();
+
+		for (ObjectField objectField :
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinition.getObjectDefinitionId(),
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			if (fileEntryId == GetterUtil.getLong(
+					values.get(objectField.getName()))) {
+
+				return objectField;
+			}
+		}
+
+		return null;
+	}
+
+	private Boolean _hasDownloadPermission(
+			DLFileEntry dlFileEntry, PermissionChecker permissionChecker)
+		throws PortalException {
 
 		String className = dlFileEntry.getClassName();
 
@@ -167,11 +188,71 @@ public class ObjectDLFileEntryModelResourcePermissionConfigurator
 			return null;
 		}
 
-		if (_log.isWarnEnabled()) {
-			_log.warn("Unable to verify download permission for " + className);
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				dlFileEntry.getCompanyId(), className);
+
+		if (objectDefinition == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to verify download permission for " + className);
+			}
+
+			return false;
 		}
 
-		return false;
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			dlFileEntry.getClassPK());
+
+		if (objectEntry == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to verify download permission for " + className);
+			}
+
+			return false;
+		}
+
+		ObjectField objectField = _getAttachmentObjectField(
+			dlFileEntry.getFileEntryId(), objectDefinition, objectEntry);
+
+		if (objectField == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to verify download permission for " + className);
+			}
+
+			return false;
+		}
+
+		return _hasDownloadPermission(
+			objectDefinition, objectEntry, objectField, permissionChecker);
+	}
+
+	private Boolean _hasDownloadPermission(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry,
+			ObjectField objectField, PermissionChecker permissionChecker)
+		throws PortalException {
+
+		ModelResourcePermission<?> objectEntryModelResourcePermission =
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				objectDefinition.getClassName());
+
+		if (objectEntryModelResourcePermission == null) {
+			return null;
+		}
+
+		if (!objectEntryModelResourcePermission.contains(
+				permissionChecker, objectEntry.getObjectEntryId(),
+				ActionKeys.VIEW) ||
+			!objectEntryModelResourcePermission.contains(
+				permissionChecker, objectEntry.getObjectEntryId(),
+				objectField.getAttachmentDownloadActionKey())) {
+
+			return false;
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
@@ -7,7 +7,6 @@ package com.liferay.object.internal.security.permission.resource.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntry;
-import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
@@ -51,6 +50,8 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -59,11 +60,11 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.HttpMethod;
 
-import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -95,18 +96,6 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
-		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
-			null, TestPropsValues.getUserId(), _company.getGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-			TempFileEntryUtil.getTempFileName("image.jpg"),
-			ContentTypes.APPLICATION_TEXT, RandomTestUtil.randomString(),
-			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 67, null,
-			null, null, serviceContext);
-
-		_dlFileEntry = _dlFileEntryLocalService.getFileEntry(
-			fileEntry.getFileEntryId());
-
 		_objectField = ObjectFieldUtil.createObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
 			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
@@ -122,7 +111,8 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 				).name(
 					ObjectFieldSettingConstants.NAME_FILE_SOURCE
 				).value(
-					ObjectFieldSettingConstants.VALUE_DOCS_AND_MEDIA
+					ObjectFieldSettingConstants.
+						VALUE_USER_COMPUTER_TO_DOCS_AND_MEDIA
 				).build(),
 				new ObjectFieldSettingBuilder(
 				).name(
@@ -137,14 +127,29 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
 			Collections.singletonList(_objectField));
 
+		FileEntry tempFileEntry = TempFileEntryUtil.addTempFileEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getPortletId(),
+			TempFileEntryUtil.getTempFileName("image.jpg"),
+			FileUtil.createTempFile(RandomTestUtil.randomBytes()),
+			ContentTypes.APPLICATION_TEXT);
+
 		_objectEntry = _objectEntryLocalService.addOrUpdateObjectEntry(
 			RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
 			_objectDefinition.getObjectDefinitionId(),
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			HashMapBuilder.<String, Serializable>put(
-				"attachment", String.valueOf(_dlFileEntry.getFileEntryId())
+				"attachment", tempFileEntry.getFileEntryId()
 			).build(),
 			serviceContext);
+
+		Map<String, Serializable> values = _objectEntry.getValues();
+
+		long fileEntryId = GetterUtil.getLong(values.get("attachment"));
+
+		_dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(fileEntryId);
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
 		_originalName = PrincipalThreadLocal.getName();
 		_originalPermissionChecker =
@@ -207,6 +212,22 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 				PermissionCheckerFactoryUtil.create(_user), _dlFileEntry,
 				ActionKeys.DOWNLOAD));
 
+		_testContains(new String[] {ActionKeys.VIEW}, false);
+		_testContains(new String[] {attachmentDownloadActionKey}, false);
+		_testContains(
+			new String[] {ActionKeys.VIEW, attachmentDownloadActionKey}, true);
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(HttpMethod.GET, StringPool.BLANK);
+
+		mockHttpServletRequest.addParameter("download", "true");
+
+		serviceContext.setRequest(mockHttpServletRequest);
+
+		_testContains(new String[0], false);
 		_testContains(new String[] {ActionKeys.VIEW}, false);
 		_testContains(new String[] {attachmentDownloadActionKey}, false);
 		_testContains(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectDLFileEntryModelResourcePermissionConfiguratorTest.java
@@ -149,8 +149,6 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 
 		_dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(fileEntryId);
 
-		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
-
 		_originalName = PrincipalThreadLocal.getName();
 		_originalPermissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -165,6 +163,8 @@ public class ObjectDLFileEntryModelResourcePermissionConfiguratorTest {
 			PermissionCheckerFactoryUtil.create(_user));
 
 		PrincipalThreadLocal.setName(_user.getUserId());
+
+		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93665

Resent from https://github.com/liferay-bpm/liferay-portal/pull/6234.
Original: https://github.com/liferay-bpm/liferay-portal/pull/6210.
Previous forward: https://github.com/brianchandotcom/liferay-portal/pull/176445.

## What Is Being Fixed

When a CMS object's attachment is rendered through a documents (Related Items) collection on a display page, the document download URL is a plain Document Library URL with no object reference codes. With the LPD-17564 feature flag active, the DLFileEntry download permission configurator could not identify the owning object from such a URL and blanket-denied the download, so the document failed with "Forbidden: You do not have permission to access the requested resource", even for administrators. The earlier change (#6192) only added the reference codes to the object's own mapped attachment field URL; it did not cover URLs generated elsewhere, such as the documents collection, so the customer scenario (LPP-64267) still failed.

## How It Is Being Fixed

Instead of relying on the object reference codes being present in the request, the permission configurator now resolves the owning object directly from the DLFileEntry: the className gives the object definition, the classPK gives the object entry, and matching the fileEntryId against the entry's attachment fields gives the object field. It then runs the same object permission check (VIEW plus the field's attachment-download action) used by the parameterized path. When the file is not a custom object attachment it defers; when it is but the user lacks object permission it denies; otherwise it defers to the normal Document Library permission. This makes the reference codes an optimization rather than a requirement, so downloads work whether or not the URL carries them.

The integration test stamps a genuine object attachment (uploaded so the framework stores it in the object's managed folder and sets className/classPK) and exercises both the with-codes and no-codes paths through the shared permission matrix.
