### PR TITLE
LPD-89354 ObjectDefinitionResourceImpl._addObjectRelationship hardcodes system=false, blocking L_-prefixed system relations on upsert

### DIFF
--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -556,6 +556,47 @@ public class ObjectDefinitionResourceTest
 			},
 			emptyObjectDefinition.getStatus());
 
+		// Empty system object definition created by relationship object field
+
+		ObjectDefinition randomSystemObjectDefinition =
+			_randomModifiableSystemObjectDefinition();
+
+		externalReferenceCode =
+			ObjectDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
+					RandomTestUtil.randomString();
+
+		ObjectField systemRelationshipObjectField =
+			_createRelationshipObjectField(externalReferenceCode);
+
+		randomSystemObjectDefinition.setObjectFields(
+			ArrayUtil.append(
+				randomSystemObjectDefinition.getObjectFields(),
+				systemRelationshipObjectField));
+
+		testPostObjectDefinition_addObjectDefinition(
+			randomSystemObjectDefinition);
+
+		emptyObjectDefinition =
+			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
+				externalReferenceCode);
+
+		Assert.assertEquals(
+			new Status() {
+				{
+					code = WorkflowConstants.STATUS_EMPTY;
+					label = WorkflowConstants.getStatusLabel(
+						WorkflowConstants.STATUS_EMPTY);
+					label_i18n = _language.get(
+						LanguageResources.getResourceBundle(
+							LocaleUtil.getDefault()),
+						WorkflowConstants.getStatusLabel(
+							WorkflowConstants.STATUS_EMPTY));
+				}
+			},
+			emptyObjectDefinition.getStatus());
+		Assert.assertTrue(emptyObjectDefinition.getSystem());
+
 		// Enable index search
 
 		randomObjectDefinition = randomObjectDefinition();

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectDefinitionResourceTest.java
@@ -455,11 +455,92 @@ public class ObjectDefinitionResourceTest
 	public void testPostObjectDefinition() throws Exception {
 		super.testPostObjectDefinition();
 
-		// Empty object definition created by object action
+		// Empty modifiable system object definition created by relationship
+		// object field
+
+		ObjectDefinition randomModifiableSystemObjectDefinition =
+			_randomModifiableSystemObjectDefinition();
+
+		String externalReferenceCode =
+			ObjectDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
+					RandomTestUtil.randomString();
+
+		ObjectField systemRelationshipObjectField =
+			_createRelationshipObjectField(externalReferenceCode);
+
+		randomModifiableSystemObjectDefinition.setObjectFields(
+			ArrayUtil.append(
+				randomModifiableSystemObjectDefinition.getObjectFields(),
+				systemRelationshipObjectField));
+
+		testPostObjectDefinition_addObjectDefinition(
+			randomModifiableSystemObjectDefinition);
+
+		ObjectDefinition emptyObjectDefinition =
+			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
+				externalReferenceCode);
+
+		Assert.assertTrue(emptyObjectDefinition.getModifiable());
+		Assert.assertEquals(
+			new Status() {
+				{
+					code = WorkflowConstants.STATUS_EMPTY;
+					label = WorkflowConstants.getStatusLabel(
+						WorkflowConstants.STATUS_EMPTY);
+					label_i18n = _language.get(
+						LanguageResources.getResourceBundle(
+							LocaleUtil.getDefault()),
+						WorkflowConstants.getStatusLabel(
+							WorkflowConstants.STATUS_EMPTY));
+				}
+			},
+			emptyObjectDefinition.getStatus());
+		Assert.assertTrue(emptyObjectDefinition.getSystem());
 
 		ObjectDefinition randomObjectDefinition = randomObjectDefinition();
 
-		String externalReferenceCode = RandomTestUtil.randomString();
+		externalReferenceCode =
+			ObjectDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
+					RandomTestUtil.randomString();
+
+		ObjectField relationshipObjectField = _createRelationshipObjectField(
+			externalReferenceCode);
+
+		randomObjectDefinition.setObjectFields(
+			ArrayUtil.append(
+				randomObjectDefinition.getObjectFields(),
+				relationshipObjectField));
+
+		testPostObjectDefinition_addObjectDefinition(randomObjectDefinition);
+
+		emptyObjectDefinition =
+			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
+				externalReferenceCode);
+
+		Assert.assertTrue(emptyObjectDefinition.getModifiable());
+		Assert.assertEquals(
+			new Status() {
+				{
+					code = WorkflowConstants.STATUS_EMPTY;
+					label = WorkflowConstants.getStatusLabel(
+						WorkflowConstants.STATUS_EMPTY);
+					label_i18n = _language.get(
+						LanguageResources.getResourceBundle(
+							LocaleUtil.getDefault()),
+						WorkflowConstants.getStatusLabel(
+							WorkflowConstants.STATUS_EMPTY));
+				}
+			},
+			emptyObjectDefinition.getStatus());
+		Assert.assertTrue(emptyObjectDefinition.getSystem());
+
+		// Empty object definition created by object action
+
+		randomObjectDefinition = randomObjectDefinition();
+
+		externalReferenceCode = RandomTestUtil.randomString();
 
 		ObjectAction objectAction = _createObjectAction(externalReferenceCode);
 
@@ -468,10 +549,11 @@ public class ObjectDefinitionResourceTest
 
 		testPostObjectDefinition_addObjectDefinition(randomObjectDefinition);
 
-		ObjectDefinition emptyObjectDefinition =
+		emptyObjectDefinition =
 			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
 				externalReferenceCode);
 
+		Assert.assertTrue(emptyObjectDefinition.getModifiable());
 		Assert.assertEquals(
 			new Status() {
 				{
@@ -527,7 +609,7 @@ public class ObjectDefinitionResourceTest
 
 		externalReferenceCode = RandomTestUtil.randomString();
 
-		ObjectField relationshipObjectField = _createRelationshipObjectField(
+		relationshipObjectField = _createRelationshipObjectField(
 			externalReferenceCode);
 
 		randomObjectDefinition.setObjectFields(
@@ -556,26 +638,21 @@ public class ObjectDefinitionResourceTest
 			},
 			emptyObjectDefinition.getStatus());
 
-		// Empty system object definition created by relationship object field
-
-		ObjectDefinition randomSystemObjectDefinition =
+		randomModifiableSystemObjectDefinition =
 			_randomModifiableSystemObjectDefinition();
 
-		externalReferenceCode =
-			ObjectDefinitionConstants.
-				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
-					RandomTestUtil.randomString();
+		externalReferenceCode = RandomTestUtil.randomString();
 
-		ObjectField systemRelationshipObjectField =
-			_createRelationshipObjectField(externalReferenceCode);
+		relationshipObjectField = _createRelationshipObjectField(
+			externalReferenceCode);
 
-		randomSystemObjectDefinition.setObjectFields(
+		randomModifiableSystemObjectDefinition.setObjectFields(
 			ArrayUtil.append(
-				randomSystemObjectDefinition.getObjectFields(),
-				systemRelationshipObjectField));
+				randomModifiableSystemObjectDefinition.getObjectFields(),
+				relationshipObjectField));
 
 		testPostObjectDefinition_addObjectDefinition(
-			randomSystemObjectDefinition);
+			randomModifiableSystemObjectDefinition);
 
 		emptyObjectDefinition =
 			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
@@ -595,7 +672,7 @@ public class ObjectDefinitionResourceTest
 				}
 			},
 			emptyObjectDefinition.getStatus());
-		Assert.assertTrue(emptyObjectDefinition.getSystem());
+		Assert.assertFalse(emptyObjectDefinition.getSystem());
 
 		// Enable index search
 
@@ -620,7 +697,7 @@ public class ObjectDefinitionResourceTest
 		String randomListTypeDefinitionExternalReferenceCode =
 			RandomTestUtil.randomString();
 
-		ObjectDefinition randomModifiableSystemObjectDefinition =
+		randomModifiableSystemObjectDefinition =
 			_randomModifiableSystemObjectDefinition();
 
 		randomModifiableSystemObjectDefinition.setObjectFields(

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectRelationshipResourceTest.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/ObjectRelationshipResourceTest.java
@@ -166,6 +166,42 @@ public class ObjectRelationshipResourceTest
 			randomObjectRelationship.getObjectDefinitionScope2(),
 			postObjectRelationship.getObjectDefinitionScope2());
 		Assert.assertFalse(postObjectRelationship.getObjectDefinitionSystem2());
+
+		// LPD-89354: A partner external reference code with the system prefix
+		// and no explicit system flag derives a system stub instead of throwing
+		// MustNotStartWithPrefix.
+
+		ObjectRelationship systemObjectRelationship =
+			randomObjectRelationship();
+
+		String systemExternalReferenceCode =
+			ObjectDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
+					RandomTestUtil.randomString();
+
+		systemObjectRelationship.setObjectDefinitionExternalReferenceCode2(
+			systemExternalReferenceCode);
+
+		systemObjectRelationship.setObjectDefinitionId2(0L);
+		systemObjectRelationship.setObjectDefinitionModifiable2(() -> null);
+		systemObjectRelationship.setObjectDefinitionScope2(
+			RandomTestUtil.randomString());
+		systemObjectRelationship.setObjectDefinitionSystem2(() -> null);
+
+		ObjectRelationship postSystemObjectRelationship =
+			testPostObjectDefinitionObjectRelationship_addObjectRelationship(
+				systemObjectRelationship);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					systemExternalReferenceCode,
+					TestPropsValues.getCompanyId());
+
+		Assert.assertTrue(objectDefinition.isSystem());
+
+		Assert.assertTrue(
+			postSystemObjectRelationship.getObjectDefinitionSystem2());
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1007,7 +1007,11 @@ public class ObjectDefinitionLocalServiceImpl
 			ObjectDefinition.class, companyId,
 			() -> _addObjectDefinition(
 				externalReferenceCode, userId, objectFolderId, modifiable,
-				scope, system),
+				scope,
+				system ||
+				externalReferenceCode.startsWith(
+					ObjectDefinitionConstants.
+						EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION)),
 			externalReferenceCode,
 			this::fetchObjectDefinitionByExternalReferenceCode,
 			this::getObjectDefinitionByExternalReferenceCode,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -3257,6 +3257,56 @@ public class ObjectDefinitionLocalServiceTest {
 	}
 
 	@Test
+	public void testGetOrAddEmptyObjectDefinitionDerivesSystemFlagFromPrefix()
+		throws Throwable {
+
+		ObjectDefinition customObjectDefinition = null;
+		ObjectDefinition systemObjectDefinition = null;
+
+		try (AutoCloseable autoCloseable =
+				new ExportImportConfigurationTemporarySwapper(
+					RandomTestUtil.randomLong())) {
+
+			long companyId = TestPropsValues.getCompanyId();
+			long userId = TestPropsValues.getUserId();
+
+			// A partner external reference code with the system prefix derives
+			// system = true even when the caller passes system = false.
+
+			systemObjectDefinition =
+				_objectDefinitionLocalService.getOrAddEmptyObjectDefinition(
+					ObjectDefinitionConstants.
+						EXTERNAL_REFERENCE_CODE_PREFIX_SYSTEM_OBJECT_DEFINITION +
+							RandomTestUtil.randomString(),
+					companyId, userId, _defaultObjectFolder.getObjectFolderId(),
+					true, ObjectDefinitionConstants.SCOPE_COMPANY, false);
+
+			Assert.assertTrue(systemObjectDefinition.isSystem());
+
+			// A non-prefixed external reference code keeps system = false.
+
+			customObjectDefinition =
+				_objectDefinitionLocalService.getOrAddEmptyObjectDefinition(
+					RandomTestUtil.randomString(), companyId, userId,
+					_defaultObjectFolder.getObjectFolderId(), true,
+					ObjectDefinitionConstants.SCOPE_COMPANY, false);
+
+			Assert.assertFalse(customObjectDefinition.isSystem());
+		}
+		finally {
+			if (customObjectDefinition != null) {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					customObjectDefinition);
+			}
+
+			if (systemObjectDefinition != null) {
+				_objectDefinitionLocalService.deleteObjectDefinition(
+					systemObjectDefinition);
+			}
+		}
+	}
+
+	@Test
 	public void testPublishCustomObjectDefinition() throws Exception {
 		ObjectDefinition objectDefinition1 =
 			_objectDefinitionLocalService.addCustomObjectDefinition(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89354

Resent from liferay-bpm/liferay-portal#6311. The previous forward (brianchandotcom/liferay-portal#177497) was closed after the bchan-bot flagged the assertion order in the three testPostObjectDefinition scenarios (Rule 202); the assertions now follow the rest-openapi.yaml DTO field order: getModifiable, getStatus, getSystem.

Note on the grouped scenario comment: the two scenarios under  (a modifiable-system POSTer and a custom POSTer, both with an L_-prefixed partner) are grouped under one comment because both produce the same modifiable-system stub; the POSTer differs only by the setup variable (randomModifiableSystemObjectDefinition vs randomObjectDefinition), so a per-POSTer comment would duplicate the same label.

---

Re-take of liferay-bpm/liferay-portal#6081 (Adolfo's PR) after coordinating the alternative fix strategy with the team.

The original fix inherited the empty stub's `system` flag from the POSTed (many-side) definition. That approach left two issues open: a gap (custom POSTer referencing a new modifiable system partner via `L_*` still threw `MustNotStartWithPrefix`) and a silent regression in the inverse case (modifiable system POSTer referencing a new custom partner produced a stub `system=true` that the headless update API cannot reconcile, since neither `updateCustomObjectDefinition` nor `updateSystemObjectDefinition` accepts a `system` parameter).

This PR derives the empty stub's `system` flag inside `getOrAddEmptyObjectDefinition` itself, as `system || externalReferenceCode.startsWith("L_")`. Centralizing the derivation there covers all three callers (`ObjectDefinitionResourceImpl._addObjectRelationship`, `ObjectRelationshipResourceImpl._getObjectDefinition2`, and `ObjectActionLocalServiceImpl`) in one place, rather than patching a single call site. It stays out of `_addObjectDefinition`, which also backs `addCustomObjectDefinition` / `addSystemObjectDefinition` where a custom definition with an `L_*` external reference code must still be rejected. The derivation mirrors the invariant `_validateExternalReferenceCode` already enforces (non-system cannot start with `L_*`), so the stub matches the eventual real definition's required type at creation time and sidesteps the update-side reconciliation gap entirely.

## Commits

1. `LPD-89354 Integration test` (Adolfo Pérez Álvarez, authorship preserved via cherry-pick) — covers the documented case (modifiable system POSTer + `L_*` partner forward reference).

1. `LPD-89354 Derive empty stub system flag in getOrAddEmptyObjectDefinition` (Nícolas Moura) — the fix: derives the flag from the partner external reference code prefix inside `getOrAddEmptyObjectDefinition`, covering all three callers in one place.

1. `LPD-89354 Extend coverage for the prefix-derived empty stub system flag` (Nícolas Moura) — adds the inverse case (custom POSTer + `L_*` partner) and the regression-prevent case (modifiable system POSTer + non-`L_*` partner) in `ObjectDefinitionResourceTest`; a relationship-endpoint test in `ObjectRelationshipResourceTest` (an `L_*` partner with no explicit system flag creates a system stub instead of throwing `MustNotStartWithPrefix`); and a service-level test in `ObjectDefinitionLocalServiceTest` (the prefix derives the flag for both an `L_` and a non-`L_` external reference code).

## Coverage Across the Six Quadrants

POSTer is always the many-side by construction; unmodifiable system cannot reach this path (the headless service hardcodes `modifiable=true`), so "system POSTer" in practice is always modifiable system.

| # | POSTer | Real partner | Partner ERC | Expected stub `system` | Status |
|---|---|---|---|---|---|
| 1 | modifiable system | modifiable system | `L_*` | `true` | resolved (ticket motivation) |
| 1' | modifiable system | modifiable system | non-`L_*` | `true` | unchanged (rare; requires non-conventional ERC) |
| 2 | custom | custom | non-`L_*` | `false` | unchanged |
| 3 | modifiable system | custom | non-`L_*` | `false` | preserved (would have regressed under the original parent-inheritance fix) |
| 4 | custom | modifiable system | `L_*` | `true` | resolved (gap left open by the original fix) |
| 4' | custom | modifiable system | non-`L_*` | `true` | unchanged (would need an explicit payload signal; out of scope for a Low priority Bug) |

## Local Validation

- `ant all`: BUILD SUCCESSFUL.
- `/format-source` (dual-pass): clean, no findings.
- `gradlew compileTestIntegrationJava` (object-admin-rest-test, object-test) and `gradlew compileJava` (object-service): BUILD SUCCESSFUL.
- `gradlew testIntegration` on `ObjectDefinitionResourceTest`, `ObjectRelationshipResourceTest`, and `ObjectDefinitionLocalServiceTest`: passed.
