### PR TITLE
LPD-94534 Fix repeatable field Poshi locators after redesign

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
@@ -107,12 +107,12 @@
 </tr>
 <tr>
 	<td>REPEATABLE_FIELD_ADD_BUTTON_INDEXED</td>
-	<td>xpath=(//*[name()='label' or name()='legend'][normalize-space(text())='${key_fieldLabel}']/ancestor::div[contains(@class,'form-group')]//div[contains(@class,'repeatable-toolbar')]//button[contains(@class,'repeatable-add-button')])[${index}]</td>
+	<td>xpath=(//*[name()='label' or name()='legend'][normalize-space(text())='${key_fieldLabel}']/ancestor::div[contains(@class,'form-group')]//button[contains(@class,'repeatable-add-button')])[${index}]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>REPEATABLE_FIELD_DELETE_BUTTON_INDEXED</td>
-	<td>xpath=(//*[name()='label' or name()='legend'][normalize-space(text())='${key_fieldLabel}']/ancestor::div[contains(@class,'form-group')]//div[contains(@class,'repeatable-toolbar')]//button[contains(@class,'repeatable-delete-button')])[${index}]</td>
+	<td>xpath=(//*[name()='label' or name()='legend'][normalize-space(text())='${key_fieldLabel}']/ancestor::div[contains(@class,'form-group')]//button[contains(@class,'repeatable-delete-button')])[${index}]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94534

## What Is Being Fixed

Poshi tests that add or remove a repetition on a Data Engine field fail with `ElementNotFoundPoshiRunnerException` on the add button — e.g. `RichTextField#ExcludeRepeatedRichTextOnWebContent` and `DEUploadField#CanInputDataOnDuplicatedField`. LPD-58342 ("Apply new Repeatable Field design to repeatable DDM fields", commit dc42538) removed the `lfr-ddm-form-field-repeatable-toolbar` wrapper div from `ReactFieldBase.js`, but the locators `REPEATABLE_FIELD_ADD_BUTTON_INDEXED` and `REPEATABLE_FIELD_DELETE_BUTTON_INDEXED` still anchored on `//div[contains(@class,'repeatable-toolbar')]`, which no longer exists.

## How It Is Being Fixed

Removed the obsolete `//div[contains(@class,'repeatable-toolbar')]` segment from both locators in `DataEngineRenderer.path`. The add and delete buttons still carry the `repeatable-add-button` and `repeatable-delete-button` classes and remain inside the field `form-group`, so the trimmed xpath resolves under the new layout. The locator is backward compatible — it matches whether or not the old toolbar wrapper is present.

## Why Are There No Tests?

This PR only changes Poshi test locators; there is no product code change to cover with new tests. It was validated by running the affected Poshi tests against a local bundle: `RichTextField#ExcludeRepeatedRichTextOnWebContent`, `DEUploadField#CanInputDataOnDuplicatedField`, `DEColorField#CanInputDataOnDuplicatedField`, and `DEMultipleSelectionField#CanInputDataOnDuplicatedField` all pass.

## PR Check

**pr-check: PASS** — tested on `64199951161f15805f967048ddc4c5f1bcea2624`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "64199951161f15805f967048ddc4c5f1bcea2624"} -->
