### PR TITLE
LPD-94390 Convert hardcoded colors in data-engine SCSS to atlas tokens

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_date-picker.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_date-picker.scss
@@ -1,6 +1,6 @@
 .datepicker {
 	body {
-		background-color: #fff;
+		background-color: $white;
 	}
 
 	.row {
@@ -42,7 +42,7 @@
 	.day {
 		align-items: center;
 		border-radius: 100%;
-		color: #6b6c7e;
+		color: $gray-600;
 		cursor: pointer;
 		display: flex;
 		height: 31px;
@@ -56,12 +56,12 @@
 	}
 
 	.day.active {
-		background-color: #0b5fff;
-		color: #fff !important;
+		background-color: $primary;
+		color: $white !important;
 	}
 
 	.day.outside {
-		color: #a7a9bc;
+		color: $gray-500;
 	}
 
 	.form-caption,
@@ -89,7 +89,7 @@
 	}
 
 	.week {
-		color: #272833;
+		color: $gray-900;
 		font-weight: 600;
 		text-align: center;
 		width: 32px;
@@ -97,8 +97,8 @@
 
 	.extension-time {
 		align-items: center;
-		background-color: rgba(241, 242, 245, 0.5);
-		color: #6b6c7e;
+		background-color: unquote('hsl(from #{$gray-200} h s l / 0.5)');
+		color: $gray-600;
 		display: flex;
 		padding: 16px 32px;
 	}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_field-type-checkbox-switch.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_field-type-checkbox-switch.scss
@@ -17,7 +17,7 @@
 }
 
 .ddm-info {
-	color: #6b6c7e;
+	color: $gray-600;
 	display: flex;
 	font-size: 0.875rem;
 	font-weight: 400;
@@ -28,7 +28,7 @@
 	}
 
 	.ddm-tooltip {
-		color: #6b6c7e;
+		color: $gray-600;
 		padding-left: 0;
 	}
 }

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_image_picker.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_image_picker.scss
@@ -17,10 +17,12 @@
 			border: none;
 
 			> button.close {
-				color: #fff;
+				color: $white;
 
 				&:hover {
-					background-color: rgba(255, 255, 255, 0.1);
+					background-color: unquote(
+						'hsl(from #{$white} h s l / 0.1)'
+					);
 				}
 			}
 		}
@@ -44,7 +46,7 @@
 		top: 0;
 
 		> svg {
-			color: rgba(255, 255, 255, 0.4);
+			color: unquote('hsl(from #{$white} h s l / 0.4)');
 			display: none;
 			height: 40px;
 			left: 48.61%;
@@ -54,7 +56,7 @@
 		}
 
 		&.image-backdor:hover {
-			background-color: rgba(39, 40, 51, 0.5);
+			background-color: unquote('hsl(from #{$gray-900} h s l / 0.5)');
 
 			> svg {
 				display: block;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 @import 'date-picker';
 @import 'field-type-checkbox-switch';
@@ -59,7 +59,7 @@ body .ddm-user-view-content {
 	}
 
 	.multi-step-item.active .multi-step-divider {
-		background-color: #1865fb;
+		background-color: $primary;
 	}
 
 	.multi-step-indicator-label {
@@ -106,14 +106,14 @@ body .ddm-user-view-content {
 		.custom-control-input:checked:disabled
 		~ .custom-control-label::before {
 		background-color: $primary;
-		border-color: #0043c5;
+		border-color: $primary-d1;
 	}
 
 	.custom-checkbox
 		.custom-control-input:checked:disabled
 		~ .custom-control-label::before {
 		background-color: $primary;
-		border-color: #0043c5;
+		border-color: $primary-d1;
 	}
 
 	.form-control:disabled {
@@ -190,7 +190,7 @@ body .ddm-user-view-content {
 	}
 
 	.lfr-ddm-form-field-repeatable-toolbar a {
-		color: #65b6f0;
+		color: $blue-l1;
 		text-decoration: none;
 
 		&:hover {
@@ -300,7 +300,7 @@ body .ddm-user-view-content {
 }
 
 .liferay-ddm-form-field-tip {
-	color: #5b7b86;
+	color: $gray-700;
 	line-height: 16px;
 }
 
@@ -343,10 +343,10 @@ body .ddm-user-view-content {
 
 .multi-step-progress-bar {
 	> .complete {
-		color: #65b6f0;
+		color: $blue-l1;
 
 		.divider {
-			background-color: #65b6f0;
+			background-color: $blue-l1;
 		}
 	}
 }
@@ -369,7 +369,7 @@ body .ddm-user-view-content {
 	position: relative;
 
 	.option-selected-placeholder {
-		color: #6a6c7d;
+		color: $gray-600;
 	}
 
 	.dropdown-menu {
@@ -403,7 +403,7 @@ body .ddm-user-view-content {
 	}
 
 	.search-chosen {
-		border-bottom: 1px solid #e4e9ec;
+		border-bottom: 1px solid $gray-300;
 		position: relative;
 	}
 
@@ -413,12 +413,12 @@ body .ddm-user-view-content {
 		top: 2px;
 
 		a {
-			color: #869cad;
+			color: $gray-500;
 		}
 	}
 
 	&.active .select-field-trigger {
-		border-bottom: 2px solid #65b6f0;
+		border-bottom: 2px solid $blue-l1;
 	}
 
 	.form-control {
@@ -431,7 +431,7 @@ body .ddm-user-view-content {
 	}
 
 	.form-control[disabled]:focus {
-		border-bottom: 2px solid #869cad;
+		border-bottom: 2px solid $gray-500;
 		text-decoration: none;
 	}
 
@@ -543,7 +543,7 @@ body .ddm-user-view-content {
 	}
 
 	fieldset {
-		border: 1px solid rgba(134, 156, 173, 0.4);
+		border: 1px solid unquote('hsl(from #{$gray-500} h s l / 0.4)');
 		border-bottom-width: 0;
 		border-top-width: 0;
 		padding: 10px 10px 0;
@@ -559,7 +559,7 @@ body .ddm-user-view-content {
 
 		legend {
 			border-width: 0;
-			color: #869cad;
+			color: $gray-500;
 			font-size: 12px;
 			font-weight: bold;
 			line-height: 20px;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.scss
@@ -1,9 +1,11 @@
+@import 'atlas-custom-properties/_variables';
+
 .ddm-field-renderer {
 	&--error {
-		background-color: #feefef;
-		border: 2px dashed #f48989;
+		background-color: $danger-l2;
+		border: 2px dashed $danger-l1;
 		border-radius: 4px;
-		color: #da1414;
+		color: $danger;
 		padding: 20px;
 	}
 

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-forms {
 	&__form-view-ddm-target {
 		align-items: center;
@@ -6,7 +8,7 @@
 		width: 100%;
 
 		&.lfr-forms__form-view-ddm-target-over > span {
-			background-color: #0b5fff;
+			background-color: $primary;
 			border-radius: 2px;
 			display: inline-block;
 			height: 2px;
@@ -22,7 +24,7 @@
 		&:focus-within,
 		&:hover {
 			&::after {
-				border: 0.125rem solid #0b5fff;
+				border: 0.125rem solid $primary;
 				border-radius: 0 4px 4px;
 				bottom: -4px;
 				content: '';
@@ -50,10 +52,10 @@
 	}
 
 	&__form-view-field-dragging {
-		background-color: #fff;
-		border: 2px dashed #a7a9bc;
+		background-color: $white;
+		border: 2px dashed $gray-500;
 		border-radius: 4px;
-		box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2);
+		box-shadow: 0 0 3px 0 unquote('hsl(from #{$black} h s l / 0.2)');
 		opacity: 0.7;
 		padding: 2px 6px 6px !important;
 		z-index: 10;
@@ -61,10 +63,10 @@
 
 	&__form-view-field-topbar {
 		align-items: center;
-		background-color: #0b5fff;
+		background-color: $primary;
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
-		color: #fff;
+		color: $white;
 		display: none;
 		font-size: 12px;
 		font-weight: 600;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 $c: '.lfr-de__form-report-sidebar';
 
 #{$c} {
@@ -15,7 +17,7 @@ $c: '.lfr-de__form-report-sidebar';
 	}
 
 	.list-group-item:hover {
-		background-color: #f0f5ff;
+		background-color: $blue-l5;
 	}
 
 	.navbar-collapse {
@@ -35,6 +37,6 @@ $c: '.lfr-de__form-report-sidebar';
 	}
 
 	.sidebar-light {
-		background-color: #fff;
+		background-color: $white;
 	}
 }

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/index.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/index.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 %entries-list {
 	font-size: 14px;
@@ -97,7 +97,7 @@
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent .menubar-toggler {
-		color: #272833;
+		color: $gray-900;
 		font-size: 0.875rem;
 		font-weight: var(--font-weight-semi-bold, 600);
 		text-decoration: none;
@@ -105,14 +105,14 @@
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent .menubar-collapse {
-		background-color: #fff;
-		border-color: #e7e7ed;
+		background-color: $white;
+		border-color: $gray-300;
 		border-radius: 0.25rem;
-		box-shadow: 0 1px 5px -1px rgb(0 0 0 / 30%);
+		box-shadow: 0 1px 5px -1px unquote('hsl(from #{$black} h s l / 0.3)');
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent {
-		background-color: #fff;
+		background-color: $white;
 		z-index: 1;
 	}
 
@@ -176,12 +176,12 @@
 }
 
 .document-title-link {
-	color: #272833;
+	color: $gray-900;
 	font-size: 0.875rem;
 	font-weight: 600;
 
 	&:hover {
-		color: #272833;
+		color: $gray-900;
 	}
 }
 
@@ -361,7 +361,7 @@
 		.custom-tooltip {
 			background: $secondary-d1;
 			border-radius: 4px;
-			box-shadow: 0 2px 4px rgba(39, 40, 51, 0.2);
+			box-shadow: 0 2px 4px unquote('hsl(from #{$gray-900} h s l / 0.2)');
 			color: $white;
 			display: flex;
 			flex-direction: column;
@@ -394,7 +394,7 @@
 			}
 
 			.header {
-				border-bottom: 1px solid #ccc;
+				border-bottom: 1px solid $gray-400;
 				font-size: 13px;
 				font-weight: 600;
 				font-weight: 600;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_ddm_form_builder.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_ddm_form_builder.scss
@@ -37,7 +37,7 @@
 
 		.ddm-drag {
 			&.dragging {
-				background-color: #fff;
+				background-color: $white;
 				padding: 2px 6px 6px !important;
 			}
 		}
@@ -74,7 +74,7 @@
 
 			&.targetOver:after,
 			&.target-over:after {
-				background-color: #0b5fff;
+				background-color: $primary;
 				border-radius: 2px;
 				bottom: 0;
 				content: '';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_modal_editor.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_modal_editor.scss
@@ -14,6 +14,6 @@
 	}
 
 	.modal-body:nth-child(3) {
-		background-color: #f1f2f5;
+		background-color: $gray-200;
 	}
 }

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_rule_item.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_rule_item.scss
@@ -18,7 +18,7 @@
 
 		.panel-unstyled {
 			border-bottom-width: 1px;
-			border-color: #e7e7ed;
+			border-color: $gray-300;
 			margin-bottom: 0;
 
 			.panel-header {
@@ -38,12 +38,12 @@
 		}
 
 		.panel-unstyled:hover {
-			background-color: #f0f5ff;
+			background-color: $blue-l5;
 		}
 	}
 
 	hr {
-		border: 0.5px solid #e7e7ed;
+		border: 0.5px solid $gray-300;
 		margin-bottom: 0;
 		margin-top: 0;
 		width: 100%;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,6 @@
+@import 'atlas-custom-properties/_variables';
+@import 'atlas-variables';
+
 @import 'variables';
 
 @import 'components/ddm_form_builder';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetModal.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetModal.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @import '../../../css/variables';
 
 .fieldset-modal {
@@ -33,8 +35,8 @@
 	}
 
 	.lfr-ddm-form-container:not(.ddm-user-view-content) {
-		background-color: white;
-		border: 1px solid #e7e7ed;
+		background-color: $white;
+		border: 1px solid $gray-300;
 		border-radius: 0.25rem;
 		margin: 1.5rem auto;
 		padding: 0 1.5rem;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
@@ -1,7 +1,9 @@
+@import 'atlas-custom-properties/_variables';
+
 @import '../../../css/variables';
 
-$fieldTypeFieldGroup: #0b5fff;
-$fieldTypeFieldSet: #5aca75;
+$fieldTypeFieldGroup: $primary;
+$fieldTypeFieldSet: $success;
 
 .field-type {
 	border: 2px solid transparent;
@@ -17,8 +19,8 @@ $fieldTypeFieldSet: #5aca75;
 
 	&:focus,
 	&:hover:not(.disabled) {
-		border-color: #80acff;
-		box-shadow: 0 2px 4px rgba(39, 40, 51, 0.12);
+		border-color: $blue-l2;
+		box-shadow: 0 2px 4px unquote('hsl(from #{$gray-900} h s l / 0.12)');
 		outline: none;
 	}
 
@@ -27,13 +29,13 @@ $fieldTypeFieldSet: #5aca75;
 	}
 
 	&.dragging {
-		background-color: #e7e7ed;
+		background-color: $gray-300;
 		opacity: 0.5;
 	}
 
 	.sticker {
-		background-color: #f7f8f9;
-		color: #6b6c7e;
+		background-color: $gray-100;
+		color: $gray-600;
 	}
 
 	.list-group-subtitle {
@@ -55,9 +57,9 @@ $fieldTypeFieldSet: #5aca75;
 	max-width: 280px;
 
 	.field-type {
-		background-color: #fff;
-		border-color: #80acff;
-		box-shadow: 0 8px 16px rgba(39, 40, 51, 0.16);
+		background-color: $white;
+		border-color: $blue-l2;
+		box-shadow: 0 8px 16px unquote('hsl(from #{$gray-900} h s l / 0.16)');
 		cursor: grabbing;
 	}
 }
@@ -66,11 +68,11 @@ $fieldTypeFieldSet: #5aca75;
 	.field-type-fieldgroup {
 		.field-type-header {
 			&:hover {
-				background-color: rgba($fieldTypeFieldGroup, 0.05) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)') !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: rgba($fieldTypeFieldGroup, 0.1) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)') !important;
 
 				.sticker-overlay {
 					svg {
@@ -81,18 +83,18 @@ $fieldTypeFieldSet: #5aca75;
 		}
 
 		.field-type-item:before {
-			border-color: rgba($fieldTypeFieldGroup, 0.2);
+			border-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)');
 		}
 	}
 
 	.field-type-fieldset {
 		.field-type-header {
 			&:hover {
-				background-color: rgba($fieldTypeFieldSet, 0.1) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.1)') !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: rgba($fieldTypeFieldSet, 0.2) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)') !important;
 
 				.sticker-overlay {
 					svg {
@@ -103,7 +105,7 @@ $fieldTypeFieldSet: #5aca75;
 		}
 
 		.field-type-item:before {
-			border-color: rgba($fieldTypeFieldSet, 0.2);
+			border-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)');
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
@@ -68,11 +68,15 @@ $fieldTypeFieldSet: $success;
 	.field-type-fieldgroup {
 		.field-type-header {
 			&:hover {
-				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)'
+				) !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)'
+				) !important;
 
 				.sticker-overlay {
 					svg {
@@ -83,18 +87,24 @@ $fieldTypeFieldSet: $success;
 		}
 
 		.field-type-item:before {
-			border-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)');
+			border-color: unquote(
+				'hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)'
+			);
 		}
 	}
 
 	.field-type-fieldset {
 		.field-type-header {
 			&:hover {
-				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.1)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldSet} h s l / 0.1)'
+				) !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldSet} h s l / 0.2)'
+				) !important;
 
 				.sticker-overlay {
 					svg {
@@ -105,7 +115,9 @@ $fieldTypeFieldSet: $success;
 		}
 
 		.field-type-item:before {
-			border-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)');
+			border-color: unquote(
+				'hsl(from #{$fieldTypeFieldSet} h s l / 0.2)'
+			);
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Calculator.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Calculator.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	.liferay-ddm-form-builder-calculator {
 		align-content: center;
@@ -7,7 +9,7 @@
 	}
 
 	.calculate-container {
-		background-color: #f8f8f8;
+		background-color: $gray-100;
 		display: flex;
 		flex-wrap: wrap;
 		margin-top: 15px;
@@ -18,10 +20,10 @@
 		padding: 8px 25px 25px;
 
 		textarea {
-			background-color: #f5f5f5;
-			border: 1px solid #ccc;
+			background-color: $gray-200;
+			border: 1px solid $gray-400;
 			border-radius: 2px;
-			color: #333;
+			color: $gray-900;
 			font-family: Menlo;
 			font-size: 13px;
 			min-height: 200px;
@@ -97,9 +99,9 @@
 				}
 
 				.calculator-add-operator-button-area {
-					background-color: #fff;
-					border: solid 1px #cdced9;
-					color: #6b6c7e;
+					background-color: $white;
+					border: solid 1px $gray-400;
+					color: $gray-600;
 
 					.calculator-add-operator-button {
 						height: 50px;
@@ -117,7 +119,7 @@
 						}
 
 						.drop-chosen {
-							border: solid 1px #dde1e3;
+							border: solid 1px $gray-300;
 							border-radius: 4px;
 							left: -17px;
 							padding: 5px 0;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Editor.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Editor.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	// Autofill
 
@@ -15,8 +17,8 @@
 		}
 
 		.data-provider-parameter-container {
-			background-color: #f8f8f8;
-			border-top: 1px solid #dce0e3;
+			background-color: $gray-100;
+			border-top: 1px solid $gray-300;
 			margin-top: 15px;
 			padding: 20px 55px;
 		}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	margin: 0;
 
@@ -8,7 +10,7 @@
 	}
 
 	.timeline-item {
-		color: #869cad;
+		color: $gray-500;
 		position: relative;
 
 		&:hover > .container-trash {
@@ -16,11 +18,11 @@
 		}
 
 		&:not(:nth-of-type(1)) .timeline-icon {
-			background-color: #6b6c7e;
+			background-color: $gray-600;
 		}
 
 		.timeline-icon {
-			border: 2px solid #6b6c7e;
+			border: 2px solid $gray-600;
 			margin-right: 2px;
 		}
 
@@ -33,7 +35,7 @@
 			top: 13px;
 
 			&:hover {
-				color: #65b6f0;
+				color: $blue-l1;
 			}
 		}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
@@ -137,7 +137,9 @@ $zIndexPanel: 1;
 				&:active,
 				&:focus,
 				&:hover {
-					background-color: unquote('hsl(from #{$white} h s l / 0.06)');
+					background-color: unquote(
+						'hsl(from #{$white} h s l / 0.06)'
+					);
 					color: $white;
 				}
 			}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
@@ -1,5 +1,7 @@
-@import '../../../css/variables';
+@import 'atlas-custom-properties/_variables';
 @import 'atlas-variables';
+
+@import '../../../css/variables';
 
 $defaultTransitionDuration: 0.5s;
 $toolbarDesktopHeight: 64px;
@@ -73,7 +75,7 @@ $zIndexPanel: 1;
 				box-shadow:
 					0 0 0 0.125rem $white,
 					0 0 0 0.25rem $primary-l1,
-					inset 0 0 fade-out($black, 1);
+					inset 0 0 unquote('hsl(from #{$black} h s l / 0)');
 				outline: none;
 			}
 		}
@@ -135,7 +137,7 @@ $zIndexPanel: 1;
 				&:active,
 				&:focus,
 				&:hover {
-					background-color: fade-out($white, 0.94);
+					background-color: unquote('hsl(from #{$white} h s l / 0.06)');
 					color: $white;
 				}
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94390

## What Is Being Fixed

SCSS files in the data-engine modules (`data-engine-js-components-web` and `data-engine-taglib`) carried hardcoded color literals (hex values, rgb/rgba, and the Sass `fade-out()` / 2-arg `rgba($var, α)` color functions) and imported the legacy `atlas-variables` partial. Because the colors were baked in at compile time, the data-engine form renderer, taglib UIs, and form report views did not respond to dark-mode theming, which is driven by atlas-custom-properties CSS variables.

## How It Is Being Fixed

The change rewrites 18 SCSS files across the two modules to use atlas-custom-properties tokens in place of raw hex values. Each top-level entry SCSS file imports `atlas-custom-properties/_variables` instead of (or alongside) `atlas-variables`. Hex literals map to their closest atlas gray or theme token; where no exact match exists, the nearest token is chosen (e.g., `#f8f8f8` → `$gray-100`, `#dde1e3` → `$gray-300`). Sass color functions that pre-resolve a variable at compile time — `fade-out($black, X)` and the 2-arg `rgba($var, α)` form — are replaced with the CSS-native `hsl(from <var> h s l / α)` relative-color syntax wrapped in `unquote()`, so the atlas custom properties stay reactive at runtime instead of getting flattened to a stale RGB triple.

## Why Are There No Tests?

This is a CSS-only token refactor: SCSS color values are mapped onto atlas-custom-properties without changing component behavior. There is no runtime logic to cover, and the visual result is verified against the existing form builder, form editor, and form report screens.

## PR Check

**pr-check: PASS** — tested on `ceed986d89f7d6ae262b7dda890680d7e01df790`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ceed986d89f7d6ae262b7dda890680d7e01df790"} -->