### PR TITLE
LPD-88970 Add Playwright tests for the Email Address object field

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -63,6 +63,7 @@ const test = mergeTests(
 	isolatedSiteTest,
 	editObjectDefinitionPagesTest,
 	featureFlagsTest({
+		'LPD-70673': {enabled: true}, // Email Address field
 		'LPD-83570': {enabled: true}, // Phone Number field
 		'LPS-178052': {enabled: true},
 	}),
@@ -2781,6 +2782,152 @@ test.describe('Manage object entries through View Object Entries', () => {
 		).toHaveText('Jun 1, 2023, 12:00:00 PM');
 	});
 
+	test(
+		'can create an object entry with email address field',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const email = 'user@example.com';
+
+			let objectDefinition: ObjectDefinition;
+			let objectFields: ObjectField[];
+
+			await test.step('Create an object definition with an Email Address field', async () => {
+				objectFields = generateObjectFields({
+					objectFieldBusinessTypes: [
+						{
+							businessType: 'EmailAddress',
+						},
+					],
+				});
+
+				objectDefinition =
+					await apiHelpers.objectAdmin.postRandomObjectDefinition({
+						objectFields,
+						status: {code: 0},
+					});
+
+				apiHelpers.data.push({
+					id: objectDefinition.id,
+					type: 'objectDefinition',
+				});
+			});
+
+			await test.step('Navigate to the object definition and add an entry', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label.en_US
+				);
+			});
+
+			await test.step('Fill the email field and save the entry', async () => {
+				await page.getByLabel(objectFields[0].label.en_US).fill(email);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(
+					viewObjectEntriesPage.successMessage
+				).toBeVisible();
+			});
+
+			await test.step('Verify the email field value is saved', async () => {
+				await viewObjectEntriesPage.backButton.click();
+
+				await viewObjectEntriesPage.frontendDatasetItems
+					.first()
+					.click();
+
+				await expect(
+					page.getByLabel(objectFields[0].label.en_US)
+				).toHaveValue(email);
+			});
+		}
+	);
+
+	test(
+		'can create an object entry with email address field and autocomplete enabled',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const autocompleteDomain = '@liferay.com';
+
+			let objectDefinition: ObjectDefinition;
+			let objectFields: ObjectField[];
+
+			await test.step('Create an object definition with autocomplete enabled', async () => {
+				objectFields = generateObjectFields({
+					objectFieldBusinessTypes: [
+						{
+							businessType: 'EmailAddress',
+							objectFieldSettings: [
+								{
+									name: 'autocompleteEnabled',
+									value: 'true',
+								},
+								{
+									name: 'autocompleteDomains',
+									value: '@liferay.com,@gmail.com',
+								},
+							],
+						},
+					],
+				});
+
+				objectDefinition =
+					await apiHelpers.objectAdmin.postRandomObjectDefinition({
+						objectFields,
+						status: {code: 0},
+					});
+
+				apiHelpers.data.push({
+					id: objectDefinition.id,
+					type: 'objectDefinition',
+				});
+			});
+
+			await test.step('Navigate to the object definition and add an entry', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+			});
+
+			await test.step('Type a partial email and select a domain suggestion', async () => {
+				await page
+					.getByLabel(objectFields[0].label.en_US)
+					.fill('user@li');
+
+				await expect(page.getByText(autocompleteDomain)).toBeVisible();
+
+				await expect(page.getByText('@gmail.com')).not.toBeVisible();
+
+				await page.getByText(autocompleteDomain).click();
+
+				await expect(
+					page.getByLabel(objectFields[0].label.en_US)
+				).toHaveValue('user@liferay.com');
+			});
+
+			await test.step('Save the entry and verify the stored value', async () => {
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(
+					viewObjectEntriesPage.successMessage
+				).toBeVisible();
+
+				await viewObjectEntriesPage.backButton.click();
+
+				await viewObjectEntriesPage.frontendDatasetItems
+					.first()
+					.click();
+
+				await expect(
+					page.getByLabel(objectFields[0].label.en_US)
+				).toHaveValue('user@liferay.com');
+			});
+		}
+	);
+
 	test('can create an object entry with special characters on a text field named Name', async ({
 		apiHelpers,
 		page,
@@ -5350,6 +5497,118 @@ test.describe('Manage object entries through View Object Entries', () => {
 			});
 
 			expect(test.info().errors).toHaveLength(0);
+		}
+	);
+
+	test(
+		'shows an error when entering an email address with a blocked domain',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const blockedDomain = '@yahoo.com';
+
+			let objectDefinition: ObjectDefinition;
+			let objectFields: ObjectField[];
+
+			await test.step('Create an object definition with a blocked domain', async () => {
+				objectFields = generateObjectFields({
+					objectFieldBusinessTypes: [
+						{
+							businessType: 'EmailAddress',
+							objectFieldSettings: [
+								{
+									name: 'blockedDomains',
+									value: blockedDomain,
+								},
+							],
+						},
+					],
+				});
+
+				objectDefinition =
+					await apiHelpers.objectAdmin.postRandomObjectDefinition({
+						objectFields,
+						status: {code: 0},
+					});
+
+				apiHelpers.data.push({
+					id: objectDefinition.id,
+					type: 'objectDefinition',
+				});
+			});
+
+			await test.step('Navigate and attempt to save an entry with the blocked domain', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+
+				await page
+					.getByLabel(objectFields[0].label.en_US)
+					.fill(`user${blockedDomain}`);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+			});
+
+			await test.step('Verify the blocked domain error is shown', async () => {
+				await expect(
+					page.getByText(
+						'The email address domain is not allowed. Enter an email address with a different domain.'
+					)
+				).toBeVisible();
+			});
+		}
+	);
+
+	test(
+		'shows an error when entering an invalid email',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const invalidEmailAddress = 'user@liferay';
+
+			let objectDefinition: ObjectDefinition;
+			let objectFields: ObjectField[];
+
+			await test.step('Create an object definition with a blocked domain', async () => {
+				objectFields = generateObjectFields({
+					objectFieldBusinessTypes: [
+						{
+							businessType: 'EmailAddress',
+						},
+					],
+				});
+
+				objectDefinition =
+					await apiHelpers.objectAdmin.postRandomObjectDefinition({
+						objectFields,
+						status: {code: 0},
+					});
+
+				apiHelpers.data.push({
+					id: objectDefinition.id,
+					type: 'objectDefinition',
+				});
+			});
+
+			await test.step('Navigate and attempt to save an entry with the invalid email', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+
+				await page
+					.getByLabel(objectFields[0].label.en_US)
+					.fill(invalidEmailAddress);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+			});
+
+			await test.step('Verify the invalid email error is shown', async () => {
+				await expect(
+					page.getByText('Please enter a valid email address.')
+				).toBeVisible();
+			});
 		}
 	);
 

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -2820,7 +2820,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 				);
 			});
 
-			await test.step('Fill the email field and save the entry', async () => {
+			await test.step('Fill the email address field and save the entry', async () => {
 				await page.getByLabel(objectFields[0].label.en_US).fill(email);
 
 				await viewObjectEntriesPage.saveObjectEntryButton.click();
@@ -2830,7 +2830,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 				).toBeVisible();
 			});
 
-			await test.step('Verify the email field value is saved', async () => {
+			await test.step('Verify the email address field value is saved', async () => {
 				await viewObjectEntriesPage.backButton.click();
 
 				await viewObjectEntriesPage.frontendDatasetItems

--- a/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
@@ -36,6 +36,7 @@ export const test = mergeTests(
 	isolatedSiteTest,
 	editObjectDefinitionPagesTest,
 	featureFlagsTest({
+		'LPD-70673': {enabled: true}, // Email field type
 		'LPD-83570': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
@@ -509,6 +510,130 @@ test.describe('Localized object entries are saved correctly', () => {
 		await expect(dateInput).toHaveValue('11/01/2025');
 
 		await expect(dateTimeInput).toHaveValue('20/02/2025 22:00');
+	});
+
+	test('Email fields', async ({apiHelpers, page, viewObjectEntriesPage}) => {
+		const objectDefinitionLabel = 'ObjectDefinitionLabel' + getRandomInt();
+		const objectDefinitionName = 'ObjectDefinitionName' + getRandomInt();
+
+		const objectFields = generateObjectFields({
+			objectFieldBusinessTypes: [
+				{
+					businessType: 'EmailAddress',
+					localized: true,
+				},
+			],
+		});
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.postObjectDefinition({
+				active: true,
+				enableLocalization: true,
+				label: {
+					en_US: objectDefinitionLabel,
+				},
+				name: objectDefinitionName,
+				objectFields,
+				pluralLabel: {
+					en_US: objectDefinitionLabel,
+				},
+				portlet: true,
+				scope: 'company',
+				status: {
+					code: 0,
+				},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		await viewObjectEntriesPage.goto(objectDefinition.className);
+
+		await viewObjectEntriesPage.clickAddObjectEntry(objectDefinitionLabel);
+
+		const emailInput = page.locator(
+			`[data-field-name="${objectFields[0].name}"] input[type="text"]`
+		);
+
+		const englishEmail = 'user@example.com';
+		const catalanEmail = 'usuario@ejemplo.es';
+
+		// with english locale, fill the email field
+
+		await emailInput.fill(englishEmail);
+
+		// switch to catalan locale
+
+		await page.getByRole('button', {name: 'en-us'}).first().click();
+
+		const catalanOption = page.getByRole('menuitem', {
+			name: 'català (Espanya)',
+		});
+
+		await catalanOption.click();
+
+		// with catalan locale selected for the first time, value should be copied from english
+
+		await expect(emailInput).toHaveValue(englishEmail);
+
+		// change the email for catalan
+
+		await emailInput.fill(catalanEmail);
+
+		await page.getByRole('button', {name: 'ca-es'}).last().click();
+
+		// catalan should show as translated, english as default
+
+		await expect(catalanOption.getByText('translated')).toBeVisible();
+
+		await expect(
+			page
+				.getByRole('menuitem', {name: 'English (United States)'})
+				.getByText('default')
+		).toBeVisible();
+
+		// save
+
+		const responsePromise = page.waitForResponse(
+			`**${objectDefinition.restContextPath}`
+		);
+
+		await catalanOption.click();
+
+		await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+		const response = await responsePromise;
+
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
+
+		// go back to list
+
+		await viewObjectEntriesPage.backButton.click();
+
+		const responseBody = await response.json();
+
+		// navigate to the entry
+
+		await page.getByRole('link', {name: responseBody.id}).click();
+
+		// verify english value is preserved
+
+		await expect(emailInput).toHaveValue(englishEmail);
+
+		// switch to catalan and verify its value
+
+		await page.getByRole('button', {name: 'en-us'}).first().click();
+
+		await catalanOption.first().click();
+
+		await expect(emailInput).toHaveValue(catalanEmail);
 	});
 
 	test('Multiselect Picklist fields', async ({

--- a/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
@@ -36,7 +36,7 @@ export const test = mergeTests(
 	isolatedSiteTest,
 	editObjectDefinitionPagesTest,
 	featureFlagsTest({
-		'LPD-70673': {enabled: true}, // Email field type
+		'LPD-70673': {enabled: true}, // Email Address field type
 		'LPD-83570': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
@@ -512,7 +512,11 @@ test.describe('Localized object entries are saved correctly', () => {
 		await expect(dateTimeInput).toHaveValue('20/02/2025 22:00');
 	});
 
-	test('Email fields', async ({apiHelpers, page, viewObjectEntriesPage}) => {
+	test('Email Address fields', async ({
+		apiHelpers,
+		page,
+		viewObjectEntriesPage,
+	}) => {
 		const objectDefinitionLabel = 'ObjectDefinitionLabel' + getRandomInt();
 		const objectDefinitionName = 'ObjectDefinitionName' + getRandomInt();
 

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -30,6 +30,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-70673': {enabled: true}, // Email Address field
 		'LPD-83570': {enabled: true}, // Phone Number field
 	}),
 	loginTest(),
@@ -966,6 +967,61 @@ test.describe('Manage object fields through Model Builder', () => {
 });
 
 test.describe('Manage objectFields through Objects Admin UI', () => {
+	test(
+		'can add blocked domains on email address field',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, objectFieldsPage}) => {
+			const objectFieldLabel = `emailAddressField${getRandomInt()}`;
+			const blockedDomain = '@gmail.com';
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await test.step('Navigate and add an Email Address field', async () => {
+				await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+				await objectFieldsPage.addObjectField({
+					objectFieldBusinessType: 'Email Address',
+					objectFieldLabel,
+				});
+			});
+
+			await test.step('Configure blocked domains in the Advanced tab', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				const input =
+					objectFieldsPage.iframeLocator.getByPlaceholder(
+						'@example.com'
+					);
+
+				await input.fill(blockedDomain);
+
+				await input.press('Enter');
+
+				await objectFieldsPage.saveObjectField();
+			});
+
+			await test.step('Verify the blocked domain is saved', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await expect(
+					objectFieldsPage.iframeLocator.getByText(blockedDomain)
+				).toBeVisible();
+			});
+		}
+	);
+
 	test('can create and edit a formula field on a custom object', async ({
 		apiHelpers,
 		objectFieldsPage,
@@ -1048,111 +1104,6 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 				'Create an expression.'
 			)
 		).toHaveValue('idfield_name1 + field_name2');
-	});
-
-	test('can edit an aggregation field', async ({
-		apiHelpers,
-		objectFieldsPage,
-		page,
-	}) => {
-		const objectDefinition =
-			await apiHelpers.objectAdmin.postRandomObjectDefinition({
-				status: {code: 0},
-			});
-
-		const objectDefinition2 =
-			await apiHelpers.objectAdmin.postRandomObjectDefinition({
-				status: {code: 0},
-			});
-
-		apiHelpers.data.push({
-			id: objectDefinition.id,
-			type: 'objectDefinition',
-		});
-
-		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
-			ObjectRelationshipAPI
-		);
-
-		const objectRelationship1 =
-			'objectRelationship' + Math.floor(Math.random() * 99);
-
-		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
-			objectDefinition.externalReferenceCode!,
-			{
-				label: {en_US: objectRelationship1},
-				name: objectRelationship1,
-				objectDefinitionExternalReferenceCode2:
-					objectDefinition.externalReferenceCode,
-				objectDefinitionId2: objectDefinition.id,
-				objectDefinitionName2: objectDefinition.name,
-				type: 'oneToMany',
-			}
-		);
-
-		const objectRelationship2 =
-			'objectRelationship' + Math.floor(Math.random() * 99);
-
-		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
-			objectDefinition.externalReferenceCode!,
-			{
-				label: {en_US: objectRelationship2},
-				name: objectRelationship2,
-				objectDefinitionExternalReferenceCode2:
-					objectDefinition2.externalReferenceCode,
-				objectDefinitionId2: objectDefinition2.id,
-				objectDefinitionName2: objectDefinition2.name,
-				type: 'oneToMany',
-			}
-		);
-
-		await objectFieldsPage.goto(objectDefinition.label['en_US']);
-
-		const objectFieldLabel = 'Custom Aggregation';
-
-		await objectFieldsPage.addObjectField({
-			aggregationField: 'ID',
-			aggregationFieldFunction: 'Max',
-			aggregationFieldRelationship: objectRelationship1,
-			objectFieldBusinessType: 'Aggregation',
-			objectFieldLabel,
-		});
-
-		await page.getByRole('link', {name: objectFieldLabel}).click();
-
-		await objectFieldsPage.iframeLocator
-			.getByLabel('LabelMandatory')
-			.fill(`${objectFieldLabel} Updated`);
-
-		await objectFieldsPage.iframeLocator
-			.getByLabel('RelationshipMandatory')
-			.click();
-
-		await objectFieldsPage.iframeLocator
-			.getByRole('option', {name: objectRelationship2})
-			.click();
-
-		await objectFieldsPage.iframeLocator
-			.getByLabel('FunctionMandatory')
-			.click();
-
-		await objectFieldsPage.iframeLocator
-			.getByRole('option', {name: 'Min'})
-			.click();
-
-		await objectFieldsPage.iframeLocator
-			.getByLabel('FieldMandatory')
-			.click();
-
-		await objectFieldsPage.iframeLocator
-			.getByRole('option', {name: 'ID'})
-			.click();
-
-		await objectFieldsPage.editFieldSaveButton.click();
-
-		await expect(
-			page.getByRole('link', {name: `${objectFieldLabel} Updated`})
-		).toBeVisible();
 	});
 
 	test('can create a formula field on a custom object', async ({
@@ -1303,6 +1254,10 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			{
 				objectFieldBusinessType: 'Decimal',
 				objectFieldLabel: `decimal${getRandomInt()}`,
+			},
+			{
+				objectFieldBusinessType: 'Email Address',
+				objectFieldLabel: `emailAddress${getRandomInt()}`,
 			},
 			{
 				objectFieldBusinessType: 'Encrypted',
@@ -1567,6 +1522,257 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			await expect(
 				page.getByRole('row').filter({hasText: fieldName})
 			).toHaveCount(0);
+		}
+	);
+
+	test('can edit an aggregation field', async ({
+		apiHelpers,
+		objectFieldsPage,
+		page,
+	}) => {
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				status: {code: 0},
+			});
+
+		const objectDefinition2 =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				status: {code: 0},
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		const objectRelationshipAPIClient = await apiHelpers.buildRestClient(
+			ObjectRelationshipAPI
+		);
+
+		const objectRelationship1 =
+			'objectRelationship' + Math.floor(Math.random() * 99);
+
+		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
+			objectDefinition.externalReferenceCode!,
+			{
+				label: {en_US: objectRelationship1},
+				name: objectRelationship1,
+				objectDefinitionExternalReferenceCode2:
+					objectDefinition.externalReferenceCode,
+				objectDefinitionId2: objectDefinition.id,
+				objectDefinitionName2: objectDefinition.name,
+				type: 'oneToMany',
+			}
+		);
+
+		const objectRelationship2 =
+			'objectRelationship' + Math.floor(Math.random() * 99);
+
+		await objectRelationshipAPIClient.postObjectDefinitionByExternalReferenceCodeObjectRelationship(
+			objectDefinition.externalReferenceCode!,
+			{
+				label: {en_US: objectRelationship2},
+				name: objectRelationship2,
+				objectDefinitionExternalReferenceCode2:
+					objectDefinition2.externalReferenceCode,
+				objectDefinitionId2: objectDefinition2.id,
+				objectDefinitionName2: objectDefinition2.name,
+				type: 'oneToMany',
+			}
+		);
+
+		await objectFieldsPage.goto(objectDefinition.label['en_US']);
+
+		const objectFieldLabel = 'Custom Aggregation';
+
+		await objectFieldsPage.addObjectField({
+			aggregationField: 'ID',
+			aggregationFieldFunction: 'Max',
+			aggregationFieldRelationship: objectRelationship1,
+			objectFieldBusinessType: 'Aggregation',
+			objectFieldLabel,
+		});
+
+		await page.getByRole('link', {name: objectFieldLabel}).click();
+
+		await objectFieldsPage.iframeLocator
+			.getByLabel('LabelMandatory')
+			.fill(`${objectFieldLabel} Updated`);
+
+		await objectFieldsPage.iframeLocator
+			.getByLabel('RelationshipMandatory')
+			.click();
+
+		await objectFieldsPage.iframeLocator
+			.getByRole('option', {name: objectRelationship2})
+			.click();
+
+		await objectFieldsPage.iframeLocator
+			.getByLabel('FunctionMandatory')
+			.click();
+
+		await objectFieldsPage.iframeLocator
+			.getByRole('option', {name: 'Min'})
+			.click();
+
+		await objectFieldsPage.iframeLocator
+			.getByLabel('FieldMandatory')
+			.click();
+
+		await objectFieldsPage.iframeLocator
+			.getByRole('option', {name: 'ID'})
+			.click();
+
+		await objectFieldsPage.editFieldSaveButton.click();
+
+		await expect(
+			page.getByRole('link', {name: `${objectFieldLabel} Updated`})
+		).toBeVisible();
+	});
+
+	test(
+		'can edit the country source and country for a phone number field',
+		{tag: ['@LPD-83570']},
+		async ({apiHelpers, objectFieldsPage}) => {
+			let objectDefinition: ObjectDefinition;
+			let selectedCountry: string;
+			let selectedCountrySource: string;
+
+			const objectFieldLabel = `phoneNumber${getRandomInt()}`;
+
+			await test.step('Create required definitions', async () => {
+				const listTypeDefinition =
+					await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
+
+				apiHelpers.data.push({
+					id: listTypeDefinition.id,
+					type: 'listTypeDefinition',
+				});
+
+				objectDefinition =
+					await apiHelpers.objectAdmin.postRandomObjectDefinition({
+						status: {code: 0},
+					});
+
+				apiHelpers.data.push({
+					id: objectDefinition.id,
+					type: 'objectDefinition',
+				});
+			});
+
+			await test.step('Navigate to the object definition and add a phone number field', async () => {
+				await objectFieldsPage.goto(objectDefinition.label!['en_US']);
+
+				await objectFieldsPage.addObjectField({
+					objectFieldBusinessType: 'Phone Number',
+					objectFieldLabel,
+				});
+			});
+
+			await test.step('Edit the country source and country for the phone number field', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.countrySourceDropdown.click();
+
+				const countrySourceOption =
+					objectFieldsPage.iframeLocator.getByRole('option', {
+						exact: true,
+						name: 'Fixed',
+					});
+
+				selectedCountrySource = await countrySourceOption.innerText();
+
+				await countrySourceOption.click();
+
+				await objectFieldsPage.countryPicker.click();
+
+				const countryOption = objectFieldsPage.iframeLocator
+					.getByRole('option')
+					.nth(1);
+
+				await countryOption.click();
+
+				selectedCountry =
+					await objectFieldsPage.countryPicker.innerText();
+
+				await objectFieldsPage.saveObjectField();
+			});
+
+			await test.step('Verify the updated country source and country are saved', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await expect(objectFieldsPage.countrySourceDropdown).toHaveText(
+					selectedCountrySource
+				);
+
+				await expect(objectFieldsPage.countryPicker).toHaveText(
+					selectedCountry
+				);
+			});
+		}
+	);
+
+	test(
+		'can enable autocomplete and add domains on an email address field',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, objectFieldsPage}) => {
+			const objectFieldLabel = `emailAddressField${getRandomInt()}`;
+			const autocompleteDomain = '@liferay.com';
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await test.step('Navigate and add an Email Address field', async () => {
+				await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+				await objectFieldsPage.addObjectField({
+					objectFieldBusinessType: 'Email Address',
+					objectFieldLabel,
+				});
+			});
+
+			await test.step('Enable autocomplete and add a domain in the Advanced tab', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await objectFieldsPage.iframeLocator
+					.getByRole('switch', {name: 'Enable Autocomplete'})
+					.check();
+
+				const input = objectFieldsPage.iframeLocator
+					.getByPlaceholder('@liferay.com')
+					.last();
+
+				await input.fill(autocompleteDomain);
+
+				await input.press('Enter');
+
+				await objectFieldsPage.saveObjectField();
+			});
+
+			await test.step('Verify autocomplete is enabled and the domain is saved', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await expect(
+					objectFieldsPage.iframeLocator.getByRole('switch', {
+						name: 'Enable Autocomplete',
+					})
+				).toBeChecked();
+
+				await expect(
+					objectFieldsPage.iframeLocator.getByText(autocompleteDomain)
+				).toBeVisible();
+			});
 		}
 	);
 
@@ -2594,88 +2800,6 @@ test.describe('Manage objectFields through Objects Admin UI', () => {
 			});
 		});
 	});
-
-	test(
-		'can edit the country source and country for a phone number field',
-		{tag: ['@LPD-83570']},
-		async ({apiHelpers, objectFieldsPage}) => {
-			let objectDefinition: ObjectDefinition;
-			let selectedCountry: string;
-			let selectedCountrySource: string;
-
-			const objectFieldLabel = `phoneNumber${getRandomInt()}`;
-
-			await test.step('Create required definitions', async () => {
-				const listTypeDefinition =
-					await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
-
-				apiHelpers.data.push({
-					id: listTypeDefinition.id,
-					type: 'listTypeDefinition',
-				});
-
-				objectDefinition =
-					await apiHelpers.objectAdmin.postRandomObjectDefinition({
-						status: {code: 0},
-					});
-
-				apiHelpers.data.push({
-					id: objectDefinition.id,
-					type: 'objectDefinition',
-				});
-			});
-
-			await test.step('Navigate to the object definition and add a phone number field', async () => {
-				await objectFieldsPage.goto(objectDefinition.label!['en_US']);
-
-				await objectFieldsPage.addObjectField({
-					objectFieldBusinessType: 'Phone Number',
-					objectFieldLabel,
-				});
-			});
-
-			await test.step('Edit the country source and country for the phone number field', async () => {
-				await objectFieldsPage.openObjectField(objectFieldLabel);
-
-				await objectFieldsPage.countrySourceDropdown.click();
-
-				const countrySourceOption =
-					objectFieldsPage.iframeLocator.getByRole('option', {
-						exact: true,
-						name: 'Fixed',
-					});
-
-				selectedCountrySource = await countrySourceOption.innerText();
-
-				await countrySourceOption.click();
-
-				await objectFieldsPage.countryPicker.click();
-
-				const countryOption = objectFieldsPage.iframeLocator
-					.getByRole('option')
-					.nth(1);
-
-				await countryOption.click();
-
-				selectedCountry =
-					await objectFieldsPage.countryPicker.innerText();
-
-				await objectFieldsPage.saveObjectField();
-			});
-
-			await test.step('Verify the updated country source and country are saved', async () => {
-				await objectFieldsPage.openObjectField(objectFieldLabel);
-
-				await expect(objectFieldsPage.countrySourceDropdown).toHaveText(
-					selectedCountrySource
-				);
-
-				await expect(objectFieldsPage.countryPicker).toHaveText(
-					selectedCountry
-				);
-			});
-		}
-	);
 });
 
 test.describe('Manage object fields default value properties', () => {
@@ -3503,6 +3627,110 @@ test.describe('Manage object fields default value properties', () => {
 			await modelBuilderRightSidebarPage.useDefaultValueToggle.uncheck();
 
 			await expect(rightSidebar).toHaveCSS('width', '320px');
+		}
+	);
+
+	test(
+		'normalizes email address default value to lowercase',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, objectFieldsPage}) => {
+			const objectFieldLabel = `emailField${getRandomInt()}`;
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await test.step('Add an Email Address field and set a mixed-case default value', async () => {
+				await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+				await objectFieldsPage.addObjectField({
+					objectFieldBusinessType: 'Email Address',
+					objectFieldLabel,
+				});
+
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await objectFieldsPage.useDefaultValueToggle.check();
+
+				await objectFieldsPage.iframeLocator
+					.getByPlaceholder('Enter a default value.')
+					.fill('User@Example.com');
+
+				await objectFieldsPage.saveObjectField();
+			});
+
+			await test.step('Verify the stored default value is lowercase', async () => {
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await expect(
+					objectFieldsPage.iframeLocator.getByPlaceholder(
+						'Enter a default value.'
+					)
+				).toHaveValue('user@example.com');
+			});
+		}
+	);
+
+	test(
+		'shows error for email address field default value when value is invalid',
+		{tag: ['@LPD-70673']},
+		async ({apiHelpers, objectFieldsPage, page}) => {
+			const objectFieldLabel = `emailAddressField${getRandomInt()}`;
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			const invalidEmailAddress = 'notanemail';
+
+			await test.step('Add an Email Address field and enter an invalid default value', async () => {
+				await objectFieldsPage.goto(objectDefinition.label.en_US);
+
+				await objectFieldsPage.addObjectField({
+					objectFieldBusinessType: 'Email Address',
+					objectFieldLabel,
+				});
+
+				await objectFieldsPage.openObjectField(objectFieldLabel);
+
+				await objectFieldsPage.advancedTab.click();
+
+				await objectFieldsPage.useDefaultValueToggle.check();
+
+				await objectFieldsPage.iframeLocator
+					.getByPlaceholder('Enter a default value.')
+					.fill(invalidEmailAddress);
+
+				await objectFieldsPage.editFieldSaveButton.click();
+			});
+
+			await test.step('Verify the save is rejected and the panel stays open', async () => {
+				await waitForAlert(
+					page,
+					`The value ${invalidEmailAddress} of setting "defaultValue" is invalid for object field "${objectFieldLabel}"`,
+					{type: 'danger'}
+				);
+
+				await expect(
+					objectFieldsPage.editFieldSaveButton
+				).toBeVisible();
+			});
 		}
 	);
 });

--- a/modules/test/playwright/tests/object-web/field/objectField.spec.ts
+++ b/modules/test/playwright/tests/object-web/field/objectField.spec.ts
@@ -3634,7 +3634,7 @@ test.describe('Manage object fields default value properties', () => {
 		'normalizes email address default value to lowercase',
 		{tag: ['@LPD-70673']},
 		async ({apiHelpers, objectFieldsPage}) => {
-			const objectFieldLabel = `emailField${getRandomInt()}`;
+			const objectFieldLabel = `emailAddressField${getRandomInt()}`;
 
 			const objectDefinition =
 				await apiHelpers.objectAdmin.postRandomObjectDefinition({

--- a/modules/test/playwright/tests/object-web/utils/generateObjectFields.ts
+++ b/modules/test/playwright/tests/object-web/utils/generateObjectFields.ts
@@ -118,6 +118,12 @@ function getObjectFieldSpecificProperties(
 				businessType: 'Decimal',
 				type: 'Double',
 			};
+		case 'EmailAddress':
+			return {
+				DBType: 'String',
+				businessType: 'EmailAddress',
+				type: 'String',
+			};
 		case 'Encrypted':
 			return {
 				DBType: 'Clob',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88970
https://liferay.atlassian.net/browse/LPD-88972
https://liferay.atlassian.net/browse/LPD-70673

## What Is Being Fixed

Support for the Email Address object field was added across the object definition, the Object Admin UI, and the object layout under LPD-70673 and its technical tasks, but the field lacked automated Playwright coverage. Without end-to-end tests, regressions in defining an Email Address field, validating its input, and rendering it on entry forms could ship undetected.

## How It Is Being Fixed

Added Playwright coverage for the Email Address object field across three areas: the field definition in the Object Admin UI (objectField.spec.ts), the entry form including validation (objectEntry.spec.ts), and localized entries (objectEntryLocalized.spec.ts), with a shared helper added to generateObjectFields.ts. The existing object field specs were also sorted, and the tests were standardized on the "Email Address" field type name with the assertion order aligned to match the field and its sibling validation errors.

## PR Check

**pr-check: PASS** — tested on `2ee85a76689470331b5fe056ce4e2e75f24a9c5d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "2ee85a76689470331b5fe056ce4e2e75f24a9c5d"} -->

cc @larissacribeiro 
