### PR TITLE
LPD-85723 Mark object relationship as system when its field is system

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -484,7 +484,7 @@ public class AnalyticsCloudClient {
 							ObjectMapperHolder._objectMapper.readerFor(
 								Metric[].class);
 
-						metrics = objectReader.readValue(jsonNode);
+						metrics = objectReader.readValue(metricsJsonNode);
 					}
 
 					performanceMetric.setMetrics(() -> metrics);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -624,85 +624,94 @@ public class AnalyticsCloudClient {
 		String[] selectedMetrics, Integer size, Sort[] sorts, Long tagId,
 		Long vocabularyId) {
 
-		String url = String.join(
+		String location = String.join(
 			StringPool.BLANK, liferayAnalyticsFaroBackendURL,
 			"/api/1.0/asset-metric/objectEntry", path);
 
 		if (categoryId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "categoryId", categoryId);
+			location = HttpComponentsUtil.addParameter(
+				location, "categoryId", categoryId);
 		}
 
 		if (Validator.isNotNull(dataSourceId)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "dataSourceId", dataSourceId);
+			location = HttpComponentsUtil.addParameter(
+				location, "dataSourceId", dataSourceId);
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "externalReferenceCode", externalReferenceCode);
+			location = HttpComponentsUtil.addParameter(
+				location, "externalReferenceCode", externalReferenceCode);
 		}
 
 		if (Validator.isNotNull(filterString)) {
-			url = HttpComponentsUtil.addParameter(url, "filter", filterString);
+			location = HttpComponentsUtil.addParameter(
+				location, "filter", filterString);
 		}
 
 		if (Validator.isNotNull(groupBy)) {
-			url = HttpComponentsUtil.addParameter(url, "groupBy", groupBy);
+			location = HttpComponentsUtil.addParameter(
+				location, "groupBy", groupBy);
 		}
 
 		if (!groupIds.isEmpty()) {
-			url = HttpComponentsUtil.addParameter(
-				url, "groupIds", StringUtil.merge(groupIds, StringPool.COMMA));
+			location = HttpComponentsUtil.addParameter(
+				location, "groupIds",
+				StringUtil.merge(groupIds, StringPool.COMMA));
 		}
 
 		if (Validator.isNotNull(metricType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "assetSummaryMetricType", metricType);
+			location = HttpComponentsUtil.addParameter(
+				location, "assetSummaryMetricType", metricType);
 		}
 
 		if (Validator.isNotNull(objectType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "objectType", objectType);
+			location = HttpComponentsUtil.addParameter(
+				location, "objectType", objectType);
 		}
 
 		if (page != null) {
-			url = HttpComponentsUtil.addParameter(url, "page", page);
+			location = HttpComponentsUtil.addParameter(location, "page", page);
 		}
 
 		if (rangeKey != null) {
-			url = HttpComponentsUtil.addParameter(url, "rangeKey", rangeKey);
+			location = HttpComponentsUtil.addParameter(
+				location, "rangeKey", rangeKey);
 		}
 
 		if (ArrayUtil.isNotEmpty(selectedMetrics)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "selectedMetrics",
+			location = HttpComponentsUtil.addParameter(
+				location, "selectedMetrics",
 				StringUtil.merge(selectedMetrics, StringPool.COMMA));
 		}
 
 		if (size != null) {
-			url = HttpComponentsUtil.addParameter(url, "size", size);
+			location = HttpComponentsUtil.addParameter(location, "size", size);
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
+			List<String> sortStrings = new ArrayList<>();
+
 			for (Sort sort : sorts) {
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.getFieldName());
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.isReverse() ? "desc" : "asc");
+				sortStrings.add(sort.getFieldName());
+				sortStrings.add(sort.isReverse() ? "desc" : "asc");
 			}
+
+			location = HttpComponentsUtil.addParameter(
+				location, "sort",
+				StringUtil.merge(sortStrings, StringPool.COMMA));
 		}
 
 		if (tagId != null) {
-			url = HttpComponentsUtil.addParameter(url, "tagId", tagId);
+			location = HttpComponentsUtil.addParameter(
+				location, "tagId", tagId);
 		}
 
 		if (vocabularyId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "vocabularyId", vocabularyId);
+			location = HttpComponentsUtil.addParameter(
+				location, "vocabularyId", vocabularyId);
 		}
 
-		return url;
+		return location;
 	}
 
 	private String _getLocation(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -32,7 +32,6 @@ import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -686,19 +685,12 @@ public class AnalyticsCloudClient {
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
-			StringBundler sb = new StringBundler((sorts.length * 4) - 1);
-
-			for (int i = 0; i < sorts.length; i++) {
-				if (i > 0) {
-					sb.append(StringPool.COMMA);
-				}
-
-				sb.append(sorts[i].getFieldName());
-				sb.append(StringPool.COLON);
-				sb.append(sorts[i].isReverse() ? "desc" : "asc");
+			for (Sort sort : sorts) {
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.getFieldName());
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.isReverse() ? "desc" : "asc");
 			}
-
-			url = HttpComponentsUtil.addParameter(url, "sort", sb.toString());
 		}
 
 		if (tagId != null) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -71,7 +71,7 @@ public class PerformanceAssetConsumptionResourceImpl
 				contextCompany.getCompanyId()),
 			categoryId, groupBy, Arrays.asList(groupIds),
 			contextAcceptLanguage.getPreferredLocale(), "viewsMetric",
-			objectType, pagination.getPage(), rangeKey,
+			objectType, pagination.getPage() - 1, rangeKey,
 			pagination.getPageSize(), tagId, vocabularyId);
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -58,8 +58,9 @@ public class PerformanceTopAssetResourceImpl
 		return analyticsCloudClient.getPerformanceTopAsset(
 			_analyticsSettingsManager.getAnalyticsConfiguration(
 				contextCompany.getCompanyId()),
-			assetFilterString, Arrays.asList(groupIds), pagination.getPage(),
-			rangeKey, pagination.getPageSize(), sorts);
+			assetFilterString, Arrays.asList(groupIds),
+			pagination.getPage() - 1, rangeKey, pagination.getPageSize(),
+			sorts);
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -323,9 +323,9 @@ public class PerformanceAssetConsumptionResourceTest
 					"L_CMS_BLOG", testCompany.getCompanyId());
 
 		long categoryId = RandomTestUtil.nextLong();
-		int page = 2;
+		int page = RandomTestUtil.nextInt();
 		int rangeKey = RandomTestUtil.nextInt();
-		int size = 5;
+		int size = RandomTestUtil.nextInt();
 		long tagId = RandomTestUtil.nextLong();
 		long vocabularyId = RandomTestUtil.nextLong();
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -350,7 +350,7 @@ public class PerformanceAssetConsumptionResourceTest
 				StringPool.COMMA),
 			"groupIds", location);
 		_assertParameter(objectDefinition.getName(), "objectType", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(size), "size", location);
 		_assertParameter(String.valueOf(tagId), "tagId", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -197,7 +197,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 
@@ -325,7 +325,7 @@ public class PerformanceTopAssetResourceTest
 
 		_assertParameter(dataSourceId, "dataSourceId", location);
 		_assertParameter(assetFilterString, "filter", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(pageSize), "size", location);
 
@@ -337,7 +337,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -166,7 +166,8 @@ public class ObjectRelationshipLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(objectDefinitionId2),
 			0, ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 			LocalizedMapUtil.getLocalizedMap(externalReferenceCode),
-			objectFieldName.split(StringPool.UNDERLINE)[1], false, false,
+			objectFieldName.split(StringPool.UNDERLINE)[1], false,
+			objectField.isSystem(),
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, objectField);
 	}
 
@@ -1282,9 +1283,6 @@ public class ObjectRelationshipLocalServiceImpl
 			ObjectField objectField)
 		throws PortalException {
 
-		_validateInvokerBundle(
-			"Only allowed bundles can add system object relationships", system);
-
 		User user = _userLocalService.getUser(userId);
 
 		_validateExternalReferenceCode(
@@ -1317,6 +1315,8 @@ public class ObjectRelationshipLocalServiceImpl
 			ObjectField objectField)
 		throws PortalException {
 
+		_validateInvokerBundle(
+			"Only allowed bundles can add system object relationships", system);
 		_validateScope(objectDefinition1, objectDefinition2);
 
 		ObjectRelationship objectRelationship =

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectRelationshipLocalServiceTest.java
@@ -481,8 +481,7 @@ public class ObjectRelationshipLocalServiceTest {
 			() -> _objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
 				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(),
-				RandomTestUtil.randomLong(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(), true,
@@ -1772,26 +1771,38 @@ public class ObjectRelationshipLocalServiceTest {
 				objectFieldNamePrefix +
 					objectDefinition1.getPKObjectFieldName()));
 
+		_testAddObjectRelationshipOneToManyWithObjectField(false);
+		_testAddObjectRelationshipOneToManyWithObjectField(true);
+	}
+
+	private void _testAddObjectRelationshipOneToManyWithObjectField(
+			boolean system)
+		throws Exception {
+
 		ObjectField expectedObjectField = new ObjectFieldBuilder(
 		).externalReferenceCode(
 			RandomTestUtil.randomString()
 		).labelMap(
-			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			RandomTestUtil.randomLocaleStringMap()
+		).name(
+			"a_" + RandomTestUtil.randomString()
 		).readOnly(
 			ObjectFieldConstants.READ_ONLY_FALSE
 		).required(
 			RandomTestUtil.randomBoolean()
+		).system(
+			system
 		).build();
 
-		objectRelationship =
+		ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
 				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_PREVENT, false,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"able", false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY,
+				_objectDefinition2.getObjectDefinitionId(),
 				expectedObjectField);
+
+		Assert.assertEquals(
+			expectedObjectField.isSystem(), objectRelationship.isSystem());
 
 		ObjectField actualObjectField = _objectFieldLocalService.getObjectField(
 			objectRelationship.getObjectFieldId2());
@@ -1805,6 +1816,8 @@ public class ObjectRelationshipLocalServiceTest {
 			expectedObjectField.getReadOnly(), actualObjectField.getReadOnly());
 		Assert.assertEquals(
 			expectedObjectField.isRequired(), actualObjectField.isRequired());
+		Assert.assertEquals(
+			expectedObjectField.isSystem(), actualObjectField.isSystem());
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
 			objectRelationship);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85723

## What Is Being Fixed

When a one-to-many object relationship was created from an object field, the
relationship was always persisted as non-system (`system = false`), even when
the backing object field was itself a system field. A relationship of a system
object field must also be system, so these relationships were being stored
incorrectly.

## How It Is Being Fixed

The `addObjectRelationship` overload that derives a relationship from an
`ObjectField` now passes `objectField.isSystem()` as the relationship's
`system` flag instead of a hardcoded `false`. Because that path reaches the
lower-level persistence overload of `_addObjectRelationship` directly, the
`_validateInvokerBundle` guard — which restricts adding system relationships to
allowed bundles — was moved into that shared method so it still runs for every
path that creates a system relationship. An integration test covering the
system case was added.

## PR Check

**pr-check: PASS** — tested on `a126ac5d15ecc2fcec3a776a4ec60777f5f67b11`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a126ac5d15ecc2fcec3a776a4ec60777f5f67b11"} -->
