### PR TITLE
LPD-91117 Use the version from the current object entry

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -67,6 +67,8 @@ public class ObjectEntryInfoItemUtil {
 				false, null, null, null, null, themeDisplay.getLocale(), null,
 				themeDisplay.getUser());
 
+		int version = serviceBuilderObjectEntry.getVersion();
+
 		if (serviceBuilderObjectEntry.getHeadObjectEntryId() > 0) {
 			serviceBuilderObjectEntry =
 				ObjectEntryLocalServiceUtil.fetchObjectEntry(
@@ -75,8 +77,7 @@ public class ObjectEntryInfoItemUtil {
 
 		ObjectEntryVersion objectEntryVersion =
 			ObjectEntryVersionLocalServiceUtil.fetchObjectEntryVersion(
-				serviceBuilderObjectEntry.getObjectEntryId(),
-				serviceBuilderObjectEntry.getVersion());
+				serviceBuilderObjectEntry.getObjectEntryId(), version);
 
 		if (objectEntryVersion != null) {
 			dtoConverterContext.setAttribute(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91117

## What Is Being Fixed

When versioning and workflow are enabled, the Object Entry Display Page exposed pending (unapproved) values. While resolving the `ObjectEntryVersion` to display, the code read the version *after* reassigning the entry to its head object entry, so it picked up the head (pending) version instead of the version of the current, approved object entry.

## How It Is Being Fixed

The version of the current object entry is now captured before the entry is reassigned to its head object entry, and that captured version is used when fetching the `ObjectEntryVersion`. The displayed field values therefore correspond to the current approved version rather than the pending head version.

## Why Are There No Tests?

The behavior is already covered by the existing integration test `ObjectEntryInfoItemFieldValuesProviderTest.testObjectEntryInfoItemFieldValuesProviderWithObjectEntryVersioning`.

<img width="3198" height="486" alt="image" src="https://github.com/user-attachments/assets/8a164706-81bc-47b7-81f1-a23a2348cd6c" />


## PR Check

**pr-check: PASS** — tested on `39c012ba5e2502cbceef382d1def6fde2be2d11f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "39c012ba5e2502cbceef382d1def6fde2be2d11f"} -->