### PR TITLE
LPD-94273 Fix double slash in calendar event display page URLs

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/info/item/provider/CalendarBookingInfoItemFriendlyURLProvider.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/info/item/provider/CalendarBookingInfoItemFriendlyURLProvider.java
@@ -8,7 +8,6 @@ package com.liferay.calendar.web.internal.info.item.provider;
 import com.liferay.calendar.model.CalendarBooking;
 import com.liferay.friendly.url.info.item.provider.InfoItemFriendlyURLProvider;
 import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
-import com.liferay.petra.string.StringPool;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +28,7 @@ public class CalendarBookingInfoItemFriendlyURLProvider
 	public String getFriendlyURL(
 		CalendarBooking calendarBooking, String languageId) {
 
-		return StringPool.SLASH + calendarBooking.getCalendarBookingId();
+		return String.valueOf(calendarBooking.getCalendarBookingId());
 	}
 
 	@Override

--- a/modules/apps/calendar/calendar-web/src/test/java/com/liferay/calendar/web/internal/info/item/provider/CalendarBookingInfoItemFriendlyURLProviderTest.java
+++ b/modules/apps/calendar/calendar-web/src/test/java/com/liferay/calendar/web/internal/info/item/provider/CalendarBookingInfoItemFriendlyURLProviderTest.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.calendar.web.internal.info.item.provider;
+
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Shakir Shamim
+ */
+public class CalendarBookingInfoItemFriendlyURLProviderTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetFriendlyURL() {
+		long calendarBookingId = RandomTestUtil.randomLong();
+
+		CalendarBooking calendarBooking = Mockito.mock(CalendarBooking.class);
+
+		Mockito.when(
+			calendarBooking.getCalendarBookingId()
+		).thenReturn(
+			calendarBookingId
+		);
+
+		Assert.assertEquals(
+			String.valueOf(calendarBookingId),
+			_calendarBookingInfoItemFriendlyURLProvider.getFriendlyURL(
+				calendarBooking, RandomTestUtil.randomString()));
+	}
+
+	private final CalendarBookingInfoItemFriendlyURLProvider
+		_calendarBookingInfoItemFriendlyURLProvider =
+			new CalendarBookingInfoItemFriendlyURLProvider();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94273

## What Is Being Fixed

The calendar event display page URL contained a double slash (e.g. `/h//{id}`). `CalendarBookingInfoItemFriendlyURLProvider` returned the booking's friendly URL with a leading slash, and when that value was composed into the display page URL it produced a redundant `//`.

## How It Is Being Fixed

`CalendarBookingInfoItemFriendlyURLProvider.getFriendlyURL` now returns the calendar booking ID as a plain string via `String.valueOf` instead of prefixing it with `StringPool.SLASH`, removing the leading slash that caused the double slash. A unit test, `CalendarBookingInfoItemFriendlyURLProviderTest`, verifies the provider returns the booking ID without a leading slash.

## PR Check

**pr-check: PASS** — tested on `ab170420ea9f88f3d481da9c92512d9cb47bd39b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ab170420ea9f88f3d481da9c92512d9cb47bd39b"} -->
