### PR TITLE
LPD-94976 fix the workflow tasks tab stat cards and filters

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -64,6 +64,9 @@ public class SearchResultEntityModel implements EntityModel {
 				"dateReview",
 				locale -> Field.getSortableFieldName("reviewDate"),
 				locale -> "reviewDate"),
+			new DateTimeEntityField(
+				"dueDate", locale -> Field.getSortableFieldName("dueDate"),
+				locale -> "dueDate"),
 			new IntegerEntityField(
 				"cmpProjectManagerUserId", locale -> "cmpProjectManagerUserId"),
 			new IntegerEntityField(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -25,6 +25,7 @@ public class SearchResultEntityModel implements EntityModel {
 	public SearchResultEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
+			new BooleanEntityField("completed", locale -> "completed"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewWorkflowTasksSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/ViewWorkflowTasksSectionDisplayContextTest.java
@@ -195,10 +195,11 @@ public class ViewWorkflowTasksSectionDisplayContextTest
 			FDSEntityFieldTypes.STRING, "cmpAssignTo", "assignee",
 			fdsFilters.get(0));
 		assertFDSFilter(
-			FDSEntityFieldTypes.DATE_TIME, "cmpDueDate", "due-date",
+			FDSEntityFieldTypes.DATE_TIME, "dueDate", "due-date",
 			fdsFilters.get(1));
 		assertFDSFilter(
-			FDSEntityFieldTypes.STRING, "cmpState", "state", fdsFilters.get(2));
+			FDSEntityFieldTypes.BOOLEAN, "completed", "status",
+			fdsFilters.get(2));
 	}
 
 	@Override

--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/WorkflowTasksOverviewComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/WorkflowTasksOverviewComponentSectionFragmentRendererTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.fragment.renderer.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
+)
+@RunWith(Arquillian.class)
+public class WorkflowTasksOverviewComponentSectionFragmentRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		Group group = CMPTestUtil.getOrAddGroup(
+			WorkflowTasksOverviewComponentSectionFragmentRendererTest.class);
+
+		_themeDisplay = new ThemeDisplay() {
+			{
+				setCompany(
+					_companyLocalService.getCompany(
+						TestPropsValues.getCompanyId()));
+				setLocale(LocaleUtil.getDefault());
+				setScopeGroupId(group.getGroupId());
+				setUser(TestPropsValues.getUser());
+			}
+		};
+	}
+
+	@Test
+	public void testGetProps() throws Exception {
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		Map<String, Object> props = ReflectionTestUtil.invoke(
+			_fragmentRenderer, "getProps",
+			new Class<?>[] {
+				FragmentRendererContext.class, HttpServletRequest.class
+			},
+			null, httpServletRequest);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"/o/search/v1.0/search?emptySearch=true&entryClassNames=",
+				"com.liferay.portal.workflow.kaleo.model.",
+				"KaleoTaskInstanceToken",
+				"&filter=keywords/any(k:startswith(k, 'L_CMP_TASK'))"),
+			props.get("filterURL"));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cmp.site.initializer.internal.fragment.renderer.WorkflowTasksOverviewComponentSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	private ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/site/site-cmp-site-initializer/build.gradle
+++ b/modules/apps/site/site-cmp-site-initializer/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewWorkflowTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewWorkflowTasksSectionDisplayContext.java
@@ -19,16 +19,15 @@ import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectStateFlowLocalService;
 import com.liferay.object.service.ObjectStateLocalService;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
 import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.AssigneeSelectionFDSFilter;
-import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.DueDateRangeFDSFilter;
-import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.StateSelectionFDSFilter;
+import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.WorkflowTaskDueDateRangeFDSFilter;
+import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.WorkflowTaskStatusSelectionFDSFilter;
+import com.liferay.site.cmp.site.initializer.internal.util.WorkflowTaskSearchURLUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -64,12 +63,10 @@ public class ViewWorkflowTasksSectionDisplayContext
 
 	@Override
 	public String getAPIURL() {
-		return StringBundler.concat(
-			"/o/search/v1.0/search?emptySearch=true&entryClassNames=",
-			KaleoTaskInstanceToken.class.getName(),
-			"&filter=keywords/any(k:startswith(k, '",
-			objectDefinition.getExternalReferenceCode(),
-			"'))&nestedFields=embedded");
+		String searchURL = WorkflowTaskSearchURLUtil.getSearchURL(
+			objectDefinition.getExternalReferenceCode());
+
+		return searchURL + "&nestedFields=embedded";
 	}
 
 	@Override
@@ -139,7 +136,8 @@ public class ViewWorkflowTasksSectionDisplayContext
 			new AssigneeSelectionFDSFilter(
 				classNameLocalService, projectObjectDefinition.getCompanyId(),
 				roleService),
-			new DueDateRangeFDSFilter(), new StateSelectionFDSFilter());
+			new WorkflowTaskDueDateRangeFDSFilter(),
+			new WorkflowTaskStatusSelectionFDSFilter());
 	}
 
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/WorkflowTasksOverviewComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/WorkflowTasksOverviewComponentSectionFragmentRenderer.java
@@ -7,6 +7,12 @@ package com.liferay.site.cmp.site.initializer.internal.fragment.renderer;
 
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cmp.site.initializer.internal.util.WorkflowTaskSearchURLUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -14,6 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jhosseph Gonzalez
@@ -47,7 +54,27 @@ public class WorkflowTasksOverviewComponentSectionFragmentRenderer
 		FragmentRendererContext fragmentRendererContext,
 		HttpServletRequest httpServletRequest) {
 
-		return Collections.emptyMap();
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_CMP_TASK", themeDisplay.getCompanyId());
+
+		if (objectDefinition == null) {
+			return Collections.emptyMap();
+		}
+
+		return HashMapBuilder.<String, Object>put(
+			"filterURL",
+			WorkflowTaskSearchURLUtil.getSearchURL(
+				objectDefinition.getExternalReferenceCode())
+		).build();
 	}
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/WorkflowTaskDueDateRangeFDSFilter.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/WorkflowTaskDueDateRangeFDSFilter.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class WorkflowTaskDueDateRangeFDSFilter extends DueDateRangeFDSFilter {
+
+	@Override
+	public String getId() {
+		return "dueDate";
+	}
+
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/WorkflowTaskStatusSelectionFDSFilter.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/frontend/data/set/filter/WorkflowTaskStatusSelectionFDSFilter.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class WorkflowTaskStatusSelectionFDSFilter
+	extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.BOOLEAN;
+	}
+
+	@Override
+	public String getId() {
+		return "completed";
+	}
+
+	@Override
+	public String getLabel() {
+		return "status";
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		return ListUtil.fromArray(
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "completed"), "true"),
+			new SelectionFDSFilterItem(
+				LanguageUtil.get(locale, "pending"), "false"));
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return false;
+	}
+
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/search/spi/model/index/contributor/CMPKaleoTaskInstanceTokenModelDocumentContributor.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/search/spi/model/index/contributor/CMPKaleoTaskInstanceTokenModelDocumentContributor.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.search.spi.model.index.contributor;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken",
+	service = ModelDocumentContributor.class
+)
+public class CMPKaleoTaskInstanceTokenModelDocumentContributor
+	implements ModelDocumentContributor<KaleoTaskInstanceToken> {
+
+	@Override
+	public void contribute(
+		Document document, KaleoTaskInstanceToken kaleoTaskInstanceToken) {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			kaleoTaskInstanceToken.getClassName(),
+			kaleoTaskInstanceToken.getClassPK());
+
+		if ((assetEntry == null) || !_hasCMPTaskTag(assetEntry)) {
+			return;
+		}
+
+		Set<String> cmpAssignTos = new HashSet<>();
+
+		for (KaleoTaskAssignmentInstance kaleoTaskAssignmentInstance :
+				kaleoTaskInstanceToken.getKaleoTaskAssignmentInstances()) {
+
+			cmpAssignTos.add(
+				StringBundler.concat(
+					_classNameLocalService.getClassNameId(
+						kaleoTaskAssignmentInstance.getAssigneeClassName()),
+					StringPool.UNDERLINE,
+					kaleoTaskAssignmentInstance.getAssigneeClassPK()));
+		}
+
+		if (!cmpAssignTos.isEmpty()) {
+			document.addKeyword(
+				"cmpAssignTo", cmpAssignTos.toArray(new String[0]));
+		}
+	}
+
+	private boolean _hasCMPTaskTag(AssetEntry assetEntry) {
+		for (String assetTagName : assetEntry.getTagNames()) {
+			if (StringUtil.startsWith(
+					StringUtil.toLowerCase(assetTagName), "l_cmp_task")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/util/WorkflowTaskSearchURLUtil.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/util/WorkflowTaskSearchURLUtil.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class WorkflowTaskSearchURLUtil {
+
+	public static String getSearchURL(String externalReferenceCode) {
+		return StringBundler.concat(
+			"/o/search/v1.0/search?emptySearch=true&entryClassNames=",
+			KaleoTaskInstanceToken.class.getName(),
+			"&filter=keywords/any(k:startswith(k, '", externalReferenceCode,
+			"'))");
+	}
+
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/WorkflowTasksOverview.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/WorkflowTasksOverview.tsx
@@ -15,9 +15,6 @@ import './WorkflowTasksOverview.scss';
 
 const CONTAINER_CLASS_NAME = 'lfr-cmp__workflow-tasks-overview-container';
 
-const WORKFLOW_TASKS_URL =
-	'/o/headless-admin-workflow/v1.0/workflow-tasks?pageSize=1';
-
 function StatCard({
 	count,
 	icon,
@@ -44,20 +41,26 @@ function StatCard({
 	);
 }
 
-export default function WorkflowTasksOverview() {
+export default function WorkflowTasksOverview({
+	filterURL,
+}: {
+	filterURL?: string;
+}) {
 	const [completedCount, setCompletedCount] = useState(0);
 	const [loading, setLoading] = useState(true);
 	const [pendingCount, setPendingCount] = useState(0);
 
 	const fetchCounts = useCallback(async () => {
+		if (!filterURL) {
+			setLoading(false);
+
+			return;
+		}
+
 		setLoading(true);
 
 		const fetchWorkflowCount = (completed: boolean) =>
-			fetch(WORKFLOW_TASKS_URL, {
-				body: JSON.stringify({completed}),
-				headers: {'Content-Type': 'application/json'},
-				method: 'POST',
-			})
+			fetch(`${filterURL} and completed eq ${completed}&pageSize=1`)
 				.then((response) => {
 					if (!response.ok) {
 						throw new Error();
@@ -83,7 +86,7 @@ export default function WorkflowTasksOverview() {
 		finally {
 			setLoading(false);
 		}
-	}, []);
+	}, [filterURL]);
 
 	useEffect(() => {
 		fetchCounts();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/WorkflowTasksOverview.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/WorkflowTasksOverview.spec.tsx
@@ -62,7 +62,9 @@ describe('WorkflowTasksOverview', () => {
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(21))
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(31));
 
-		const {getByText} = render(<WorkflowTasksOverview />);
+		const {getByText} = render(
+			<WorkflowTasksOverview filterURL="/o/search/v1.0/search?filter=test" />
+		);
 
 		await waitFor(() => getByText('30'));
 
@@ -73,12 +75,24 @@ describe('WorkflowTasksOverview', () => {
 		});
 	});
 
+	it('renders nothing and skips the fetch when filterURL is missing', async () => {
+		const {container} = render(<WorkflowTasksOverview />);
+
+		await waitFor(() => {
+			expect(container.firstChild).toBeNull();
+		});
+
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
 	it('renders pending and completed counts', async () => {
 		mockFetch
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(20))
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(30));
 
-		const {getByText} = render(<WorkflowTasksOverview />);
+		const {getByText} = render(
+			<WorkflowTasksOverview filterURL="/o/search/v1.0/search?filter=test" />
+		);
 
 		await waitFor(() => {
 			expect(getByText('30')).toBeInTheDocument();
@@ -86,12 +100,21 @@ describe('WorkflowTasksOverview', () => {
 			expect(getByText('20')).toBeInTheDocument();
 			expect(getByText('completed')).toBeInTheDocument();
 		});
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/o/search/v1.0/search?filter=test and completed eq true&pageSize=1'
+		);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'/o/search/v1.0/search?filter=test and completed eq false&pageSize=1'
+		);
 	});
 
 	it('returns null when API fetch fails', async () => {
 		mockFetch.mockRejectedValueOnce(new Error('network error'));
 
-		const {container} = render(<WorkflowTasksOverview />);
+		const {container} = render(
+			<WorkflowTasksOverview filterURL="/o/search/v1.0/search?filter=test" />
+		);
 
 		await waitFor(() => {
 			expect(container.firstChild).toBeNull();
@@ -103,7 +126,9 @@ describe('WorkflowTasksOverview', () => {
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(0))
 			.mockResolvedValueOnce(mockWorkflowTasksResponse(0));
 
-		const {container} = render(<WorkflowTasksOverview />);
+		const {container} = render(
+			<WorkflowTasksOverview filterURL="/o/search/v1.0/search?filter=test" />
+		);
 
 		await waitFor(() => {
 			expect(container.firstChild).toBeNull();
@@ -113,7 +138,9 @@ describe('WorkflowTasksOverview', () => {
 	it('shows loading indicator before fetch completes', () => {
 		mockFetch.mockImplementation(() => new Promise(() => {}));
 
-		const {container} = render(<WorkflowTasksOverview />);
+		const {container} = render(
+			<WorkflowTasksOverview filterURL="/o/search/v1.0/search?filter=test" />
+		);
 
 		expect(
 			container.querySelector('.loading-animation')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94976

## What Is Being Fixed

On the Workflow Tasks tab, the Pending and Completed stat cards counted every workflow task in the system instead of only the tasks scoped to the current project, and the Status, Assignee, and Due Date filters returned no results.

## How It Is Being Fixed

The stat cards now derive their counts from the same project-scoped search query the table uses: the fragment renderer passes a filter URL as a prop and the component appends a completed predicate for each card. The filters are reworked to operate on the workflow task itself. Status offers Pending and Completed mapped to the task's indexed completed field, Due Date queries the task's native dueDate field, and Assignee queries a cmpAssignTo field that a document contributor denormalizes from the workflow task's assignee, since the assignee has no native single field equivalent. The completed and dueDate fields are exposed in the search result entity model so the data set can filter on them.

## PR Check

**pr-check: PASS** — tested on `f8ab5b28c15ac98444f91ba372aa7bb9bb0d4f9d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f8ab5b28c15ac98444f91ba372aa7bb9bb0d4f9d"} -->
