### PR TITLE
LPD-94886 Honor connected site permissions for depot object entries

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -8,6 +8,8 @@ package com.liferay.object.internal.deployer;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
@@ -132,6 +134,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			accountEntryOrganizationRelLocalService,
 		AssetEntryLocalService assetEntryLocalService,
 		BundleContext bundleContext,
+		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
+		DepotEntryLocalService depotEntryLocalService,
 		DLFileEntryLocalService dlFileEntryLocalService,
 		GroupLocalService groupLocalService,
 		KaleoDefinitionLocalService kaleoDefinitionLocalService,
@@ -168,6 +172,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			accountEntryOrganizationRelLocalService;
 		_assetEntryLocalService = assetEntryLocalService;
 		_bundleContext = bundleContext;
+		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
 		_dlFileEntryLocalService = dlFileEntryLocalService;
 		_groupLocalService = groupLocalService;
 		_kaleoDefinitionLocalService = kaleoDefinitionLocalService;
@@ -461,12 +467,13 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		ModelResourcePermission<ObjectEntry> modelResourcePermission =
 			new ObjectEntryModelResourcePermission(
 				_accountEntryLocalService,
-				_accountEntryOrganizationRelLocalService, _groupLocalService,
-				objectDefinition.getClassName(), _objectActionLocalService,
-				_objectDefinitionLocalService, _objectEntryLocalService,
-				consumerSupplier, _objectFieldLocalService,
-				portletResourcePermission, _resourcePermissionLocalService,
-				_userGroupRoleLocalService);
+				_accountEntryOrganizationRelLocalService,
+				_depotEntryGroupRelLocalService, _depotEntryLocalService,
+				_groupLocalService, objectDefinition.getClassName(),
+				_objectActionLocalService, _objectDefinitionLocalService,
+				_objectEntryLocalService, consumerSupplier,
+				_objectFieldLocalService, portletResourcePermission,
+				_resourcePermissionLocalService, _userGroupRoleLocalService);
 
 		serviceRegistrations.add(
 			_bundleContext.registerService(
@@ -642,6 +649,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_accountEntryOrganizationRelLocalService;
 	private final AssetEntryLocalService _assetEntryLocalService;
 	private final BundleContext _bundleContext;
+	private final DepotEntryGroupRelLocalService
+		_depotEntryGroupRelLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
 	private final DLFileEntryLocalService _dlFileEntryLocalService;
 	private final GroupLocalService _groupLocalService;
 	private final KaleoDefinitionLocalService _kaleoDefinitionLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -9,7 +9,12 @@ import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.internal.security.permission.util.ObjectEntryPermissionUtil;
@@ -45,6 +50,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.io.Serializable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -60,6 +66,8 @@ public class ObjectEntryModelResourcePermission
 		AccountEntryLocalService accountEntryLocalService,
 		AccountEntryOrganizationRelLocalService
 			accountEntryOrganizationRelLocalService,
+		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
+		DepotEntryLocalService depotEntryLocalService,
 		GroupLocalService groupLocalService, String modelName,
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
@@ -74,6 +82,8 @@ public class ObjectEntryModelResourcePermission
 		_accountEntryLocalService = accountEntryLocalService;
 		_accountEntryOrganizationRelLocalService =
 			accountEntryOrganizationRelLocalService;
+		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
 		_groupLocalService = groupLocalService;
 		_modelName = modelName;
 		_objectActionLocalService = objectActionLocalService;
@@ -168,9 +178,8 @@ public class ObjectEntryModelResourcePermission
 		}
 
 		if (user.isGuestUser()) {
-			return permissionChecker.hasPermission(
-				objectEntry.getGroupId(), objectDefinition.getClassName(),
-				objectEntry.getHeadObjectEntryId(), actionId);
+			return _hasPermission(
+				actionId, objectDefinition, objectEntry, permissionChecker);
 		}
 
 		if (permissionChecker.hasOwnerPermission(
@@ -178,9 +187,8 @@ public class ObjectEntryModelResourcePermission
 				objectDefinition.getClassName(),
 				objectEntry.getHeadObjectEntryId(), objectEntry.getUserId(),
 				actionId) ||
-			permissionChecker.hasPermission(
-				objectEntry.getGroupId(), objectDefinition.getClassName(),
-				objectEntry.getHeadObjectEntryId(), actionId)) {
+			_hasPermission(
+				actionId, objectDefinition, objectEntry, permissionChecker)) {
 
 			return true;
 		}
@@ -300,6 +308,48 @@ public class ObjectEntryModelResourcePermission
 		return false;
 	}
 
+	private boolean _hasPermission(
+			String actionId, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry, PermissionChecker permissionChecker)
+		throws PortalException {
+
+		if (permissionChecker.hasPermission(
+				objectEntry.getGroupId(), objectDefinition.getClassName(),
+				objectEntry.getHeadObjectEntryId(), actionId)) {
+
+			return true;
+		}
+
+		if (!Objects.equals(
+				objectDefinition.getScope(),
+				ObjectDefinitionConstants.SCOPE_DEPOT)) {
+
+			return false;
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			objectEntry.getGroupId());
+
+		if (depotEntry == null) {
+			return false;
+		}
+
+		List<DepotEntryGroupRel> depotEntryGroupRels =
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(depotEntry);
+
+		for (DepotEntryGroupRel depotEntryGroupRel : depotEntryGroupRels) {
+			if (permissionChecker.hasPermission(
+					depotEntryGroupRel.getToGroupId(),
+					objectDefinition.getClassName(),
+					objectEntry.getHeadObjectEntryId(), actionId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private boolean _isObjectActionName(
 		String actionId, long objectDefinitionId) {
 
@@ -364,6 +414,9 @@ public class ObjectEntryModelResourcePermission
 	private final AccountEntryLocalService _accountEntryLocalService;
 	private final AccountEntryOrganizationRelLocalService
 		_accountEntryOrganizationRelLocalService;
+	private final DepotEntryGroupRelLocalService
+		_depotEntryGroupRelLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
 	private final GroupLocalService _groupLocalService;
 	private final String _modelName;
 	private final ObjectActionLocalService _objectActionLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -11,6 +11,8 @@ import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManager;
 import com.liferay.exportimport.kernel.empty.model.EmptyModelManagerUtil;
@@ -1084,6 +1086,7 @@ public class ObjectDefinitionLocalServiceImpl
 				_accountEntryLocalService,
 				_accountEntryOrganizationRelLocalService,
 				_assetEntryLocalService, _bundleContext,
+				_depotEntryGroupRelLocalService, _depotEntryLocalService,
 				_dlFileEntryLocalService, _groupLocalService,
 				_kaleoDefinitionLocalService, _listTypeLocalService,
 				_objectActionLocalService, objectDefinitionLocalService,
@@ -4062,6 +4065,12 @@ public class ObjectDefinitionLocalServiceImpl
 
 	@Reference
 	private CurrentConnection _currentConnection;
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectEntryModelResourcePermissionTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/security/permission/resource/test/ObjectEntryModelResourcePermissionTest.java
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.security.permission.resource.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class ObjectEntryModelResourcePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					RandomTestUtil.randomLocaleStringMap()
+				).name(
+					"textObjectFieldName"
+				).build()),
+			ObjectDefinitionConstants.SCOPE_DEPOT);
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPTED_GROUP_IDS,
+			String.valueOf(_depotEntry.getGroupId()));
+
+		_objectEntry = _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"textObjectFieldName", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		_modelResourcePermission =
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				_objectDefinition.getClassName());
+
+		_guestPermissionChecker = PermissionCheckerFactoryUtil.create(
+			_userLocalService.getGuestUser(TestPropsValues.getCompanyId()));
+		_guestRole = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.GUEST);
+	}
+
+	@Test
+	@TestInfo("LPD-94886")
+	public void testContains() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			TestPropsValues.getCompanyId(), _objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(group.getGroupId()),
+			_guestRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		Assert.assertFalse(
+			_modelResourcePermission.contains(
+				_guestPermissionChecker, _objectEntry, ActionKeys.VIEW));
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			_depotEntry.getDepotEntryId(), group.getGroupId());
+
+		Assert.assertTrue(
+			_modelResourcePermission.contains(
+				_guestPermissionChecker, _objectEntry, ActionKeys.VIEW));
+	}
+
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private PermissionChecker _guestPermissionChecker;
+	private Role _guestRole;
+	private ModelResourcePermission<ObjectEntry> _modelResourcePermission;
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94886

## What is this trying to solve?

A depot-scoped object definition (a "connected CMS") exposes its entries through the headless Objects API at /o/c/<context>/{id}. When an asset library is connected to a site and the Guest role's View permission is granted scoped to that connected site (instead of "All Assets and Sites"), fetching an entry returns 404. Granting View on "All Assets and Sites" works, but a site-restricted grant does not.

## How am I fixing it?

The permission check in ObjectEntryModelResourcePermission only checked the object entry against its own group (the depot), so a site-scoped grant on the connected site was never consulted. The object entry query path already spans the groups of depots connected to a site; the permission check now mirrors that — when the direct group check fails for a depot-scoped definition, it also checks the groups of the sites connected to the depot (via DepotEntryGroupRelLocalService). This applies to both the guest and signed-in paths.

## How can you verify that it works?

Run the integration test

## PR Check

**pr-check: PASS** — tested on `bd745b1fd68cf2377ce17e466d74d052eb9c0c5a`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bd745b1fd68cf2377ce17e466d74d052eb9c0c5a"} -->
