### PR TITLE
LPD-94546 Fix workflow task search test after cross-company guard

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -1490,6 +1490,9 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 	public void testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler()
 		throws Exception {
 
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
 		try (ServiceRegistrationHolder serviceRegistrationHolder =
 				registryWorkflowHandler()) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94546

## What Is Being Fixed

`WorkflowTaskManagerImplTest#testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler` started failing: `searchWorkflowTasks` returned 0 tasks instead of 1. LPD-91697 added a cross-virtual-instance permission guard in `KaleoTaskModelResourcePermission` that filters a workflow task when the task's company differs from the permission checker's company. This test's `setUp` (`_setUpPermissionThreadLocal`) installs a permission checker for `_companyAdminUser`, a separate virtual instance created by `CompanyTestUtil.addCompany()`, but `registryWorkflowHandler` hardcodes `TestPropsValues.getCompanyId()` when it creates the workflow definition link and starts the workflow instance, so the task lives in the default company. The company mismatch made the new guard drop the task from the search results.

The failure was reported in the release analysis task LPD-94303 alongside `testIsNotifiableUser`. `testIsNotifiableUser` was already fixed under LPD-91697 (commit 26a6a43); only `testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler` remained.

## How It Is Being Fixed

The test now installs a permission checker for the default company user (`PermissionCheckerFactoryUtil.create(TestPropsValues.getUser())`) at the start of the method, so the permission checker's company matches the company the workflow task is created in and the guard no longer filters it. The `@After` `tearDown` restores the original checker. This is a test fix, not a product change: the cross-company guard is intended behavior.

Both `testIsNotifiableUser` and `testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler` pass locally via `testIntegration`.

## Why Are There No Tests?

This change is itself a fix to an existing integration test. No production code changed, so the fixed test, now passing, is the coverage.

## PR Check

**pr-check: PASS** — tested on `d7c10437001238dbd54b85d7bd6444aa9b98c508`

| Validation | Result |
| --- | --- |
| Integration Test Compile | PASS |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d7c10437001238dbd54b85d7bd6444aa9b98c508"} -->
