### PR TITLE
LPD-94997 Sync CAPTCHA and upload field labels with form language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/captcha/CaptchaDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/captcha/CaptchaDDMFormFieldTemplateContextContributor.java
@@ -15,13 +15,16 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.servlet.PageContextFactoryUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -76,7 +79,37 @@ public class CaptchaDDMFormFieldTemplateContextContributor
 				new PipingServletResponse(
 					httpServletResponse, unsyncStringWriter)));
 
-		captchaTag.runTag();
+		Locale locale = ddmFormFieldRenderingContext.getLocale();
+		Object originalLocale = null;
+		Locale originalThemeDisplayLocale = null;
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (locale != null) {
+			originalLocale = httpServletRequest.getAttribute(WebKeys.LOCALE);
+
+			httpServletRequest.setAttribute(WebKeys.LOCALE, locale);
+
+			if (themeDisplay != null) {
+				originalThemeDisplayLocale = themeDisplay.getLocale();
+
+				themeDisplay.setLocale(locale);
+			}
+		}
+
+		try {
+			captchaTag.runTag();
+		}
+		finally {
+			if (locale != null) {
+				httpServletRequest.setAttribute(WebKeys.LOCALE, originalLocale);
+
+				if (themeDisplay != null) {
+					themeDisplay.setLocale(originalThemeDisplayLocale);
+				}
+			}
+		}
 
 		return unsyncStringWriter.toString();
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -148,6 +149,8 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 			"objectFieldAcceptedFileExtensions",
 			GetterUtil.getString(
 				ddmFormField.getProperty("objectFieldAcceptedFileExtensions"))
+		).put(
+			"strings", _getStrings(ddmFormFieldRenderingContext)
 		).put(
 			"value",
 			() -> {
@@ -584,6 +587,64 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		serviceContext.setAddGuestPermissions(true);
 
 		return serviceContext;
+	}
+
+	private Map<String, String> _getStrings(
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		Locale locale = ddmFormFieldRenderingContext.getLocale();
+
+		if (locale == null) {
+			locale = LocaleUtil.getDefault();
+		}
+
+		ResourceBundle resourceBundle = getResourceBundle(locale);
+
+		return HashMapBuilder.put(
+			"attentionValueIsAtLabel",
+			_language.get(resourceBundle, "attention-value-is-at-x")
+		).put(
+			"clearLabel", _language.get(resourceBundle, "clear")
+		).put(
+			"completeLabel", _language.get(resourceBundle, "complete")
+		).put(
+			"documentLabel", _language.get(resourceBundle, "document")
+		).put(
+			"fileLabel", _language.get(resourceBundle, "file")
+		).put(
+			"invalidExtensionErrorMessage",
+			_language.get(
+				resourceBundle, "please-enter-a-file-with-a-valid-extension-x")
+		).put(
+			"invalidFileSizeErrorMessage",
+			_language.get(
+				resourceBundle,
+				"please-enter-a-file-with-a-valid-file-size-no-larger-than-x")
+		).put(
+			"maximumSubmissionLimitReachedErrorMessage",
+			_language.get(
+				resourceBundle,
+				"the-maximum-number-of-submissions-allowed-for-this-form-has-" +
+					"been-reached")
+		).put(
+			"progressLabel", _language.get(resourceBundle, "progress-x")
+		).put(
+			"selectLabel", _language.get(resourceBundle, "select")
+		).put(
+			"selectXLabel", _language.get(resourceBundle, "select-x")
+		).put(
+			"signInRequiredErrorMessage",
+			_language.get(
+				resourceBundle, "you-need-to-be-signed-in-to-edit-this-field")
+		).put(
+			"unselectFileLabel", _language.get(resourceBundle, "unselect-file")
+		).put(
+			"uploadPermissionErrorMessage",
+			_language.get(
+				resourceBundle,
+				"you-need-to-be-assigned-to-the-same-site-where-the-form-was-" +
+					"created-to-use-this-field")
+		).build();
 	}
 
 	private Map<String, Object> _getUploadParameters(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -143,6 +143,7 @@ const DocumentLibrary = ({
 	onSelectButtonClicked,
 	placeholder,
 	readOnly,
+	strings,
 	value,
 }) => {
 	const [transformedFileEntryTitle] = useMemo(
@@ -165,7 +166,10 @@ const DocumentLibrary = ({
 				<ClayInput.Group>
 					<ClayInput.GroupItem prepend>
 						<ClayInput
-							aria-label={Liferay.Language.get('file')}
+							aria-label={
+								strings?.fileLabel ??
+								Liferay.Language.get('file')
+							}
 							className="bg-light field"
 							dir={Liferay.Language.direction[editingLanguageId]}
 							disabled={readOnly}
@@ -188,7 +192,8 @@ const DocumentLibrary = ({
 							onClick={onSelectButtonClicked}
 						>
 							<span className="lfr-btn-label">
-								{Liferay.Language.get('select')}
+								{strings?.selectLabel ??
+									Liferay.Language.get('select')}
 							</span>
 						</ClayButton>
 					</ClayInput.GroupItem>
@@ -196,14 +201,16 @@ const DocumentLibrary = ({
 					{transformedFileEntryTitle && (
 						<ClayInput.GroupItem shrink>
 							<ClayButton
-								aria-label={Liferay.Language.get(
-									'unselect-file'
-								)}
+								aria-label={
+									strings?.unselectFileLabel ??
+									Liferay.Language.get('unselect-file')
+								}
 								displayType="secondary"
 								onClick={onClearButtonClicked}
 								type="button"
 							>
-								{Liferay.Language.get('clear')}
+								{strings?.clearLabel ??
+									Liferay.Language.get('clear')}
 							</ClayButton>
 						</ClayInput.GroupItem>
 					)}
@@ -233,6 +240,7 @@ const GuestUploadFile = ({
 	placeholder,
 	progress,
 	readOnly,
+	strings,
 	value,
 }) => {
 	const [transformedFileEntryTitle] = useMemo(
@@ -269,7 +277,7 @@ const GuestUploadFile = ({
 						}
 						htmlFor={`${name}inputFileGuestUpload`}
 					>
-						{Liferay.Language.get('select')}
+						{strings?.selectLabel ?? Liferay.Language.get('select')}
 					</label>
 
 					<input
@@ -284,12 +292,16 @@ const GuestUploadFile = ({
 				{transformedFileEntryTitle && (
 					<ClayInput.GroupItem shrink>
 						<ClayButton
-							aria-label={Liferay.Language.get('unselect-file')}
+							aria-label={
+								strings?.unselectFileLabel ??
+								Liferay.Language.get('unselect-file')
+							}
 							displayType="secondary"
 							onClick={onClearButtonClicked}
 							type="button"
 						>
-							{Liferay.Language.get('clear')}
+							{strings?.clearLabel ??
+								Liferay.Language.get('clear')}
 						</ClayButton>
 					</ClayInput.GroupItem>
 				)}
@@ -306,11 +318,15 @@ const GuestUploadFile = ({
 			{progress !== 0 && (
 				<ClayProgressBar
 					messages={{
-						ariaLabelAttention: Liferay.Language.get(
-							'attention-value-is-at-x'
-						),
-						ariaLabelComplete: Liferay.Language.get('complete'),
-						ariaLabelInProgress: Liferay.Language.get('progress-x'),
+						ariaLabelAttention:
+							strings?.attentionValueIsAtLabel ??
+							Liferay.Language.get('attention-value-is-at-x'),
+						ariaLabelComplete:
+							strings?.completeLabel ??
+							Liferay.Language.get('complete'),
+						ariaLabelInProgress:
+							strings?.progressLabel ??
+							Liferay.Language.get('progress-x'),
 					}}
 					value={progress}
 				/>
@@ -462,6 +478,7 @@ const Main = ({
 	placeholder,
 	readOnly,
 	showUploadPermissionMessage,
+	strings,
 	valid: initialValid,
 	value = '{}',
 	...otherProps
@@ -499,31 +516,35 @@ const Main = ({
 
 		if (!allowGuestUsers && !isSignedIn) {
 			errorMessages.push(
-				Liferay.Language.get(
-					'you-need-to-be-signed-in-to-edit-this-field'
-				)
+				strings?.signInRequiredErrorMessage ??
+					Liferay.Language.get(
+						'you-need-to-be-signed-in-to-edit-this-field'
+					)
 			);
 		}
 		else if (maximumSubmissionLimitReached) {
 			errorMessages.push(
-				Liferay.Language.get(
-					'the-maximum-number-of-submissions-allowed-for-this-form-has-been-reached'
-				)
+				strings?.maximumSubmissionLimitReachedErrorMessage ??
+					Liferay.Language.get(
+						'the-maximum-number-of-submissions-allowed-for-this-form-has-been-reached'
+					)
 			);
 		}
 		else if (showUploadPermissionMessage) {
 			errorMessages.push(
-				Liferay.Language.get(
-					'you-need-to-be-assigned-to-the-same-site-where-the-form-was-created-to-use-this-field'
-				)
+				strings?.uploadPermissionErrorMessage ??
+					Liferay.Language.get(
+						'you-need-to-be-assigned-to-the-same-site-where-the-form-was-created-to-use-this-field'
+					)
 			);
 		}
 		else if (objectFieldInvalidExtension) {
 			errorMessages.push(
 				Liferay.Util.sub(
-					Liferay.Language.get(
-						'please-enter-a-file-with-a-valid-extension-x'
-					),
+					strings?.invalidExtensionErrorMessage ??
+						Liferay.Language.get(
+							'please-enter-a-file-with-a-valid-extension-x'
+						),
 					objectFieldAcceptedFileExtensions
 				)
 			);
@@ -610,9 +631,10 @@ const Main = ({
 		}
 
 		const errorMessage = sub(
-			Liferay.Language.get(
-				'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
-			),
+			strings?.invalidFileSizeErrorMessage ??
+				Liferay.Language.get(
+					'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
+				),
 			[formatStorage(uploadRequestSizeLimit)]
 		);
 
@@ -645,8 +667,8 @@ const Main = ({
 			onSelect: handleFieldChanged,
 			selectEventName: `${portletNamespace}selectDocumentLibrary`,
 			title: sub(
-				Liferay.Language.get('select-x'),
-				Liferay.Language.get('document')
+				strings?.selectXLabel ?? Liferay.Language.get('select-x'),
+				strings?.documentLabel ?? Liferay.Language.get('document')
 			),
 			url: itemSelectorURL,
 		});
@@ -772,6 +794,7 @@ const Main = ({
 					placeholder={placeholder}
 					progress={progress}
 					readOnly={hasCustomError ? true : readOnly}
+					strings={strings}
 					value={currentValue || ''}
 				/>
 			) : (
@@ -795,6 +818,7 @@ const Main = ({
 					onSelectButtonClicked={handleSelectButtonClicked}
 					placeholder={placeholder}
 					readOnly={hasCustomError ? true : readOnly}
+					strings={strings}
 					value={currentValue || ''}
 				/>
 			)}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -84,6 +86,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 		_setUpItemSelector();
 		_setUpJSONFactory();
 		_setUpJSONFactoryUtil();
+		_setUpLanguage();
 		_setUpPortal();
 		_setUpPortletFileRepository();
 		_setUpRequestBackedPortletURLFactory();
@@ -343,6 +346,49 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 	}
 
 	@Test
+	public void testGetParametersShouldLocalizeStringsUsingDisplayLocale() {
+		DocumentLibraryDDMFormFieldTemplateContextContributor
+			documentLibraryDDMFormFieldTemplateContextContributor = _createSpy(
+				_mockThemeDisplay());
+
+		ResourceBundle resourceBundle = Mockito.mock(ResourceBundle.class);
+
+		Mockito.doReturn(
+			resourceBundle
+		).when(
+			documentLibraryDDMFormFieldTemplateContextContributor
+		).getResourceBundle(
+			LocaleUtil.BRAZIL
+		);
+
+		Mockito.when(
+			_language.get(Mockito.eq(resourceBundle), Mockito.anyString())
+		).thenAnswer(
+			invocation -> invocation.getArgument(1) + "_pt_BR"
+		);
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			_createDDMFormFieldRenderingContext();
+
+		ddmFormFieldRenderingContext.setLocale(LocaleUtil.BRAZIL);
+
+		Map<String, Object> parameters =
+			documentLibraryDDMFormFieldTemplateContextContributor.getParameters(
+				new DDMFormField("field", "document_library"),
+				ddmFormFieldRenderingContext);
+
+		Map<String, String> stringsMap = (Map<String, String>)parameters.get(
+			"strings");
+
+		Assert.assertEquals("clear_pt_BR", stringsMap.get("clearLabel"));
+		Assert.assertEquals("file_pt_BR", stringsMap.get("fileLabel"));
+		Assert.assertEquals("select_pt_BR", stringsMap.get("selectLabel"));
+		Assert.assertEquals(
+			"you-need-to-be-signed-in-to-edit-this-field_pt_BR",
+			stringsMap.get("signInRequiredErrorMessage"));
+	}
+
+	@Test
 	public void testGetParametersShouldUseExistingGuestUploadURL() {
 		DocumentLibraryDDMFormFieldTemplateContextContributor
 			documentLibraryDDMFormFieldTemplateContextContributor = _createSpy(
@@ -446,6 +492,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 
 		ddmFormFieldRenderingContext.setHttpServletRequest(
 			_createHttpServletRequest());
+		ddmFormFieldRenderingContext.setLocale(LocaleUtil.US);
 		ddmFormFieldRenderingContext.setPortletNamespace(_PORTLET_NAMESPACE);
 		ddmFormFieldRenderingContext.setProperty("groupId", _GROUP_ID);
 		ddmFormFieldRenderingContext.setValue(
@@ -733,6 +780,19 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
 	}
 
+	private void _setUpLanguage() {
+		ReflectionTestUtil.setFieldValue(
+			_documentLibraryDDMFormFieldTemplateContextContributor, "_language",
+			_language);
+
+		Mockito.when(
+			_language.get(
+				Mockito.any(ResourceBundle.class), Mockito.anyString())
+		).thenAnswer(
+			invocation -> invocation.getArgument(1)
+		);
+	}
+
 	private void _setUpPortal() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			_documentLibraryDDMFormFieldTemplateContextContributor, "_portal",
@@ -844,6 +904,7 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest {
 		GroupLocalService.class);
 	private final ItemSelector _itemSelector = Mockito.mock(ItemSelector.class);
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
+	private final Language _language = Mockito.mock(Language.class);
 	private final Portal _portal = Mockito.mock(Portal.class);
 	private final PortletFileRepository _portletFileRepository = Mockito.mock(
 		PortletFileRepository.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -88,6 +88,8 @@ describe('Field DocumentLibrary', () => {
 	beforeEach(() => {
 		jest.useFakeTimers();
 		fetch.mockResponseOnce(JSON.stringify({}));
+
+		Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
 	});
 
 	it('disables guest upload field if maximumSubmissionLimitReached property is true', () => {
@@ -144,6 +146,20 @@ describe('Field DocumentLibrary', () => {
 		const button = container.querySelector('button[aria-required="true"]');
 
 		expect(button.hasAttribute('aria-invalid')).toBe(false);
+	});
+
+	it('falls back to Liferay.Language.get for the select label when the strings prop is not provided', () => {
+		Liferay.ThemeDisplay.isSignedIn = jest.fn(() => true);
+
+		const {getByText} = render(
+			<DocumentLibraryWithProvider {...defaultDocumentLibraryConfig} />
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(getByText('select')).toBeInTheDocument();
 	});
 
 	it('has a helptext', () => {
@@ -354,6 +370,23 @@ describe('Field DocumentLibrary', () => {
 		});
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('renders the select label from the strings prop when provided', () => {
+		Liferay.ThemeDisplay.isSignedIn = jest.fn(() => true);
+
+		const {getByText} = render(
+			<DocumentLibraryWithProvider
+				{...defaultDocumentLibraryConfig}
+				strings={{selectLabel: 'Selecionar'}}
+			/>
+		);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(getByText('Selecionar')).toBeInTheDocument();
 	});
 
 	it('shows guest upload field if allowGuestUsers property is enabled', () => {

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/captcha.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/main/captcha.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {captchaConfigPageTest} from '../../../fixtures/captchaConfigPageTest';
+import {formsPagesTest} from '../../../fixtures/formsPagesTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {getRandomInt} from '../../../utils/getRandomInt';
+
+const test = mergeTests(
+	captchaConfigPageTest,
+	formsPagesTest,
+	isolatedSiteTest,
+	loginTest()
+);
+
+test(
+	'CAPTCHA labels follow the form display language on the shared link',
+	{tag: '@LPD-94997'},
+	async ({
+		captchaConfigPage,
+		formBuilderPage,
+		formBuilderSidePanelPage,
+		formSettingsModalPage,
+		formViewPage,
+		page,
+		site,
+	}) => {
+		await captchaConfigPage.goTo();
+
+		await captchaConfigPage.resetCaptchaConfiguration();
+
+		// Create a form with a text field translated to Portuguese
+
+		await formBuilderPage.goToNew(site.friendlyUrlPath);
+
+		await expect(formBuilderPage.newFormHeading).toBeVisible();
+
+		await formBuilderPage.fillFormTitle('Form' + getRandomInt());
+
+		await formBuilderSidePanelPage.addFieldByDoubleClick('Text');
+
+		await formBuilderSidePanelPage.label.fill('Text Field');
+
+		await formBuilderPage.changeFormBuilderLanguage('Portuguese (Brazil)');
+
+		await formBuilderSidePanelPage.label.fill('Campo de texto');
+
+		// Require CAPTCHA
+
+		await formBuilderPage.formSettingsButton.click();
+
+		await formBuilderPage.requireCaptchaToggle.click();
+
+		await formSettingsModalPage.clickDoneButton();
+
+		// Publish and open the shared form link
+
+		await formBuilderPage.clickPublishFormButton();
+
+		await page.goto(await formBuilderPage.getFormSubmissionURL());
+
+		// The CAPTCHA renders in the default language (English)
+
+		await expect(page.getByText('Text Verification')).toBeVisible();
+
+		await expect(page.getByTitle('Refresh CAPTCHA')).toBeVisible();
+
+		// Switch the form to Portuguese
+
+		await clickAndExpectToBeVisible({
+			target: page.getByRole('link', {name: 'português-Brasil'}),
+			trigger: formViewPage.languageSelector,
+		});
+
+		await clickAndExpectToBeVisible({
+			target: page.getByText('Verificação de texto'),
+			trigger: page.getByRole('link', {name: 'português-Brasil'}),
+		});
+
+		// The CAPTCHA labels now follow the form's display language (LPD-94997)
+
+		await expect(page.getByTitle('Atualizar CAPTCHA')).toBeVisible();
+
+		await expect(page.getByText('Text Verification')).toBeHidden();
+
+		await expect(page.getByTitle('Refresh CAPTCHA')).toBeHidden();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94997

## What Is Being Fixed

On a published form's shared link, the CAPTCHA labels ("Text Verification", "Refresh CAPTCHA", "Text to Identify") and the document/upload field labels (Select, Clear, file, and so on) always rendered in the server's default language instead of following the form's display language. When a guest opened the shared link and switched the form to another language (for example, Portuguese), those labels stayed in English. This is a follow-up to LPD-92219 (LPP-64189), which fixed the same class of issue for other fields.

## How It Is Being Fixed

Both field types now resolve their labels server-side in their DDMFormFieldTemplateContextContributor, keyed off the form's display locale (ddmFormFieldRenderingContext.getLocale()) rather than the viewer's locale.

For the upload (document library) field, the contributor pre-translates its labels into a "strings" parameter, mirroring SelectDDMFormFieldTemplateContextContributor, and DocumentLibrary.es.js consumes them with a `strings?.x ?? Liferay.Language.get('x')` fallback, threading the prop through the Main, DocumentLibrary, and GuestUploadFile components.

For the CAPTCHA field, the contributor renders the captcha tag in the form's display locale by temporarily overriding both locale channels the tag reads — the WebKeys.LOCALE request attribute (used by liferay-ui:message and the image alt text) and themeDisplay.getLocale() (used by the aui:input label) — and restoring the originals afterward. When the display locale is unavailable, the request locale is left untouched so the tag still falls back correctly.

## PR Check

**pr-check: PASS** — tested on `4960cddf3550a8e4a3b50344b488543e7094a4b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4960cddf3550a8e4a3b50344b488543e7094a4b7"} -->