### PR TITLE
LPD-94545 Fix Link to Page selection click for the new tree view

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -461,10 +461,11 @@ definition {
 
 		Portlet.expandTree();
 
-		AssertClick.assertPartialTextClickAt(
+		AssertElementPresent(
 			key_nodeName = ${linkToPageContent},
-			locator1 = "Treeview#NODE_UNSELECTED",
-			value1 = ${linkToPageContent});
+			locator1 = "Treeview#NODE_UNSELECTED");
+
+		Click(locator1 = "//div[contains(@class,'treeview-link') and @role='treeitem'][.//span[normalize-space(text())='${linkToPageContent}']]");
 
 		SelectFrameTop();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94545

## What Is Being Fixed

`DELinkToPageField#CanInputLink` and `#CanInputDataOnDuplicatedField` fail: after picking a page in the Link to Page selector, the field reads empty (`AssertTextEquals` expects "Pages > Test Page Name", actual ""). The page selection never registers.

This is a **test fix, not a product bug** — confirmed by manual UI check: a real user selects a page and the field populates correctly (`layoutId`, `value: "Pages > Test Page Name"`, Clear button appears). The Clay `@clayui/core` TreeView upgrade (LPD-90002 / LPD-89587) changed the selector's DOM. The Poshi step `AssertClick.assertPartialTextClickAt` resolved to the inner `span` and called `selenium.clickAt(span, "Test Page Name")` — passing the node name as the click *coordinate* — so the click no longer lands on the new TreeView's actionable row and its React `onClick` (which fires the `selectLayout` event) never runs. Instrumenting the field's `onSelect` handler confirmed it is never called during the test, while it fires normally for a real click.

## How It Is Being Fixed

In `DERenderer.inputDataInLinkToPageField`, assert the node is present, then click the tree node's row element (`div.treeview-link[role='treeitem']`) directly instead of `clickAt`-ing the inner span with a bogus coordinate. Clicking the row triggers the TreeView selection handler, matching a real user click.

## Why Are There No Tests?

This PR only changes a Poshi test macro; there is no product code change. Validated against a local bundle: `DELinkToPageField#CanInputLink` passes, and `#CanInputDataOnDuplicatedField` passes with LPD-94534 also applied.

## Note

`#CanInputDataOnDuplicatedField` exercises `DataEngine.addRepeatableField` first, so it goes fully green only with **LPD-94534** (PR liferay-bpm/liferay-portal#6244) also applied. `#CanInputLink` passes on this change alone.

## PR Check

**pr-check: PASS** — tested on `4c8d1c6b4a5875d0b3ee95670a9333bf99daaa7c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "4c8d1c6b4a5875d0b3ee95670a9333bf99daaa7c"} -->
