### PR TITLE
LPD-94185 LPD-92731 Add calendar task cards and View More popover

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/StateLabel.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/StateLabel.tsx
@@ -6,6 +6,8 @@
 import Label from '@clayui/label';
 import React from 'react';
 
+import isOverdue from '../utils/isOverdue';
+
 type NameDisplayType =
 	| 'danger'
 	| 'info'
@@ -39,16 +41,13 @@ function StateLabel({dueDate, state}: StateLabelProps) {
 		return null;
 	}
 
-	const isOverdue =
-		dueDate && state.key !== 'done' && Date.parse(dueDate) < Date.now();
-
 	return (
 		<div>
 			<Label displayType={mapKeyToNameDisplayType[state.key]}>
 				{state.name}
 			</Label>
 
-			{isOverdue && (
+			{isOverdue({dueDate, state}) && (
 				<Label displayType="warning">
 					{Liferay.Language.get('overdue')}
 				</Label>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
@@ -1,0 +1,31 @@
+@import 'atlas-variables';
+
+.lfr__cmp-calendar-more-link-popover {
+	max-height: 20rem;
+	overflow-y: auto;
+	width: 16rem;
+
+	&-task {
+		align-items: center;
+		display: flex;
+		gap: 0.5rem;
+		padding: 0.25rem 1rem;
+
+		&-assignee {
+			flex-shrink: 0;
+		}
+
+		&-state {
+			flex-shrink: 0;
+		}
+
+		&-title {
+			color: $secondary;
+			flex-grow: 1;
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
@@ -18,7 +18,7 @@
 		&-state {
 			flex-shrink: 0;
 
-			label {
+			.label {
 				margin-right: 0;
 			}
 		}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.scss
@@ -17,6 +17,10 @@
 
 		&-state {
 			flex-shrink: 0;
+
+			label {
+				margin-right: 0;
+			}
 		}
 
 		&-title {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayDropDown from '@clayui/drop-down';
+import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
+import React from 'react';
+
+import {ITaskObjectEntry} from '../../../../utils/types';
+import StateLabel from '../../../StateLabel';
+
+import './CalendarMoreLinkPopover.scss';
+
+const STATE_PRIORITY: {[key: string]: number} = {
+	blocked: 1,
+	done: 4,
+	inProgress: 2,
+	notStarted: 3,
+};
+
+const OVERDUE_PRIORITY = 0;
+
+const UNKNOWN_PRIORITY = 5;
+
+function isTaskOverdue(task: ITaskObjectEntry): boolean {
+	return (
+		Boolean(task.dueDate) &&
+		task.state?.key !== 'done' &&
+		Date.parse(task.dueDate) < Date.now()
+	);
+}
+
+function getDisplayState(task: ITaskObjectEntry) {
+	if (isTaskOverdue(task)) {
+		return {key: 'overdue', name: Liferay.Language.get('overdue')};
+	}
+
+	return task.state;
+}
+
+function getTaskPriority(task: ITaskObjectEntry): number {
+	if (isTaskOverdue(task)) {
+		return OVERDUE_PRIORITY;
+	}
+
+	return STATE_PRIORITY[task.state?.key] ?? UNKNOWN_PRIORITY;
+}
+
+interface CalendarMoreLinkPopoverProps {
+	alignElement: HTMLElement;
+	onClose: () => void;
+	tasks: ITaskObjectEntry[];
+}
+
+export default function CalendarMoreLinkPopover({
+	alignElement,
+	onClose,
+	tasks,
+}: CalendarMoreLinkPopoverProps) {
+	const sortedTasks = [...tasks].sort(
+		(taskA, taskB) => getTaskPriority(taskA) - getTaskPriority(taskB)
+	);
+
+	return (
+		<ClayDropDown.Menu
+			active
+			alignElementRef={{current: alignElement}}
+			className="lfr__cmp-calendar-more-link-popover"
+			onActiveChange={onClose}
+		>
+			<div className="lfr__cmp-calendar-more-link-popover-tasks">
+				{sortedTasks.map((task) => (
+					<div
+						className="lfr__cmp-calendar-more-link-popover-task"
+						key={task.id}
+					>
+						<span className="lfr__cmp-calendar-more-link-popover-task-title">
+							{task.title}
+						</span>
+
+						<span className="lfr__cmp-calendar-more-link-popover-task-state">
+							<StateLabel state={getDisplayState(task)} />
+						</span>
+
+						<span className="lfr__cmp-calendar-more-link-popover-task-assignee">
+							<AssigneeAvatar
+								name={task.assignTo?.name}
+								portrait={task.assignTo?.portrait}
+							/>
+						</span>
+					</div>
+				))}
+			</div>
+		</ClayDropDown.Menu>
+	);
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
@@ -27,7 +27,7 @@ function isTaskOverdue(task: ITaskObjectEntry): boolean {
 	return (
 		Boolean(task.dueDate) &&
 		task.state?.key !== 'done' &&
-		Date.parse(task.dueDate) < Date.now()
+		task.dueDate.slice(0, 10) < new Date().toISOString().slice(0, 10)
 	);
 }
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
@@ -75,7 +75,10 @@ export default function CalendarMoreLinkPopover({
 						className="lfr__cmp-calendar-more-link-popover-task"
 						key={task.id}
 					>
-						<span className="lfr__cmp-calendar-more-link-popover-task-title">
+						<span
+							className="lfr__cmp-calendar-more-link-popover-task-title"
+							data-testid="calendarMoreLinkPopoverTaskTitle"
+						>
 							{task.title}
 						</span>
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
@@ -67,6 +67,7 @@ export default function CalendarMoreLinkPopover({
 			active
 			alignElementRef={{current: alignElement}}
 			className="lfr__cmp-calendar-more-link-popover"
+			data-testid="calendarMoreLinkPopover"
 			onActiveChange={onClose}
 		>
 			<div className="lfr__cmp-calendar-more-link-popover-tasks">

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover.tsx
@@ -7,6 +7,7 @@ import ClayDropDown from '@clayui/drop-down';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import React from 'react';
 
+import isOverdue from '../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../utils/types';
 import StateLabel from '../../../StateLabel';
 
@@ -23,16 +24,8 @@ const OVERDUE_PRIORITY = 0;
 
 const UNKNOWN_PRIORITY = 5;
 
-function isTaskOverdue(task: ITaskObjectEntry): boolean {
-	return (
-		Boolean(task.dueDate) &&
-		task.state?.key !== 'done' &&
-		task.dueDate.slice(0, 10) < new Date().toISOString().slice(0, 10)
-	);
-}
-
 function getDisplayState(task: ITaskObjectEntry) {
-	if (isTaskOverdue(task)) {
+	if (isOverdue(task)) {
 		return {key: 'overdue', name: Liferay.Language.get('overdue')};
 	}
 
@@ -40,7 +33,7 @@ function getDisplayState(task: ITaskObjectEntry) {
 }
 
 function getTaskPriority(task: ITaskObjectEntry): number {
-	if (isTaskOverdue(task)) {
+	if (isOverdue(task)) {
 		return OVERDUE_PRIORITY;
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.scss
@@ -15,14 +15,6 @@
 		flex-shrink: 0;
 	}
 
-	&-blocked {
-		background-color: $danger-l2;
-	}
-
-	&-done {
-		background-color: $success-l2;
-	}
-
 	&-icon {
 		flex-shrink: 0;
 		font-size: 1rem;
@@ -37,15 +29,23 @@
 		color: $warning;
 	}
 
-	&-inProgress {
+	&-state-blocked {
+		background-color: $danger-l2;
+	}
+
+	&-state-done {
+		background-color: $success-l2;
+	}
+
+	&-state-inProgress {
 		background-color: $info-l2;
 	}
 
-	&-notStarted {
-		background-color: $secondary-l2;
+	&-state-notStarted {
+		background-color: $white;
 	}
 
-	&-overdue {
+	&-state-overdue {
 		background-color: $warning-l2;
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.scss
@@ -1,0 +1,60 @@
+@import 'atlas-variables';
+
+.lfr__cmp-calendar-task-card {
+	align-items: center;
+	border: 1px solid $border-color;
+	border-radius: 0.5rem;
+	color: $body-color;
+	display: flex;
+	gap: 0.25rem;
+	height: 2rem;
+	padding: 0.25rem 0.5rem;
+	width: 100%;
+
+	&-assignee {
+		flex-shrink: 0;
+	}
+
+	&-blocked {
+		background-color: $danger-l2;
+	}
+
+	&-done {
+		background-color: $success-l2;
+	}
+
+	&-icon {
+		flex-shrink: 0;
+		font-size: 1rem;
+		margin-top: 0;
+	}
+
+	&-icon-blocked {
+		color: $danger;
+	}
+
+	&-icon-overdue {
+		color: $warning;
+	}
+
+	&-inProgress {
+		background-color: $info-l2;
+	}
+
+	&-notStarted {
+		background-color: $secondary-l2;
+	}
+
+	&-overdue {
+		background-color: $warning-l2;
+	}
+
+	&-title {
+		flex-grow: 1;
+		font-size: map-get($font-scale, 2);
+		font-weight: $font-weight-normal;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
+import classNames from 'classnames';
+import React from 'react';
+
+import {ITaskObjectEntry} from '../../../../utils/types';
+
+import './CalendarTaskCard.scss';
+
+interface CalendarTaskCardProps {
+	task: ITaskObjectEntry;
+}
+
+export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
+	const {assignTo, dueDate, state, title} = task;
+
+	const isBlocked = state?.key === 'blocked';
+
+	const isOverdue =
+		Boolean(dueDate) &&
+		state?.key !== 'done' &&
+		Date.parse(dueDate) < Date.now();
+
+	return (
+		<div
+			className={classNames(
+				'lfr__cmp-calendar-task-card',
+				isOverdue
+					? 'lfr__cmp-calendar-task-card-overdue'
+					: state?.key && `lfr__cmp-calendar-task-card-${state.key}`
+			)}
+		>
+			<span className="lfr__cmp-calendar-task-card-title">{title}</span>
+
+			{isBlocked && !isOverdue && (
+				<ClayIcon
+					className="lfr__cmp-calendar-task-card-icon lfr__cmp-calendar-task-card-icon-blocked"
+					symbol="block"
+				/>
+			)}
+
+			{isOverdue && (
+				<ClayIcon
+					className="lfr__cmp-calendar-task-card-icon lfr__cmp-calendar-task-card-icon-overdue"
+					symbol="exclamation-full"
+				/>
+			)}
+
+			<span className="lfr__cmp-calendar-task-card-assignee">
+				<AssigneeAvatar
+					name={assignTo?.name}
+					portrait={assignTo?.portrait}
+				/>
+			</span>
+		</div>
+	);
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
@@ -24,7 +24,7 @@ export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
 	const isOverdue =
 		Boolean(dueDate) &&
 		state?.key !== 'done' &&
-		Date.parse(dueDate) < Date.now();
+		dueDate.slice(0, 10) < new Date().toISOString().slice(0, 10);
 
 	return (
 		<div

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
@@ -25,13 +25,11 @@ export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
 
 	return (
 		<div
-			className={classNames(
-				'lfr__cmp-calendar-task-card',
-				overdue
-					? 'lfr__cmp-calendar-task-card-state-overdue'
-					: state?.key &&
-							`lfr__cmp-calendar-task-card-state-${state.key}`
-			)}
+			className={classNames('lfr__cmp-calendar-task-card', {
+				'lfr__cmp-calendar-task-card-state-overdue': overdue,
+				[`lfr__cmp-calendar-task-card-state-${state?.key}`]:
+					!overdue && state?.key,
+			})}
 		>
 			<span className="lfr__cmp-calendar-task-card-title">{title}</span>
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
@@ -31,8 +31,9 @@ export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
 			className={classNames(
 				'lfr__cmp-calendar-task-card',
 				isOverdue
-					? 'lfr__cmp-calendar-task-card-overdue'
-					: state?.key && `lfr__cmp-calendar-task-card-${state.key}`
+					? 'lfr__cmp-calendar-task-card-state-overdue'
+					: state?.key &&
+							`lfr__cmp-calendar-task-card-state-${state.key}`
 			)}
 		>
 			<span className="lfr__cmp-calendar-task-card-title">{title}</span>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarTaskCard.tsx
@@ -8,6 +8,7 @@ import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-ty
 import classNames from 'classnames';
 import React from 'react';
 
+import isOverdue from '../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../utils/types';
 
 import './CalendarTaskCard.scss';
@@ -19,18 +20,14 @@ interface CalendarTaskCardProps {
 export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
 	const {assignTo, dueDate, state, title} = task;
 
-	const isBlocked = state?.key === 'blocked';
-
-	const isOverdue =
-		Boolean(dueDate) &&
-		state?.key !== 'done' &&
-		dueDate.slice(0, 10) < new Date().toISOString().slice(0, 10);
+	const blocked = state?.key === 'blocked';
+	const overdue = isOverdue({dueDate, state});
 
 	return (
 		<div
 			className={classNames(
 				'lfr__cmp-calendar-task-card',
-				isOverdue
+				overdue
 					? 'lfr__cmp-calendar-task-card-state-overdue'
 					: state?.key &&
 							`lfr__cmp-calendar-task-card-state-${state.key}`
@@ -38,14 +35,14 @@ export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
 		>
 			<span className="lfr__cmp-calendar-task-card-title">{title}</span>
 
-			{isBlocked && !isOverdue && (
+			{blocked && !overdue && (
 				<ClayIcon
 					className="lfr__cmp-calendar-task-card-icon lfr__cmp-calendar-task-card-icon-blocked"
 					symbol="block"
 				/>
 			)}
 
-			{isOverdue && (
+			{overdue && (
 				<ClayIcon
 					className="lfr__cmp-calendar-task-card-icon lfr__cmp-calendar-task-card-icon-overdue"
 					symbol="exclamation-full"

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -11,6 +11,7 @@
 	.fc-daygrid-event {
 		border: 0;
 		box-shadow: none;
+		margin-top: 4px;
 	}
 
 	// Override the global ".fds a" rule that underlines event links

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -15,12 +15,25 @@
 
 	// Override the global ".fds a" rule that underlines event links
 
-	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link) {
+	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link),
+	.fc-daygrid-more-link:not(.btn):not(.component-action):not(.page-link) {
 		text-decoration: none;
 	}
 
 	.fc-daygrid-block-event .fc-event-main {
 		padding: 0;
+	}
+
+	.fc-daygrid-more-link.fc-more-link {
+		padding: 0;
+
+		.btn {
+			font-size: map-get($font-scale, 2);
+		}
+
+		&:hover {
+			background-color: transparent;
+		}
 	}
 
 	.fc-direction-ltr .fc-daygrid-event.fc-event-end,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -16,8 +16,7 @@
 
 	// Override the global ".fds a" rule that underlines event links
 
-	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link),
-	.fc-daygrid-more-link:not(.btn):not(.component-action):not(.page-link) {
+	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link) {
 		text-decoration: none;
 	}
 
@@ -26,14 +25,14 @@
 	}
 
 	.fc-daygrid-more-link.fc-more-link {
-		padding: 0;
-
-		.btn {
-			font-size: map-get($font-scale, 2);
-		}
+		font-size: map-get($font-scale, 2);
+		line-height: 1.5;
+		margin: 4px;
+		padding: 0.125rem 0.5rem;
 
 		&:hover {
-			background-color: transparent;
+			background-color: rgba($gray-900, 0.06);
+			color: $gray-900;
 		}
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -2,9 +2,36 @@
 
 .lfr__calendar-view {
 	--fc-border-color: #{$border-color};
+	--fc-event-bg-color: transparent;
+	--fc-event-border-color: transparent;
 	--fc-today-bg-color: transparent;
 
 	margin-top: -1rem;
+
+	.fc-daygrid-event {
+		border: 0;
+		box-shadow: none;
+	}
+
+	// Override the global ".fds a" rule that underlines event links
+
+	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link) {
+		text-decoration: none;
+	}
+
+	.fc-daygrid-block-event .fc-event-main {
+		padding: 0;
+	}
+
+	.fc-direction-ltr .fc-daygrid-event.fc-event-end,
+	.fc-direction-rtl .fc-daygrid-event.fc-event-start {
+		margin-right: 0.25rem;
+	}
+
+	.fc-direction-ltr .fc-daygrid-event.fc-event-start,
+	.fc-direction-rtl .fc-daygrid-event.fc-event-end {
+		margin-left: 0.25rem;
+	}
 
 	&-toolbar {
 		align-items: center;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -201,7 +201,7 @@ export default function CalendarView({items}: CalendarViewProps) {
 					return true as unknown as void;
 				}}
 				moreLinkContent={(arg) => (
-					<ClayButton borderless displayType="secondary" size="sm">
+					<ClayButton borderless displayType="secondary" size="xs">
 						{`${arg.num} ${Liferay.Language.get('more')}`}
 
 						<span className="inline-item inline-item-after">

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -5,7 +5,6 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDatePicker from '@clayui/date-picker';
-import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import FullCalendar from '@fullcalendar/react';
@@ -15,6 +14,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {ITask, ITaskObjectEntry} from '../../../../utils/types';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
+import CalendarMoreLinkPopover from './CalendarMoreLinkPopover';
 import CalendarTaskCard from './CalendarTaskCard';
 
 import './CalendarView.scss';
@@ -214,19 +214,11 @@ export default function CalendarView({items}: CalendarViewProps) {
 			/>
 
 			{moreLinkPopover && (
-				<ClayDropDown.Menu
-					active
-					alignElementRef={{current: moreLinkPopover.alignElement}}
-					onActiveChange={() => setMoreLinkPopover(null)}
-				>
-					<ClayDropDown.ItemList>
-						{moreLinkPopover.tasks.map((task) => (
-							<ClayDropDown.Item key={task.id}>
-								{task.title}
-							</ClayDropDown.Item>
-						))}
-					</ClayDropDown.ItemList>
-				</ClayDropDown.Menu>
+				<CalendarMoreLinkPopover
+					alignElement={moreLinkPopover.alignElement}
+					onClose={() => setMoreLinkPopover(null)}
+					tasks={moreLinkPopover.tasks}
+				/>
 			)}
 		</div>
 	);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -5,6 +5,7 @@
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDatePicker from '@clayui/date-picker';
+import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import FullCalendar from '@fullcalendar/react';
@@ -12,7 +13,7 @@ import classNames from 'classnames';
 import {dateUtils} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
-import {ITask} from '../../../../utils/types';
+import {ITask, ITaskObjectEntry} from '../../../../utils/types';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
 import CalendarTaskCard from './CalendarTaskCard';
 
@@ -24,11 +25,19 @@ interface CalendarViewProps {
 	items: ITask[];
 }
 
+interface MoreLinkPopover {
+	alignElement: HTMLElement;
+	date: Date;
+	tasks: ITaskObjectEntry[];
+}
+
 export default function CalendarView({items}: CalendarViewProps) {
 	const calendarRef = useRef<FullCalendar>(null);
 
 	const [datePickerExpanded, setDatePickerExpanded] = useState(false);
 	const [datePickerValue, setDatePickerValue] = useState('');
+	const [moreLinkPopover, setMoreLinkPopover] =
+		useState<MoreLinkPopover | null>(null);
 	const [title, setTitle] = useState('');
 
 	const events = useMemo(
@@ -37,6 +46,11 @@ export default function CalendarView({items}: CalendarViewProps) {
 				.filter((item) => item.embedded?.dueDate)
 				.map((item) => ({
 					allDay: true,
+
+					// Attach the full task entry to the event so the custom
+					// renderers (eventContent and the "more" popover) can read
+					// it back through event.extendedProps.
+
 					extendedProps: {task: item.embedded},
 					id: String(item.embedded.id),
 					start: item.embedded.dueDate.slice(0, 10),
@@ -161,15 +175,59 @@ export default function CalendarView({items}: CalendarViewProps) {
 			<FullCalendar
 				datesSet={({view}) => setTitle(view.title)}
 				dayHeaderFormat={{weekday: 'long'}}
+				dayMaxEvents
 				eventContent={(arg) => (
 					<CalendarTaskCard task={arg.event.extendedProps.task} />
 				)}
 				events={events}
 				headerToolbar={false}
 				initialView="dayGridMonth"
+				moreLinkClick={(arg) => {
+					setMoreLinkPopover({
+						alignElement: arg.jsEvent.currentTarget as HTMLElement,
+						date: arg.date,
+						tasks: arg.hiddenSegs.map(
+							(seg) => seg.event.extendedProps.task
+						),
+					});
+
+					// Prevent FullCalendar's built-in popover from opening.
+					// It stays closed only when the handler returns a truthy
+					// value other than "popover". The return type is
+					// "string | void", which rejects a boolean, so "true" is
+					// force-cast to void for the compiler; at runtime the
+					// value is still true.
+
+					return true as unknown as void;
+				}}
+				moreLinkContent={(arg) => (
+					<ClayButton borderless displayType="secondary" size="sm">
+						{`${arg.num} ${Liferay.Language.get('more')}`}
+
+						<span className="inline-item inline-item-after">
+							<ClayIcon symbol="caret-bottom" />
+						</span>
+					</ClayButton>
+				)}
 				plugins={[dayGridPlugin]}
 				ref={calendarRef}
 			/>
+
+			{moreLinkPopover && (
+				<ClayDropDown.Menu
+					active
+					alignElementRef={{current: moreLinkPopover.alignElement}}
+					onActiveChange={() => setMoreLinkPopover(null)}
+				>
+					<ClayDropDown.ItemList>
+						{moreLinkPopover.tasks.map((task) => (
+							<ClayDropDown.Item key={task.id}>
+								{task.title}
+							</ClayDropDown.Item>
+						))}
+					</ClayDropDown.ItemList>
+				</ClayDropDown.Menu>
+			)}
 		</div>
 	);
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -14,6 +14,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {ITask} from '../../../../utils/types';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
+import CalendarTaskCard from './CalendarTaskCard';
 
 import './CalendarView.scss';
 
@@ -36,12 +37,16 @@ export default function CalendarView({items}: CalendarViewProps) {
 				.filter((item) => item.embedded?.dueDate)
 				.map((item) => ({
 					allDay: true,
+					extendedProps: {task: item.embedded},
 					id: String(item.embedded.id),
 					start: item.embedded.dueDate.slice(0, 10),
 					title: item.embedded.title,
 				})),
 		[items]
 	);
+
+	const currentYear = new Date().getFullYear();
+	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
 
 	useEffect(() => {
 		Liferay.fire(UPDATE_TASKS_QUICK_FILTER_VISIBILITY, {visible: false});
@@ -50,9 +55,6 @@ export default function CalendarView({items}: CalendarViewProps) {
 			Liferay.fire(UPDATE_TASKS_QUICK_FILTER_VISIBILITY, {visible: true});
 		};
 	}, []);
-
-	const currentYear = new Date().getFullYear();
-	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
 
 	return (
 		<div className="lfr__calendar-view">
@@ -159,6 +161,9 @@ export default function CalendarView({items}: CalendarViewProps) {
 			<FullCalendar
 				datesSet={({view}) => setTitle(view.title)}
 				dayHeaderFormat={{weekday: 'long'}}
+				eventContent={(arg) => (
+					<CalendarTaskCard task={arg.event.extendedProps.task} />
+				)}
 				events={events}
 				headerToolbar={false}
 				initialView="dayGridMonth"

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -191,7 +191,7 @@ export default function CalendarView({items}: CalendarViewProps) {
 					setMoreLinkPopover({
 						alignElement: arg.jsEvent.currentTarget as HTMLElement,
 						date: arg.date,
-						tasks: arg.hiddenSegs.map(
+						tasks: arg.allSegs.map(
 							(seg) => seg.event.extendedProps.task
 						),
 					});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -182,6 +182,11 @@ export default function CalendarView({items}: CalendarViewProps) {
 				events={events}
 				headerToolbar={false}
 				initialView="dayGridMonth"
+				moreLinkClassNames={[
+					'btn',
+					'btn-outline-secondary',
+					'btn-outline-borderless',
+				]}
 				moreLinkClick={(arg) => {
 					setMoreLinkPopover({
 						alignElement: arg.jsEvent.currentTarget as HTMLElement,
@@ -201,14 +206,15 @@ export default function CalendarView({items}: CalendarViewProps) {
 					return true as unknown as void;
 				}}
 				moreLinkContent={(arg) => (
-					<ClayButton borderless displayType="secondary" size="xs">
+					<>
 						{`${arg.num} ${Liferay.Language.get('more')}`}
 
 						<span className="inline-item inline-item-after">
 							<ClayIcon symbol="caret-bottom" />
 						</span>
-					</ClayButton>
+					</>
 				)}
+				moreLinkHint={Liferay.Language.get('view-all-tasks')}
 				plugins={[dayGridPlugin]}
 				ref={calendarRef}
 			/>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/isOverdue.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/isOverdue.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function isOverdue({
+	dueDate,
+	state,
+}: {
+	dueDate?: string;
+	state?: {
+		key: string;
+		name: string;
+	};
+}): boolean {
+	return (
+		Boolean(dueDate) &&
+		state?.key !== 'done' &&
+		dueDate!.slice(0, 10) < new Date().toISOString().slice(0, 10)
+	);
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import CalendarMoreLinkPopover from '../../js/components/props_transformer/views/calendar_view/CalendarMoreLinkPopover';
+import {ITaskObjectEntry} from '../../js/utils/types';
+
+jest.mock('@clayui/drop-down', () => ({
+	__esModule: true,
+	default: {
+		Menu: ({children}: {children: React.ReactNode}) => (
+			<div>{children}</div>
+		),
+	},
+}));
+
+jest.mock('@liferay/object-dynamic-data-mapping-form-field-type', () => ({
+	AssigneeAvatar: ({name}: {name: string}) => <span>{name}</span>,
+}));
+
+const futureDueDate = '2026-02-10T00:00:00Z';
+const mockedSystemDate = '2026-02-05T00:00:00Z';
+const pastDueDate = '2026-02-04T00:00:00Z';
+
+function createTask(overrides: Partial<ITaskObjectEntry> = {}) {
+	return {
+		assignTo: {
+			name: 'Jane Doe',
+			portrait: 'https://example.com/jane.png',
+		},
+		dueDate: futureDueDate,
+		id: 1,
+		state: {
+			key: 'inProgress',
+			name: 'In Progress',
+		},
+		title: 'Design the landing page',
+		...overrides,
+	} as ITaskObjectEntry;
+}
+
+function renderPopover(tasks: ITaskObjectEntry[]) {
+	return render(
+		<CalendarMoreLinkPopover
+			alignElement={document.createElement('a')}
+			onClose={jest.fn()}
+			tasks={tasks}
+		/>
+	);
+}
+
+describe('CalendarMoreLinkPopover', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+
+		jest.setSystemTime(new Date(mockedSystemDate));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	it('renders every task for the day', () => {
+		const {getByText} = renderPopover([
+			createTask({id: 1, title: 'Alpha'}),
+			createTask({id: 2, title: 'Beta'}),
+		]);
+
+		expect(getByText('Alpha')).toBeInTheDocument();
+		expect(getByText('Beta')).toBeInTheDocument();
+	});
+
+	it('renders the state label for a task', () => {
+		const {getByText} = renderPopover([
+			createTask({state: {key: 'inProgress', name: 'In Progress'}}),
+		]);
+
+		expect(getByText('In Progress')).toBeInTheDocument();
+	});
+
+	it('shows only the overdue label for an overdue task', () => {
+		const {getByText, queryByText} = renderPopover([
+			createTask({
+				dueDate: pastDueDate,
+				state: {key: 'inProgress', name: 'In Progress'},
+			}),
+		]);
+
+		expect(getByText('overdue')).toBeInTheDocument();
+		expect(queryByText('In Progress')).not.toBeInTheDocument();
+	});
+
+	it('orders tasks by overdue, blocked, in progress, not started, then done', () => {
+		const {getAllByTestId} = renderPopover([
+			createTask({
+				id: 1,
+				state: {key: 'done', name: 'Done'},
+				title: 'DoneTask',
+			}),
+			createTask({
+				id: 2,
+				state: {key: 'notStarted', name: 'Not Started'},
+				title: 'NotStartedTask',
+			}),
+			createTask({
+				id: 3,
+				state: {key: 'inProgress', name: 'In Progress'},
+				title: 'InProgressTask',
+			}),
+			createTask({
+				id: 4,
+				state: {key: 'blocked', name: 'Blocked'},
+				title: 'BlockedTask',
+			}),
+			createTask({
+				dueDate: pastDueDate,
+				id: 5,
+				state: {key: 'inProgress', name: 'In Progress'},
+				title: 'OverdueTask',
+			}),
+		]);
+
+		const titles = getAllByTestId('calendarMoreLinkPopoverTaskTitle').map(
+			(element) => element.textContent
+		);
+
+		expect(titles).toEqual([
+			'OverdueTask',
+			'BlockedTask',
+			'InProgressTask',
+			'NotStartedTask',
+			'DoneTask',
+		]);
+	});
+});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
@@ -65,36 +65,6 @@ describe('CalendarMoreLinkPopover', () => {
 		jest.useRealTimers();
 	});
 
-	it('renders every task for the day', () => {
-		const {getByText} = renderPopover([
-			createTask({id: 1, title: 'Alpha'}),
-			createTask({id: 2, title: 'Beta'}),
-		]);
-
-		expect(getByText('Alpha')).toBeInTheDocument();
-		expect(getByText('Beta')).toBeInTheDocument();
-	});
-
-	it('renders the state label for a task', () => {
-		const {getByText} = renderPopover([
-			createTask({state: {key: 'inProgress', name: 'In Progress'}}),
-		]);
-
-		expect(getByText('In Progress')).toBeInTheDocument();
-	});
-
-	it('shows only the overdue label for an overdue task', () => {
-		const {getByText, queryByText} = renderPopover([
-			createTask({
-				dueDate: pastDueDate,
-				state: {key: 'inProgress', name: 'In Progress'},
-			}),
-		]);
-
-		expect(getByText('overdue')).toBeInTheDocument();
-		expect(queryByText('In Progress')).not.toBeInTheDocument();
-	});
-
 	it('orders tasks by overdue, blocked, in progress, not started, then done', () => {
 		const {getAllByTestId} = renderPopover([
 			createTask({
@@ -136,5 +106,35 @@ describe('CalendarMoreLinkPopover', () => {
 			'NotStartedTask',
 			'DoneTask',
 		]);
+	});
+
+	it('renders every task for the day', () => {
+		const {getByText} = renderPopover([
+			createTask({id: 1, title: 'Alpha'}),
+			createTask({id: 2, title: 'Beta'}),
+		]);
+
+		expect(getByText('Alpha')).toBeInTheDocument();
+		expect(getByText('Beta')).toBeInTheDocument();
+	});
+
+	it('renders the state label for a task', () => {
+		const {getByText} = renderPopover([
+			createTask({state: {key: 'inProgress', name: 'In Progress'}}),
+		]);
+
+		expect(getByText('In Progress')).toBeInTheDocument();
+	});
+
+	it('shows only the overdue label for an overdue task', () => {
+		const {getByText, queryByText} = renderPopover([
+			createTask({
+				dueDate: pastDueDate,
+				state: {key: 'inProgress', name: 'In Progress'},
+			}),
+		]);
+
+		expect(getByText('overdue')).toBeInTheDocument();
+		expect(queryByText('In Progress')).not.toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
@@ -47,55 +47,9 @@ describe('CalendarTaskCard', () => {
 		jest.useRealTimers();
 	});
 
-	it('renders the task title', () => {
-		const {getByText} = render(<CalendarTaskCard task={createTask()} />);
-
-		expect(getByText('Design the landing page')).toBeInTheDocument();
-	});
-
-	it('renders the blocked icon when the task is blocked', () => {
-		const {container} = render(
-			<CalendarTaskCard
-				task={createTask({state: {key: 'blocked', name: 'Blocked'}})}
-			/>
-		);
-
-		expect(
-			container.querySelector('.lexicon-icon-block')
-		).toBeInTheDocument();
-	});
-
 	it('does not render the blocked icon when the task is not blocked', () => {
 		const {container} = render(<CalendarTaskCard task={createTask()} />);
 
-		expect(
-			container.querySelector('.lexicon-icon-block')
-		).not.toBeInTheDocument();
-	});
-
-	it('renders the overdue icon when the due date is past and the state is not done', () => {
-		const {container} = render(
-			<CalendarTaskCard task={createTask({dueDate: pastDueDate})} />
-		);
-
-		expect(
-			container.querySelector('.lexicon-icon-exclamation-full')
-		).toBeInTheDocument();
-	});
-
-	it('shows the overdue icon instead of the blocked icon when a blocked task is also overdue', () => {
-		const {container} = render(
-			<CalendarTaskCard
-				task={createTask({
-					dueDate: pastDueDate,
-					state: {key: 'blocked', name: 'Blocked'},
-				})}
-			/>
-		);
-
-		expect(
-			container.querySelector('.lexicon-icon-exclamation-full')
-		).toBeInTheDocument();
 		expect(
 			container.querySelector('.lexicon-icon-block')
 		).not.toBeInTheDocument();
@@ -123,5 +77,51 @@ describe('CalendarTaskCard', () => {
 
 		expect(avatar).toBeInTheDocument();
 		expect(avatar).toHaveAttribute('src', 'https://example.com/jane.png');
+	});
+
+	it('renders the blocked icon when the task is blocked', () => {
+		const {container} = render(
+			<CalendarTaskCard
+				task={createTask({state: {key: 'blocked', name: 'Blocked'}})}
+			/>
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-block')
+		).toBeInTheDocument();
+	});
+
+	it('renders the overdue icon when the due date is past and the state is not done', () => {
+		const {container} = render(
+			<CalendarTaskCard task={createTask({dueDate: pastDueDate})} />
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-exclamation-full')
+		).toBeInTheDocument();
+	});
+
+	it('renders the task title', () => {
+		const {getByText} = render(<CalendarTaskCard task={createTask()} />);
+
+		expect(getByText('Design the landing page')).toBeInTheDocument();
+	});
+
+	it('shows the overdue icon instead of the blocked icon when a blocked task is also overdue', () => {
+		const {container} = render(
+			<CalendarTaskCard
+				task={createTask({
+					dueDate: pastDueDate,
+					state: {key: 'blocked', name: 'Blocked'},
+				})}
+			/>
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-exclamation-full')
+		).toBeInTheDocument();
+		expect(
+			container.querySelector('.lexicon-icon-block')
+		).not.toBeInTheDocument();
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarTaskCard.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import CalendarTaskCard from '../../js/components/props_transformer/views/calendar_view/CalendarTaskCard';
+import {ITaskObjectEntry} from '../../js/utils/types';
+
+jest.mock('@liferay/object-dynamic-data-mapping-form-field-type', () => ({
+	AssigneeAvatar: ({name, portrait}: {name: string; portrait: string}) => (
+		<img alt={name} src={portrait} />
+	),
+}));
+
+const futureDueDate = '2026-02-10T00:00:00Z';
+const mockedSystemDate = '2026-02-05T00:00:00Z';
+const pastDueDate = '2026-02-04T00:00:00Z';
+
+function createTask(overrides: Partial<ITaskObjectEntry> = {}) {
+	return {
+		assignTo: {
+			name: 'Jane Doe',
+			portrait: 'https://example.com/jane.png',
+		},
+		dueDate: futureDueDate,
+		state: {
+			key: 'inProgress',
+			name: 'In Progress',
+		},
+		title: 'Design the landing page',
+		...overrides,
+	} as ITaskObjectEntry;
+}
+
+describe('CalendarTaskCard', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+
+		jest.setSystemTime(new Date(mockedSystemDate));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	it('renders the task title', () => {
+		const {getByText} = render(<CalendarTaskCard task={createTask()} />);
+
+		expect(getByText('Design the landing page')).toBeInTheDocument();
+	});
+
+	it('renders the blocked icon when the task is blocked', () => {
+		const {container} = render(
+			<CalendarTaskCard
+				task={createTask({state: {key: 'blocked', name: 'Blocked'}})}
+			/>
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-block')
+		).toBeInTheDocument();
+	});
+
+	it('does not render the blocked icon when the task is not blocked', () => {
+		const {container} = render(<CalendarTaskCard task={createTask()} />);
+
+		expect(
+			container.querySelector('.lexicon-icon-block')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the overdue icon when the due date is past and the state is not done', () => {
+		const {container} = render(
+			<CalendarTaskCard task={createTask({dueDate: pastDueDate})} />
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-exclamation-full')
+		).toBeInTheDocument();
+	});
+
+	it('shows the overdue icon instead of the blocked icon when a blocked task is also overdue', () => {
+		const {container} = render(
+			<CalendarTaskCard
+				task={createTask({
+					dueDate: pastDueDate,
+					state: {key: 'blocked', name: 'Blocked'},
+				})}
+			/>
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-exclamation-full')
+		).toBeInTheDocument();
+		expect(
+			container.querySelector('.lexicon-icon-block')
+		).not.toBeInTheDocument();
+	});
+
+	it('does not render the overdue icon when the state is done', () => {
+		const {container} = render(
+			<CalendarTaskCard
+				task={createTask({
+					dueDate: pastDueDate,
+					state: {key: 'done', name: 'Done'},
+				})}
+			/>
+		);
+
+		expect(
+			container.querySelector('.lexicon-icon-exclamation-full')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the assignee avatar', () => {
+		const {getByAltText} = render(<CalendarTaskCard task={createTask()} />);
+
+		const avatar = getByAltText('Jane Doe');
+
+		expect(avatar).toBeInTheDocument();
+		expect(avatar).toHaveAttribute('src', 'https://example.com/jane.png');
+	});
+});

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
@@ -20,6 +20,8 @@ export class TasksPage {
 	readonly assignTaskToDialog: Locator;
 	readonly calendarView: {
 		datePickerMenu: Locator;
+		moreLinkButton: Locator;
+		moreLinkPopover: Locator;
 		nextMonthButton: Locator;
 		previousMonthButton: Locator;
 		title: Locator;
@@ -60,6 +62,8 @@ export class TasksPage {
 		});
 		this.calendarView = {
 			datePickerMenu: page.getByRole('dialog', {name: 'Choose date'}),
+			moreLinkButton: page.getByRole('button', {name: /\d+ More/}),
+			moreLinkPopover: page.getByTestId('calendarMoreLinkPopover'),
 			nextMonthButton: page.getByRole('button', {name: 'Next Month'}),
 			previousMonthButton: page.getByRole('button', {
 				name: 'Previous Month',

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
@@ -62,7 +62,7 @@ export class TasksPage {
 		});
 		this.calendarView = {
 			datePickerMenu: page.getByRole('dialog', {name: 'Select Date'}),
-			moreLinkButton: page.getByRole('link', {name: /\d+ More/}),
+			moreLinkButton: page.getByText(/\d+ More/),
 			moreLinkPopover: page.getByTestId('calendarMoreLinkPopover'),
 			nextMonthButton: page.getByRole('button', {name: 'Next Month'}),
 			previousMonthButton: page.getByRole('button', {

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
@@ -61,7 +61,7 @@ export class TasksPage {
 			name: 'Assign Tasks to',
 		});
 		this.calendarView = {
-			datePickerMenu: page.getByRole('dialog', {name: 'Choose date'}),
+			datePickerMenu: page.getByRole('dialog', {name: 'Select Date'}),
 			moreLinkButton: page.getByRole('button', {name: /\d+ More/}),
 			moreLinkPopover: page.getByTestId('calendarMoreLinkPopover'),
 			nextMonthButton: page.getByRole('button', {name: 'Next Month'}),

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
@@ -62,7 +62,7 @@ export class TasksPage {
 		});
 		this.calendarView = {
 			datePickerMenu: page.getByRole('dialog', {name: 'Select Date'}),
-			moreLinkButton: page.getByRole('button', {name: /\d+ More/}),
+			moreLinkButton: page.getByRole('link', {name: /\d+ More/}),
 			moreLinkPopover: page.getByTestId('calendarMoreLinkPopover'),
 			nextMonthButton: page.getByRole('button', {name: 'Next Month'}),
 			previousMonthButton: page.getByRole('button', {

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -11,6 +11,7 @@ import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {workflowPagesTest} from '../../../fixtures/workflowPagesTest';
 import {addSpaceUser} from '../../../utils/addSpaceUser';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {performUserSwitch} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -558,18 +559,25 @@ test(
 
 		const dueDate = toDateString(tomorrow);
 
-		const taskTitle = getRandomString();
+		const taskTitleBase = getRandomString();
 
-		await test.step('Create a task with a due date', async () => {
-			await apiHelpers.objectEntry.postObjectEntry(
-				{
-					dueDate: `${dueDate}T00:00:00Z`,
-					r_cmpProjectToCMPTasks_c_cmpProjectId: project.id,
-					title: taskTitle,
-				},
-				cmpTask,
-				project.scopeKey
-			);
+		const taskTitles = Array.from(
+			{length: 3},
+			(_, index) => `${taskTitleBase}-${index}`
+		);
+
+		await test.step('Create three tasks on the same due date', async () => {
+			for (const title of taskTitles) {
+				await apiHelpers.objectEntry.postObjectEntry(
+					{
+						dueDate: `${dueDate}T00:00:00Z`,
+						r_cmpProjectToCMPTasks_c_cmpProjectId: project.id,
+						title,
+					},
+					cmpTask,
+					project.scopeKey
+				);
+			}
 		});
 
 		const {calendarView} = tasksPage;
@@ -638,11 +646,40 @@ test(
 			);
 		});
 
-		await test.step('The task appears on its due date', async () => {
+		await test.step('The tasks appear on their due date', async () => {
 			await expect(
 				page
 					.locator(`[data-date="${dueDate}"]`)
-					.getByText(taskTitle, {exact: true})
+					.getByText(taskTitles[0], {exact: true})
+			).toBeVisible();
+		});
+
+		await test.step('A More link reveals the tasks hidden in a dense day', async () => {
+			const dayCell = page.locator(`[data-date="${dueDate}"]`);
+
+			await expect(
+				dayCell.getByText(taskTitles[1], {exact: true})
+			).toBeHidden();
+			await expect(
+				dayCell.getByText(taskTitles[2], {exact: true})
+			).toBeHidden();
+
+			await expect(calendarView.moreLinkButton).toBeVisible();
+
+			await clickAndExpectToBeVisible({
+				target: calendarView.moreLinkPopover,
+				trigger: calendarView.moreLinkButton,
+			});
+
+			await expect(
+				calendarView.moreLinkPopover.getByText(taskTitles[1], {
+					exact: true,
+				})
+			).toBeVisible();
+			await expect(
+				calendarView.moreLinkPopover.getByText(taskTitles[2], {
+					exact: true,
+				})
 			).toBeVisible();
 		});
 	}

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -666,9 +666,15 @@ test(
 
 			await expect(calendarView.moreLinkButton).toBeVisible();
 
-			await clickAndExpectToBeVisible({
-				target: calendarView.moreLinkPopover,
-				trigger: calendarView.moreLinkButton,
+			await test.step('Check that the custom popover opens', async () => {
+				await clickAndExpectToBeVisible({
+					target: calendarView.moreLinkPopover,
+					trigger: calendarView.moreLinkButton,
+				});
+			});
+
+			await test.step('Check that the default FullCalendar popover does not open', async () => {
+				await expect(page.locator('.fc-popover')).toBeHidden();
 			});
 
 			await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94185
https://liferay.atlassian.net/browse/LPD-92731

## What Is Being Fixed

- **LPD-94185** — Calendar tasks rendered as plain, unstyled titles, so you could not tell a task's status or assignee without opening it. This styles each task and shows that information on the card.
- **LPD-92731** — Days with many tasks had no overflow handling, so a dense cell grew unbounded and became unreadable. This handles the overflow.

## How It Is Being Fixed

**Task cards (LPD-94185)**

- Tasks now render through a custom `CalendarTaskCard` via FullCalendar's `eventContent`.
- Each card shows the task title, a status-tinted background, a status icon (`block` for blocked, `warning-full` for overdue), and the assignee avatar — reusing the existing `StateLabel` colors.
- The full task data object is passed on each event's `extendedProps` so the card can read it.

**Overflow handling (LPD-92731)**

- `dayMaxEvents` collapses the extra tasks on a dense day behind a "N More" button.
- Clicking it opens a custom `CalendarMoreLinkPopover` that lists only the hidden tasks, ordered Overdue → Blocked → In Progress → Not Started → Done.
- The handler suppresses FullCalendar's built-in popover so only the custom one shows.

<img width="1245" height="961" alt="Screenshot 2026-06-13 at 12 53 30 AM" src="https://github.com/user-attachments/assets/b96da1dd-c7c9-49b5-8388-e48debcfca55" />

## PR Check

**pr-check: PASS** — tested on `25811ceaa1e6c5f47d168388322c1455e11960d2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "25811ceaa1e6c5f47d168388322c1455e11960d2"} -->
