### PR TITLE
LPD-95115 Fetch only the role fields used by the designer UI

### DIFF
--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseNotificationsInfo.js
@@ -95,7 +95,7 @@ const BaseNotificationsInfo = ({
 			headers: HEADERS,
 		},
 		fetchPolicy: 'cache-first',
-		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions`,
+		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType`,
 		onNetworkStatusChange: setNetworkStatus,
 		variables: {
 			pageSize: -1,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.tsx
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.tsx
@@ -52,8 +52,8 @@ export default function BaseRole({
 			setLoading(true);
 
 			const params = new URLSearchParams({
+				fields: 'id,name,roleType',
 				pageSize: '-1',
-				restrictedFields: 'rolePermissions',
 			});
 
 			const response = await fetch(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/diagram-builder/components/sidebar/sections/timers/select-reassignment/RoleType.js
@@ -27,7 +27,7 @@ const RoleType = ({subSectionIdentifier, subSectionsLength, ...otherProps}) => {
 			headers: HEADERS,
 		},
 		fetchPolicy: 'cache-first',
-		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions`,
+		link: `${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType`,
 		onNetworkStatusChange: setNetworkStatus,
 		variables: {
 			pageSize: -1,

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.ts
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/fetchUtil.ts
@@ -78,7 +78,7 @@ export function retrieveRoleById(roleId: number) {
 
 export function retrieveRoles() {
 	return fetch(
-		`${window.location.origin}${contextUrl}${userBaseURL}/roles?restrictFields=rolePermissions&pageSize=-1`,
+		`${window.location.origin}${contextUrl}${userBaseURL}/roles?fields=id,name,roleType&pageSize=-1`,
 		{
 			headers: HEADERS,
 			method: 'GET',

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.spec.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/test/js/designer/definition-builder/diagram-builder/components/sidebar/sections/shared-components/BaseRole.spec.js
@@ -37,7 +37,7 @@ describe('The BaseRole component should', () => {
 		});
 
 		expect(frontendJSWebFetchSpier).toHaveBeenCalledWith(
-			'/o/headless-admin-user/v1.0/roles?pageSize=-1&restrictedFields=rolePermissions',
+			'/o/headless-admin-user/v1.0/roles?fields=id%2Cname%2CroleType&pageSize=-1',
 			expect.any(Object)
 		);
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95115

## What Is Being Fixed

The workflow definition builder's ASSIGNMENTS node was slow to load roles. When a Role was selected, the UI fetched `/roles` with `restrictFields=rolePermissions` (and `restrictedFields=rolePermissions` in the `BaseRole` component), which only excluded the permissions field while the service still serialized every other field for every role. On installations with many roles this made the request unnecessarily expensive.

## How It Is Being Fixed

Each role request now uses `fields=id,name,roleType` instead of `restrictFields=rolePermissions`, so the service returns only the three fields the designer UI actually consumes. The change is applied consistently across every roles fetch in the module — `BaseNotificationsInfo.js`, `BaseRole.tsx`, `RoleType.js`, and `fetchUtil.ts` — and the `BaseRole` spec assertion is updated to match the new query string.

## PR Check

**pr-check: PASS** — tested on `9cc6f1de12ab3be194e9db348fc537b4ad4f92e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9cc6f1de12ab3be194e9db348fc537b4ad4f92e7"} -->
