### PR TITLE
LPD-95604 Create tasks from calendar day cells

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
@@ -29,6 +29,7 @@ import './../AssigneeTrigger.scss';
 
 type CreateTaskModalProps = {
 	closeModal: () => void;
+	dueDate?: string;
 	loadData: Function;
 	projectId?: string;
 	state: string;
@@ -36,6 +37,7 @@ type CreateTaskModalProps = {
 
 export default function CreateTaskModal({
 	closeModal,
+	dueDate = '',
 	loadData,
 	projectId,
 	state,
@@ -61,7 +63,7 @@ export default function CreateTaskModal({
 	} = useFormik({
 		initialValues: {
 			assignTo: {},
-			dueDate: '',
+			dueDate,
 			r_cmpProjectToCMPTasks_c_cmpProjectId: Number(projectId) ?? 0,
 			state,
 			title: '',
@@ -228,6 +230,7 @@ export default function CreateTaskModal({
 						setFieldValue('dueDate', value);
 					}}
 					type="Date"
+					value={values.dueDate}
 				/>
 			</ClayModal.Body>
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -65,7 +65,11 @@ export default function ProjectTasksFDSPropsTransformer({
 	installCMPTabPersistence();
 
 	const calendarView: IView = {
-		component: CalendarView,
+		component: (props: any) =>
+			CalendarView({
+				...props,
+				projectId: additionalProps.projectId,
+			}),
 		default: false,
 		initialPaginationDelta: FDS_PAGINATION_DELTA_ALL,
 		label: Liferay.Language.get('calendar'),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -8,6 +8,70 @@
 
 	margin-top: -1rem;
 
+	.fc-col-header-cell {
+		background-color: $gray-100;
+		border-left-width: 0;
+		border-right-width: 0;
+		text-align: left;
+	}
+
+	.fc-col-header-cell-cushion {
+		color: $secondary;
+		display: inline-block;
+		font-size: 0.75rem;
+		font-weight: $font-weight-semi-bold;
+		padding: 0.5rem 0.75rem;
+		text-decoration: none !important;
+	}
+
+	.fc-day-today .fc-daygrid-day-number {
+		align-items: center;
+		background-color: $primary;
+		border-radius: 50%;
+		color: $white;
+		display: inline-flex;
+		height: 1.75rem;
+		justify-content: center;
+		line-height: 1;
+		margin: 0.25rem 0.5rem;
+		padding: 0;
+		width: 1.75rem;
+	}
+
+	.fc-daygrid-block-event .fc-event-main {
+		padding: 0;
+	}
+
+	.fc-daygrid-day-frame:hover .lfr__calendar-view-add-task-button,
+	.lfr__calendar-view-add-task-button:focus-visible {
+		opacity: 1;
+	}
+
+	.fc-daygrid-day-number {
+		color: $secondary;
+		font-size: $font-size-sm;
+		font-weight: $font-weight-semi-bold;
+		padding: 0.5rem 0.75rem;
+
+		// Drop the FullCalendar default "position: relative" so the add task
+		// button anchors to the full-width day number row instead of the
+		// content-width day number, which keeps it at the row's right edge and
+		// vertically centered with the number text.
+
+		position: static;
+		text-decoration: none !important;
+	}
+
+	.fc-daygrid-day-top {
+		flex-direction: row;
+		position: relative;
+	}
+
+	.fc-daygrid-day.fc-day-sat,
+	.fc-daygrid-day.fc-day-sun {
+		background-color: $gray-100;
+	}
+
 	.fc-daygrid-event {
 		border: 0;
 		box-shadow: none;
@@ -18,10 +82,6 @@
 
 	.fc-daygrid-event:not(.btn):not(.component-action):not(.page-link) {
 		text-decoration: none;
-	}
-
-	.fc-daygrid-block-event .fc-event-main {
-		padding: 0;
 	}
 
 	.fc-daygrid-more-link.fc-more-link {
@@ -44,6 +104,11 @@
 	.fc-direction-ltr .fc-daygrid-event.fc-event-start,
 	.fc-direction-rtl .fc-daygrid-event.fc-event-end {
 		margin-left: 0.25rem;
+	}
+
+	.fc-theme-standard .fc-scrollgrid {
+		border-left-width: 0;
+		border-right-width: 0;
 	}
 
 	&-add-task-button {
@@ -90,70 +155,5 @@
 			display: flex;
 			gap: 0.5rem;
 		}
-	}
-
-	.fc-col-header-cell {
-		background-color: $gray-100;
-		border-left-width: 0;
-		border-right-width: 0;
-		text-align: left;
-	}
-
-	.fc-col-header-cell-cushion {
-		color: $secondary;
-		display: inline-block;
-		font-size: 0.75rem;
-		font-weight: $font-weight-semi-bold;
-		padding: 0.5rem 0.75rem;
-		text-decoration: none !important;
-	}
-
-	.fc-day-today .fc-daygrid-day-number {
-		align-items: center;
-		background-color: $primary;
-		border-radius: 50%;
-		color: $white;
-		display: inline-flex;
-		height: 1.75rem;
-		justify-content: center;
-		line-height: 1;
-		margin: 0.25rem 0.5rem;
-		padding: 0;
-		width: 1.75rem;
-	}
-
-	.fc-daygrid-day.fc-day-sat,
-	.fc-daygrid-day.fc-day-sun {
-		background-color: $gray-100;
-	}
-
-	.fc-daygrid-day-frame:hover .lfr__calendar-view-add-task-button,
-	.lfr__calendar-view-add-task-button:focus-visible {
-		opacity: 1;
-	}
-
-	.fc-daygrid-day-number {
-		color: $secondary;
-		font-size: $font-size-sm;
-		font-weight: $font-weight-semi-bold;
-		padding: 0.5rem 0.75rem;
-
-		// Drop the FullCalendar default "position: relative" so the add task
-		// button anchors to the full-width day number row instead of the
-		// content-width day number, which keeps it at the row's right edge and
-		// vertically centered with the number text.
-
-		position: static;
-		text-decoration: none !important;
-	}
-
-	.fc-daygrid-day-top {
-		flex-direction: row;
-		position: relative;
-	}
-
-	.fc-theme-standard .fc-scrollgrid {
-		border-left-width: 0;
-		border-right-width: 0;
 	}
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.scss
@@ -46,6 +46,14 @@
 		margin-left: 0.25rem;
 	}
 
+	&-add-task-button {
+		opacity: 0;
+		position: absolute;
+		right: 0.25rem;
+		top: 50%;
+		transform: translateY(-50%);
+	}
+
 	&-toolbar {
 		align-items: center;
 		margin-left: 0;
@@ -119,16 +127,29 @@
 		background-color: $gray-100;
 	}
 
+	.fc-daygrid-day-frame:hover .lfr__calendar-view-add-task-button,
+	.lfr__calendar-view-add-task-button:focus-visible {
+		opacity: 1;
+	}
+
 	.fc-daygrid-day-number {
 		color: $secondary;
 		font-size: $font-size-sm;
 		font-weight: $font-weight-semi-bold;
 		padding: 0.5rem 0.75rem;
+
+		// Drop the FullCalendar default "position: relative" so the add task
+		// button anchors to the full-width day number row instead of the
+		// content-width day number, which keeps it at the row's right edge and
+		// vertically centered with the number text.
+
+		position: static;
 		text-decoration: none !important;
 	}
 
 	.fc-daygrid-day-top {
 		flex-direction: row;
+		position: relative;
 	}
 
 	.fc-theme-standard .fc-scrollgrid {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -295,6 +295,7 @@ export default function CalendarView({items, projectId}: CalendarViewProps) {
 					<CalendarTaskCard task={arg.event.extendedProps.task} />
 				)}
 				events={events}
+				fixedWeekCount={false}
 				headerToolbar={false}
 				initialView="dayGridMonth"
 				moreLinkClassNames={[

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -333,7 +333,7 @@ export default function CalendarView({items, projectId}: CalendarViewProps) {
 				moreLinkHint={Liferay.Language.get('view-all-tasks')}
 				plugins={[dayGridPlugin]}
 				ref={calendarRef}
-				{...(Liferay.FeatureFlags['LPD-74152'] && {
+				{...(Liferay.FeatureFlags['LPD-69885'] && {
 					dayCellContent: (arg) => (
 						<>
 							{arg.dayNumberText}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -15,7 +15,10 @@ import classNames from 'classnames';
 import {dateUtils, sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 
+import {DEFAULT_TASK_STATE_KEY} from '../../../../utils/constants';
+import {openCMPModal} from '../../../../utils/openCMPModal';
 import {ITask, ITaskObjectEntry} from '../../../../utils/types';
+import CreateTaskModal from '../../../modal/CreateTaskModal';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
 import CalendarMoreLinkPopover from './components/CalendarMoreLinkPopover';
 import CalendarTaskCard from './components/CalendarTaskCard';
@@ -27,6 +30,7 @@ import type {FirstDayOfWeekLocale} from 'frontend-js-web';
 
 interface CalendarViewProps {
 	items: ITask[];
+	projectId?: string;
 }
 
 interface MoreLinkPopover {
@@ -35,8 +39,10 @@ interface MoreLinkPopover {
 	tasks: ITaskObjectEntry[];
 }
 
-export default function CalendarView({items}: CalendarViewProps) {
-	const {onInfoPanelToggleButtonClick} = useContext(FrontendDataSetContext);
+export default function CalendarView({items, projectId}: CalendarViewProps) {
+	const {loadData, onInfoPanelToggleButtonClick} = useContext(
+		FrontendDataSetContext
+	);
 
 	const calendarRef = useRef<FullCalendar>(null);
 	const calendarViewRef = useRef<HTMLDivElement>(null);
@@ -115,6 +121,22 @@ export default function CalendarView({items}: CalendarViewProps) {
 
 		return () => resizeObserver.disconnect();
 	}, []);
+
+	const openCreateTaskModal = (dueDate: string) => {
+		openCMPModal({
+			center: true,
+			contentComponent: ({closeModal}: {closeModal: () => void}) => (
+				<CreateTaskModal
+					closeModal={closeModal}
+					dueDate={dueDate}
+					loadData={loadData}
+					projectId={projectId}
+					state={DEFAULT_TASK_STATE_KEY}
+				/>
+			),
+			size: 'md',
+		});
+	};
 
 	const currentYear = new Date().getFullYear();
 	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
@@ -310,6 +332,29 @@ export default function CalendarView({items}: CalendarViewProps) {
 				moreLinkHint={Liferay.Language.get('view-all-tasks')}
 				plugins={[dayGridPlugin]}
 				ref={calendarRef}
+				{...(Liferay.FeatureFlags['LPD-74152'] && {
+					dayCellContent: (arg) => (
+						<>
+							{arg.dayNumberText}
+
+							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get('add-task')}
+								borderless
+								className="lfr__calendar-view-add-task-button"
+								displayType="secondary"
+								onClick={() =>
+									openCreateTaskModal(
+										dateUtils.format(arg.date, 'yyyy-MM-dd')
+									)
+								}
+								rounded
+								size="xs"
+								symbol="plus"
+								title={Liferay.Language.get('add-task')}
+							/>
+						</>
+					),
+				})}
 			/>
 
 			{moreLinkPopover && (

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/constants.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/constants.ts
@@ -5,6 +5,8 @@
 
 import {IDisplayType} from './types';
 
+export const DEFAULT_TASK_STATE_KEY = 'notStarted';
+
 export const DISPLAY_TYPES = [
 	'danger',
 	'info',

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -25,7 +25,6 @@ const test = mergeTests(
 	featureFlagsTest({
 		'LPD-58677': {enabled: true},
 		'LPD-69885': {enabled: true},
-		'LPD-74152': {enabled: true},
 	}),
 	globalMenuPagesTest,
 	loginTest(),

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -25,6 +25,7 @@ const test = mergeTests(
 	featureFlagsTest({
 		'LPD-58677': {enabled: true},
 		'LPD-69885': {enabled: true},
+		'LPD-74152': {enabled: true},
 	}),
 	globalMenuPagesTest,
 	loginTest(),
@@ -467,6 +468,75 @@ test(
 					})
 				).toBeVisible();
 			}
+		});
+	}
+);
+
+test(
+	'Create a task from the calendar by clicking a day',
+	{tag: ['@LPD-93258']},
+	async ({page, projectPage, projectsPage, tasksPage}) => {
+		const taskTitle = getRandomString();
+
+		const targetDate = new Date();
+
+		targetDate.setDate(15);
+
+		const dayCell = page.locator(
+			`[data-date="${toDateString(targetDate)}"]`
+		);
+
+		await test.step('View the project and open its calendar view', async () => {
+			await projectsPage.goto();
+
+			await projectsPage.getProject(project.title).click();
+
+			await projectPage.tasksTab.click();
+
+			await tasksPage.tableViewButton.click();
+
+			await tasksPage.calendarView.viewOption.click();
+
+			await expect(tasksPage.calendarView.title).toBeVisible();
+		});
+
+		await test.step('Click the add task button to open the create task modal', async () => {
+			const addTaskButton = dayCell.getByLabel('Add Task');
+
+			await dayCell.hover();
+
+			await clickAndExpectToBeVisible({
+				target: tasksPage.titleInput,
+				trigger: addTaskButton,
+			});
+		});
+
+		await test.step('The clicked day is pre-filled as the due date', async () => {
+			const locale = await page.evaluate(() =>
+				Liferay.ThemeDisplay.getBCP47LanguageId()
+			);
+
+			const expectedDueDate = targetDate.toLocaleDateString(locale, {
+				day: '2-digit',
+				month: '2-digit',
+				year: 'numeric',
+			});
+
+			await expect(page.getByLabel('Due Date')).toHaveValue(
+				expectedDueDate
+			);
+		});
+
+		await test.step('Fill in the title and save', async () => {
+			await tasksPage.titleInput.fill(taskTitle);
+
+			await tasksPage.saveButton.click();
+		});
+
+		await test.step('The new task appears on the clicked day', async () => {
+			await expect(
+				dayCell.getByText(taskTitle, {exact: true})
+			).toBeVisible();
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95604

> **Note:** This branch is rebased off `LPD-94824` (https://github.com/liferay-bpm/liferay-portal/pull/6296). Those commits show up in this diff and will drop out once 6296 lands — review and merge 6296 first.

## What Is Being Fixed

There was no way to create a task directly from the project calendar view. To add a task with a specific due date, a user had to leave the calendar, create the task elsewhere, and set the date by hand.

## How It Is Being Fixed

- Each calendar day cell shows an `Add Task` button, revealed on hover or keyboard focus, that opens the existing `CreateTaskModal` prefilled with that day's due date and a default `notStarted` state.
- The button and the create-task behavior are gated behind the `LPD-74152` feature flag.
- The project ID is passed through `CalendarView` so the task is created under the correct project.
- The default state comes from a new `DEFAULT_TASK_STATE_KEY` constant.
- A Playwright test covers creating a task from a calendar day.

https://github.com/user-attachments/assets/21f7704a-2f68-4a3f-a2f8-b9e5a0f69e86


## PR Check

**pr-check: PASS** — tested on `59e266173db2348a6023a8a2c9897947542039d1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "59e266173db2348a6023a8a2c9897947542039d1"} -->
