### PR TITLE
LPD-95997 Picklist options not sorted alphabetically on first load

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
@@ -103,13 +103,22 @@ public class SelectDDMFormFieldTemplateContextContributor
 					ddmFormField.getProperty("objectFieldId"));
 
 				if (objectFieldId > 0) {
-					return DDMFormFieldTemplateContextContributorUtil.
-						getOptions(
+					List<Map<String, Object>> options =
+						DDMFormFieldTemplateContextContributorUtil.getOptions(
 							ddmFormFieldOptions,
 							GetterUtil.getLong(
 								ddmFormField.getProperty(
 									"listTypeDefinitionId")),
 							_listTypeEntryLocalService);
+
+					if (GetterUtil.getBoolean(
+							ddmFormField.getProperty("alphabeticalOrder"))) {
+
+						return _getSortedOptions(
+							ddmFormFieldRenderingContext.getLocale(), options);
+					}
+
+					return options;
 				}
 
 				return getOptions(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -304,40 +305,11 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 
 	@Test
 	public void testGetOptionsAlphabeticallyOrdered() {
-		List<Object> expectedOptions = new ArrayList<>();
-
-		expectedOptions.add(
-			DDMFormFieldOptionsTestUtil.createOption(
-				"Label 1",
-				HashMapBuilder.put(
-					LocaleUtil.US, "Label 1"
-				).build(),
-				"Reference 1", "value 1"));
-		expectedOptions.add(
-			DDMFormFieldOptionsTestUtil.createOption(
-				"Label 2",
-				HashMapBuilder.put(
-					LocaleUtil.US, "Label 2"
-				).build(),
-				"Reference 2", "value 2"));
-		expectedOptions.add(
-			DDMFormFieldOptionsTestUtil.createOption(
-				"Label 3",
-				HashMapBuilder.put(
-					LocaleUtil.US, "Label 3"
-				).build(),
-				"Reference 3", "value 3"));
+		List<Map<String, Object>> expectedOptions = _createExpectedOptions();
 
 		DDMFormField ddmFormField = new DDMFormField("field", "select");
 
-		DDMFormFieldOptions ddmFormFieldOptions = new DDMFormFieldOptions();
-
-		for (int i = 3; i > 0; i--) {
-			ddmFormFieldOptions.addOptionLabel(
-				"value " + i, LocaleUtil.US, "Label " + i);
-			ddmFormFieldOptions.addOptionReference(
-				"value " + i, "Reference " + i);
-		}
+		DDMFormFieldOptions ddmFormFieldOptions = _createDDMFormFieldOptions();
 
 		Assert.assertNotEquals(
 			expectedOptions,
@@ -509,6 +481,43 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 	}
 
 	@Test
+	public void testGetParametersAlphabeticallyOrdered() throws Exception {
+		List<Map<String, Object>> expectedOptions = _createExpectedOptions();
+
+		DDMFormField ddmFormField = new DDMFormField("field", "select");
+
+		ddmFormField.setDDMForm(getDDMForm());
+		ddmFormField.setProperty(
+			"listTypeDefinitionId", RandomTestUtil.randomLong());
+		ddmFormField.setProperty("objectFieldId", RandomTestUtil.randomLong());
+
+		DDMFormFieldOptions ddmFormFieldOptions = _createDDMFormFieldOptions();
+
+		ddmFormFieldOptions.setDefaultLocale(LocaleUtil.US);
+
+		ddmFormField.setDDMFormFieldOptions(ddmFormFieldOptions);
+
+		SelectDDMFormFieldTemplateContextContributor
+			selectDDMFormFieldTemplateContextContributor = _createSpy();
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			createDDMFormFieldRenderingContext();
+
+		Map<String, Object> parameters =
+			selectDDMFormFieldTemplateContextContributor.getParameters(
+				ddmFormField, ddmFormFieldRenderingContext);
+
+		Assert.assertNotEquals(expectedOptions, parameters.get("options"));
+
+		ddmFormField.setProperty("alphabeticalOrder", "true");
+
+		parameters = selectDDMFormFieldTemplateContextContributor.getParameters(
+			ddmFormField, ddmFormFieldRenderingContext);
+
+		Assert.assertEquals(expectedOptions, parameters.get("options"));
+	}
+
+	@Test
 	public void testGetValue1() {
 		List<String> values =
 			_selectDDMFormFieldTemplateContextContributor.getValue(
@@ -533,6 +542,41 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 		ddmFormField.setProperty("multiple", multiple);
 
 		return ddmFormField;
+	}
+
+	private DDMFormFieldOptions _createDDMFormFieldOptions() {
+		DDMFormFieldOptions ddmFormFieldOptions = new DDMFormFieldOptions();
+
+		for (int i = 3; i > 0; i--) {
+			ddmFormFieldOptions.addOptionLabel(
+				"value " + i, LocaleUtil.US, "Label " + i);
+			ddmFormFieldOptions.addOptionReference(
+				"value " + i, "Reference " + i);
+		}
+
+		return ddmFormFieldOptions;
+	}
+
+	private List<Map<String, Object>> _createExpectedOptions() {
+		return ListUtil.fromArray(
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 1",
+				HashMapBuilder.put(
+					LocaleUtil.US, "Label 1"
+				).build(),
+				"Reference 1", "value 1"),
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 2",
+				HashMapBuilder.put(
+					LocaleUtil.US, "Label 2"
+				).build(),
+				"Reference 2", "value 2"),
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 3",
+				HashMapBuilder.put(
+					LocaleUtil.US, "Label 3"
+				).build(),
+				"Reference 3", "value 3"));
 	}
 
 	private SelectDDMFormFieldTemplateContextContributor _createSpy() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95997

## What Is Being Fixed

On a form backed by an Object, a "Select From List" field mapped to a picklist (list type) object field with "Order Options Alphabetically" enabled rendered its options unsorted on the first load of the dropdown. The entries only became alphabetical after the field was opened and reopened, so the initial order did not match the configured alphabetical ordering.

## How It Is Being Fixed

When the Select field is mapped to an object field (objectFieldId > 0), SelectDDMFormFieldTemplateContextContributor built the options through DDMFormFieldTemplateContextContributorUtil.getOptions, which returns them in insertion order and never applies the alphabeticalOrder flag. The first server-side render therefore skipped sorting, while later client interactions re-rendered through a sorting path. The fix sorts the options in that branch when alphabeticalOrder is enabled, using the rendering context locale, so the first render is ordered the same way the field's other option paths already sort. A unit test exercises the object-field branch through getParameters, asserting the options come back ordered only when the flag is set.

## PR Check

**pr-check: PASS** — tested on `092092be9b390cd7bf12bc063e423f22670c3017`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "092092be9b390cd7bf12bc063e423f22670c3017"} -->
