### PR TITLE
LPD-79017 Long texts causing the Task History tab layout to break

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
@@ -163,7 +163,7 @@ function HistoryItemDetails({
 						<strong>{fields[auditFieldChange.name].label}:</strong>
 
 						<div className="autofit-padded-no-gutters-x autofit-row autofit-row-center">
-							<div className="autofit-col autofit-col-expand text-secondary">
+							<div className="autofit-col autofit-col-expand flex-wrap text-secondary">
 								{getAuditFieldChangeValueLabel(
 									auditFieldChange.name,
 									auditFieldChange.oldValue
@@ -176,7 +176,7 @@ function HistoryItemDetails({
 								</div>
 							</div>
 
-							<div className="autofit-col autofit-col-expand">
+							<div className="autofit-col autofit-col-expand flex-wrap">
 								{getAuditFieldChangeValueLabel(
 									auditFieldChange.name,
 									auditFieldChange.newValue

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
@@ -163,7 +163,7 @@ function HistoryItemDetails({
 						<strong>{fields[auditFieldChange.name].label}:</strong>
 
 						<div className="autofit-padded-no-gutters-x autofit-row autofit-row-center">
-							<div className="autofit-col text-secondary">
+							<div className="autofit-col autofit-col-expand text-secondary">
 								{getAuditFieldChangeValueLabel(
 									auditFieldChange.name,
 									auditFieldChange.oldValue

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/History.tsx
@@ -163,7 +163,7 @@ function HistoryItemDetails({
 						<strong>{fields[auditFieldChange.name].label}:</strong>
 
 						<div className="autofit-padded-no-gutters-x autofit-row autofit-row-center">
-							<div className="autofit-col autofit-col-expand flex-wrap text-secondary">
+							<div className="autofit-col autofit-col-expand flex-grow-0 flex-wrap text-secondary">
 								{getAuditFieldChangeValueLabel(
 									auditFieldChange.name,
 									auditFieldChange.oldValue
@@ -176,7 +176,7 @@ function HistoryItemDetails({
 								</div>
 							</div>
 
-							<div className="autofit-col autofit-col-expand flex-wrap">
+							<div className="autofit-col autofit-col-expand flex-grow-0 flex-wrap">
 								{getAuditFieldChangeValueLabel(
 									auditFieldChange.name,
 									auditFieldChange.newValue


### PR DESCRIPTION
# Summary of Changes

Make sure that history entries for Projects and Tasks (CMS/CMP) wrap correctly for long and short pieces of text.

# Motivation / Context

[/LPD-79017](https://liferay.atlassian.net/browse/LPD-79017)

Before the fix, adding for example a very long piece of text for the description of a Project or Taks within would show that piece of text in one line, requiring horizontal scrolling.

The fix makes sure that long text is correctly wrapped around giving more horizontal space to longer text. Short texts (like "None" where there's no description for instance) are not split into two lines either.

# Technical Approach

Add classname `autofit-col-expand` also for the "before" column in the history entry like there is for the "after" column.
Leverage classnames `flex-grow-0 flex-wrap` to wrap text and expand horizontally according to the amount of it.

# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [x] Not applicable (visual change not related to loss of information)

**Manual Testing**

1. Enable CMS/CMP (via Feature Flag for the latter).
2. Create a new space.
3. Create a new project. Edit several times to add long and short descriptions.
4. Check the history tab.
- Expected result: No matter how long or short the text, it's displayed without needing to scroll horizontally
- Actual result: Long texts are shown in one line.
The same thing happens for the History section of Tasks within Projects.

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![Project Before](https://github.com/user-attachments/assets/f6a00589-3bc1-418e-9597-48f6ea61d0ec) |![Project After](https://github.com/user-attachments/assets/b661d97a-76e0-4598-8391-05b93d1dfb3e)|
|![Task Before](https://github.com/user-attachments/assets/8e61b7d8-d778-438c-861c-3a11a2a7bbf3)|![Task After](https://github.com/user-attachments/assets/b8d5eb2b-a251-4f8c-9628-f5875b64614c)|


# Alternatives Considered

I considered given half the space to each column (before and after) but it looked weird for short texts on both columns.

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [ ] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.
- [x] `../gradlew -b util.gradle validateBranch`
