### PR TITLE
LPD-94504 Forward publish and expiration dates to the asset entry

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntry.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntry.java
@@ -62,6 +62,8 @@ public interface ObjectEntry
 
 	public ObjectDefinition getObjectDefinition();
 
+	public java.util.Date getPublishDate();
+
 	public java.util.Map<java.util.Locale, String> getTitleMap()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
@@ -92,4 +94,4 @@ public interface ObjectEntry
 	public void setValues(java.util.Map<String, java.io.Serializable> values);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1501007772
+// LIFERAY-SERVICE-BUILDER-HASH:1856044374

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/model/ObjectEntryWrapper.java
@@ -403,6 +403,11 @@ public class ObjectEntryWrapper
 		return model.getPrimaryKey();
 	}
 
+	@Override
+	public Date getPublishDate() {
+		return model.getPublishDate();
+	}
+
 	/**
 	 * Returns the review date of this object entry.
 	 *
@@ -1007,4 +1012,4 @@ public class ObjectEntryWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-375848396
+// LIFERAY-SERVICE-BUILDER-HASH:-536486699

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/model/packageinfo
@@ -1,1 +1,1 @@
-version 13.3.0
+version 13.4.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/model/impl/ObjectEntryImpl.java
@@ -21,6 +21,7 @@ import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -133,6 +135,17 @@ public class ObjectEntryImpl extends ObjectEntryBaseImpl {
 		}
 
 		return _objectDefinition;
+	}
+
+	@Override
+	public Date getPublishDate() {
+		if (!FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-17564") ||
+			!isApproved()) {
+
+			return null;
+		}
+
+		return getDisplayDate();
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2435,7 +2435,8 @@ public class ObjectEntryLocalServiceImpl
 		else {
 			_assetEntryLocalService.updateEntry(
 				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-				null, null, true, objectEntry.isApproved());
+				objectEntry.getPublishDate(), objectEntry.getExpirationDate(),
+				true, objectEntry.isApproved());
 		}
 
 		_reindex(objectEntry);
@@ -6922,9 +6923,10 @@ public class ObjectEntryLocalServiceImpl
 				objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
 				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
 				objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-				objectEntry.isApproved(), null, null, null, null, mimeType,
-				title, String.valueOf(objectEntry.getObjectEntryId()), null,
-				null, null, 0, 0, priority, serviceContext);
+				objectEntry.isApproved(), null, null,
+				objectEntry.getPublishDate(), objectEntry.getExpirationDate(),
+				mimeType, title, String.valueOf(objectEntry.getObjectEntryId()),
+				null, null, null, 0, 0, priority, serviceContext);
 
 			if (assetLinkEntryIds != null) {
 				_assetLinkLocalService.updateLinks(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -6863,8 +6863,11 @@ public class ObjectEntryLocalServiceTest {
 		Assert.assertEquals(0, baseModelSearchResult.getLength());
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testUpdateAsset() throws Exception {
+		_objectDefinition = _updateEnableObjectEntryDraft(_objectDefinition);
+
 		ObjectField objectField = _objectFieldLocalService.getObjectField(
 			_objectDefinition.getObjectDefinitionId(), "emailAddressRequired");
 
@@ -6872,22 +6875,48 @@ public class ObjectEntryLocalServiceTest {
 			_objectDefinition.getObjectDefinitionId(),
 			objectField.getObjectFieldId());
 
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
 		ObjectEntry objectEntry = _addObjectEntry(
 			HashMapBuilder.<String, Serializable>put(
+				"displayDate", new Date()
+			).put(
 				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"expirationDate",
+				new Date(System.currentTimeMillis() + Time.DAY)
+			).put(
+				"listTypeEntryKeyRequired", "listTypeEntryKey1"
+			).build(),
+			serviceContext);
+
+		_assertAssetEntry(
+			objectEntry.getExpirationDate(), null, "john@liferay.com",
+			objectEntry);
+
+		objectEntry = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"displayDate", new Date()
+			).put(
+				"emailAddressRequired", "john@liferay.com"
+			).put(
+				"expirationDate",
+				new Date(System.currentTimeMillis() + Time.DAY)
 			).put(
 				"listTypeEntryKeyRequired", "listTypeEntryKey1"
 			).build());
 
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			_objectDefinition.getClassName(), objectEntry.getObjectEntryId());
-
-		Assert.assertEquals("john@liferay.com", assetEntry.getTitle());
+		_assertAssetEntry(
+			objectEntry.getExpirationDate(), objectEntry.getDisplayDate(),
+			"john@liferay.com", objectEntry);
 
 		objectField = _addCustomObjectField(
 			new TextObjectFieldBuilder(
 			).labelMap(
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+				RandomTestUtil.randomLocaleStringMap()
 			).localized(
 				true
 			).name(
@@ -6906,23 +6935,19 @@ public class ObjectEntryLocalServiceTest {
 			"pt_BR", RandomTestUtil.randomString()
 		).build();
 
-		objectEntry = _addObjectEntry(
-			HashMapBuilder.<String, Serializable>put(
-				"emailAddressRequired", "john@liferay.com"
-			).put(
-				"listTypeEntryKeyRequired", "listTypeEntryKey1"
-			).put(
-				objectField.getI18nObjectFieldName(),
-				(Serializable)localizedValues
-			).build());
-
-		assetEntry = _assetEntryLocalService.fetchEntry(
-			_objectDefinition.getClassName(), objectEntry.getObjectEntryId());
-
-		Assert.assertEquals(
+		_assertAssetEntry(
+			null, null,
 			_localization.getXml(
 				localizedValues, objectEntry.getDefaultLanguageId(), "title"),
-			assetEntry.getTitle());
+			_addObjectEntry(
+				HashMapBuilder.<String, Serializable>put(
+					"emailAddressRequired", "john@liferay.com"
+				).put(
+					"listTypeEntryKeyRequired", "listTypeEntryKey1"
+				).put(
+					objectField.getI18nObjectFieldName(),
+					(Serializable)localizedValues
+				).build()));
 	}
 
 	@Test
@@ -8321,7 +8346,14 @@ public class ObjectEntryLocalServiceTest {
 		throws Exception {
 
 		return _addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(), values);
+			values, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectEntry _addObjectEntry(
+			Map<String, Serializable> values, ServiceContext serviceContext)
+		throws Exception {
+
+		return _addObjectEntry(_objectDefinition, values, serviceContext);
 	}
 
 	private ObjectEntry _addObjectEntry(
@@ -8429,6 +8461,20 @@ public class ObjectEntryLocalServiceTest {
 			TempFileEntryUtil.getTempFileName(title + ".txt"),
 			FileUtil.createTempFile(DLTestUtil.randomTextFileBytes()),
 			ContentTypes.TEXT_PLAIN);
+	}
+
+	private void _assertAssetEntry(
+			Date expectedExpirationDate, Date expectedPublishDate,
+			String expectedTitle, ObjectEntry objectEntry)
+		throws Exception {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			objectEntry.getModelClassName(), objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(
+			expectedExpirationDate, assetEntry.getExpirationDate());
+		Assert.assertEquals(expectedPublishDate, assetEntry.getPublishDate());
+		Assert.assertEquals(expectedTitle, assetEntry.getTitle());
 	}
 
 	private void _assertAuditMessage(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94504

## What Is Being Fixed

When an object entry's asset entry was created or updated, the publish and expiration dates were always passed as null. As a result, the asset entry stored and indexed a publish date of epoch (19700101000000) instead of the object entry's actual publish date.

## How It Is Being Fixed

ObjectEntryLocalServiceImpl now forwards the object entry's publish and expiration dates when creating or updating the asset entry, instead of passing null. A new getPublishDate() method on ObjectEntry returns the display date when the object entry is approved and the LPD-17564 feature flag is enabled, and null otherwise, so the published date is only surfaced for approved entries.

## PR Check

**pr-check: PASS** — tested on `ef8a461ba12a364063167f796e447407a47d5552`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ef8a461ba12a364063167f796e447407a47d5552"} -->
