### PR TITLE
LPD-24684 Replace the guest upload submission loop with a count query

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 38.0.1
+Bundle-Version: 38.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalService.java
@@ -377,6 +377,10 @@ public interface DDMFormInstanceRecordLocalService
 	public int getFormInstanceRecordsCount(long ddmFormInstanceId, long userId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
 	/**
@@ -452,4 +456,4 @@ public interface DDMFormInstanceRecordLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1334577577
+// LIFERAY-SERVICE-BUILDER-HASH:-1656096514

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceUtil.java
@@ -435,6 +435,13 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			ddmFormInstanceId, userId);
 	}
 
+	public static int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return getService().getFormInstanceRecordsCount(
+			ddmFormInstanceId, ipAddress);
+	}
+
 	public static
 		com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 			getIndexableActionableDynamicQuery() {
@@ -533,4 +540,4 @@ public class DDMFormInstanceRecordLocalServiceUtil {
 			DDMFormInstanceRecordLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:512484366
+// LIFERAY-SERVICE-BUILDER-HASH:-740446410

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceRecordLocalServiceWrapper.java
@@ -502,6 +502,14 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 	}
 
 	@Override
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return _ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+			ddmFormInstanceId, ipAddress);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 		getIndexableActionableDynamicQuery() {
 
@@ -643,4 +651,4 @@ public class DDMFormInstanceRecordLocalServiceWrapper
 		_ddmFormInstanceRecordLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1303133393
+// LIFERAY-SERVICE-BUILDER-HASH:1942133548

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordPersistence.java
@@ -457,6 +457,72 @@ public interface DDMFormInstanceRecordPersistence
 	public int countByF_F(long formInstanceId, String formInstanceVersion);
 
 	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException;
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator);
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public void removeByF_I(long formInstanceId, String ipAddress);
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public int countByF_I(long formInstanceId, String ipAddress);
+
+	/**
 	 * Creates a new ddm form instance record with the primary key. Does not add the ddm form instance record to the database.
 	 *
 	 * @param formInstanceRecordId the primary key for the new ddm form instance record
@@ -844,5 +910,63 @@ public interface DDMFormInstanceRecordPersistence
 			true);
 	}
 
+	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return findByF_I(
+			formInstanceId, ipAddress,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return findByF_I(formInstanceId, ipAddress, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public default java.util.List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstanceRecord>
+			orderByComparator) {
+
+		return findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator, true);
+	}
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:81216796
+// LIFERAY-SERVICE-BUILDER-HASH:218622664

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceRecordUtil.java
@@ -656,6 +656,87 @@ public class DDMFormInstanceRecordUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws com.liferay.dynamic.data.mapping.exception.
+			NoSuchFormInstanceRecordException {
+
+		return getPersistence().findByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	public static DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().fetchByF_I_First(
+			formInstanceId, ipAddress, orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	public static void removeByF_I(long formInstanceId, String ipAddress) {
+		getPersistence().removeByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	public static int countByF_I(long formInstanceId, String ipAddress) {
+		return getPersistence().countByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
 	 * Creates a new ddm form instance record with the primary key. Does not add the ddm form instance record to the database.
 	 *
 	 * @param formInstanceRecordId the primary key for the new ddm form instance record
@@ -1037,6 +1118,61 @@ public class DDMFormInstanceRecordUtil {
 			formInstanceId, formInstanceVersion, start, end, orderByComparator);
 	}
 
+	/**
+	 * Returns all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress) {
+
+		return getPersistence().findByF_I(formInstanceId, ipAddress);
+	}
+
+	/**
+	 * Returns a range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @return the range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	public static List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return getPersistence().findByF_I(
+			formInstanceId, ipAddress, start, end, orderByComparator);
+	}
+
 	public static DDMFormInstanceRecordPersistence getPersistence() {
 		return _persistence;
 	}
@@ -1050,4 +1186,4 @@ public class DDMFormInstanceRecordUtil {
 	private static volatile DDMFormInstanceRecordPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-20287883
+// LIFERAY-SERVICE-BUILDER-HASH:-912639907

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtil.java
@@ -8,16 +8,13 @@ package com.liferay.dynamic.data.mapping.form.web.internal.display.context.util;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
-import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -45,24 +42,16 @@ public class DDMFormGuestUploadFieldUtil {
 			return false;
 		}
 
-		int count = 0;
-
 		DDMFormInstanceRecordLocalService ddmFormInstanceRecordLocalService =
 			_ddmFormInstanceRecordLocalServiceSnapshot.get();
 
-		for (DDMFormInstanceRecord ddmFormInstanceRecord :
-				ddmFormInstanceRecordLocalService.getFormInstanceRecords(
-					ddmFormInstance.getFormInstanceId(),
-					WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
-					QueryUtil.ALL_POS, null)) {
+		int count =
+			ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+				ddmFormInstance.getFormInstanceId(),
+				httpServletRequest.getRemoteAddr());
 
-			if (Objects.equals(
-					ddmFormInstanceRecord.getIpAddress(),
-					httpServletRequest.getRemoteAddr()) &&
-				(++count == guestUploadMaximumSubmissions)) {
-
-				return true;
-			}
+		if (count >= guestUploadMaximumSubmissions) {
+			return true;
 		}
 
 		return false;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormGuestUploadFieldUtilTest.java
@@ -10,28 +10,24 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
-import com.liferay.dynamic.data.mapping.model.DDMFormInstanceRecord;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.impl.DDMStructureImpl;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.portal.json.JSONFactoryImpl;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -94,14 +90,14 @@ public class DDMFormGuestUploadFieldUtilTest {
 
 	@After
 	public void tearDown() {
-		_ddmFormInstanceRecords = new ArrayList<>();
+		_ddmFormInstanceRecordsCountMap.clear();
 	}
 
 	@Test
 	public void testGuestUserAnsweringForFifthTime() throws Exception {
 		_addUploadField(true);
 
-		_addDDMFormInstanceRecords(_IP_ADDRESS_1, _MAXIMUM_SUBMISSIONS - 1);
+		_addDDMFormInstanceRecords(_MAXIMUM_SUBMISSIONS - 1, _IP_ADDRESS_1);
 
 		Assert.assertFalse(
 			DDMFormGuestUploadFieldUtil.isMaximumSubmissionLimitReached(
@@ -114,7 +110,7 @@ public class DDMFormGuestUploadFieldUtilTest {
 	public void testGuestUserAnsweringForSixthTime() throws Exception {
 		_addUploadField(true);
 
-		_addDDMFormInstanceRecords(_IP_ADDRESS_1, _MAXIMUM_SUBMISSIONS);
+		_addDDMFormInstanceRecords(_MAXIMUM_SUBMISSIONS, _IP_ADDRESS_1);
 
 		Assert.assertTrue(
 			DDMFormGuestUploadFieldUtil.isMaximumSubmissionLimitReached(
@@ -129,8 +125,8 @@ public class DDMFormGuestUploadFieldUtilTest {
 
 		_addUploadField(true);
 
-		_addDDMFormInstanceRecords(_IP_ADDRESS_1, 1);
-		_addDDMFormInstanceRecords(_IP_ADDRESS_2, _MAXIMUM_SUBMISSIONS - 1);
+		_addDDMFormInstanceRecords(1, _IP_ADDRESS_1);
+		_addDDMFormInstanceRecords(_MAXIMUM_SUBMISSIONS - 1, _IP_ADDRESS_2);
 
 		Assert.assertFalse(
 			DDMFormGuestUploadFieldUtil.isMaximumSubmissionLimitReached(
@@ -143,7 +139,7 @@ public class DDMFormGuestUploadFieldUtilTest {
 				_mockHttpServletRequest(_IP_ADDRESS_2, false),
 				_MAXIMUM_SUBMISSIONS));
 
-		_addDDMFormInstanceRecords(_IP_ADDRESS_2, 1);
+		_addDDMFormInstanceRecords(1, _IP_ADDRESS_2);
 
 		Assert.assertFalse(
 			DDMFormGuestUploadFieldUtil.isMaximumSubmissionLimitReached(
@@ -204,27 +200,15 @@ public class DDMFormGuestUploadFieldUtilTest {
 
 	protected static final JSONFactory jsonFactory = new JSONFactoryImpl();
 
-	private void _addDDMFormInstanceRecords(String ipAddress, int size) {
-		DDMFormInstanceRecord ddmFormInstanceRecord = Mockito.mock(
-			DDMFormInstanceRecord.class);
+	private void _addDDMFormInstanceRecords(int count, String ipAddress) {
+		int ddmFormInstanceRecordsCount = _ddmFormInstanceRecordsCountMap.merge(
+			ipAddress, count, Integer::sum);
 
 		Mockito.when(
-			ddmFormInstanceRecord.getIpAddress()
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecordsCount(
+				_DDM_FORM_INSTANCE_ID, ipAddress)
 		).thenReturn(
-			ipAddress
-		);
-
-		_ddmFormInstanceRecords.addAll(
-			Collections.nCopies(size, ddmFormInstanceRecord));
-
-		Mockito.when(
-			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
-				Mockito.eq(_DDM_FORM_INSTANCE_ID),
-				Mockito.eq(WorkflowConstants.STATUS_ANY),
-				Mockito.eq(QueryUtil.ALL_POS), Mockito.eq(QueryUtil.ALL_POS),
-				Mockito.eq(null))
-		).thenReturn(
-			_ddmFormInstanceRecords
+			ddmFormInstanceRecordsCount
 		);
 	}
 
@@ -310,7 +294,7 @@ public class DDMFormGuestUploadFieldUtilTest {
 	private static final MockedStatic<FrameworkUtil>
 		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
 
-	private List<DDMFormInstanceRecord> _ddmFormInstanceRecords =
-		new ArrayList<>();
+	private final Map<String, Integer> _ddmFormInstanceRecordsCountMap =
+		new HashMap<>();
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/service.xml
@@ -272,6 +272,10 @@
 			<finder-column name="formInstanceId" />
 			<finder-column name="formInstanceVersion" />
 		</finder>
+		<finder name="F_I" return-type="Collection">
+			<finder-column name="formInstanceId" />
+			<finder-column name="ipAddress" />
+		</finder>
 	</entity>
 	<entity local-service="true" name="DDMFormInstanceRecordVersion" remote-service="true">
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceRecordModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFormInstanceRecordModelImpl.java
@@ -149,20 +149,26 @@ public class DDMFormInstanceRecordModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 16L;
+	public static final long IPADDRESS_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 32L;
+	public static final long USERID_COLUMN_BITMASK = 32L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long FORMINSTANCERECORDID_COLUMN_BITMASK = 64L;
+	public static final long FORMINSTANCERECORDID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -791,6 +797,15 @@ public class DDMFormInstanceRecordModelImpl
 		_ipAddress = ipAddress;
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalIpAddress() {
+		return getColumnOriginalValue("ipAddress");
+	}
+
 	@JSON
 	@Override
 	public Date getLastPublishDate() {
@@ -1314,4 +1329,4 @@ public class DDMFormInstanceRecordModelImpl
 	private DDMFormInstanceRecord _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:593226394
+// LIFERAY-SERVICE-BUILDER-HASH:1388686114

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
@@ -322,6 +322,14 @@ public class DDMFormInstanceRecordLocalServiceImpl
 	}
 
 	@Override
+	public int getFormInstanceRecordsCount(
+		long ddmFormInstanceId, String ipAddress) {
+
+		return ddmFormInstanceRecordPersistence.countByF_I(
+			ddmFormInstanceId, ipAddress);
+	}
+
+	@Override
 	public void revertFormInstanceRecord(
 			long userId, long ddmFormInstanceRecordId, String version,
 			ServiceContext serviceContext)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceRecordPersistenceImpl.java
@@ -688,6 +688,99 @@ public class DDMFormInstanceRecordPersistenceImpl
 			finderCache, new Object[] {formInstanceId, formInstanceVersion});
 	}
 
+	private CollectionPersistenceFinder
+		<DDMFormInstanceRecord, NoSuchFormInstanceRecordException>
+			_collectionPersistenceFinderByF_I;
+
+	/**
+	 * Returns an ordered range of all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>DDMFormInstanceRecordModelImpl</code>.
+	 * </p>
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param start the lower bound of the range of ddm form instance records
+	 * @param end the upper bound of the range of ddm form instance records (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching ddm form instance records
+	 */
+	@Override
+	public List<DDMFormInstanceRecord> findByF_I(
+		long formInstanceId, String ipAddress, int start, int end,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByF_I.find(
+			finderCache, new Object[] {formInstanceId, ipAddress}, start, end,
+			orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record
+	 * @throws NoSuchFormInstanceRecordException if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord findByF_I_First(
+			long formInstanceId, String ipAddress,
+			OrderByComparator<DDMFormInstanceRecord> orderByComparator)
+		throws NoSuchFormInstanceRecordException {
+
+		return _collectionPersistenceFinderByF_I.findFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first ddm form instance record in the ordered set where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching ddm form instance record, or <code>null</code> if a matching ddm form instance record could not be found
+	 */
+	@Override
+	public DDMFormInstanceRecord fetchByF_I_First(
+		long formInstanceId, String ipAddress,
+		OrderByComparator<DDMFormInstanceRecord> orderByComparator) {
+
+		return _collectionPersistenceFinderByF_I.fetchFirst(
+			finderCache, new Object[] {formInstanceId, ipAddress},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the ddm form instance records where formInstanceId = &#63; and ipAddress = &#63; from the database.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 */
+	@Override
+	public void removeByF_I(long formInstanceId, String ipAddress) {
+		_collectionPersistenceFinderByF_I.remove(
+			finderCache, new Object[] {formInstanceId, ipAddress});
+	}
+
+	/**
+	 * Returns the number of ddm form instance records where formInstanceId = &#63; and ipAddress = &#63;.
+	 *
+	 * @param formInstanceId the form instance ID
+	 * @param ipAddress the ip address
+	 * @return the number of matching ddm form instance records
+	 */
+	@Override
+	public int countByF_I(long formInstanceId, String ipAddress) {
+		return _collectionPersistenceFinderByF_I.count(
+			finderCache, new Object[] {formInstanceId, ipAddress});
+	}
+
 	public DDMFormInstanceRecordPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -1196,6 +1289,37 @@ public class DDMFormInstanceRecordPersistenceImpl
 				FinderColumn.Type.STRING, "=", true, true,
 				DDMFormInstanceRecord::getFormInstanceVersion));
 
+		_collectionPersistenceFinderByF_I = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByF_I",
+				new String[] {
+					Long.class.getName(), String.class.getName(),
+					Integer.class.getName(), Integer.class.getName(),
+					OrderByComparator.class.getName()
+				},
+				new String[] {"formInstanceId", "ipAddress"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, true, null),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByF_I",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"formInstanceId", "ipAddress"}, 0, 2, false,
+				null),
+			_SQL_SELECT_DDMFORMINSTANCERECORD_WHERE,
+			_SQL_COUNT_DDMFORMINSTANCERECORD_WHERE,
+			DDMFormInstanceRecordModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX,
+			"",
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "formInstanceId",
+				FinderColumn.Type.LONG, "=", true, true,
+				DDMFormInstanceRecord::getFormInstanceId),
+			new FinderColumn<>(
+				"ddmFormInstanceRecord.", "ipAddress", FinderColumn.Type.STRING,
+				"=", true, true, DDMFormInstanceRecord::getIpAddress));
+
 		DDMFormInstanceRecordUtil.setPersistence(this);
 	}
 
@@ -1268,4 +1392,4 @@ public class DDMFormInstanceRecordPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1624523404
+// LIFERAY-SERVICE-BUILDER-HASH:-210569973

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/indexes.sql
@@ -25,6 +25,7 @@ create unique index IX_EAB7A400 on DDMFormInstance (uuid_[$COLUMN_LENGTH:75$], g
 
 create index IX_5BC982B on DDMFormInstanceRecord (companyId);
 create index IX_242301EA on DDMFormInstanceRecord (formInstanceId, formInstanceVersion[$COLUMN_LENGTH:75$]);
+create index IX_2C10D58 on DDMFormInstanceRecord (formInstanceId, ipAddress[$COLUMN_LENGTH:75$]);
 create index IX_3C8DBDFF on DDMFormInstanceRecord (formInstanceId, userId);
 create unique index IX_90833BB1 on DDMFormInstanceRecord (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/service.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.dynamic.data.mapping.service
-    build.number=3
-    build.date=1776296275274
+    build.number=4
+    build.date=1781703481939

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFormInstanceRecordPersistenceTest.java
@@ -278,6 +278,15 @@ public class DDMFormInstanceRecordPersistenceTest {
 	}
 
 	@Test
+	public void testCountByF_I() throws Exception {
+		_persistence.countByF_I(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByF_I(0L, "null");
+
+		_persistence.countByF_I(0L, (String)null);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		DDMFormInstanceRecord newDDMFormInstanceRecord =
 			addDDMFormInstanceRecord();
@@ -670,4 +679,4 @@ public class DDMFormInstanceRecordPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1762158866
+// LIFERAY-SERVICE-BUILDER-HASH:-1265570633


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24684

## What Is Being Fixed

`DDMFormGuestUploadFieldUtil.isMaximumSubmissionLimitReached` fetched every past submission for a form instance (all columns, any status) and counted the ones matching the guest's IP address in Java. On forms with a large submission history this scales poorly: once the result sets no longer fit the database cache they are refetched and evicted endlessly, overloading database threads (seen in the customer thread dumps on the ticket).

## How It Is Being Fixed

Added an `F_I` finder on `formInstanceId` and `ipAddress` and a `getFormInstanceRecordsCount(long, String)` local service method backed by the generated `countByF_I`, then replaced the fetch-all-and-iterate loop with a single indexed `COUNT` query, preserving the existing behavior. The new index `IX_2C10D58 (formInstanceId, ipAddress)` keeps the count cheap, and the unit test was updated to stub the count method in the same commit. `buildService` regenerated the persistence layer.

## PR Check

**pr-check: PASS** — tested on `c6f90a80259e65729a8415235ca9b2414b4c4d3f`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Scoped run: Cross-Module Compile and the 191-consumer Per-Module expansion were skipped because the API change is a backward-compatible addition (new `getFormInstanceRecordsCount` / `countByF_I`), so existing consumers do not reference the new members. The post-review test refactor (extracting the merge result into a local) was re-verified with Source Format and Java Unit Tests; the non-test files are unchanged from the previously tested tree.

<!-- pr-check {"result": "success", "sha": "c6f90a80259e65729a8415235ca9b2414b4c4d3f"} -->
