### PR TITLE
LPD-94261 Fix test assertion in testUpdateKaleoInstance

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/service/test/KaleoInstanceLocalServiceTest.java
@@ -119,9 +119,7 @@ public class KaleoInstanceLocalServiceTest
 		kaleoInstance = _kaleoInstanceLocalService.getKaleoInstance(
 			kaleoInstanceId);
 
-		Assert.assertEquals(
-			kaleoInstance.getMvccVersion() + parties,
-			kaleoInstance.getMvccVersion());
+		Assert.assertEquals(parties, kaleoInstance.getMvccVersion());
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94261

## What Is Being Fixed

The `testUpdateKaleoInstance` assertion compared `kaleoInstance.getMvccVersion() + parties` to `kaleoInstance.getMvccVersion()` — both sides evaluated from the same post-update instance reference, so the expected value was always greater than actual and the assertion always failed.

## How It Is Being Fixed

The assertion is simplified to `Assert.assertEquals(parties, kaleoInstance.getMvccVersion())`, directly verifying that after five concurrent updates the MVCC version equals five, as expected when the instance starts at version zero.

## PR Check

**pr-check: PASS** — tested on `907d0a6e3cf866cdb42795379188fe9fce9b2795`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "907d0a6e3cf866cdb42795379188fe9fce9b2795"} -->