### PR TITLE
LPD-93484 Compare friendly URL separators at slash boundaries

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -2866,7 +2866,7 @@ public class ObjectDefinitionLocalServiceTest {
 								StringUtil.randomId()
 							).objectDefinitionId(
 								_addCustomObjectDefinition(
-									"Test" + RandomTestUtil.randomString()
+									ObjectDefinitionTestUtil.getRandomName()
 								).getObjectDefinitionId()
 							).required(
 								true
@@ -2887,7 +2887,7 @@ public class ObjectDefinitionLocalServiceTest {
 								StringUtil.randomId()
 							).objectDefinitionId(
 								_addCustomObjectDefinition(
-									"Test" + RandomTestUtil.randomString()
+									ObjectDefinitionTestUtil.getRandomName()
 								).getObjectDefinitionId()
 							).required(
 								true
@@ -3010,10 +3010,10 @@ public class ObjectDefinitionLocalServiceTest {
 				_objectRelationshipLocalService.addObjectRelationship(
 					null, TestPropsValues.getUserId(),
 					_addCustomObjectDefinition(
-						"Test" + RandomTestUtil.randomString()
+						ObjectDefinitionTestUtil.getRandomName()
 					).getObjectDefinitionId(),
 					_addCustomObjectDefinition(
-						"Test" + RandomTestUtil.randomString()
+						ObjectDefinitionTestUtil.getRandomName()
 					).getObjectDefinitionId(),
 					0, ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 					LocalizedMapUtil.getLocalizedMap(
@@ -3326,9 +3326,25 @@ public class ObjectDefinitionLocalServiceTest {
 			FriendlyURLResolverConstants.URL_SEPARATOR_Y_OBJECT_ENTRY,
 			objectDefinition2.getFriendlyURLSeparator());
 
+		String name = ObjectDefinitionTestUtil.getRandomName();
+
 		ObjectDefinition objectDefinition3 =
 			ObjectDefinitionTestUtil.publishObjectDefinition(
-				"Test",
+				name + RandomTestUtil.randomString(),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						StringUtil.randomId()
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				TestPropsValues.getUserId());
+
+		ObjectDefinition objectDefinition4 =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				name,
 				Collections.singletonList(
 					new TextObjectFieldBuilder(
 					).labelMap(
@@ -3341,9 +3357,10 @@ public class ObjectDefinitionLocalServiceTest {
 				TestPropsValues.getUserId());
 
 		Assert.assertEquals(
-			"c_test", objectDefinition3.getFriendlyURLSeparator());
+			StringUtil.toLowerCase("c_" + name),
+			objectDefinition4.getFriendlyURLSeparator());
 
-		ObjectDefinition objectDefinition4 =
+		ObjectDefinition objectDefinition5 =
 			_objectDefinitionLocalService.addCustomObjectDefinition(
 				null, TestPropsValues.getUserId(), 0, null, true, false, true,
 				true, true, false, false, false, false, "api",
@@ -3365,12 +3382,13 @@ public class ObjectDefinitionLocalServiceTest {
 			"Other asset types may use this prefix.",
 			() -> _objectDefinitionLocalService.publishCustomObjectDefinition(
 				TestPropsValues.getUserId(),
-				objectDefinition4.getObjectDefinitionId()));
+				objectDefinition5.getObjectDefinitionId()));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition3);
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition4);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition5);
 	}
 
 	@FeatureFlag("LPD-17564")

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -470,8 +470,8 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 			String urlSeparator = friendlyURLResolver.getURLSeparator();
 
-			if (urlSeparator.contains(friendlyURL) ||
-				friendlyURL.startsWith(urlSeparator)) {
+			if (friendlyURL.startsWith(urlSeparator) ||
+				urlSeparator.startsWith(friendlyURL + StringPool.SLASH)) {
 
 				keywordConflict = urlSeparator;
 			}
@@ -481,8 +481,9 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 
 			if (Validator.isNull(keywordConflict) &&
 				friendlyURLResolver.isURLSeparatorConfigurable() &&
-				(defaultURLSeparator.contains(friendlyURL) ||
-				 friendlyURL.startsWith(defaultURLSeparator))) {
+				(friendlyURL.startsWith(defaultURLSeparator) ||
+				 defaultURLSeparator.startsWith(
+					 friendlyURL + StringPool.SLASH))) {
 
 				keywordConflict = defaultURLSeparator;
 			}


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-93484

Followup: https://github.com/brianchandotcom/liferay-portal/pull/177142

## What Is Being Fixed

Publishing a custom Object definition failed with an ObjectDefinitionFriendlyURLSeparatorException ("Other asset types may use this prefix.", HTTP 400) whenever its auto-generated friendly-URL separator happened to be a plain string prefix of an already-published definition's separator. For example, with "c_universityclass" published first, publishing a definition whose separator was "c_university" was rejected, even though /c_university/ and /c_universityclass/ are distinct path namespaces that never collide at runtime. The failure was order-dependent — publishing the shorter name first succeeded — which is the classic symptom of a raw substring comparison.

## How It Is Being Fixed

In LayoutLocalServiceHelper.validateFriendlyURLKeyword the raw substring test urlSeparator.contains(friendlyURL) is replaced with a slash-boundary test urlSeparator.startsWith(friendlyURL + StringPool.SLASH), applied at both edited call sites — the resolver urlSeparator branch and the analogous configurable defaultURLSeparator branch. The friendlyURL.startsWith(urlSeparator) disjunct is left byte-for-byte unchanged, so every genuine conflict (exact match and true path-namespace prefixes like /l vs /l/) is still caught, while a separator that is merely a string prefix of a longer one is no longer flagged. This makes the validator's namespace semantics match the runtime resolution in PortalImpl, which dispatches via friendlyURL.startsWith(urlSeparator), so the permitted namespaces are provably collision-free. An integration test, testPublishObjectDefinitionWithFriendlyURLSeparator in ObjectDefinitionLocalServiceTest, publishes the longer separator first and then its strict prefix to exercise the exact order that threw on master, while retaining the pre-existing "api" case as a genuine must-fail control.

## PR Check

**pr-check: PASS** — tested on `27511e75758cdea5f076b5dd286c04dcff903305`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "27511e75758cdea5f076b5dd286c04dcff903305"} -->
