### PR TITLE
LPD-94261 Fix KaleoInstance @Retry by switching to StaleStateException

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
@@ -377,7 +377,7 @@ public interface KaleoInstanceLocalService
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)
@@ -401,4 +401,4 @@ public interface KaleoInstanceLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1052490119
+// LIFERAY-SERVICE-BUILDER-HASH:-980243224

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.0.1

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -439,7 +439,7 @@ public class KaleoInstanceLocalServiceImpl
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
@@ -10,19 +10,27 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.portal.kernel.exception.NoSuchWorkflowInstanceLinkException;
 import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.FutureTask;
+
 import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,12 +38,8 @@ import org.junit.runner.RunWith;
  * @author Mateus Xavier
  */
 @RunWith(Arquillian.class)
-public class KaleoInstanceLocalServiceTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+public class KaleoInstanceLocalServiceTest
+	extends BaseKaleoLocalServiceTestCase {
 
 	@Test
 	public void testDeleteKaleoInstance() throws Exception {
@@ -62,6 +66,63 @@ public class KaleoInstanceLocalServiceTest {
 			() -> _workflowInstanceLinkLocalService.getWorkflowInstanceLink(
 				blogsEntry.getCompanyId(), blogsEntry.getGroupId(),
 				BlogsEntry.class.getName(), blogsEntry.getEntryId()));
+	}
+
+	@Test
+	public void testUpdateKaleoInstance() throws Exception {
+		KaleoInstance kaleoInstance = addKaleoInstance();
+
+		int threadCount = 5;
+
+		CyclicBarrier cyclicBarrier = new CyclicBarrier(threadCount);
+
+		List<FutureTask<KaleoInstance>> futureTasks = new ArrayList<>();
+
+		long kaleoInstanceId = kaleoInstance.getKaleoInstanceId();
+
+		for (int i = 0; i < threadCount; i++) {
+			FutureTask<KaleoInstance> futureTask = new FutureTask<>(
+				new CompanyInheritableThreadLocalCallable<>(
+					() -> {
+						cyclicBarrier.await();
+
+						return _kaleoInstanceLocalService.updateKaleoInstance(
+							kaleoInstanceId,
+							HashMapBuilder.<String, Serializable>put(
+								RandomTestUtil.randomString(),
+								RandomTestUtil.randomString()
+							).build());
+					}));
+
+			futureTasks.add(futureTask);
+		}
+
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.workflow.metrics.internal.petra.executor." +
+					"WorkflowMetricsPortalExecutor",
+				LoggerTestUtil.ERROR)) {
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				Thread thread = new Thread(futureTask);
+
+				thread.start();
+			}
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				futureTask.get();
+			}
+		}
+
+		long mvccVersion = kaleoInstance.getMvccVersion();
+
+		kaleoInstance = _kaleoInstanceLocalService.getKaleoInstance(
+			kaleoInstanceId);
+
+		Assert.assertEquals(
+			mvccVersion + threadCount, kaleoInstance.getMvccVersion());
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94261

## What Is Being Fixed

When Hibernate executes batch updates (batch_size > 0), a concurrent modification does not throw `StaleObjectStateException` directly — it wraps it in a `StaleStateException` (the parent class). The `@Retry` annotation on `updateKaleoInstance` was configured with `StaleObjectStateException`, so retries were never triggered in batched scenarios, causing concurrent updates to fail instead of being retried.

## How It Is Being Fixed

The exception name in the `@Retry` annotation is changed from `org.hibernate.StaleObjectStateException` to `org.hibernate.StaleStateException` so that it matches regardless of whether Hibernate is operating in batch or non-batch mode. An integration test using a `CyclicBarrier` fires 5 concurrent `updateKaleoInstance` calls and asserts that all succeed and that the MVCC version increments by exactly 5.

## PR Check

**pr-check: PASS** — tested on `4a5c60fd73d9f9cd3e0df8ac04bf80fa512bea2f`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4a5c60fd73d9f9cd3e0df8ac04bf80fa512bea2f"} -->