### PR TITLE
LPD-94261 Fix @Retry not retrying StaleStateException in batched scenarios

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/KaleoInstanceLocalService.java
@@ -377,7 +377,7 @@ public interface KaleoInstanceLocalService
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)
@@ -401,4 +401,4 @@ public interface KaleoInstanceLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1052490119
+// LIFERAY-SERVICE-BUILDER-HASH:-980243224

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-api/src/main/resources/com/liferay/portal/workflow/kaleo/service/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.0.1

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -439,7 +439,7 @@ public class KaleoInstanceLocalServiceImpl
 		properties = {
 			@Property(
 				name = ExceptionRetryAcceptor.EXCEPTION_NAME,
-				value = "org.hibernate.StaleObjectStateException"
+				value = "org.hibernate.StaleStateException"
 			)
 		}
 	)

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
@@ -10,19 +10,27 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.portal.kernel.exception.NoSuchWorkflowInstanceLinkException;
 import com.liferay.portal.kernel.model.WorkflowInstanceLink;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.FutureTask;
+
 import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -30,12 +38,8 @@ import org.junit.runner.RunWith;
  * @author Mateus Xavier
  */
 @RunWith(Arquillian.class)
-public class KaleoInstanceLocalServiceTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+public class KaleoInstanceLocalServiceTest
+	extends BaseKaleoLocalServiceTestCase {
 
 	@Test
 	public void testDeleteKaleoInstance() throws Exception {
@@ -62,6 +66,63 @@ public class KaleoInstanceLocalServiceTest {
 			() -> _workflowInstanceLinkLocalService.getWorkflowInstanceLink(
 				blogsEntry.getCompanyId(), blogsEntry.getGroupId(),
 				BlogsEntry.class.getName(), blogsEntry.getEntryId()));
+	}
+
+	@Test
+	public void testUpdateKaleoInstance() throws Exception {
+		int threadCount = 5;
+
+		CyclicBarrier cyclicBarrier = new CyclicBarrier(threadCount);
+
+		List<FutureTask<KaleoInstance>> futureTasks = new ArrayList<>();
+
+		KaleoInstance kaleoInstance = addKaleoInstance();
+
+		long kaleoInstanceId = kaleoInstance.getKaleoInstanceId();
+
+		for (int i = 0; i < threadCount; i++) {
+			FutureTask<KaleoInstance> futureTask = new FutureTask<>(
+				new CompanyInheritableThreadLocalCallable<>(
+					() -> {
+						cyclicBarrier.await();
+
+						return _kaleoInstanceLocalService.updateKaleoInstance(
+							kaleoInstanceId,
+							HashMapBuilder.<String, Serializable>put(
+								RandomTestUtil.randomString(),
+								RandomTestUtil.randomString()
+							).build());
+					}));
+
+			futureTasks.add(futureTask);
+		}
+
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				"org.hibernate.engine.jdbc.batch.internal.BatchingBatch",
+				LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.workflow.metrics.internal.petra.executor." +
+					"WorkflowMetricsPortalExecutor",
+				LoggerTestUtil.ERROR)) {
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				Thread thread = new Thread(futureTask);
+
+				thread.start();
+			}
+
+			for (FutureTask<KaleoInstance> futureTask : futureTasks) {
+				futureTask.get();
+			}
+		}
+
+		long mvccVersion = kaleoInstance.getMvccVersion();
+
+		kaleoInstance = _kaleoInstanceLocalService.getKaleoInstance(
+			kaleoInstanceId);
+
+		Assert.assertEquals(
+			mvccVersion + threadCount, kaleoInstance.getMvccVersion());
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94261

## What Is Being Fixed

`KaleoInstanceLocalService.updateKaleoInstance` is annotated with `@Retry`
to handle `StaleObjectStateException` on concurrent updates. When Hibernate
batching is enabled (`batch_size > 0`), however, the actual exception thrown
is the parent `StaleStateException` — Hibernate wraps the row-level conflict
before the child class is visible. The `@Retry` interceptor only matched the
child class name, so retries were silently skipped under batching, causing
concurrent updates to fail instead of being retried.

## How It Is Being Fixed

The `@Retry` annotation on `updateKaleoInstance` is changed from
`org.hibernate.StaleObjectStateException` to the parent
`org.hibernate.StaleStateException`, which matches both the batched and
non-batched cases. The generated API interface and baseline are updated
accordingly. A new integration test `testUpdateKaleoInstance` launches five
threads behind a `CyclicBarrier` to force concurrent writes and asserts that
every update is eventually committed (MVCC version advances by the thread
count), verifying the retry logic holds under contention.

## PR Check

**pr-check: PASS** — tested on `c98444c2b0cb35f63283fbdb8af59bae7424e759`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c98444c2b0cb35f63283fbdb8af59bae7424e759"} -->