### PR TITLE
LPD-94545 Fix Link to Page tree selection after Clay TreeView upgrade

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -461,10 +461,13 @@ definition {
 
 		Portlet.expandTree();
 
-		AssertClick.assertPartialTextClickAt(
+		AssertElementPresent(
 			key_nodeName = ${linkToPageContent},
-			locator1 = "Treeview#NODE_UNSELECTED",
-			value1 = ${linkToPageContent});
+			locator1 = "Treeview#NODE_UNSELECTED_TREEITEM");
+
+		Click(
+			key_nodeName = ${linkToPageContent},
+			locator1 = "Treeview#NODE_UNSELECTED_TREEITEM");
 
 		SelectFrameTop();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -71,6 +71,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>NODE_UNSELECTED_TREEITEM</td>
+	<td>//div[contains(@role,'treeitem') and not(contains(@class,'active'))][.//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>NODE_LIST</td>
 	<td>//*[@role='tree'] | //ul[contains(@class,'tree-pages')] | //div[contains(@class,'navigation-menu-items-tree')]</td>
 	<td></td>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94545

## What Is Being Fixed

`DELinkToPageField#CanInputLink` and `#CanInputDataOnDuplicatedField` fail: after picking a page in the Link to Page selector, the field reads empty (`AssertTextEquals` expects "Pages > Test Page Name", actual "").

This is a **test fix, not a product bug** — confirmed by a manual UI check: a real user selects a page and the field populates correctly (`layoutId`, `value: "Pages > Test Page Name"`, Clear button appears), and the field's `onSelect` handler fires. The `@clayui/core` TreeView upgrade (LPD-90002 / LPD-89587) changed the selector DOM. The Poshi step resolved `Treeview#NODE_UNSELECTED` to the inner text `span` and called `selenium.clickAt(span, "Test Page Name")` — passing the node name as a click *coordinate*. On the new TreeView, clicking the `span` (by coordinate, plain click, or JS click) no longer triggers selection; only clicking the `treeitem` row does. This was verified empirically.

## How It Is Being Fixed

- `Treeview.path`: add a named locator `NODE_UNSELECTED_TREEITEM` resolving to the unselected `treeitem` row that contains the node text.
- `DERenderer.inputDataInLinkToPageField`: `AssertElementPresent` + a plain `Click` on that row locator, instead of the coordinate-click on the span.

## Alternatives Considered

We evaluated changing the shared `Treeview#NODE_UNSELECTED` locator itself to target the row. We deliberately chose the scoped change, because the goal of this task is to resolve this specific failure without altering the behavior of unrelated tests.

`NODE_UNSELECTED` is a broadly shared locator that backs several tree implementations and is consumed in different ways across many suites. Repointing it from the text node to the row would change the element all of those consumers act on, so a blanket edit is not a safe, universal fix and could affect tests unrelated to this ticket. Adding a dedicated locator resolves the failure under test while keeping the blast radius at zero. Aligning the broader tree-selection helpers with the new TreeView is better handled as its own deliberate, separately validated effort.

## Why Are There No Tests?

This PR only changes Poshi test artifacts (a `.path` locator and a macro); there is no product code change. Validated against a local bundle: `DELinkToPageField#CanInputLink` passes, and `#CanInputDataOnDuplicatedField` passes with LPD-94534 also applied.

## Note

`#CanInputDataOnDuplicatedField` exercises `DataEngine.addRepeatableField` first, so it goes fully green only with **LPD-94534** (PR liferay-bpm/liferay-portal#6244) also applied. `#CanInputLink` passes on this change alone.

## PR Check

**pr-check: PASS** — tested on `0baf5ac224deef3583d7b433599e82365544ac60`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "0baf5ac224deef3583d7b433599e82365544ac60"} -->
