### PR TITLE
LPD-96123 Publish and expire object entries missed during downtime

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -176,10 +176,12 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -3208,33 +3210,49 @@ public class ObjectEntryLocalServiceImpl
 
 		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.displayDate.lt(date)
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.isNull(
-					).or(
-						ObjectEntryTable.INSTANCE.expirationDate.gte(
-							nextExpirationDate)
-					)
-				).and(
-					ObjectEntryTable.INSTANCE.status.eq(
-						WorkflowConstants.STATUS_SCHEDULED)
-				)
-			));
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			updateStatus(
-				objectEntry.getUserId(), objectEntry,
-				WorkflowConstants.STATUS_APPROVED, new ServiceContext());
-		}
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property displayDateProperty = PropertyFactoryUtil.forName(
+					"displayDate");
+
+				dynamicQuery.add(displayDateProperty.lt(date));
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.or(
+						RestrictionsFactoryUtil.isNull("expirationDate"),
+						RestrictionsFactoryUtil.ge(
+							"expirationDate", nextExpirationDate)));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(
+					statusProperty.eq(WorkflowConstants.STATUS_SCHEDULED));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				try {
+					updateStatus(
+						objectEntry.getUserId(), objectEntry,
+						WorkflowConstants.STATUS_APPROVED,
+						new ServiceContext());
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to publish object entry " +
+								objectEntry.getObjectEntryId(),
+							portalException);
+					}
+				}
+			});
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _checkObjectEntriesByExpirationDate(
@@ -3243,80 +3261,97 @@ public class ObjectEntryLocalServiceImpl
 
 		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.lte(
-						nextExpirationDate)
-				).and(
-					ObjectEntryTable.INSTANCE.status.notIn(
-						new Integer[] {
-							WorkflowConstants.STATUS_DRAFT,
-							WorkflowConstants.STATUS_EXPIRED,
-							WorkflowConstants.STATUS_IN_TRASH,
-							WorkflowConstants.STATUS_PENDING
-						})
-				)
-			));
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			expireObjectEntry(
-				objectEntry.getUserId(), objectEntry.getObjectEntryId(),
-				new ServiceContext());
-		}
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property expirationDateProperty = PropertyFactoryUtil.forName(
+					"expirationDate");
+
+				dynamicQuery.add(expirationDateProperty.le(nextExpirationDate));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.not(
+						statusProperty.in(
+							new int[] {
+								WorkflowConstants.STATUS_DRAFT,
+								WorkflowConstants.STATUS_EXPIRED,
+								WorkflowConstants.STATUS_IN_TRASH,
+								WorkflowConstants.STATUS_PENDING
+							})));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				try {
+					expireObjectEntry(
+						objectEntry.getUserId(), objectEntry.getObjectEntryId(),
+						new ServiceContext());
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to expire object entry " +
+								objectEntry.getObjectEntryId(),
+							portalException);
+					}
+				}
+			});
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _checkObjectEntriesByReviewDate(long companyId, Date date)
 		throws PortalException {
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.reviewDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
-				).and(
-					ObjectEntryTable.INSTANCE.reviewDate.lte(date)
-				)
-			));
+		Date previousCheckDate = _companyIdPreviousCheckDate.get(companyId);
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			JSONObject payloadJSONObject = JSONUtil.put(
-				"classPK", objectEntry.getObjectEntryId()
-			).put(
-				"notificationMessageArg", objectEntry.getTitleValue()
-			).put(
-				"notificationMessageKey", "x-has-reached-its-review-date"
-			);
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-			for (ObjectEntryReviewNotificationContributor contributor :
-					_objectEntryReviewNotificationContributors) {
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property reviewDateProperty = PropertyFactoryUtil.forName(
+					"reviewDate");
 
-				if (contributor.isApplicable(objectEntry)) {
-					contributor.contribute(objectEntry, payloadJSONObject);
+				dynamicQuery.add(reviewDateProperty.ge(previousCheckDate));
+				dynamicQuery.add(reviewDateProperty.le(date));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				JSONObject payloadJSONObject = JSONUtil.put(
+					"classPK", objectEntry.getObjectEntryId()
+				).put(
+					"notificationMessageArg", objectEntry.getTitleValue()
+				).put(
+					"notificationMessageKey", "x-has-reached-its-review-date"
+				);
+
+				for (ObjectEntryReviewNotificationContributor contributor :
+						_objectEntryReviewNotificationContributors) {
+
+					if (contributor.isApplicable(objectEntry)) {
+						contributor.contribute(objectEntry, payloadJSONObject);
+					}
 				}
-			}
 
-			ObjectDefinition objectDefinition =
-				_objectDefinitionPersistence.fetchByPrimaryKey(
-					objectEntry.getObjectDefinitionId());
+				ObjectDefinition objectDefinition =
+					_objectDefinitionPersistence.fetchByPrimaryKey(
+						objectEntry.getObjectDefinitionId());
 
-			_userNotificationEventLocalService.sendUserNotificationEvents(
-				objectEntry.getUserId(), objectDefinition.getPortletId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-				payloadJSONObject);
-		}
+				_userNotificationEventLocalService.sendUserNotificationEvents(
+					objectEntry.getUserId(), objectDefinition.getPortletId(),
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+					payloadJSONObject);
+			});
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _contributeValues(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -721,14 +721,14 @@ public class ObjectEntryLocalServiceImpl
 
 		Date date = new Date();
 
+		long checkInterval = _getObjectEntryCheckInterval(companyId);
+
 		_companyIdPreviousCheckDate.computeIfAbsent(
-			companyId,
-			key -> new Date(
-				date.getTime() - _getObjectEntryCheckInterval(companyId)));
+			companyId, key -> new Date(date.getTime() - checkInterval));
 
-		_checkObjectEntriesByDisplayDate(companyId, date);
+		_checkObjectEntriesByDisplayDate(companyId, date, checkInterval);
 
-		_checkObjectEntriesByExpirationDate(companyId, date);
+		_checkObjectEntriesByExpirationDate(companyId, date, checkInterval);
 
 		_checkObjectEntriesByReviewDate(companyId, date);
 
@@ -3202,8 +3202,11 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _checkObjectEntriesByDisplayDate(long companyId, Date date)
+	private void _checkObjectEntriesByDisplayDate(
+			long companyId, Date date, long checkInterval)
 		throws PortalException {
+
+		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -3214,10 +3217,13 @@ public class ObjectEntryLocalServiceImpl
 				ObjectEntryTable.INSTANCE.companyId.eq(
 					companyId
 				).and(
-					ObjectEntryTable.INSTANCE.displayDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
+					ObjectEntryTable.INSTANCE.displayDate.lt(date)
 				).and(
-					ObjectEntryTable.INSTANCE.displayDate.lte(date)
+					ObjectEntryTable.INSTANCE.expirationDate.isNull(
+					).or(
+						ObjectEntryTable.INSTANCE.expirationDate.gte(
+							nextExpirationDate)
+					)
 				).and(
 					ObjectEntryTable.INSTANCE.status.eq(
 						WorkflowConstants.STATUS_SCHEDULED)
@@ -3231,8 +3237,11 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _checkObjectEntriesByExpirationDate(long companyId, Date date)
+	private void _checkObjectEntriesByExpirationDate(
+			long companyId, Date date, long checkInterval)
 		throws PortalException {
+
+		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -3243,10 +3252,8 @@ public class ObjectEntryLocalServiceImpl
 				ObjectEntryTable.INSTANCE.companyId.eq(
 					companyId
 				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.lte(date)
+					ObjectEntryTable.INSTANCE.expirationDate.lte(
+						nextExpirationDate)
 				).and(
 					ObjectEntryTable.INSTANCE.status.notIn(
 						new Integer[] {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
@@ -150,6 +150,34 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 	}
 
 	@Test
+	public void testCheckObjectEntryDisplayDateAfterMissedInterval()
+		throws Exception {
+
+		Date date = new Date();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).put(
+				"displayDate",
+				new Date(date.getTime() + TimeUnit.DAY.toMillis(1))
+			).build());
+
+		Assert.assertTrue(objectEntry.isScheduled());
+
+		_updateDisplayDate(
+			new Date(date.getTime() - TimeUnit.DAY.toMillis(1)), objectEntry);
+
+		_jobExecutorUnsafeRunnable.run();
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(objectEntry.isApproved());
+	}
+
+	@Test
 	public void testCheckObjectEntryExpirationDate() throws Exception {
 		Date date = new Date();
 
@@ -180,8 +208,7 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			).build());
 
 		_updateExpirationDate(
-			new Date(date.getTime() + TimeUnit.MINUTE.toMillis(5)),
-			objectEntry2);
+			new Date(date.getTime() + TimeUnit.DAY.toMillis(1)), objectEntry2);
 
 		_jobExecutorUnsafeRunnable.run();
 
@@ -372,6 +399,12 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			).minusMonths(
 				months
 			));
+	}
+
+	private void _updateDisplayDate(Date displayDate, ObjectEntry objectEntry) {
+		objectEntry.setDisplayDate(displayDate);
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry);
 	}
 
 	private void _updateExpirationDate(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96123

## What Is Being Fixed

Scheduled publishing and expiration of Object Entries is driven by a periodic poll (CheckObjectEntrySchedulerJobConfiguration, default 15 minutes) that transitions entries on their display, expiration, and review dates. The display and expiration checks queried a bounded time window (the date between the previous check and now), so when a poll tick was missed - the server down longer than one interval, or the in-memory previous-check-date map resetting on restart, where it initializes to now minus one interval - any entry whose date fell in the gap was skipped permanently. The entry stayed SCHEDULED and was never published, or it never expired. JournalArticle does not have this defect: its equivalent check uses an unbounded lower bound and relies on the workflow status as the guard against reprocessing, which makes it self-healing across downtime.

## How It Is Being Fixed

The object entry display and expiration checks are aligned with the journal article scheduler. The previous-check-date lower bound is removed from both queries, so any entry whose display or expiration date has passed is caught on the next poll, with the SCHEDULED status guard preventing reprocessing. The display check additionally adopts the journal guard that avoids publishing an entry that is about to expire within the next interval, and the expiration check adopts the forward interval window. Review-date notifications remain windowed so they are not re-sent on every poll. A regression test, testCheckObjectEntryDisplayDateAfterMissedInterval, back-dates a scheduled entry's display date beyond one interval and asserts the next poll publishes it; the existing expiration test was adjusted for the forward window.

## PR Check

**pr-check: PASS** — tested on `c6363b37e5a2525c23d09d35f55d82ffe90008a8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c6363b37e5a2525c23d09d35f55d82ffe90008a8"} -->
