### PR TITLE
LPD-94544 Fix date input locator for repeated fields after redesign

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
@@ -47,7 +47,7 @@
 </tr>
 <tr>
 	<td>DATE_INPUT_INDEXED</td>
-	<td>xpath=(//label[normalize-space(text())='${key_fieldLabel}']//following-sibling::div/div[contains(@class, 'date-picker')]//input[contains(@type, 'text')])[${index}]</td>
+	<td>xpath=(//label[normalize-space(text())='${key_fieldLabel}']//following-sibling::div//div[contains(@class, 'date-picker')]//input[contains(@type, 'text')])[${index}]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94544

## What Is Being Fixed

`DEDateField#CanInputDataOnDuplicatedField` fails with `ElementNotFoundPoshiRunnerException` on the date input locator `DATE_INPUT_INDEXED`. The new Repeatable Field design (LPD-58342, commit dc42538) wraps each field's content in a `flex-fill` div, adding one level to the DOM. The locator used a rigid direct-child path (`/div[date-picker]`) that no longer matched; field types with depth-agnostic locators were unaffected.

## How It Is Being Fixed

Changed the direct-child step `/div[contains(@class, 'date-picker')]` to a descendant step `//div[contains(@class, 'date-picker')]` in `DATE_INPUT_INDEXED`. The date input still renders with the `date-picker` class; it is just one level deeper now.

## Why Are There No Tests?

This PR only changes a Poshi test locator; there is no product code change to cover with new tests. Validated by running `DEDateField#CanInputDataOnDuplicatedField` against a local bundle (with LPD-94534 applied) — it passes.

## Note

The test exercises `DataEngine.addRepeatableField` before reaching this locator, so it goes fully green only with **LPD-94534** (PR liferay-bpm/liferay-portal#6244) also applied. This PR fixes the second, distinct locator that surfaced after that one.

## PR Check

**pr-check: PASS** — tested on `4b944b67001f8f3d35fdfec4fa2851141ebd9dae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "4b944b67001f8f3d35fdfec4fa2851141ebd9dae"} -->
