### PR TITLE
LPD-93214 move comments from ObjectEntry into SystemProperties

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 35.1.0
+Bundle-Version: 36.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.headless.delivery.dto.v1_0.Creator;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
@@ -146,52 +145,6 @@ public class ObjectEntry implements Serializable {
 
 	@JsonIgnore
 	private Supplier<AuditEvent[]> _auditEventsSupplier;
-
-	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
-	)
-	@Valid
-	public Comment[] getComments() {
-		if (_commentsSupplier != null) {
-			comments = _commentsSupplier.get();
-
-			_commentsSupplier = null;
-		}
-
-		return comments;
-	}
-
-	public void setComments(Comment[] comments) {
-		this.comments = comments;
-
-		_commentsSupplier = null;
-	}
-
-	@JsonIgnore
-	public void setComments(
-		UnsafeSupplier<Comment[], Exception> commentsUnsafeSupplier) {
-
-		_commentsSupplier = () -> {
-			try {
-				return commentsUnsafeSupplier.get();
-			}
-			catch (RuntimeException runtimeException) {
-				throw runtimeException;
-			}
-			catch (Exception exception) {
-				throw new RuntimeException(exception);
-			}
-		};
-	}
-
-	@GraphQLField(
-		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
-	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Comment[] comments;
-
-	@JsonIgnore
-	private Supplier<Comment[]> _commentsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
@@ -1198,7 +1151,7 @@ public class ObjectEntry implements Serializable {
 	}
 
 	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected SystemProperties systemProperties;
 
 	@JsonIgnore
@@ -1320,9 +1273,6 @@ public class ObjectEntry implements Serializable {
 		else if (Objects.equals(propertyName, "auditEvents")) {
 			return getAuditEvents();
 		}
-		else if (Objects.equals(propertyName, "comments")) {
-			return getComments();
-		}
 		else if (Objects.equals(propertyName, "creator")) {
 			return getCreator();
 		}
@@ -1426,9 +1376,6 @@ public class ObjectEntry implements Serializable {
 		}
 		else if (Objects.equals(propertyName, "auditEvents")) {
 			setAuditEvents((AuditEvent[])propertyValue);
-		}
-		else if (Objects.equals(propertyName, "comments")) {
-			setComments((Comment[])propertyValue);
 		}
 		else if (Objects.equals(propertyName, "creator")) {
 			setCreator((Creator)propertyValue);
@@ -1580,28 +1527,6 @@ public class ObjectEntry implements Serializable {
 				sb.append(String.valueOf(auditEvents[i]));
 
 				if ((i + 1) < auditEvents.length) {
-					sb.append(", ");
-				}
-			}
-
-			sb.append("]");
-		}
-
-		Comment[] comments = getComments();
-
-		if (comments != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"comments\": ");
-
-			sb.append("[");
-
-			for (int i = 0; i < comments.length; i++) {
-				sb.append(comments[i]);
-
-				if ((i + 1) < comments.length) {
 					sb.append(", ");
 				}
 			}
@@ -2101,4 +2026,4 @@ public class ObjectEntry implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1395753834
+// LIFERAY-REST-BUILDER-HASH:-1649858630

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/SystemProperties.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.liferay.headless.delivery.dto.v1_0.Comment;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -90,6 +91,52 @@ public class SystemProperties implements Serializable {
 
 	@JsonIgnore
 	private Supplier<CollaboratorBrief> _collaboratorBriefSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
+	)
+	@Valid
+	public Comment[] getComments() {
+		if (_commentsSupplier != null) {
+			comments = _commentsSupplier.get();
+
+			_commentsSupplier = null;
+		}
+
+		return comments;
+	}
+
+	public void setComments(Comment[] comments) {
+		this.comments = comments;
+
+		_commentsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setComments(
+		UnsafeSupplier<Comment[], Exception> commentsUnsafeSupplier) {
+
+		_commentsSupplier = () -> {
+			try {
+				return commentsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "Optional field with the comments associated with this object entry, can be embedded with nestedFields"
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Comment[] comments;
+
+	@JsonIgnore
+	private Supplier<Comment[]> _commentsSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema
 	@Valid
@@ -260,6 +307,28 @@ public class SystemProperties implements Serializable {
 			sb.append(String.valueOf(collaboratorBrief));
 		}
 
+		Comment[] comments = getComments();
+
+		if (comments != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"comments\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < comments.length; i++) {
+				sb.append(comments[i]);
+
+				if ((i + 1) < comments.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		ObjectDefinitionBrief objectDefinitionBrief =
 			getObjectDefinitionBrief();
 
@@ -398,4 +467,4 @@ public class SystemProperties implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-171984500
+// LIFERAY-REST-BUILDER-HASH:1036222607

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/util/ObjectEntryManagerUtil.java
@@ -10,6 +10,7 @@ import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.dto.v1_0.SystemProperties;
 import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 
 import java.util.Map;
@@ -23,8 +24,26 @@ public class ObjectEntryManagerUtil {
 		ObjectEntry existingObjectEntry, long objectDefinitionId,
 		ObjectEntry objectEntry) {
 
-		if (objectEntry.getComments() != null) {
-			existingObjectEntry.setComments(objectEntry::getComments);
+		SystemProperties systemProperties = objectEntry.getSystemProperties();
+
+		if ((systemProperties != null) &&
+			(systemProperties.getComments() != null)) {
+
+			SystemProperties existingSystemProperties =
+				existingObjectEntry.getSystemProperties();
+
+			if (existingSystemProperties == null) {
+				SystemProperties newSystemProperties = new SystemProperties();
+
+				newSystemProperties.setComments(systemProperties::getComments);
+
+				existingObjectEntry.setSystemProperties(
+					() -> newSystemProperties);
+			}
+			else {
+				existingSystemProperties.setComments(
+					systemProperties::getComments);
+			}
 		}
 
 		if (objectEntry.getDateCreated() != null) {

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.6.0
+version 5.0.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -185,12 +185,6 @@ components:
                         $ref: "#/components/schemas/AuditEvent"
                     readOnly: true
                     type: array
-                comments:
-                    description:
-                        Optional field with the comments associated with this object entry, can be embedded with nestedFields
-                    items:
-                        $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Comment
-                    type: array
                 creator:
                     $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator
                     readOnly: true
@@ -267,7 +261,6 @@ components:
                     $ref: "#/components/schemas/Status"
                 systemProperties:
                     $ref: "#/components/schemas/SystemProperties"
-                    readOnly: true
                 taxonomyCategoryBriefs:
                     description:
                         The categories associated with this object entry.
@@ -300,6 +293,12 @@ components:
             properties:
                 collaboratorBrief:
                     $ref: "#/components/schemas/CollaboratorBrief"
+                comments:
+                    description:
+                        Optional field with the comments associated with this object entry, can be embedded with nestedFields
+                    items:
+                        $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Comment
+                    type: array
                 objectDefinitionBrief:
                     $ref: "#/components/schemas/ObjectDefinitionBrief"
                 scope:

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -269,8 +269,6 @@ public class ObjectEntryDTOConverter
 			() -> _toAuditEvents(
 				dtoConverterContext, objectDefinition,
 				serviceBuilderObjectEntry));
-		objectEntry.setComments(
-			() -> _toComments(objectDefinition, serviceBuilderObjectEntry));
 		objectEntry.setCreator(
 			() -> {
 				long userId = _getAttribute(
@@ -448,6 +446,7 @@ public class ObjectEntryDTOConverter
 						serviceBuilderObjectEntry.getGroupId(),
 						dtoConverterContext.getLocale(), objectDefinition,
 						serviceBuilderObjectEntry.getObjectEntryId(),
+						serviceBuilderObjectEntry,
 						dtoConverterContext.getUserId(),
 						objectEntryVersion.getVersion());
 				}
@@ -456,7 +455,7 @@ public class ObjectEntryDTOConverter
 					serviceBuilderObjectEntry.getGroupId(),
 					dtoConverterContext.getLocale(), objectDefinition,
 					serviceBuilderObjectEntry.getObjectEntryId(),
-					dtoConverterContext.getUserId(),
+					serviceBuilderObjectEntry, dtoConverterContext.getUserId(),
 					serviceBuilderObjectEntry.getVersion());
 			});
 		objectEntry.setTaxonomyCategoryBriefs(
@@ -1018,7 +1017,7 @@ public class ObjectEntryDTOConverter
 		throws Exception {
 
 		return NestedFieldsSupplier.supply(
-			"comments",
+			"systemProperties.comments",
 			nestedFieldNames -> {
 				if ((!Objects.equals(
 						objectDefinition.getScope(),
@@ -1301,10 +1300,15 @@ public class ObjectEntryDTOConverter
 
 	private SystemProperties _toSystemProperties(
 			long groupId, Locale locale, ObjectDefinition objectDefinition,
-			long objectEntryId, long userId, int versionInt)
+			long objectEntryId,
+			com.liferay.object.model.ObjectEntry serviceBuilderObjectEntry,
+			long userId, int versionInt)
 		throws Exception {
 
 		Group group = _groupLocalService.fetchGroup(groupId);
+
+		Comment[] nestedComments = _toComments(
+			objectDefinition, serviceBuilderObjectEntry);
 
 		SharingEntry nestedSharingEntry = NestedFieldsSupplier.supply(
 			"systemProperties.collaboratorBrief",
@@ -1321,7 +1325,8 @@ public class ObjectEntryDTOConverter
 					locale, objectDefinition));
 
 		if (!objectDefinition.isEnableObjectEntryVersioning() &&
-			(group == null) && (nestedObjectDefinitionBrief == null) &&
+			(group == null) && (nestedComments == null) &&
+			(nestedObjectDefinitionBrief == null) &&
 			(nestedSharingEntry == null)) {
 
 			return null;
@@ -1337,6 +1342,7 @@ public class ObjectEntryDTOConverter
 
 						return _toCollaboratorBrief(nestedSharingEntry);
 					});
+				setComments(() -> nestedComments);
 				setObjectDefinitionBrief(() -> nestedObjectDefinitionBrief);
 				setScope(
 					() -> {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -51,6 +51,7 @@ import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.Folder;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.dto.v1_0.Status;
+import com.liferay.object.rest.dto.v1_0.SystemProperties;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.rest.filter.parser.ObjectDefinitionFilterParser;
 import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryRelatedObjectsResourceImpl;
@@ -2091,8 +2092,10 @@ public class DefaultObjectEntryManagerImpl
 		}
 
 		List<ObjectEntryComment> objectEntryComments = null;
+		SystemProperties systemProperties = objectEntry.getSystemProperties();
 
-		if ((objectEntry.getComments() != null) &&
+		if ((systemProperties != null) &&
+			(systemProperties.getComments() != null) &&
 			(Objects.equals(
 				objectDefinition.getScope(),
 				ObjectDefinitionConstants.SCOPE_SITE) ||
@@ -2100,7 +2103,7 @@ public class DefaultObjectEntryManagerImpl
 				 objectDefinition.getCompanyId(), "LPD-43996"))) {
 
 			objectEntryComments = TransformUtil.transformToList(
-				objectEntry.getComments(),
+				systemProperties.getComments(),
 				comment -> new ObjectEntryComment(
 					comment.getExternalReferenceCode(),
 					comment.getParentCommentExternalReferenceCode(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/vulcan/openapi/contributor/ObjectEntryOpenAPIContributor.java
@@ -212,10 +212,30 @@ public class ObjectEntryOpenAPIContributor extends BaseOpenAPIContributor {
 			schemas.remove("TaxonomyCategoryBrief");
 		}
 
-		if (!_objectDefinition.isEnableObjectEntryVersioning()) {
+		if (!_objectDefinition.isEnableComments() &&
+			!_objectDefinition.isEnableObjectEntryVersioning()) {
+
 			objectDefinitionSchemaProperties.remove("systemProperties");
 
 			schemas.remove("SystemProperties");
+		}
+		else {
+			Schema systemPropertiesSchema = schemas.get("SystemProperties");
+
+			if (systemPropertiesSchema != null) {
+				Map<String, Schema> systemPropertiesSchemaProperties =
+					systemPropertiesSchema.getProperties();
+
+				if (systemPropertiesSchemaProperties != null) {
+					if (!_objectDefinition.isEnableComments()) {
+						systemPropertiesSchemaProperties.remove("comments");
+					}
+
+					if (!_objectDefinition.isEnableObjectEntryVersioning()) {
+						systemPropertiesSchemaProperties.remove("version");
+					}
+				}
+			}
 		}
 
 		if ((openAPIContext != null) &&

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11301,15 +11301,19 @@ public class ObjectEntryResourceTest {
 		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 			new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
 				{
-					comments = new Comment[] {
-						new Comment() {
-							{
-								externalReferenceCode =
-									RandomTestUtil.randomString();
-								parentCommentExternalReferenceCode =
-									parentExternalReferenceCode;
-								text = RandomTestUtil.randomString();
-							}
+					systemProperties = new SystemProperties() {
+						{
+							comments = new Comment[] {
+								new Comment() {
+									{
+										externalReferenceCode =
+											RandomTestUtil.randomString();
+										parentCommentExternalReferenceCode =
+											parentExternalReferenceCode;
+										text = RandomTestUtil.randomString();
+									}
+								}
+							};
 						}
 					};
 				}
@@ -16472,14 +16476,18 @@ public class ObjectEntryResourceTest {
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			null,
-			_getEndpoint(objectDefinition, groupId) + "?nestedFields=comments",
+			_getEndpoint(objectDefinition, groupId) +
+				"?nestedFields=systemProperties.comments",
 			Http.Method.GET);
 
 		JSONArray jsonArray = jsonObject.getJSONArray("items");
 
 		jsonObject = jsonArray.getJSONObject(0);
 
-		return jsonObject.getJSONArray("comments");
+		JSONObject systemPropertiesJSONObject = jsonObject.getJSONObject(
+			"systemProperties");
+
+		return systemPropertiesJSONObject.getJSONArray("comments");
 	}
 
 	private String _getDeletePatchPutEndpoint(
@@ -17218,17 +17226,20 @@ public class ObjectEntryResourceTest {
 		String endpoint = _getDeletePatchPutEndpoint(
 			groupId, objectDefinition, objectEntryJSONObject);
 
-		endpoint = endpoint + "?nestedFields=comments";
+		endpoint = endpoint + "?nestedFields=systemProperties.comments";
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
 			endpoint, httpMethod);
 
-		return jsonObject.getJSONArray("comments");
+		JSONObject systemPropertiesJSONObject = jsonObject.getJSONObject(
+			"systemProperties");
+
+		return systemPropertiesJSONObject.getJSONArray("comments");
 	}
 
 	private JSONObject _postCustomObjectEntryWithAssigneeObjectField(
@@ -17304,18 +17315,24 @@ public class ObjectEntryResourceTest {
 		String endpoint = _getEndpoint(objectDefinition, groupId);
 
 		if (nestedFields) {
-			endpoint = endpoint + "?nestedFields=comments";
+			endpoint = endpoint + "?nestedFields=systemProperties.comments";
 		}
 
 		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
 			endpoint, Http.Method.POST);
 
-		JSONArray jsonArray = jsonObject.getJSONArray("comments");
+		JSONArray jsonArray = null;
+		JSONObject systemPropertiesJSONObject = jsonObject.getJSONObject(
+			"systemProperties");
+
+		if (systemPropertiesJSONObject != null) {
+			jsonArray = systemPropertiesJSONObject.getJSONArray("comments");
+		}
 
 		if (jsonArray == null) {
 			return JSONFactoryUtil.createJSONArray();
@@ -17505,9 +17522,10 @@ public class ObjectEntryResourceTest {
 			JSONUtil.put(
 				_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 			).put(
-				"comments", commentsJSONArray
+				"systemProperties", JSONUtil.put("comments", commentsJSONArray)
 			).toString(),
-			endpoint + "?nestedFields=comments", Http.Method.POST);
+			endpoint + "?nestedFields=systemProperties.comments",
+			Http.Method.POST);
 
 		long objectEntryId = objectEntryJSONObject.getLong("id");
 
@@ -19524,20 +19542,24 @@ public class ObjectEntryResourceTest {
 		com.liferay.object.rest.dto.v1_0.ObjectEntry objectEntry =
 			new com.liferay.object.rest.dto.v1_0.ObjectEntry() {
 				{
-					comments = new Comment[] {
-						new Comment() {
-							{
-								externalReferenceCode =
-									RandomTestUtil.randomString();
-								parentCommentExternalReferenceCode =
-									parentExternalReferenceCode;
-								text = RandomTestUtil.randomString();
-							}
-						}
-					};
 					properties = HashMapBuilder.<String, Object>put(
 						_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
 					).build();
+					systemProperties = new SystemProperties() {
+						{
+							comments = new Comment[] {
+								new Comment() {
+									{
+										externalReferenceCode =
+											RandomTestUtil.randomString();
+										parentCommentExternalReferenceCode =
+											parentExternalReferenceCode;
+										text = RandomTestUtil.randomString();
+									}
+								}
+							};
+						}
+					};
 				}
 			};
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11406,6 +11406,36 @@ public class ObjectEntryResourceTest {
 		}
 	}
 
+	@FeatureFlag("LPD-43996")
+	@Test
+	public void testPostObjectEntryWithObjectFieldNamedComments()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						"comments", "comments", false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_enableComments(objectDefinition);
+
+		String value = RandomTestUtil.randomString();
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"comments", value
+			).toString(),
+			objectDefinition.getRESTContextPath(), Http.Method.POST);
+
+		Assert.assertEquals(value, jsonObject.getString("comments"));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+	}
+
 	@Test
 	public void testPostObjectEntryWithTaxonomyCategories() throws Exception {
 		Company company = _companyLocalService.getCompany(

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/OpenAPIResourceTest.java
@@ -410,6 +410,46 @@ public class OpenAPIResourceTest {
 			"expected_openapi_actions_object_action.json", _objectDefinition);
 	}
 
+	@FeatureFlag("LPD-43996")
+	@Test
+	public void testGetOpenAPIWithComments() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
+						"field", "field", false)),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		objectDefinition.setEnableComments(true);
+
+		objectDefinition = _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+
+		_objectDefinitions.add(objectDefinition);
+
+		JSONObject openAPIJSONObject = HTTPTestUtil.invokeToJSONObject(
+			null, objectDefinition.getRESTContextPath() + "/openapi.json",
+			Http.Method.GET);
+
+		JSONObject componentsJSONObject = openAPIJSONObject.getJSONObject(
+			"components");
+
+		JSONObject schemasJSONObject = componentsJSONObject.getJSONObject(
+			"schemas");
+
+		JSONObject systemPropertiesJSONObject = schemasJSONObject.getJSONObject(
+			"SystemProperties");
+
+		JSONObject propertiesJSONObject =
+			systemPropertiesJSONObject.getJSONObject("properties");
+
+		Assert.assertNotNull(propertiesJSONObject.opt("comments"));
+		Assert.assertNull(propertiesJSONObject.opt("version"));
+	}
+
 	@Test
 	public void testGetOpenAPIWithSystemObjectRelationship() throws Exception {
 		_user = TestPropsValues.getUser();

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi.json
@@ -536,13 +536,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",
@@ -1352,13 +1345,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions.json
@@ -564,13 +564,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_actions_object_action.json
@@ -576,13 +576,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_categorization_disabled.json
@@ -388,13 +388,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_related.json
@@ -537,13 +537,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",
@@ -1353,13 +1346,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,
@@ -2301,13 +2287,6 @@
 						"readOnly": true,
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
-					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
 					},
 					"creator": {
 						"readOnly": true,

--- a/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
+++ b/modules/apps/object/object-rest-test/src/testIntegration/resources/com/liferay/object/rest/internal/resource/v1_0/test/dependencies/expected_openapi_site.json
@@ -388,13 +388,6 @@
 						"type": "array",
 						"x-batch-unsupported-formats": "CSV"
 					},
-					"comments": {
-						"description": "Optional field with the comments associated with this object entry, can be embedded with nestedFields",
-						"items": {
-							"$ref": "#/components/schemas/Comment"
-						},
-						"type": "array"
-					},
 					"creator": {
 						"readOnly": true,
 						"type": "string",


### PR DESCRIPTION
## Summary

- Moves `comments` from the top-level `ObjectEntry` DTO into the nested `SystemProperties` DTO, so a custom object field named `comments` no longer collides with the built-in comments field when binding the request body.
- Updates `ObjectEntryDTOConverter`, `DefaultObjectEntryManagerImpl`, `ObjectEntryManagerUtil`, and the `NestedFieldsSupplier` key (`"comments"` → `"systemProperties.comments"`) to match the new location.
- Prunes inactive `SystemProperties` sub-properties from the generated OpenAPI schema in `ObjectEntryOpenAPIContributor`: `comments` when comments are disabled and `version` when versioning is disabled (the whole schema is still removed when both are off).
- Adds a regression test (`testPostObjectEntryWithObjectFieldNamedComments`) that publishes an object definition with a text field named `comments`, enables comments, and verifies the value round-trips via the REST API.
- Bumps `object-rest-api` Bundle-Version to `36.0.0` and packageinfo to `5.0.0` to reflect the breaking API change; the breaking-change note is recorded on the baseline commit.

## Test plan

- [x] `testPostObjectEntryWithObjectFieldNamedComments` — POST an object entry with an object field named `comments`; value round-trips.
- [x] Comments suite — `testPostObjectEntriesWithComments`, `testGetObjectEntriesPageWithComments`, `testPatchPutObjectEntryWithComments`, `testDeleteObjectEntryWithComments` all pass.
- [x] Full `ObjectEntryResourceTest` / OpenAPI fixture suite — no regressions.

## pr-check: PASS — tested on `0383ae6f130abae75399b8def9f778edcedf347a`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Baseline | PASS |
| Integration Test Compile | PASS |
| Structural Smoke (ModulesStructureTest) | PASS |

Scope: essential validations. Build validations carried over from the byte-identical prior run (`f23fe5b`) — the reword that produced `630cef6` changed only commit messages, not code. **Cross-Module Compile** and **Per-Module Compile** were not run, so consumers of the removed public `ObjectEntry.getComments()`/`setComments()` API were not compile-verified.
