### PR TITLE
LPD-96173 Stop deleting the current DocumentLibrary file on unload

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -322,7 +322,6 @@ const GuestUploadFile = ({
 };
 
 function useFileLifecycle({
-	currentValue,
 	fileEntryDeleteURL,
 	portletNamespace,
 	readOnly,
@@ -390,15 +389,7 @@ function useFileLifecycle({
 				return;
 			}
 
-			const currentFileEntryId = getFileEntryId(currentValue);
 			const originalFileEntryId = originalFileEntryIdRef.current;
-
-			if (
-				currentFileEntryId &&
-				currentFileEntryId !== originalFileEntryId
-			) {
-				deleteFileEntry(currentFileEntryId, {beacon: true});
-			}
 
 			pendingDeletionsRef.current.forEach((fileEntryId) => {
 				if (fileEntryId !== originalFileEntryId) {
@@ -414,7 +405,7 @@ function useFileLifecycle({
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 			Liferay.detach('beforeNavigate', handleBeforeUnload);
 		};
-	}, [currentValue, deleteFileEntry, readOnly]);
+	}, [deleteFileEntry, readOnly]);
 
 	useEffect(() => {
 		const onSubmit = () => {
@@ -476,7 +467,6 @@ const Main = ({
 	const [progress, setProgress] = useState(0);
 
 	const {stagePendingDeletion} = useFileLifecycle({
-		currentValue,
 		fileEntryDeleteURL,
 		portletNamespace,
 		readOnly,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -587,64 +587,6 @@ describe('Field DocumentLibrary', () => {
 			navigator.sendBeacon = originalSendBeacon;
 		});
 
-		it('cleans up intermediate replacements on unload after multiple replaces in edit mode', () => {
-			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
-
-			renderField({
-				allowGuestUsers: true,
-				value: valueWithFileEntry(42),
-			});
-
-			triggerGuestUpload();
-			completeUpload(88);
-			triggerGuestUpload();
-			completeUpload(99);
-			triggerBeforeUnload();
-
-			expectDeleted(88, 99);
-		});
-
-		it('deletes both the previous and current upload on new-entry abandon after replace', () => {
-			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
-
-			renderField({allowGuestUsers: true, value: '{}'});
-
-			triggerGuestUpload();
-			completeUpload(88);
-			triggerGuestUpload();
-			completeUpload(99);
-			triggerBeforeUnload();
-
-			expectDeleted(88, 99);
-		});
-
-		it('deletes only the replacement on unload when replacing in edit mode', () => {
-			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
-
-			renderField({
-				allowGuestUsers: true,
-				value: valueWithFileEntry(42),
-			});
-
-			triggerGuestUpload();
-			completeUpload(99);
-			triggerBeforeUnload();
-
-			expectDeleted(99);
-		});
-
-		it('deletes the new entry session upload on abandon', () => {
-			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
-
-			renderField({allowGuestUsers: true, value: '{}'});
-
-			triggerGuestUpload();
-			completeUpload(99);
-			triggerBeforeUnload();
-
-			expectDeleted(99);
-		});
-
 		it('deletes the original on Save after Clear', () => {
 			renderField({value: valueWithFileEntry(42)});
 
@@ -677,21 +619,6 @@ describe('Field DocumentLibrary', () => {
 			expectNoDeletes();
 		});
 
-		it('cleans up the orphan on SPA navigation away from a replaced entry', () => {
-			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
-
-			renderField({
-				allowGuestUsers: true,
-				value: valueWithFileEntry(42),
-			});
-
-			triggerGuestUpload();
-			completeUpload(99);
-			triggerBeforeNavigate();
-
-			expectDeleted(99);
-		});
-
 		it('does not delete on unload when read-only (LPP-63922)', () => {
 			renderField({readOnly: true, value: valueWithFileEntry(42)});
 
@@ -718,7 +645,34 @@ describe('Field DocumentLibrary', () => {
 			expectNoDeletes();
 		});
 
-		it('preserves the original on Cancel after Replace and cleans the orphan on unload', () => {
+		it('preserves the current replacement on SPA navigation away from a replaced entry', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeNavigate();
+
+			expectNoDeletes();
+		});
+
+		it('preserves the new entry session upload on abandon', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({allowGuestUsers: true, value: '{}'});
+
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectNoDeletes();
+		});
+
+		it('preserves the original and the current replacement on unload after replace in edit mode', () => {
 			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
 
 			renderField({
@@ -730,7 +684,38 @@ describe('Field DocumentLibrary', () => {
 			completeUpload(99);
 			triggerBeforeUnload();
 
-			expectDeleted(99);
+			expectNoDeletes();
+		});
+
+		it('reclaims intermediate replacements but preserves the current upload on unload in edit mode', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({
+				allowGuestUsers: true,
+				value: valueWithFileEntry(42),
+			});
+
+			triggerGuestUpload();
+			completeUpload(88);
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(88);
+		});
+
+		it('reclaims the superseded upload but preserves the current upload on new-entry abandon after replace', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({allowGuestUsers: true, value: '{}'});
+
+			triggerGuestUpload();
+			completeUpload(88);
+			triggerGuestUpload();
+			completeUpload(99);
+			triggerBeforeUnload();
+
+			expectDeleted(88);
 		});
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96173

## What Is Being Fixed

A guest's uploaded file is intermittently lost on form submit (the entry shows "Content is temporarily unavailable"). The DocumentLibrary field's unload handler beacons a delete of its current value during the submit navigation, and the server deletes the guest-owned file before the record persists, so the saved record points at a missing file. The issue is intermittent and not reproducible locally; it was diagnosed from the customer logs (`validate_csrf_token → delete_file_entry → add_form_instance_record`). This is the guest variant of LPP-63917 / LPP-63922 (report: LPP-64542).

## How It Is Being Fixed

Remove the unload branch that deleted the field's current value. Its only guard was a fragile in-memory flag that does not survive a remount, and a page unload can be the submission itself. The submitted file is now preserved by construction; only explicitly superseded uploads (replace or clear) are still reclaimed on unload. An abandoned upload is left as a recoverable orphan rather than risk deleting a submission.

## Why Are There No Tests?

The fix removes code already covered by the DocumentLibrary lifecycle Jest suite; those tests were updated to assert the corrected contract (the current upload is preserved on both `beforeunload` and SPA `beforeNavigate`). A new test would duplicate the existing "preserves the new entry session upload on abandon" case.

## PR Check

**pr-check: PASS** — tested on `28634acb3ccf28302551bd9cb12c79245524180f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "28634acb3ccf28302551bd9cb12c79245524180f"} -->
