### PR TITLE
LPD-94545 Select the Link to Page tree node by its treeitem row

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/macros/DERenderer.macro
@@ -461,10 +461,13 @@ definition {
 
 		Portlet.expandTree();
 
-		AssertClick.assertPartialTextClickAt(
+		AssertElementPresent(
 			key_nodeName = ${linkToPageContent},
-			locator1 = "Treeview#NODE_UNSELECTED",
-			value1 = ${linkToPageContent});
+			locator1 = "Treeview#NODE_UNSELECTED_TREEITEM");
+
+		Click(
+			key_nodeName = ${linkToPageContent},
+			locator1 = "Treeview#NODE_UNSELECTED_TREEITEM");
 
 		SelectFrameTop();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -71,6 +71,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>NODE_UNSELECTED_TREEITEM</td>
+	<td>//div[contains(@role,'treeitem') and not(contains(@class,'active'))][.//*[contains(@class,'component-text') or contains(@class,'flex-grow')][normalize-space(text())='${key_nodeName}']]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>NODE_LIST</td>
 	<td>//*[@role='tree'] | //ul[contains(@class,'tree-pages')] | //div[contains(@class,'navigation-menu-items-tree')]</td>
 	<td></td>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94545

## What Is Being Fixed

The functional test `DELinkToPageField#CanInputDataOnDuplicatedField` failed after the Clay TreeView upgrade. The `DERenderer` macro selected the "Link to Page" node with `AssertClick.assertPartialTextClickAt` against `Treeview#NODE_UNSELECTED`, which matches the node's text label. The redesigned tree changed the markup so clicking the label text no longer reliably selects the node.

## How It Is Being Fixed

A new named locator `Treeview#NODE_UNSELECTED_TREEITEM` targets the whole unselected `treeitem` row containing the node label, rather than the label text alone. The macro now asserts that row is present and clicks it, which matches the redesigned TreeView structure and reliably selects the node.

## Alternatives Considered

We evaluated changing the shared Treeview#NODE_UNSELECTED locator itself to target the row. We deliberately chose the scoped change, because the goal of this task is to resolve this specific failure without altering the behavior of unrelated tests.

NODE_UNSELECTED is a broadly shared locator that backs several tree implementations and is consumed in different ways across many suites. Repointing it from the text node to the row would change the element all of those consumers act on, so a blanket edit is not a safe, universal fix and could affect tests unrelated to this ticket. Adding a dedicated locator resolves the failure under test while keeping the blast radius at zero. Aligning the broader tree-selection helpers with the new TreeView is better handled as its own deliberate, separately validated effort.

## PR Check

**pr-check: PASS** — tested on `0baf5ac224deef3583d7b433599e82365544ac60`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "0baf5ac224deef3583d7b433599e82365544ac60"} -->