### PR TITLE
LPD-95988 Use the correct date time pattern when converting the string

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/field/business/type/DateTimeObjectFieldBusinessType.java
@@ -146,9 +146,9 @@ public class DateTimeObjectFieldBusinessType
 			return null;
 		}
 
-		if (serializable instanceof String) {
+		if (serializable instanceof String dateString) {
 			Date date = DateUtil.parseDate(
-				"yyyy-MM-dd", (String)serializable,
+				ObjectFieldUtil.getDateTimePattern(dateString), dateString,
 				LocaleUtil.getSiteDefault());
 
 			serializable = new Timestamp(date.getTime());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/DateTimeObjectFieldBusinessTypeTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/field/business/type/test/DateTimeObjectFieldBusinessTypeTest.java
@@ -10,12 +10,12 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.builder.DateTimeObjectFieldBuilder;
 import com.liferay.object.field.business.type.ObjectFieldBusinessType;
 import com.liferay.object.field.business.type.ObjectFieldBusinessTypeRegistry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
 
@@ -57,18 +57,36 @@ public class DateTimeObjectFieldBusinessTypeTest {
 			_getDisplayContextValue("2025-08-04 09:10:11.123"));
 	}
 
+	@Test
+	public void testGetDTOValue() throws Exception {
+		Assert.assertEquals(
+			"2025-08-04T00:00:00.000", _getDTOValue("2025-08-04"));
+		Assert.assertEquals(
+			"2025-08-04T09:10:00.000", _getDTOValue("2025-08-04 09:10"));
+		Assert.assertEquals(
+			"2025-08-04T09:10:11.123", _getDTOValue("2025-08-04 09:10:11.123"));
+	}
+
 	private String _getDisplayContextValue(String value) throws Exception {
 		return String.valueOf(
 			_objectFieldBusinessType.getDisplayContextValue(
-				new DateTimeObjectFieldBuilder(
-				).labelMap(
-					LocalizedMapUtil.getLocalizedMap(
-						RandomTestUtil.randomString())
-				).name(
-					_OBJECT_FIELD_NAME
-				).build(),
-				TestPropsValues.getUserId(),
+				_getObjectField(), TestPropsValues.getUserId(),
 				Collections.singletonMap(_OBJECT_FIELD_NAME, value)));
+	}
+
+	private String _getDTOValue(String value) throws Exception {
+		return String.valueOf(
+			_objectFieldBusinessType.getDTOValue(
+				null, null, null, _getObjectField(), value));
+	}
+
+	private ObjectField _getObjectField() {
+		return new DateTimeObjectFieldBuilder(
+		).labelMap(
+			RandomTestUtil.randomLocaleStringMap()
+		).name(
+			_OBJECT_FIELD_NAME
+		).build();
 	}
 
 	private static final String _OBJECT_FIELD_NAME =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95988

## What Is Being Fixed

When a date-time object field value arrived as a String, DateTimeObjectFieldBusinessType converted it to a Timestamp using a hardcoded "yyyy-MM-dd" pattern. That pattern covers only the date, so the time component was dropped and the resulting DTO value was truncated to midnight.

## How It Is Being Fixed

The conversion now derives the pattern from the value itself with ObjectFieldUtil.getDateTimePattern(dateString), which selects the matching date-time pattern (for example "yyyy-MM-dd HH:mm" or one that includes seconds and milliseconds). This preserves the time when parsing the string into a Timestamp.

## PR Check

**pr-check: PASS** — tested on `763f4313014774321f0e8caf07da324286b65bd2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "763f4313014774321f0e8caf07da324286b65bd2"} -->
