### PR TITLE
LPD-94932 Render repeatable relationship field values in templates

### DIFF
--- a/modules/apps/object/object-info-api/bnd.bnd
+++ b/modules/apps/object/object-info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object Info API
 Bundle-SymbolicName: com.liferay.object.info.api
-Bundle-Version: 6.0.1
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.object.info.collection.provider.util,\
 	com.liferay.object.info.field.converter,\

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -39,6 +39,8 @@ import com.liferay.object.related.models.ObjectRelatedModelsProvider;
 import com.liferay.object.related.models.ObjectRelatedModelsProviderRegistry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
@@ -49,6 +51,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -66,6 +69,9 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -74,10 +80,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Carolina Barbosa
@@ -302,6 +310,113 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 		}
 
 		return null;
+	}
+
+	public static List<InfoFieldValue<Object>> getRelatedInfoFieldValues(
+			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+			ListTypeEntryLocalService listTypeEntryLocalService,
+			ObjectDefinition objectDefinition,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectEntryManagerRegistry objectEntryManagerRegistry,
+			ObjectEntryService objectEntryService,
+			ObjectFieldInfoFieldConverter objectFieldInfoFieldConverter,
+			ObjectFieldLocalService objectFieldLocalService,
+			ObjectRelationshipLocalService objectRelationshipLocalService,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		if (themeDisplay == null) {
+			return Collections.emptyList();
+		}
+
+		List<InfoFieldValue<Object>> relatedInfoFieldValues = new ArrayList<>();
+
+		for (ObjectRelationship objectRelationship :
+				objectRelationshipLocalService.getObjectRelationships(
+					objectDefinition.getObjectDefinitionId(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+			if (objectRelationship.isSelf() ||
+				Objects.equals(
+					objectDefinition.getObjectDefinitionId(),
+					objectRelationship.getObjectDefinitionId2())) {
+
+				continue;
+			}
+
+			ObjectDefinition relatedObjectDefinition =
+				objectDefinitionLocalService.fetchObjectDefinition(
+					objectRelationship.getObjectDefinitionId2());
+
+			if ((relatedObjectDefinition == null) ||
+				!relatedObjectDefinition.isDefaultStorageType() ||
+				relatedObjectDefinition.isUnmodifiableSystemObject()) {
+
+				continue;
+			}
+
+			DefaultObjectEntryManager defaultObjectEntryManager =
+				DefaultObjectEntryManagerProvider.provide(
+					objectEntryManagerRegistry.getObjectEntryManager(
+						relatedObjectDefinition.getCompanyId(),
+						relatedObjectDefinition.getStorageType()));
+
+			Page<ObjectEntry> relatedObjectEntriesPage =
+				defaultObjectEntryManager.getRelatedObjectEntries(
+					null,
+					new DefaultDTOConverterContext(
+						false, null, null, null, null, themeDisplay.getLocale(),
+						null, themeDisplay.getUser()),
+					serviceBuilderObjectEntry.getExternalReferenceCode(), null,
+					objectRelationship,
+					Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+					String.valueOf(serviceBuilderObjectEntry.getGroupId()),
+					null, null);
+
+			List<ObjectEntry> relatedObjectEntries = ListUtil.fromCollection(
+				relatedObjectEntriesPage.getItems());
+
+			if (ListUtil.isEmpty(relatedObjectEntries)) {
+				continue;
+			}
+
+			for (ObjectField objectField :
+					objectFieldLocalService.getObjectFields(
+						relatedObjectDefinition.getObjectDefinitionId(),
+						false)) {
+
+				List<InfoFieldValue<Object>> infoFieldValues =
+					new ArrayList<>();
+
+				for (ObjectEntry relatedObjectEntry : relatedObjectEntries) {
+					_addInfoFieldValue(
+						relatedObjectEntry.getDefaultLanguageId(),
+						dlAppLocalService, dlURLHelper, infoFieldValues,
+						listTypeEntryLocalService, relatedObjectDefinition,
+						objectEntryLocalService, objectEntryService,
+						objectField, objectFieldInfoFieldConverter,
+						ObjectField.class.getSimpleName(),
+						objectRelationshipLocalService, null, themeDisplay,
+						relatedObjectEntry.getProperties());
+				}
+
+				relatedInfoFieldValues.add(
+					new InfoFieldValue<>(
+						objectFieldInfoFieldConverter.getInfoField(
+							false,
+							ObjectEntryInfoItemUtil.getInfoFieldNamespace(
+								relatedObjectDefinition, objectRelationship),
+							objectField),
+						TransformUtil.transform(
+							infoFieldValues,
+							infoFieldValue -> infoFieldValue.getValue(
+								themeDisplay.getLocale()))));
+			}
+		}
+
+		return relatedInfoFieldValues;
 	}
 
 	private static void _addInfoFieldValue(

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -139,12 +139,6 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				continue;
 			}
 
-			Object value = values.get(objectField.getName());
-
-			if (objectField.isLocalized()) {
-				value = values.get(objectField.getI18nObjectFieldName());
-			}
-
 			_addInfoFieldValue(
 				defaultLanguageId, dlAppLocalService, dlURLHelper,
 				infoFieldValues, listTypeEntryLocalService, objectDefinition,
@@ -152,7 +146,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				objectFieldInfoFieldConverter,
 				ObjectField.class.getSimpleName(),
 				objectRelationshipLocalService, serviceBuilderObjectEntry,
-				themeDisplay, value);
+				themeDisplay, values);
 
 			if (!objectField.compareBusinessType(
 					ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP)) {
@@ -200,13 +194,6 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					ObjectEntryInfoItemUtil.getInfoFieldNamespace(
 						parentObjectDefinition, objectRelationship);
 
-				value = properties.get(relatedObjectField.getName());
-
-				if (relatedObjectField.isLocalized()) {
-					value = properties.get(
-						relatedObjectField.getI18nObjectFieldName());
-				}
-
 				_addInfoFieldValue(
 					relatedObjectEntryDefaultLanguageId, dlAppLocalService,
 					dlURLHelper, infoFieldValues, listTypeEntryLocalService,
@@ -214,7 +201,7 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					objectEntryService, relatedObjectField,
 					objectFieldInfoFieldConverter, namespace,
 					objectRelationshipLocalService,
-					serviceBuilderRelatedObjectEntry, themeDisplay, value);
+					serviceBuilderRelatedObjectEntry, themeDisplay, properties);
 
 				infoFieldValues.add(
 					new InfoFieldValue<>(
@@ -329,8 +316,14 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 			String objectFieldNamespace,
 			ObjectRelationshipLocalService objectRelationshipLocalService,
 			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
-			ThemeDisplay themeDisplay, Object value)
+			ThemeDisplay themeDisplay, Map<String, Object> values)
 		throws Exception {
+
+		Object value = values.get(objectField.getName());
+
+		if (objectField.isLocalized()) {
+			value = values.get(objectField.getI18nObjectFieldName());
+		}
 
 		if (value == null) {
 			infoFieldValues.add(
@@ -465,9 +458,12 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					InfoLocalizedValue<Object> infoLocalizedValue =
 						(InfoLocalizedValue<Object>)infoFieldValue;
 
-					Map<Locale, Object> values = infoLocalizedValue.getValues();
+					Map<Locale, Object> localizedValues =
+						infoLocalizedValue.getValues();
 
-					for (Map.Entry<Locale, Object> entry : values.entrySet()) {
+					for (Map.Entry<Locale, Object> entry :
+							localizedValues.entrySet()) {
+
 						FileEntry fileEntry = dlAppLocalService.fetchFileEntry(
 							GetterUtil.getLong(entry.getValue()));
 

--- a/modules/apps/object/object-info-api/src/main/resources/com/liferay/object/info/item/provider/util/packageinfo
+++ b/modules/apps/object/object-info-api/src/main/resources/com/liferay/object/info/item/provider/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -30,11 +30,13 @@ import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.info.item.util.ObjectEntryInfoItemUtil;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
@@ -53,6 +55,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -85,6 +88,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -175,6 +179,12 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				Collections.emptyList()
 			).state(
 				false
+			).build(),
+			new TextObjectFieldBuilder(
+			).labelMap(
+				RandomTestUtil.randomLocaleStringMap()
+			).name(
+				"textObjectFieldName"
 			).build());
 
 		_childObjectDefinition =
@@ -195,14 +205,15 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				TestPropsValues.getUserId(),
 				_parentObjectDefinition.getObjectDefinitionId());
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			null, TestPropsValues.getUserId(),
-			_parentObjectDefinition.getObjectDefinitionId(),
-			_childObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false,
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-			"oneToManyRelationshipName", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+		_objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_parentObjectDefinition.getObjectDefinitionId(),
+				_childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"oneToManyRelationshipName", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -431,6 +442,77 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	@Test
+	public void testObjectEntryInfoItemFieldValuesProviderWithRelatedObjectEntries()
+		throws Exception {
+
+		ObjectEntry parentObjectEntry = _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_parentObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, Collections.emptyMap(),
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
+		ObjectField relationshipObjectField =
+			_objectFieldLocalService.fetchObjectField(
+				_objectRelationship.getObjectFieldId2());
+		String textObjectFieldValue1 = RandomTestUtil.randomString();
+
+		_objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_childObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				relationshipObjectField.getName(),
+				parentObjectEntry.getObjectEntryId()
+			).put(
+				"textObjectFieldName", textObjectFieldValue1
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
+
+		String textObjectFieldValue2 = RandomTestUtil.randomString();
+
+		_objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_childObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				relationshipObjectField.getName(),
+				parentObjectEntry.getObjectEntryId()
+			).put(
+				"textObjectFieldName", textObjectFieldValue2
+			).build(),
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
+
+		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
+
+		InfoItemFieldValuesProvider<ObjectEntry> infoItemFieldValuesProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFieldValuesProvider.class,
+				_parentObjectDefinition.getClassName());
+
+		InfoItemFieldValues infoItemFieldValues =
+			infoItemFieldValuesProvider.getInfoItemFieldValues(
+				parentObjectEntry);
+
+		String namespace = ObjectEntryInfoItemUtil.getInfoFieldNamespace(
+			_childObjectDefinition, _objectRelationship);
+
+		InfoFieldValue<Object> infoFieldValue =
+			infoItemFieldValues.getInfoFieldValue(
+				namespace + "_textObjectFieldName");
+
+		AssertUtils.assertEquals(
+			Arrays.asList(textObjectFieldValue1, textObjectFieldValue2),
+			(List<String>)infoFieldValue.getValue());
+
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	private ObjectDefinition _addObjectDefinition(
@@ -714,6 +796,8 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 	@Inject
 	private ObjectFieldSettingLocalService _objectFieldSettingLocalService;
+
+	private ObjectRelationship _objectRelationship;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -269,6 +269,14 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					objectEntry.getObjectDefinitionId()),
 				_objectRelationshipLocalService, _objectScopeProviderRegistry,
 				_portal, objectEntry, themeDisplay, properties));
+		objectEntryFieldValues.addAll(
+			ObjectEntryInfoItemValuesProviderUtil.getRelatedInfoFieldValues(
+				_dlAppLocalService, _dlURLHelper, _listTypeEntryLocalService,
+				_objectDefinition, _objectDefinitionLocalService,
+				_objectEntryLocalService, _objectEntryManagerRegistry,
+				_objectEntryService, _objectFieldInfoFieldConverter,
+				_objectFieldLocalService, _objectRelationshipLocalService,
+				objectEntry, themeDisplay));
 
 		objectEntryFieldValues.add(
 			new InfoFieldValue<>(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94932

## What Is Being Fixed

An information template did not render repeatable content. A CMS content structure's repeatable field is modeled as a one-to-many object relationship, but the object entry info item field values provider only exposed related field values for the many-to-one direction. An information template rendered against the parent entry therefore found no value for the repeatable child field and displayed nothing.

## How It Is Being Fixed

The provider now fetches the related child entries for the relationship and exposes each child field's values, resolved for the current locale, as a list under the relationship namespace so the templates render them. Related entries are retrieved through the default object entry manager, guarding against a missing theme display and skipping relationships whose related definition is not a default-storage object. Supporting refactors move the shared value-building logic into the public ObjectEntryInfoItemValuesProviderUtil (adding addInfoFieldValue and promoting the helper methods to public) and drop the duplicated code. An integration test covers the repeatable relationship rendering.

## PR Check

**pr-check: PASS** — tested on `eba9dac505e5e7d0534f6b4cac35b8945f464a8e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "eba9dac505e5e7d0534f6b4cac35b8945f464a8e"} -->