### PR TITLE
LPD-93214 Move comments from ObjectEntry into SystemProperties

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
@@ -146,52 +145,6 @@ public class ObjectEntry implements Serializable {
 
 	@JsonIgnore
 	private Supplier<AuditEvent[]> _auditEventsSupplier;
-
-	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
-	)
-	@Valid
-	public Comment[] getComments() {
-		if (_commentsSupplier != null) {
-			comments = _commentsSupplier.get();
-
-			_commentsSupplier = null;
-		}
-
-		return comments;
-	}
-
-	public void setComments(Comment[] comments) {
-		this.comments = comments;
-
-		_commentsSupplier = null;
-	}
-
-	@JsonIgnore
-	public void setComments(
-		UnsafeSupplier<Comment[], Exception> commentsUnsafeSupplier) {
-
-		_commentsSupplier = () -> {
-			try {
-				return commentsUnsafeSupplier.get();
-			}
-			catch (RuntimeException runtimeException) {
-				throw runtimeException;
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		};
-	}
-
-	@GraphQLField(
-		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
-	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Comment[] comments;
-
-	@JsonIgnore
-	private Supplier<Comment[]> _commentsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
@@ -1278,9 +1231,6 @@ public class ObjectEntry implements Serializable {
 		else if (Objects.equals(propertyName, "auditEvents")) {
 			return getAuditEvents();
 		}
-		else if (Objects.equals(propertyName, "comments")) {
-			return getComments();
-		}
 		else if (Objects.equals(propertyName, "creator")) {
 			return getCreator();
 		}
@@ -1381,9 +1331,6 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "auditEvents")) {
 			setAuditEvents((AuditEvent[])propertyValue);
-		}
-		else if (Objects.equals(propertyName, "comments")) {
-			setComments((Comment[])propertyValue);
 		}
 		else if (Objects.equals(propertyName, "creator")) {
 			setCreator((Creator)propertyValue);
@@ -1532,28 +1479,6 @@ public class ObjectEntry implements Serializable {
 				sb.append(String.valueOf(auditEvents[i]));
 
 				if ((i + 1) < auditEvents.length) {
-					sb.append(", ");
-				}
-			}
-
-			sb.append("]");
-		}
-
-		Comment[] comments = getComments();
-
-		if (comments != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"comments\": ");
-
-			sb.append("[");
-
-			for (int i = 0; i < comments.length; i++) {
-				sb.append(comments[i]);
-
-				if ((i + 1) < comments.length) {
 					sb.append(", ");
 				}
 			}
@@ -2041,4 +1966,4 @@ public class ObjectEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1306455185
+// LIFERAY-REST-BUILDER-HASH:-2052334864

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -90,6 +91,52 @@ public class SystemProperties implements Serializable {
 
 	@JsonIgnore
 	private Supplier<CollaboratorBrief> _collaboratorBriefSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
+	)
+	@Valid
+	public Comment[] getComments() {
+		if (_commentsSupplier != null) {
+			comments = _commentsSupplier.get();
+
+			_commentsSupplier = null;
+		}
+
+		return comments;
+	}
+
+	public void setComments(Comment[] comments) {
+		this.comments = comments;
+
+		_commentsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setComments(
+		UnsafeSupplier<Comment[], Exception> commentsUnsafeSupplier) {
+
+		_commentsSupplier = () -> {
+			try {
+				return commentsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Comment[] comments;
+
+	@JsonIgnore
+	private Supplier<Comment[]> _commentsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
@@ -260,6 +307,28 @@ public class SystemProperties implements Serializable {
 			sb.append(String.valueOf(collaboratorBrief));
 		}
 
+		Comment[] comments = getComments();
+
+		if (comments != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < comments.length; i++) {
+				sb.append(comments[i]);
+
+				if ((i + 1) < comments.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		ObjectDefinitionBrief objectDefinitionBrief =
 			getObjectDefinitionBrief();
 
@@ -398,4 +467,4 @@ public class SystemProperties implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-171984500
+// LIFERAY-REST-BUILDER-HASH:1036222607

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
@@ -10,6 +10,7 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.SystemProperties;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 
 import java.util.Map;
@@ -23,8 +24,26 @@ public class ObjectEntryManagerUtil {
 		ObjectEntry existingObjectEntry, long objectDefinitionId,
 		ObjectEntry objectEntry) {
 
-		if (objectEntry.getComments() != null) {
-			existingObjectEntry.setComments(objectEntry::getComments);
+		SystemProperties objectEntrySystemProperties =
+			objectEntry.getSystemProperties();
+
+		if ((objectEntrySystemProperties != null) &&
+			(objectEntrySystemProperties.getComments() != null)) {
+
+			SystemProperties mergedSystemProperties =
+				existingObjectEntry.getSystemProperties();
+
+			if (mergedSystemProperties == null) {
+				mergedSystemProperties = new SystemProperties();
+			}
+
+			SystemProperties finalSystemProperties = mergedSystemProperties;
+
+			finalSystemProperties.setComments(
+				objectEntrySystemProperties::getComments);
+
+			existingObjectEntry.setSystemProperties(
+				() -> finalSystemProperties);
 		}
 
 		if (objectEntry.getDateCreated() != null) {

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
@@ -30,20 +30,18 @@ public class ObjectEntryManagerUtil {
 		if ((objectEntrySystemProperties != null) &&
 			(objectEntrySystemProperties.getComments() != null)) {
 
-			SystemProperties mergedSystemProperties =
+			SystemProperties existingSystemProperties =
 				existingObjectEntry.getSystemProperties();
 
-			if (mergedSystemProperties == null) {
-				mergedSystemProperties = new SystemProperties();
-			}
+			SystemProperties mergedSystemProperties =
+				(existingSystemProperties != null) ? existingSystemProperties :
+					new SystemProperties();
 
-			SystemProperties finalSystemProperties = mergedSystemProperties;
-
-			finalSystemProperties.setComments(
+			mergedSystemProperties.setComments(
 				objectEntrySystemProperties::getComments);
 
 			existingObjectEntry.setSystemProperties(
-				() -> finalSystemProperties);
+				() -> mergedSystemProperties);
 		}
 
 		if (objectEntry.getDateCreated() != null) {

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -185,12 +185,6 @@ components:
                         $ref: "#/components/schemas/AuditEvent"
                     readOnly: true
                     type: array
-                comments:
-                    description:
-                        Optional field with the comments associated with this object entry, can be embedded with nestedFields
-                    items:
-                        $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Comment
-                    type: array
                 creator:
                     $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator
                     readOnly: true
@@ -297,6 +291,12 @@ components:
             properties:
                 collaboratorBrief:
                     $ref: "#/components/schemas/CollaboratorBrief"
+                comments:
+                    description:
+                        Optional field with the comments associated with this object entry, can be embedded with nestedFields
+                    items:
+                        $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Comment
+                    type: array
                 objectDefinitionBrief:
                     $ref: "#/components/schemas/ObjectDefinitionBrief"
                 scope:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -268,8 +268,6 @@ public class ObjectEntryDTOConverter
 			() -> _toAuditEvents(
 				dtoConverterContext, objectDefinition,
 				serviceBuilderObjectEntry));
-		objectEntry.setComments(
-			() -> _toComments(objectDefinition, serviceBuilderObjectEntry));
 		objectEntry.setCreator(
 			() -> {
 				long userId = _getAttribute(
@@ -418,6 +416,7 @@ public class ObjectEntryDTOConverter
 						serviceBuilderObjectEntry.getGroupId(),
 						dtoConverterContext.getLocale(), objectDefinition,
 						serviceBuilderObjectEntry.getObjectEntryId(),
+						serviceBuilderObjectEntry,
 						dtoConverterContext.getUserId(),
 						objectEntryVersion.getVersion());
 				}
@@ -426,7 +425,7 @@ public class ObjectEntryDTOConverter
 					serviceBuilderObjectEntry.getGroupId(),
 					dtoConverterContext.getLocale(), objectDefinition,
 					serviceBuilderObjectEntry.getObjectEntryId(),
-					dtoConverterContext.getUserId(),
+					serviceBuilderObjectEntry, dtoConverterContext.getUserId(),
 					serviceBuilderObjectEntry.getVersion());
 			});
 		objectEntry.setTaxonomyCategoryBriefs(
@@ -988,7 +987,7 @@ public class ObjectEntryDTOConverter
 		throws Exception {
 
 		return NestedFieldsSupplier.supply(
-			"comments",
+			"systemProperties.comments",
 			nestedFieldNames -> {
 				if ((!Objects.equals(
 						objectDefinition.getScope(),
@@ -1271,10 +1270,15 @@ public class ObjectEntryDTOConverter
 
 	private SystemProperties _toSystemProperties(
 			long groupId, Locale locale, ObjectDefinition objectDefinition,
-			long objectEntryId, long userId, int versionInt)
+			long objectEntryId,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
+			long userId, int versionInt)
 		throws Exception {
 
 		Group group = _groupLocalService.fetchGroup(groupId);
+
+		Comment[] nestedComments = _toComments(
+			objectDefinition, serviceBuilderObjectEntry);
 
 		SharingEntry nestedSharingEntry = NestedFieldsSupplier.supply(
 			"systemProperties.collaboratorBrief",
@@ -1291,7 +1295,8 @@ public class ObjectEntryDTOConverter
 					locale, objectDefinition));
 
 		if (!objectDefinition.isEnableObjectEntryVersioning() &&
-			(group == null) && (nestedObjectDefinitionBrief == null) &&
+			(group == null) && (nestedComments == null) &&
+			(nestedObjectDefinitionBrief == null) &&
 			(nestedSharingEntry == null)) {
 
 			return null;
@@ -1307,6 +1312,7 @@ public class ObjectEntryDTOConverter
 
 						return _toCollaboratorBrief(nestedSharingEntry);
 					});
+				setComments(() -> nestedComments);
 				setObjectDefinitionBrief(() -> nestedObjectDefinitionBrief);
 				setScope(
 					() -> {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -51,6 +51,7 @@ import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.Folder;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.dto.v1_0.SystemProperties;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.rest.filter.parser.ObjectDefinitionFilterParser;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
@@ -2091,8 +2092,10 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		List<ObjectEntryComment> objectEntryComments = null;
+		SystemProperties systemProperties = objectEntry.getSystemProperties();
 
-		if ((objectEntry.getComments() != null) &&
+		if ((systemProperties != null) &&
+			(systemProperties.getComments() != null) &&
 			(Objects.equals(
 				objectDefinition.getScope(),
 				ObjectDefinitionConstants.SCOPE_SITE) ||
@@ -2100,7 +2103,7 @@ public class DefaultObjectEntryManagerImpl
 				 objectDefinition.getCompanyId(), "LPD-43996"))) {
 
 			objectEntryComments = TransformUtil.transformToList(
-				objectEntry.getComments(),
+				systemProperties.getComments(),
 				comment -> new ObjectEntryComment(
 					comment.getExternalReferenceCode(),
 					comment.getParentCommentExternalReferenceCode(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -212,7 +212,9 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 			schemas.remove("TaxonomyCategoryBrief");
 		}
 
-		if (!_objectDefinition.isEnableObjectEntryVersioning()) {
+		if (!_objectDefinition.isEnableComments() &&
+			!_objectDefinition.isEnableObjectEntryVersioning()) {
+
 			objectDefinitionSchemaProperties.remove("systemProperties");
 
 			schemas.remove("SystemProperties");

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -17358,10 +17358,9 @@ public class ObjectEntryResourceTest {
 			).toString(),
 			endpoint, Http.Method.POST);
 
+		JSONArray jsonArray = null;
 		JSONObject systemPropertiesJSONObject = jsonObject.getJSONObject(
 			"systemProperties");
-
-		JSONArray jsonArray = null;
 
 		if (systemPropertiesJSONObject != null) {
 			jsonArray = systemPropertiesJSONObject.getJSONArray("comments");

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -16472,14 +16472,19 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
-			_getEndpoint(objectDefinition, groupId) + "?nestedFields=comments",
+			_getEndpoint(objectDefinition, groupId) +
+				"?nestedFields=systemProperties.comments",
 			Http.Method.GET);
 
 		JSONArray jsonArray = jsonObject.getJSONArray("items");
 
 		jsonObject = jsonArray.getJSONObject(0);
 
-		return jsonObject.getJSONArray("comments");
+		return jsonObject.getJSONObject(
+			"systemProperties"
+		).getJSONArray(
+			"comments"
+		);
 	}
 
 	private String _getDeletePatchPutEndpoint(
@@ -17218,17 +17223,21 @@ public class ObjectEntryResourceTest {
 		String endpoint = _getDeletePatchPutEndpoint(
 			groupId, objectDefinition, objectEntryJSONObject);
 
-		endpoint = endpoint + "?nestedFields=comments";
+		endpoint = endpoint + "?nestedFields=systemProperties.comments";
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
 			endpoint, httpMethod);
 
-		return jsonObject.getJSONArray("comments");
+		return jsonObject.getJSONObject(
+			"systemProperties"
+		).getJSONArray(
+			"comments"
+		);
 	}
 
 	private JSONObject _postCustomObjectEntryWithAssigneeObjectField(
@@ -17304,18 +17313,25 @@ public class ObjectEntryResourceTest {
 		String endpoint = _getEndpoint(objectDefinition, groupId);
 
 		if (nestedFields) {
-			endpoint = endpoint + "?nestedFields=comments";
+			endpoint = endpoint + "?nestedFields=systemProperties.comments";
 		}
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
 			endpoint, Http.Method.POST);
 
-		JSONArray jsonArray = jsonObject.getJSONArray("comments");
+		JSONObject systemPropertiesJSONObject = jsonObject.getJSONObject(
+			"systemProperties");
+
+		JSONArray jsonArray = null;
+
+		if (systemPropertiesJSONObject != null) {
+			jsonArray = systemPropertiesJSONObject.getJSONArray("comments");
+		}
 
 		if (jsonArray == null) {
 			return JSONFactoryUtil.createJSONArray();
@@ -17505,9 +17521,10 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
-			endpoint + "?nestedFields=comments", Http.Method.POST);
+			endpoint + "?nestedFields=systemProperties.comments",
+			Http.Method.POST);
 
 		long objectEntryId = objectEntryJSONObject.getLong("id");
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11347,6 +11347,36 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testPostObjectEntryWithCustomFieldNamedComments()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						"comments", "comments", false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		try {
+			String value = RandomTestUtil.randomString();
+
+			JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					"comments", value
+				).toString(),
+				objectDefinition.getRESTContextPath(), Http.Method.POST);
+
+			Assert.assertEquals(value, jsonObject.getString("comments"));
+		}
+		finally {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+		}
+	}
+
+	@Test
 	public void testPostObjectEntryWithKeywordsAndTaxonomyCategoryIdsWhenCategorizationDisabled()
 		throws Exception {
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11301,15 +11301,19 @@ public class ObjectEntryResourceTest {
 		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 			new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
 				{
-					comments = new Comment[] {
-						new Comment() {
-							{
-								externalReferenceCode =
-									RandomTestUtil.randomString();
-								parentCommentExternalReferenceCode =
-									parentExternalReferenceCode;
-								text = RandomTestUtil.randomString();
-							}
+					systemProperties = new SystemProperties() {
+						{
+							comments = new Comment[] {
+								new Comment() {
+									{
+										externalReferenceCode =
+											RandomTestUtil.randomString();
+										parentCommentExternalReferenceCode =
+											parentExternalReferenceCode;
+										text = RandomTestUtil.randomString();
+									}
+								}
+							};
 						}
 					};
 				}
@@ -19571,20 +19575,24 @@ public class ObjectEntryResourceTest {
 		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 			new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
 				{
-					comments = new Comment[] {
-						new Comment() {
-							{
-								externalReferenceCode =
-									RandomTestUtil.randomString();
-								parentCommentExternalReferenceCode =
-									parentExternalReferenceCode;
-								text = RandomTestUtil.randomString();
-							}
-						}
-					};
 					properties = HashMapBuilder.<String, Object>put(
 						_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 					).build();
+					systemProperties = new SystemProperties() {
+						{
+							comments = new Comment[] {
+								new Comment() {
+									{
+										externalReferenceCode =
+											RandomTestUtil.randomString();
+										parentCommentExternalReferenceCode =
+											parentExternalReferenceCode;
+										text = RandomTestUtil.randomString();
+									}
+								}
+							};
+						}
+					};
 				}
 			};
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -536,13 +536,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",
@@ -1349,13 +1342,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -564,13 +564,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -576,13 +576,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -388,13 +388,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -537,13 +537,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",
@@ -1350,13 +1343,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,
@@ -2295,13 +2281,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -388,13 +388,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93214

## What Is Being Fixed

When a custom object field is named `comments`, creating or updating an entry via the REST API fails with HTTP 400 "Unable to map JSON path: comments". This happens because `comments` is a top-level field on the `ObjectEntry` DTO — Jackson's `@JsonAnySetter` mechanism, which routes unknown JSON keys to the `properties` map for custom fields, never fires because `comments` is already claimed by the DTO.

## How It Is Being Fixed

Rather than blocking `comments` as a reserved field name (which would be a breaking change for any existing setup where that field is already in production), `comments` is moved out of `ObjectEntry` and into the nested `SystemProperties` object. `SystemProperties` already holds other system-managed fields (`scope`, `version`, `collaboratorBrief`, `objectDefinitionBrief`), so comments belong there conceptually.

With `comments` removed from the `ObjectEntry` top level, an incoming `{"comments": "value"}` from a custom field now falls through `@JsonAnySetter` into the `properties` map as intended, and the HTTP 400 no longer occurs. Consumers that used `nestedFields=comments` now use `nestedFields=systemProperties.comments`. The `ObjectEntryOpenAPIContributor` is updated to keep `systemProperties` in the schema whenever comments are enabled. All comment-related test helpers are updated to use `systemProperties.comments`, and a new regression test `testPostObjectEntryWithCustomFieldNamedComments` directly exercises the reported failure mode.

## PR Check

**pr-check: PASS** — tested on `da8b753bcec0f28a04e2eac11d4dcb5826c60874`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "da8b753bcec0f28a04e2eac11d4dcb5826c60874"} -->