### PR TITLE
LPD-92696 Preserve object relationships when updating a CMS structure

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:list-type:list-type-api")
+	testIntegrationImplementation project(":apps:object:object-admin-rest-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-api")
 	testIntegrationImplementation project(":apps:object:object-rest-test-util")

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.struts.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Yuri Monteiro
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class UpdateStructureStrutsActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-92696")
+	public void testExecute() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition1),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2()));
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
+	private HttpServletRequest _getMockHttpServletRequest(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockHttpServletRequest.setParameter(
+			"objectDefinition",
+			_getObjectDefinitionJSON(objectDefinition.getObjectDefinitionId()));
+
+		return mockHttpServletRequest;
+	}
+
+	private String _getObjectDefinitionJSON(long objectDefinitionId)
+		throws Exception {
+
+		ObjectDefinitionResource objectDefinitionResource =
+			_objectDefinitionResourceFactory.create(
+			).user(
+				TestPropsValues.getUser()
+			).build();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			String.valueOf(
+				objectDefinitionResource.getObjectDefinition(
+					objectDefinitionId)));
+
+		jsonObject.put(
+			"objectRelationships", JSONFactoryUtil.createJSONArray());
+
+		return jsonObject.toString();
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectDefinitionResource.Factory _objectDefinitionResourceFactory;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject(filter = "path=/cms/update-structure")
+	private StrutsAction _updateStructureStrutsAction;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -37,7 +37,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import org.osgi.service.component.annotations.Component;
@@ -115,6 +118,49 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		ServletResponseUtil.write(httpServletResponse, jsonObject.toString());
 
 		return null;
+	}
+
+	private void _addObjectRelationships(
+			ObjectDefinition objectDefinition, long objectDefinitionId,
+			ObjectDefinitionResource objectDefinitionResource)
+		throws Exception {
+
+		ObjectDefinition existingObjectDefinition =
+			objectDefinitionResource.getObjectDefinition(objectDefinitionId);
+
+		ObjectRelationship[] existingObjectRelationships =
+			existingObjectDefinition.getObjectRelationships();
+
+		if (ArrayUtil.isEmpty(existingObjectRelationships)) {
+			return;
+		}
+
+		Map<String, ObjectRelationship> objectRelationshipsMap =
+			new LinkedHashMap<>();
+
+		ObjectRelationship[] objectRelationships =
+			objectDefinition.getObjectRelationships();
+
+		if (objectRelationships != null) {
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				objectRelationshipsMap.put(
+					objectRelationship.getName(), objectRelationship);
+			}
+		}
+
+		for (ObjectRelationship existingObjectRelationship :
+				existingObjectRelationships) {
+
+			objectRelationshipsMap.putIfAbsent(
+				existingObjectRelationship.getName(),
+				existingObjectRelationship);
+		}
+
+		Collection<ObjectRelationship> mergedObjectRelationships =
+			objectRelationshipsMap.values();
+
+		objectDefinition.setObjectRelationships(
+			() -> mergedObjectRelationships.toArray(new ObjectRelationship[0]));
 	}
 
 	private void _deleteRelationships(long objectDefinitionId)
@@ -310,6 +356,10 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 							objectDefinition);
 				}
 			}
+
+			_addObjectRelationships(
+				_objectDefinition, _objectDefinitionId,
+				objectDefinitionResource);
 
 			objectDefinitionResource.putObjectDefinition(
 				_objectDefinitionId, _objectDefinition);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92696

## What is being fixed

When a user edits a CMS Content Type that is *referenced* by another Content Type's "Related Content" field, publishing it deletes the relationship between them and cascade-deletes the relationship field on the other side. The relationship configuration and existing content references are lost.

## How it is being fixed

The CMS structure-builder saves through the `/cms/update-structure` Struts action (`UpdateStructureStrutsAction`), which calls `objectDefinitionResource.putObjectDefinition(...)`. The payload built by `buildObjectDefinition` only lists the relationships the structure itself defines — never the relationships where the structure is merely the referenced (side 1) target of another structure's Related Content. The PUT's replace-diff then deletes those omitted relationships and cascades to their field.

The fix stays entirely on the client (the Struts action), keeping the REST API's PUT replace semantics untouched and client-agnostic. Before the PUT, `UpdateStructureStrutsAction` fetches the object definition's existing relationships and merges into the payload any relationship the payload omits, indexing by relationship name in a single map pass (payload entries take priority; existing entries fill in only where absent). The diff then deletes nothing it should not, while the structure-builder's own relationship additions and deletions (handled explicitly elsewhere) keep working — including field deletion, which still depends on the PUT replace semantics.

A merge (not an overwrite) is required: overwriting the payload's relationships with the existing set would drop the relationships the user just added in the same edit (referenced structures, repeatable groups, multi-select Related Content), which are created only through the PUT payload.

## Test

A new integration test (`UpdateStructureStrutsActionTest`) reproduces the scenario: two object definitions with a relationship where the edited one is the referenced (side 1) target, then an update of that referenced definition with the relationship omitted from the payload. Verified to fail without the fix (the relationship and its field are deleted) and pass with it.

## PR Check

**pr-check: PASS** — tested on `f468bc458ddae9b199ebc5ceccee1c2cf43f128c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | N/A |

**Java Unit Tests** — N/A: the changed class has no unit-test counterpart; behavior is covered by the `UpdateStructureStrutsActionTest` integration test (passes locally on this SHA).

<!-- pr-check {"result": "success", "sha": "f468bc458ddae9b199ebc5ceccee1c2cf43f128c"} -->
