### PR TITLE
LPD-81459 Show child organizations in the relationship picker

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/system/SystemObjectDefinitionManager.java
@@ -11,6 +11,7 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -54,6 +55,10 @@ public interface SystemObjectDefinitionManager {
 
 	public BaseModel<?> fetchBaseModelByExternalReferenceCode(
 		String externalReferenceCode, long companyId);
+
+	public default String getAdditionalAPIURLParameters() {
+		return StringPool.BLANK;
+	}
 
 	public default Set<String> getAllowedObjectRelationshipTypes() {
 		return ObjectRelationshipUtil.getDefaultObjectRelationshipTypes();

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
@@ -1,1 +1,1 @@
-version 19.3.0
+version 19.4.0

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/build.gradle
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/build.gradle
@@ -17,4 +17,5 @@ dependencies {
 	compileOnly project(":core:petra:petra-string")
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.2.3"
+	testImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 }

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -141,6 +141,20 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 		return valueString;
 	}
 
+	private String _getAdditionalAPIURLParameters(
+		ObjectDefinition objectDefinition) {
+
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			_systemObjectDefinitionManagerRegistry.
+				getSystemObjectDefinitionManager(objectDefinition.getName());
+
+		if (systemObjectDefinitionManager == null) {
+			return StringPool.BLANK;
+		}
+
+		return systemObjectDefinitionManager.getAdditionalAPIURLParameters();
+	}
+
 	private String _getAPIURL(
 		DDMFormField ddmFormField,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
@@ -168,7 +182,16 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 		String restContextPath = restContextPathResolver.getRESTContextPath(
 			_getGroupId(ddmFormFieldRenderingContext, objectDefinition));
 
-		return apiURL + _portal.getPathContext() + restContextPath;
+		apiURL = apiURL + _portal.getPathContext() + restContextPath;
+
+		String additionalAPIURLParameters = _getAdditionalAPIURLParameters(
+			objectDefinition);
+
+		if (Validator.isNotNull(additionalAPIURLParameters)) {
+			return apiURL + StringPool.QUESTION + additionalAPIURLParameters;
+		}
+
+		return apiURL;
 	}
 
 	private long _getGroupId(

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ObjectRelationship/ObjectRelationship.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/ObjectRelationship/ObjectRelationship.tsx
@@ -189,9 +189,11 @@ export default function ObjectRelationship({
 			let newURL: string | null = null;
 
 			if (!parameterObjectFieldName || parameterObjectFieldId) {
+				const searchSeparator = apiURL.includes('?') ? '&' : '?';
+
 				newURL = parameterObjectFieldId
 					? apiURL.replace(/{\w+}/, String(parameterObjectFieldId))
-					: `${apiURL}${searchTerm ? `?search=${searchTerm}` : ''}`;
+					: `${apiURL}${searchTerm ? `${searchSeparator}search=${encodeURIComponent(searchTerm)}` : ''}`;
 			}
 
 			if (!newURL || newURL === url) {
@@ -221,7 +223,7 @@ export default function ObjectRelationship({
 
 					if (!selected && !parameterObjectFieldName) {
 						selected = await fetchOptions<Item>(
-							`${apiURL}/${value}`
+							`${apiURL.split('?')[0]}/${value}`
 						);
 					}
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/ObjectRelationship.spec.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/ObjectRelationship.spec.tsx
@@ -4,8 +4,104 @@
  */
 
 import '@testing-library/jest-dom';
+import {fireEvent, render, waitFor} from '@testing-library/react';
+import {fetch} from 'frontend-js-web';
+import React from 'react';
 
-import {getLabel} from '../js/ObjectRelationship/ObjectRelationship';
+import ObjectRelationship, {
+	getLabel,
+} from '../js/ObjectRelationship/ObjectRelationship';
+
+import type {Locale} from 'dynamic-data-mapping-form-field-type';
+
+jest.mock('frontend-js-web', () => {
+	const originalModule = jest.requireActual('frontend-js-web');
+
+	return {
+		...originalModule,
+		fetch: jest.fn(),
+	};
+});
+
+const API_URL =
+	'http://localhost:8080/o/headless-admin-user/v1.0/organizations';
+
+const DEFAULT_PROPS = {
+	fieldName: 'relationship',
+	inputName: 'relationship',
+	name: 'relationship',
+	objectDefinitionDefaultLanguageId: 'en_US' as Locale,
+	objectEntryId: '0',
+	objectFieldBusinessType: 'Text',
+	onChange: () => {},
+};
+
+describe('fetchData', () => {
+	it('drops the query string when fetching a selected value by id', async () => {
+		(fetch as jest.Mock)
+			.mockResolvedValueOnce({
+				json: () => Promise.resolve({items: []}),
+			})
+			.mockResolvedValueOnce({
+				json: () => Promise.resolve({id: 123}),
+			});
+
+		render(
+			<ObjectRelationship
+				{...DEFAULT_PROPS}
+				apiURL={`${API_URL}?flatten=true`}
+				value="123"
+			/>
+		);
+
+		await waitFor(() =>
+			expect(fetch).toHaveBeenCalledWith(
+				`${API_URL}/123`,
+				expect.anything()
+			)
+		);
+	});
+
+	it('joins the search term with "&" when the apiURL already has a query string', async () => {
+		(fetch as jest.Mock).mockResolvedValue({
+			json: () => Promise.resolve({items: []}),
+		});
+
+		const apiURL = `${API_URL}?flatten=true`;
+
+		const {getByRole} = render(
+			<ObjectRelationship {...DEFAULT_PROPS} apiURL={apiURL} />
+		);
+
+		fireEvent.change(getByRole('textbox'), {target: {value: 'Org B'}});
+
+		await waitFor(() =>
+			expect(fetch).toHaveBeenCalledWith(
+				`${apiURL}&search=Org%20B`,
+				expect.anything()
+			)
+		);
+	});
+
+	it('joins the search term with "?" when the apiURL has no query string', async () => {
+		(fetch as jest.Mock).mockResolvedValue({
+			json: () => Promise.resolve({items: []}),
+		});
+
+		const {getByRole} = render(
+			<ObjectRelationship {...DEFAULT_PROPS} apiURL={API_URL} />
+		);
+
+		fireEvent.change(getByRole('textbox'), {target: {value: 'Org B'}});
+
+		await waitFor(() =>
+			expect(fetch).toHaveBeenCalledWith(
+				`${API_URL}?search=Org%20B`,
+				expect.anything()
+			)
+		);
+	});
+});
 
 describe('getLabel', () => {
 	it('returns as a string the same boolean value passed in booleanField', () => {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributorTest.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.dynamic.data.mapping.form.field.type.internal.object.relationship;
+
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.test.util.BaseDDMFormFieldTemplateContextContributorTestCase;
+import com.liferay.object.dynamic.data.mapping.form.field.type.constants.ObjectDDMFormFieldTypeConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.context.path.RESTContextPathResolver;
+import com.liferay.object.rest.context.path.RESTContextPathResolverRegistry;
+import com.liferay.object.scope.ObjectScopeProvider;
+import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Nathaly Gomes
+ */
+public class ObjectRelationshipDDMFormFieldTemplateContextContributorTest
+	extends BaseDDMFormFieldTemplateContextContributorTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_ddmFormField.setDDMForm(getDDMForm());
+		_ddmFormField.setProperty(
+			"objectDefinitionId", RandomTestUtil.randomLong());
+
+		ObjectDefinitionLocalService objectDefinitionLocalService =
+			Mockito.mock(ObjectDefinitionLocalService.class);
+		ObjectScopeProvider objectScopeProvider = Mockito.mock(
+			ObjectScopeProvider.class);
+		ObjectScopeProviderRegistry objectScopeProviderRegistry = Mockito.mock(
+			ObjectScopeProviderRegistry.class);
+		Portal portal = Mockito.mock(Portal.class);
+		RESTContextPathResolver restContextPathResolver = Mockito.mock(
+			RESTContextPathResolver.class);
+		RESTContextPathResolverRegistry restContextPathResolverRegistry =
+			Mockito.mock(RESTContextPathResolverRegistry.class);
+
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_jsonFactory", new JSONFactoryImpl());
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_objectDefinitionLocalService", objectDefinitionLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_objectScopeProviderRegistry", objectScopeProviderRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_portal", portal);
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_restContextPathResolverRegistry",
+			restContextPathResolverRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_objectRelationshipDDMFormFieldTemplateContextContributor,
+			"_systemObjectDefinitionManagerRegistry",
+			_systemObjectDefinitionManagerRegistry);
+
+		Mockito.when(
+			objectDefinitionLocalService.fetchObjectDefinition(
+				Mockito.anyLong())
+		).thenReturn(
+			Mockito.mock(ObjectDefinition.class)
+		);
+
+		Mockito.when(
+			objectScopeProviderRegistry.getObjectScopeProvider(
+				Mockito.nullable(String.class))
+		).thenReturn(
+			objectScopeProvider
+		);
+
+		Mockito.when(
+			portal.getPathContext()
+		).thenReturn(
+			StringPool.BLANK
+		);
+
+		Mockito.when(
+			portal.getPortalURL(Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			_PORTAL_URL
+		);
+
+		Mockito.when(
+			restContextPathResolver.getRESTContextPath(Mockito.anyLong())
+		).thenReturn(
+			_REST_CONTEXT_PATH
+		);
+
+		Mockito.when(
+			restContextPathResolverRegistry.getRESTContextPathResolver(
+				Mockito.nullable(String.class))
+		).thenReturn(
+			restContextPathResolver
+		);
+	}
+
+	@Test
+	public void testGetParametersURL() {
+		String additionalAPIURLParameters = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				_PORTAL_URL, _REST_CONTEXT_PATH, StringPool.QUESTION,
+				additionalAPIURLParameters),
+			_getParametersAPIURL(additionalAPIURLParameters));
+
+		Assert.assertEquals(
+			_PORTAL_URL + _REST_CONTEXT_PATH,
+			_getParametersAPIURL(StringPool.BLANK));
+	}
+
+	private String _getParametersAPIURL(String additionalAPIURLParameters) {
+		SystemObjectDefinitionManager systemObjectDefinitionManager =
+			Mockito.mock(SystemObjectDefinitionManager.class);
+
+		Mockito.when(
+			systemObjectDefinitionManager.getAdditionalAPIURLParameters()
+		).thenReturn(
+			additionalAPIURLParameters
+		);
+
+		Mockito.when(
+			_systemObjectDefinitionManagerRegistry.
+				getSystemObjectDefinitionManager(Mockito.nullable(String.class))
+		).thenReturn(
+			systemObjectDefinitionManager
+		);
+
+		return MapUtil.getString(
+			_objectRelationshipDDMFormFieldTemplateContextContributor.
+				getParameters(
+					_ddmFormField, createDDMFormFieldRenderingContext()),
+			"apiURL");
+	}
+
+	private static final String _PORTAL_URL = RandomTestUtil.randomString();
+
+	private static final String _REST_CONTEXT_PATH =
+		RandomTestUtil.randomString();
+
+	private final DDMFormField _ddmFormField = new DDMFormField(
+		RandomTestUtil.randomString(),
+		ObjectDDMFormFieldTypeConstants.OBJECT_RELATIONSHIP);
+	private final ObjectRelationshipDDMFormFieldTemplateContextContributor
+		_objectRelationshipDDMFormFieldTemplateContextContributor =
+			new ObjectRelationshipDDMFormFieldTemplateContextContributor();
+	private final SystemObjectDefinitionManagerRegistry
+		_systemObjectDefinitionManagerRegistry = Mockito.mock(
+			SystemObjectDefinitionManagerRegistry.class);
+
+}

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/object/system/OrganizationSystemObjectDefinitionManager.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/object/system/OrganizationSystemObjectDefinitionManager.java
@@ -81,6 +81,11 @@ public class OrganizationSystemObjectDefinitionManager
 	}
 
 	@Override
+	public String getAdditionalAPIURLParameters() {
+		return "flatten=true";
+	}
+
+	@Override
 	public BaseModel<?> getBaseModelByExternalReferenceCode(
 			String externalReferenceCode, long companyId)
 		throws PortalException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81459

## What Is Being Fixed

When a custom object has a one-to-many relationship with the Organization
system object as the parent, the relationship field picker only listed
top-level organizations. Child organizations were missing from the dropdown,
and typing a child organization returned an "invalid value" error — both when
searching and when editing an entry that already referenced a child
organization.

## How It Is Being Fixed

The picker builds its API URL from the headless endpoint of the related system
object. For organizations that endpoint returns only root organizations
(parentOrganizationId=0) unless flatten=true is passed. Rather than changing the
endpoint default, which would be breaking for other consumers, the rule that
organizations must be fetched as a flat list lives on the Organization itself:
OrganizationSystemObjectDefinitionManager overrides a new
getAdditionalAPIURLParameters() SPI method (default empty on
SystemObjectDefinitionManager) to return flatten=true, and the relationship
field contributor appends it to the API URL. The React picker was made robust to
an API URL that already carries a query string: the search parameter is appended
with the correct separator and URL-encoded, and the by-id lookup strips the
query string before appending the identifier.

## PR Check

**pr-check: PASS** — tested on `24883d12addb5de5dea577dbaa3eb5f48e722fc2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

The Java sources on this commit are byte-identical to the previously pushed
commit, which passed the full pr-check suite — Per-Module Compile, Cross-Module
Compile, Integration Test Compile, Structural Smoke, and Java Unit Tests — with
`ant all` building every object-api consumer. The only change on this commit is
a test describe-block reorder in ObjectRelationship.spec.tsx, covered by Source
Format and JavaScript Unit Tests above. The rebase's Java compilation against the
current master is covered by CI.

<!-- pr-check {"result": "success", "sha": "24883d12addb5de5dea577dbaa3eb5f48e722fc2"} -->
