### PR TITLE
LPD-24684 Optimize DDMFormGuestUploadFieldUtil

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 38.0.1
+Bundle-Version: 38.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
@@ -368,11 +368,6 @@ public interface DDMFormInstanceRecordLocalService
 		OrderByComparator<DDMFormInstanceRecord> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public List<DDMFormInstanceRecord> getFormInstanceRecords(
-		long ddmFormInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator);
-
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -461,4 +456,4 @@ public interface DDMFormInstanceRecordLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:327938531
+// LIFERAY-SERVICE-BUILDER-HASH:-1656096514

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
@@ -368,6 +368,11 @@ public interface DDMFormInstanceRecordLocalService
 		OrderByComparator<DDMFormInstanceRecord> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstanceRecord> getFormInstanceRecords(
+		long ddmFormInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -375,6 +380,10 @@ public interface DDMFormInstanceRecordLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId, long userId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
@@ -452,4 +461,4 @@ public interface DDMFormInstanceRecordLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1334577577
+// LIFERAY-SERVICE-BUILDER-HASH:327938531

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
@@ -417,14 +417,6 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			ddmFormInstanceId, userId, start, end, orderByComparator);
 	}
 
-	public static List<DDMFormInstanceRecord> getFormInstanceRecords(
-		long ddmFormInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return getService().getFormInstanceRecords(
-			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
-	}
-
 	public static int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return getService().getFormInstanceRecordsCount(ddmFormInstanceId);
 	}
@@ -548,4 +540,4 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			DDMFormInstanceRecordLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:829937258
+// LIFERAY-SERVICE-BUILDER-HASH:-740446410

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
@@ -417,6 +417,14 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			ddmFormInstanceId, userId, start, end, orderByComparator);
 	}
 
+	public static List<DDMFormInstanceRecord> getFormInstanceRecords(
+		long ddmFormInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getService().getFormInstanceRecords(
+			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
 	public static int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return getService().getFormInstanceRecordsCount(ddmFormInstanceId);
 	}
@@ -433,6 +441,13 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 
 		return getService().getFormInstanceRecordsCount(
 			ddmFormInstanceId, userId);
+	}
+
+	public static int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return getService().getFormInstanceRecordsCount(
+			ddmFormInstanceId, ipAddress);
 	}
 
 	public static
@@ -533,4 +548,4 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			DDMFormInstanceRecordLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:512484366
+// LIFERAY-SERVICE-BUILDER-HASH:829937258

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
@@ -482,6 +482,16 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<DDMFormInstanceRecord> getFormInstanceRecords(
+		long ddmFormInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator) {
+
+		return _ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
+	@Override
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return _ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
 			ddmFormInstanceId);
@@ -499,6 +509,14 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 
 		return _ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
 			ddmFormInstanceId, userId);
+	}
+
+	@Override
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return _ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+			ddmFormInstanceId, ipAddress);
 	}
 
 	@Override
@@ -643,4 +661,4 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 		_ddmFormInstanceRecordLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1303133393
+// LIFERAY-SERVICE-BUILDER-HASH:557135681

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
@@ -482,16 +482,6 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 	}
 
 	@Override
-	public java.util.List<DDMFormInstanceRecord> getFormInstanceRecords(
-		long ddmFormInstanceId, String ipAddress, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
-			orderByComparator) {
-
-		return _ddmFormInstanceRecordLocalService.getFormInstanceRecords(
-			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
-	}
-
-	@Override
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return _ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
 			ddmFormInstanceId);
@@ -661,4 +651,4 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 		_ddmFormInstanceRecordLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:557135681
+// LIFERAY-SERVICE-BUILDER-HASH:1942133548

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
@@ -391,72 +391,6 @@ public interface DDMFormInstanceRecordPersistence
 	public int countByU_F(long userId, long formInstanceId);
 
 	/**
-	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching ddm form instance records
-	 */
-	public java.util.List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
-			orderByComparator,
-		boolean useFinderCache);
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record
-	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
-	 */
-	public DDMFormInstanceRecord findByF_I_First(
-			long formInstanceId, String ipAddress,
-			com.liferay.portal.kernel.util.OrderByComparator
-				<DDMFormInstanceRecord> orderByComparator)
-		throws NoSuchFormInstanceRecordException;
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
-	 */
-	public DDMFormInstanceRecord fetchByF_I_First(
-		long formInstanceId, String ipAddress,
-		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
-			orderByComparator);
-
-	/**
-	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 */
-	public void removeByF_I(long formInstanceId, String ipAddress);
-
-	/**
-	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @return the number of matching ddm form instance records
-	 */
-	public int countByF_I(long formInstanceId, String ipAddress);
-
-	/**
 	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * <p>
@@ -521,6 +455,72 @@ public interface DDMFormInstanceRecordPersistence
 	 * @return the number of matching ddm form instance records
 	 */
 	public int countByF_F(long formInstanceId, String formInstanceVersion);
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException;
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator);
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public void removeByF_I(long formInstanceId, String ipAddress);
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public int countByF_I(long formInstanceId, String ipAddress);
 
 	/**
 	 * Creates a new ddm form instance record with the primary key. Does not add the ddm form instance record to the database.
@@ -851,64 +851,6 @@ public interface DDMFormInstanceRecordPersistence
 	}
 
 	/**
-	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @return the matching ddm form instance records
-	 */
-	public default java.util.List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress) {
-
-		return findByF_I(
-			formInstanceId, ipAddress,
-			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
-			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
-	}
-
-	/**
-	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @return the range of matching ddm form instance records
-	 */
-	public default java.util.List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end) {
-
-		return findByF_I(formInstanceId, ipAddress, start, end, null, true);
-	}
-
-	/**
-	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching ddm form instance records
-	 */
-	public default java.util.List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
-			orderByComparator) {
-
-		return findByF_I(
-			formInstanceId, ipAddress, start, end, orderByComparator, true);
-	}
-
-	/**
 	 * Returns all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * @param formInstanceId the form instance ID
@@ -968,5 +910,63 @@ public interface DDMFormInstanceRecordPersistence
 			true);
 	}
 
+	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return findByF_I(
+			formInstanceId, ipAddress,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return findByF_I(formInstanceId, ipAddress, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator) {
+
+		return findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator, true);
+	}
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1243009126
+// LIFERAY-SERVICE-BUILDER-HASH:218622664

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
@@ -391,6 +391,72 @@ public interface DDMFormInstanceRecordPersistence
 	public int countByU_F(long userId, long formInstanceId);
 
 	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException;
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator);
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public void removeByF_I(long formInstanceId, String ipAddress);
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public int countByF_I(long formInstanceId, String ipAddress);
+
+	/**
 	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * <p>
@@ -785,6 +851,64 @@ public interface DDMFormInstanceRecordPersistence
 	}
 
 	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return findByF_I(
+			formInstanceId, ipAddress,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return findByF_I(formInstanceId, ipAddress, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator) {
+
+		return findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator, true);
+	}
+
+	/**
 	 * Returns all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * @param formInstanceId the form instance ID
@@ -845,4 +969,4 @@ public interface DDMFormInstanceRecordPersistence
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:81216796
+// LIFERAY-SERVICE-BUILDER-HASH:1243009126

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
@@ -571,6 +571,87 @@ public class DDMFormInstanceRecordUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws com.liferay.dynamic.data.mapping.exception.
+			NoSuchFormInstanceRecordException {
+
+		return getPersistence().findByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().fetchByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public static void removeByF_I(long formInstanceId, String ipAddress) {
+		getPersistence().removeByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public static int countByF_I(long formInstanceId, String ipAddress) {
+		return getPersistence().countByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
 	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * <p>
@@ -983,6 +1064,61 @@ public class DDMFormInstanceRecordUtil {
 	}
 
 	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return getPersistence().findByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
+	/**
 	 * Returns all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * @param formInstanceId the form instance ID
@@ -1050,4 +1186,4 @@ public class DDMFormInstanceRecordUtil {
 	private static volatile DDMFormInstanceRecordPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-20287883
+// LIFERAY-SERVICE-BUILDER-HASH:-945613383

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
@@ -571,87 +571,6 @@ public class DDMFormInstanceRecordUtil {
 	}
 
 	/**
-	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching ddm form instance records
-	 */
-	public static List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
-		boolean useFinderCache) {
-
-		return getPersistence().findByF_I(
-			formInstanceId, ipAddress, start, end, orderByComparator,
-			useFinderCache);
-	}
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record
-	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
-	 */
-	public static DDMFormInstanceRecord findByF_I_First(
-			long formInstanceId, String ipAddress,
-			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
-		throws com.liferay.dynamic.data.mapping.exception.
-			NoSuchFormInstanceRecordException {
-
-		return getPersistence().findByF_I_First(
-			formInstanceId, ipAddress, orderByComparator);
-	}
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
-	 */
-	public static DDMFormInstanceRecord fetchByF_I_First(
-		long formInstanceId, String ipAddress,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return getPersistence().fetchByF_I_First(
-			formInstanceId, ipAddress, orderByComparator);
-	}
-
-	/**
-	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 */
-	public static void removeByF_I(long formInstanceId, String ipAddress) {
-		getPersistence().removeByF_I(formInstanceId, ipAddress);
-	}
-
-	/**
-	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @return the number of matching ddm form instance records
-	 */
-	public static int countByF_I(long formInstanceId, String ipAddress) {
-		return getPersistence().countByF_I(formInstanceId, ipAddress);
-	}
-
-	/**
 	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * <p>
@@ -734,6 +653,87 @@ public class DDMFormInstanceRecordUtil {
 		long formInstanceId, String formInstanceVersion) {
 
 		return getPersistence().countByF_F(formInstanceId, formInstanceVersion);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws com.liferay.dynamic.data.mapping.exception.
+			NoSuchFormInstanceRecordException {
+
+		return getPersistence().findByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().fetchByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public static void removeByF_I(long formInstanceId, String ipAddress) {
+		getPersistence().removeByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public static int countByF_I(long formInstanceId, String ipAddress) {
+		return getPersistence().countByF_I(formInstanceId, ipAddress);
 	}
 
 	/**
@@ -1064,61 +1064,6 @@ public class DDMFormInstanceRecordUtil {
 	}
 
 	/**
-	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @return the matching ddm form instance records
-	 */
-	public static List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress) {
-
-		return getPersistence().findByF_I(formInstanceId, ipAddress);
-	}
-
-	/**
-	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @return the range of matching ddm form instance records
-	 */
-	public static List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end) {
-
-		return getPersistence().findByF_I(
-			formInstanceId, ipAddress, start, end);
-	}
-
-	/**
-	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @return the ordered range of matching ddm form instance records
-	 */
-	public static List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return getPersistence().findByF_I(
-			formInstanceId, ipAddress, start, end, orderByComparator);
-	}
-
-	/**
 	 * Returns all the ddm form instance records where formInstanceId = &#63; and formInstanceVersion = &#63;.
 	 *
 	 * @param formInstanceId the form instance ID
@@ -1173,6 +1118,61 @@ public class DDMFormInstanceRecordUtil {
 			formInstanceId, formInstanceVersion, start, end, orderByComparator);
 	}
 
+	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return getPersistence().findByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
 	public static DDMFormInstanceRecordPersistence getPersistence() {
 		return _persistence;
 	}
@@ -1186,4 +1186,4 @@ public class DDMFormInstanceRecordUtil {
 	private static volatile DDMFormInstanceRecordPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-945613383
+// LIFERAY-SERVICE-BUILDER-HASH:-912639907

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
@@ -17,10 +17,10 @@ import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -45,27 +45,14 @@ public class DDMFormGuestUploadFieldUtil {
 			return false;
 		}
 
-		int count = 0;
-
 		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService =
 			_ddmFormInstanceRecordLocalServiceSnapshot.get();
 
-		for (DDMFormInstanceRecord ddmFormInstanceRecord :
-				ddmFormInstanceRecordLocalService.getFormInstanceRecords(
-					ddmFormInstance.getFormInstanceId(),
-					WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null)) {
+		int count = ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+				ddmFormInstance.getFormInstanceId(),
+				httpServletRequest.getRemoteAddr());
 
-			if (Objects.equals(
-					ddmFormInstanceRecord.getIpAddress(),
-					httpServletRequest.getRemoteAddr()) &&
-				(++count == guestUploadMaximumSubmissions)) {
-
-				return true;
-			}
-		}
-
-		return false;
+		return count >= guestUploadMaximumSubmissions;
 	}
 
 	protected static boolean hasGuestUploadField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
@@ -8,10 +8,8 @@ package com.liferay.dynamic.data.mapping.form.web.internal.display.context.util;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
-import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -20,7 +18,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -48,11 +45,16 @@ public class DDMFormGuestUploadFieldUtil {
 		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService =
 			_ddmFormInstanceRecordLocalServiceSnapshot.get();
 
-		int count = ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+		int count =
+			ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
 				ddmFormInstance.getFormInstanceId(),
 				httpServletRequest.getRemoteAddr());
 
-		return count >= guestUploadMaximumSubmissions;
+		if (count >= guestUploadMaximumSubmissions) {
+			return true;
+		}
+
+		return false;
 	}
 
 	protected static boolean hasGuestUploadField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
@@ -268,13 +268,13 @@
 			<finder-column name="userId" />
 			<finder-column name="formInstanceId" />
 		</finder>
-		<finder name="F_I" return-type="Collection">
-			<finder-column name="formInstanceId" />
-			<finder-column name="ipAddress" />
-		</finder>
 		<finder name="F_F" return-type="Collection">
 			<finder-column name="formInstanceId" />
 			<finder-column name="formInstanceVersion" />
+		</finder>
+		<finder name="F_I" return-type="Collection">
+			<finder-column name="formInstanceId" />
+			<finder-column name="ipAddress" />
 		</finder>
 	</entity>
 	<entity local-service="true" name="DDMFormInstanceRecordVersion" remote-service="true">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
@@ -268,6 +268,10 @@
 			<finder-column name="userId" />
 			<finder-column name="formInstanceId" />
 		</finder>
+		<finder name="F_I" return-type="Collection">
+			<finder-column name="formInstanceId" />
+			<finder-column name="ipAddress" />
+		</finder>
 		<finder name="F_F" return-type="Collection">
 			<finder-column name="formInstanceId" />
 			<finder-column name="formInstanceVersion" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceRecordModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceRecordModelImpl.java
@@ -149,20 +149,26 @@ public class DDMFormInstanceRecordModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 16L;
+	public static final long IPADDRESS_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
+	public static final long USERID_COLUMN_BITMASK = 32L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long FORMINSTANCERECORDID_COLUMN_BITMASK = 64L;
+	public static final long FORMINSTANCERECORDID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -791,6 +797,15 @@ public class DDMFormInstanceRecordModelImpl
 		_ipAddress = ipAddress;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalIpAddress() {
+		return getColumnOriginalValue("ipAddress");
+	}
+
 	@JSON
 	@Override
 	public Date getLastPublishDate() {
@@ -1314,4 +1329,4 @@ public class DDMFormInstanceRecordModelImpl
 	private DDMFormInstanceRecord _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:593226394
+// LIFERAY-SERVICE-BUILDER-HASH:1388686114

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
@@ -294,15 +294,6 @@ public class DDMFormInstanceRecordLocalServiceImpl
 
 	@Override
 	public List<DDMFormInstanceRecord> getFormInstanceRecords(
-		long ddmFormInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return ddmFormInstanceRecordPersistence.findByF_I(
-			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
-	}
-
-	@Override
-	public List<DDMFormInstanceRecord> getFormInstanceRecords(
 		long ddmFormInstanceId, long userId, int start, int end,
 		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
 
@@ -311,15 +302,18 @@ public class DDMFormInstanceRecordLocalServiceImpl
 	}
 
 	@Override
-	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
-		return ddmFormInstanceRecordPersistence.countByFormInstanceId(
-			ddmFormInstanceId);
+	public List<DDMFormInstanceRecord> getFormInstanceRecords(
+		long ddmFormInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return ddmFormInstanceRecordPersistence.findByF_I(
+			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
 	}
 
 	@Override
-	public int getFormInstanceRecordsCount(long ddmFormInstanceId, String ipAddress) {
-		return ddmFormInstanceRecordPersistence.countByF_I(
-			ddmFormInstanceId, ipAddress);
+	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
+		return ddmFormInstanceRecordPersistence.countByFormInstanceId(
+			ddmFormInstanceId);
 	}
 
 	@Override
@@ -334,6 +328,14 @@ public class DDMFormInstanceRecordLocalServiceImpl
 
 		return ddmFormInstanceRecordPersistence.countByU_F(
 			userId, ddmFormInstanceId);
+	}
+
+	@Override
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return ddmFormInstanceRecordPersistence.countByF_I(
+			ddmFormInstanceId, ipAddress);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
@@ -302,15 +302,6 @@ public class DDMFormInstanceRecordLocalServiceImpl
 	}
 
 	@Override
-	public List<DDMFormInstanceRecord> getFormInstanceRecords(
-		long ddmFormInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return ddmFormInstanceRecordPersistence.findByF_I(
-			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
-	}
-
-	@Override
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return ddmFormInstanceRecordPersistence.countByFormInstanceId(
 			ddmFormInstanceId);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
@@ -294,6 +294,15 @@ public class DDMFormInstanceRecordLocalServiceImpl
 
 	@Override
 	public List<DDMFormInstanceRecord> getFormInstanceRecords(
+		long ddmFormInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return ddmFormInstanceRecordPersistence.findByF_I(
+			ddmFormInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstanceRecord> getFormInstanceRecords(
 		long ddmFormInstanceId, long userId, int start, int end,
 		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
 
@@ -305,6 +314,12 @@ public class DDMFormInstanceRecordLocalServiceImpl
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId) {
 		return ddmFormInstanceRecordPersistence.countByFormInstanceId(
 			ddmFormInstanceId);
+	}
+
+	@Override
+	public int getFormInstanceRecordsCount(long ddmFormInstanceId, String ipAddress) {
+		return ddmFormInstanceRecordPersistence.countByF_I(
+			ddmFormInstanceId, ipAddress);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
@@ -597,99 +597,6 @@ public class DDMFormInstanceRecordPersistenceImpl
 
 	private CollectionPersistenceFinder
 		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
-			_collectionPersistenceFinderByF_I;
-
-	/**
-	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * <p>
-	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DDMFormInstanceRecordModelImpl</code>.
-	 * </p>
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param start the lower bound of the range of ddm form instance records
-	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
-	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the ordered range of matching ddm form instance records
-	 */
-	@Override
-	public List<DDMFormInstanceRecord> findByF_I(
-		long formInstanceId, String ipAddress, int start, int end,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
-		boolean useFinderCache) {
-
-		return _collectionPersistenceFinderByF_I.find(
-			finderCache, new Object[] {formInstanceId, ipAddress}, start, end,
-			orderByComparator, useFinderCache);
-	}
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record
-	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
-	 */
-	@Override
-	public DDMFormInstanceRecord findByF_I_First(
-			long formInstanceId, String ipAddress,
-			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
-		throws NoSuchFormInstanceRecordException {
-
-		return _collectionPersistenceFinderByF_I.findFirst(
-			finderCache, new Object[] {formInstanceId, ipAddress},
-			orderByComparator);
-	}
-
-	/**
-	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
-	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
-	 */
-	@Override
-	public DDMFormInstanceRecord fetchByF_I_First(
-		long formInstanceId, String ipAddress,
-		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
-
-		return _collectionPersistenceFinderByF_I.fetchFirst(
-			finderCache, new Object[] {formInstanceId, ipAddress},
-			orderByComparator);
-	}
-
-	/**
-	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 */
-	@Override
-	public void removeByF_I(long formInstanceId, String ipAddress) {
-		_collectionPersistenceFinderByF_I.remove(
-			finderCache, new Object[] {formInstanceId, ipAddress});
-	}
-
-	/**
-	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
-	 *
-	 * @param formInstanceId the form instance ID
-	 * @param ipAddress the ip address
-	 * @return the number of matching ddm form instance records
-	 */
-	@Override
-	public int countByF_I(long formInstanceId, String ipAddress) {
-		return _collectionPersistenceFinderByF_I.count(
-			finderCache, new Object[] {formInstanceId, ipAddress});
-	}
-
-	private CollectionPersistenceFinder
-		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
 			_collectionPersistenceFinderByF_F;
 
 	/**
@@ -779,6 +686,99 @@ public class DDMFormInstanceRecordPersistenceImpl
 	public int countByF_F(long formInstanceId, String formInstanceVersion) {
 		return _collectionPersistenceFinderByF_F.count(
 			finderCache, new Object[] {formInstanceId, formInstanceVersion});
+	}
+
+	private CollectionPersistenceFinder
+		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
+			_collectionPersistenceFinderByF_I;
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	@Override
+	public List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByF_I.find(
+			finderCache, new Object[] {formInstanceId, ipAddress}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException {
+
+		return _collectionPersistenceFinderByF_I.findFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return _collectionPersistenceFinderByF_I.fetchFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	@Override
+	public void removeByF_I(long formInstanceId, String ipAddress) {
+		_collectionPersistenceFinderByF_I.remove(
+			finderCache, new Object[] {formInstanceId, ipAddress});
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	@Override
+	public int countByF_I(long formInstanceId, String ipAddress) {
+		return _collectionPersistenceFinderByF_I.count(
+			finderCache, new Object[] {formInstanceId, ipAddress});
 	}
 
 	public DDMFormInstanceRecordPersistenceImpl() {
@@ -1256,37 +1256,6 @@ public class DDMFormInstanceRecordPersistenceImpl
 				FinderColumn.Type.LONG, "=", true, true,
 				DDMFormInstanceRecord::getFormInstanceId));
 
-		_collectionPersistenceFinderByF_I = new CollectionPersistenceFinder<>(
-			this,
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByF_I",
-				new String[] {
-					Long.class.getName(), String.class.getName(),
-					Integer.class.getName(), Integer.class.getName(),
-					OrderByComparator.class.getName()
-				},
-				new String[] {"formInstanceId", "ipAddress"}, true),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByF_I",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"formInstanceId", "ipAddress"}, 0, 2, true, null),
-			new FinderPath(
-				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByF_I",
-				new String[] {Long.class.getName(), String.class.getName()},
-				new String[] {"formInstanceId", "ipAddress"}, 0, 2, false,
-				null),
-			_SQL_SELECT_DDMFORMINSTANCERECORD_WHERE,
-			_SQL_COUNT_DDMFORMINSTANCERECORD_WHERE,
-			DDMFormInstanceRecordModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
-			"",
-			new FinderColumn<>(
-				"ddmFormInstanceRecord.", "formInstanceId",
-				FinderColumn.Type.LONG, "=", true, true,
-				DDMFormInstanceRecord::getFormInstanceId),
-			new FinderColumn<>(
-				"ddmFormInstanceRecord.", "ipAddress", FinderColumn.Type.STRING,
-				"=", true, true, DDMFormInstanceRecord::getIpAddress));
-
 		_collectionPersistenceFinderByF_F = new CollectionPersistenceFinder<>(
 			this,
 			new FinderPath(
@@ -1319,6 +1288,37 @@ public class DDMFormInstanceRecordPersistenceImpl
 				"ddmFormInstanceRecord.", "formInstanceVersion",
 				FinderColumn.Type.STRING, "=", true, true,
 				DDMFormInstanceRecord::getFormInstanceVersion));
+
+		_collectionPersistenceFinderByF_I = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByF_I",
+				new String[] {
+					Long.class.getName(), String.class.getName(),
+					Integer.class.getName(), Integer.class.getName(),
+					OrderByComparator.class.getName()
+				},
+				new String[] {"formInstanceId", "ipAddress"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, true, null),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, false,
+				null),
+			_SQL_SELECT_DDMFORMINSTANCERECORD_WHERE,
+			_SQL_COUNT_DDMFORMINSTANCERECORD_WHERE,
+			DDMFormInstanceRecordModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+			"",
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "formInstanceId",
+				FinderColumn.Type.LONG, "=", true, true,
+				DDMFormInstanceRecord::getFormInstanceId),
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "ipAddress", FinderColumn.Type.STRING,
+				"=", true, true, DDMFormInstanceRecord::getIpAddress));
 
 		DDMFormInstanceRecordUtil.setPersistence(this);
 	}
@@ -1392,4 +1392,4 @@ public class DDMFormInstanceRecordPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-162177615
+// LIFERAY-SERVICE-BUILDER-HASH:-210569973

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
@@ -597,6 +597,99 @@ public class DDMFormInstanceRecordPersistenceImpl
 
 	private CollectionPersistenceFinder
 		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
+			_collectionPersistenceFinderByF_I;
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	@Override
+	public List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByF_I.find(
+			finderCache, new Object[] {formInstanceId, ipAddress}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException {
+
+		return _collectionPersistenceFinderByF_I.findFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return _collectionPersistenceFinderByF_I.fetchFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	@Override
+	public void removeByF_I(long formInstanceId, String ipAddress) {
+		_collectionPersistenceFinderByF_I.remove(
+			finderCache, new Object[] {formInstanceId, ipAddress});
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	@Override
+	public int countByF_I(long formInstanceId, String ipAddress) {
+		return _collectionPersistenceFinderByF_I.count(
+			finderCache, new Object[] {formInstanceId, ipAddress});
+	}
+
+	private CollectionPersistenceFinder
+		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
 			_collectionPersistenceFinderByF_F;
 
 	/**
@@ -1163,6 +1256,37 @@ public class DDMFormInstanceRecordPersistenceImpl
 				FinderColumn.Type.LONG, "=", true, true,
 				DDMFormInstanceRecord::getFormInstanceId));
 
+		_collectionPersistenceFinderByF_I = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByF_I",
+				new String[] {
+					Long.class.getName(), String.class.getName(),
+					Integer.class.getName(), Integer.class.getName(),
+					OrderByComparator.class.getName()
+				},
+				new String[] {"formInstanceId", "ipAddress"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, true, null),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, false,
+				null),
+			_SQL_SELECT_DDMFORMINSTANCERECORD_WHERE,
+			_SQL_COUNT_DDMFORMINSTANCERECORD_WHERE,
+			DDMFormInstanceRecordModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+			"",
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "formInstanceId",
+				FinderColumn.Type.LONG, "=", true, true,
+				DDMFormInstanceRecord::getFormInstanceId),
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "ipAddress", FinderColumn.Type.STRING,
+				"=", true, true, DDMFormInstanceRecord::getIpAddress));
+
 		_collectionPersistenceFinderByF_F = new CollectionPersistenceFinder<>(
 			this,
 			new FinderPath(
@@ -1268,4 +1392,4 @@ public class DDMFormInstanceRecordPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1624523404
+// LIFERAY-SERVICE-BUILDER-HASH:-162177615

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/indexes.sql
@@ -25,6 +25,7 @@ create unique index IX_EAB7A400 on DDMFormInstance (uuid_[$COLUMN_LENGTH:75$], g
 
 create index IX_5BC982B on DDMFormInstanceRecord (companyId);
 create index IX_242301EA on DDMFormInstanceRecord (formInstanceId, formInstanceVersion[$COLUMN_LENGTH:75$]);
+create index IX_2C10D58 on DDMFormInstanceRecord (formInstanceId, ipAddress[$COLUMN_LENGTH:75$]);
 create index IX_3C8DBDFF on DDMFormInstanceRecord (formInstanceId, userId);
 create unique index IX_90833BB1 on DDMFormInstanceRecord (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/service.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.dynamic.data.mapping.service
-    build.number=3
-    build.date=1776296275274
+    build.number=4
+    build.date=1781103841629

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
@@ -273,21 +273,21 @@ public class DDMFormInstanceRecordPersistenceTest {
 	}
 
 	@Test
-	public void testCountByF_I() throws Exception {
-		_persistence.countByF_I(RandomTestUtil.nextLong(), "");
-
-		_persistence.countByF_I(0L, "null");
-
-		_persistence.countByF_I(0L, (String)null);
-	}
-
-	@Test
 	public void testCountByF_F() throws Exception {
 		_persistence.countByF_F(RandomTestUtil.nextLong(), "");
 
 		_persistence.countByF_F(0L, "null");
 
 		_persistence.countByF_F(0L, (String)null);
+	}
+
+	@Test
+	public void testCountByF_I() throws Exception {
+		_persistence.countByF_I(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByF_I(0L, "null");
+
+		_persistence.countByF_I(0L, (String)null);
 	}
 
 	@Test
@@ -685,4 +685,4 @@ public class DDMFormInstanceRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1419534999
+// LIFERAY-SERVICE-BUILDER-HASH:2100464873

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
@@ -273,6 +273,15 @@ public class DDMFormInstanceRecordPersistenceTest {
 	}
 
 	@Test
+	public void testCountByF_I() throws Exception {
+		_persistence.countByF_I(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByF_I(0L, "null");
+
+		_persistence.countByF_I(0L, (String)null);
+	}
+
+	@Test
 	public void testCountByF_F() throws Exception {
 		_persistence.countByF_F(RandomTestUtil.nextLong(), "");
 
@@ -676,4 +685,4 @@ public class DDMFormInstanceRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:920909394
+// LIFERAY-SERVICE-BUILDER-HASH:-1419534999


### PR DESCRIPTION
[LPD-24684](https://liferay.atlassian.net/browse/LPD-24684)

## What Is Being Fixed

For every submission submitted by a guest user (on any form of any site), where guest submissions are allowed and should be limited, there’s a code checking how many times given IP submitted the form before. The code fetches all (!) the past submissions (and all the columns), with any status for the given form. Then it iterates over the resultset in Java, doing an if statement and holding a counter. Then it returns true/false.

For a large number of forms, with a large-enough history of past submissions, this will scale quite badly. Once all the past submissions of all the forms cannot fit into DB cache, they will be refetched / checked / evicted endlessly. 


## How It Is Being Fixed

Since this method always passes STATUS_ANY (no status filtering is actually needed) so we can avoid custom SQL entirely and use a plain Service Builder persistence finder. Adding a new F_I finder (formInstanceId + ipAddress) to service.xml for DDMFormInstanceRecord replaces the current loop with a single indexed COUNT query, regardless of how many submissions a form has.


## PR Check

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0fa24983-ce80-48ac-91f3-f9f510cd7211" />






[LPD-24684]: https://liferay.atlassian.net/browse/LPD-24684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ