### PR TITLE
LPD-95667 Preserve reminder time unit when editing a calendar event

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_reminders.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/legacy/calendar_reminders.js
@@ -19,10 +19,10 @@ AUI.add(
 			'</label>' +
 			'<input class="input-mini reminder-value" <tpl if="disabled">disabled="disabled"</tpl> name="{portletNamespace}reminderValue{i}" size="5" type="text" value="{time.value}" /> ' +
 			'<select class="reminder-duration span2" <tpl if="disabled">disabled="disabled"</tpl> name="{portletNamespace}reminderDuration{i}">' +
-			'<option <tpl if="time.desc == \'minutes\'">selected="selected"</tpl> value="60">{minutes}</option>' +
-			'<option <tpl if="time.desc == \'hours\'">selected="selected"</tpl> value="3600">{hours}</option>' +
-			'<option <tpl if="time.desc == \'days\'">selected="selected"</tpl> value="86400">{days}</option>' +
-			'<option <tpl if="time.desc == \'weeks\'">selected="selected"</tpl> value="604800">{weeks}</option>' +
+			'<option <tpl if="time.description == \'minutes\'">selected="selected"</tpl> value="60">{minutes}</option>' +
+			'<option <tpl if="time.description == \'hours\'">selected="selected"</tpl> value="3600">{hours}</option>' +
+			'<option <tpl if="time.description == \'days\'">selected="selected"</tpl> value="86400">{days}</option>' +
+			'<option <tpl if="time.description == \'weeks\'">selected="selected"</tpl> value="604800">{weeks}</option>' +
 			'</select>' +
 			'</div>';
 

--- a/modules/apps/calendar/calendar-web/test/js/legacy/calendar_reminders.js
+++ b/modules/apps/calendar/calendar-web/test/js/legacy/calendar_reminders.js
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+describe('liferay-calendar-reminders', () => {
+	let Reminders;
+	let Time;
+
+	beforeEach((done) => {
+		const add = AUI.add;
+
+		AUI.add = function (name, callback, version, metadata) {
+			add.call(AUI, name, callback, version, {
+				...metadata,
+				requires: metadata.requires.filter(
+					(name) =>
+						name !== 'aui-scheduler' &&
+						name !== 'aui-toolbar' &&
+						name !== 'autocomplete'
+				),
+			});
+		};
+
+		require('../../../src/main/resources/META-INF/resources/js/legacy/calendar_util');
+		require('../../../src/main/resources/META-INF/resources/js/legacy/calendar_reminders');
+
+		AUI().use(['liferay-calendar-util'], (A) => {
+			Time = global.Liferay.Time;
+
+			// Stub for "aui-component", which refuses to load in test env.
+
+			A.Component = {
+				create({prototype}) {
+					const constructor = function (config) {
+						this.initializer(config);
+					};
+
+					Object.assign(constructor.prototype, prototype);
+
+					return constructor;
+				},
+			};
+
+			AUI().use(['liferay-calendar-reminders'], () => {
+				Reminders = global.Liferay.Reminders;
+
+				done();
+			});
+		});
+	});
+
+	test.each`
+		unit         | interval
+		${'minutes'} | ${'MINUTE'}
+		${'hours'}   | ${'HOUR'}
+		${'days'}    | ${'DAY'}
+		${'weeks'}   | ${'WEEK'}
+	`(
+		'preselects the $unit duration for a reminder stored in $unit',
+		({interval, unit}) => {
+			const reminders = new Reminders();
+
+			const node = document.createElement('div');
+
+			reminders.get = (key) =>
+				({
+					boundingBox: {
+						setContent(content) {
+							node.innerHTML = content;
+						},
+					},
+					portletNamespace: '_test_',
+					strings: {
+						days: 'days',
+						email: 'email',
+						hours: 'hours',
+						minutes: 'minutes',
+						weeks: 'weeks',
+					},
+				})[key];
+
+			reminders._uiSetValues([{interval: Time[interval]}]);
+
+			expect(
+				node.querySelector('.reminder-duration option[selected]')?.text
+			).toBe(unit);
+		}
+	);
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95667

## What Is Being Fixed

In the Calendar portlet, a reminder set in a unit other than minutes was not preserved. Opening a saved event whose reminder was set for hours, days, or weeks showed the duration dropdown on "minutes", and re-saving stored the reminder as minutes. Reproducible on Master and on 2023.Q3.1.

## How It Is Being Fixed

The four `<option>` conditions in the reminder duration template tested `time.desc`, which is always undefined — `Liferay.Time.getDescription` returns the unit under `time.description`. So no option was ever selected and the dropdown defaulted to minutes. Changed them to `time.description` so the stored unit is preselected. Added a Jest unit test covering all four units.

## How Can You Verify That It Works?

Run the unit test, or check manually in the reminder section of a calendar event.

Automated, from `modules/apps/calendar/calendar-web`:

    npm test -- --testNamePattern=liferay-calendar-reminders

Manual: in a calendar event's reminder section, set a reminder of 1 hour (or 1 day / 1 week), save, reopen, and confirm the dropdown still shows the saved unit instead of minutes.

## PR Check

**pr-check: PASS** — tested on `9631580a5be889a017a25a6beb851c5972be6946`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JavaScript Unit Tests | PASS |

_Scoped to the two commits on this branch (local `master` is behind the branch base), so only the JS-relevant validations matched._

<!-- pr-check {"result": "success", "sha": "9631580a5be889a017a25a6beb851c5972be6946"} -->
