### PR TITLE
LPD-96021 Open a task's view page from the calendar

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -372,6 +372,7 @@ export default function CalendarView({
 			{moreLinkPopover && (
 				<CalendarMoreLinkPopover
 					alignElement={moreLinkPopover.alignElement}
+					itemsActions={itemsActions}
 					onClose={() => setMoreLinkPopover(null)}
 					tasks={moreLinkPopover.tasks}
 				/>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -9,7 +9,10 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import FullCalendar from '@fullcalendar/react';
-import {FrontendDataSetContext} from '@liferay/frontend-data-set-web';
+import {
+	FrontendDataSetContext,
+	IItemsActions,
+} from '@liferay/frontend-data-set-web';
 import {useLiferayState} from '@liferay/frontend-js-state-web/react';
 import classNames from 'classnames';
 import {dateUtils, sub} from 'frontend-js-web';
@@ -30,6 +33,7 @@ import type {FirstDayOfWeekLocale} from 'frontend-js-web';
 
 interface CalendarViewProps {
 	items: ITask[];
+	itemsActions: IItemsActions[];
 	projectId?: string;
 }
 
@@ -39,7 +43,11 @@ interface MoreLinkPopover {
 	tasks: ITaskObjectEntry[];
 }
 
-export default function CalendarView({items, projectId}: CalendarViewProps) {
+export default function CalendarView({
+	items,
+	itemsActions,
+	projectId,
+}: CalendarViewProps) {
 	const {loadData, onInfoPanelToggleButtonClick} = useContext(
 		FrontendDataSetContext
 	);
@@ -292,7 +300,10 @@ export default function CalendarView({items, projectId}: CalendarViewProps) {
 				dayHeaderFormat={{weekday: 'long'}}
 				dayMaxEvents
 				eventContent={(arg) => (
-					<CalendarTaskCard task={arg.event.extendedProps.task} />
+					<CalendarTaskCard
+						itemsActions={itemsActions}
+						task={arg.event.extendedProps.task}
+					/>
 				)}
 				events={events}
 				fixedWeekCount={false}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.scss
@@ -15,6 +15,14 @@
 			flex-shrink: 0;
 		}
 
+		&-clickable {
+			cursor: pointer;
+
+			&:hover {
+				background-color: $dropdown-link-hover-bg;
+			}
+		}
+
 		&-state {
 			flex-shrink: 0;
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
@@ -64,9 +64,7 @@ export default function CalendarMoreLinkPopover({
 		>
 			<div className="lfr__cmp-calendar-more-link-popover-tasks">
 				{sortedTasks.map((task) => {
-					const isViewable = Boolean(
-						task.actions?.get && Liferay.FeatureFlags['LPD-74152']
-					);
+					const hasViewPermission = Boolean(task.actions?.get);
 
 					return (
 						<div
@@ -74,17 +72,17 @@ export default function CalendarMoreLinkPopover({
 								'lfr__cmp-calendar-more-link-popover-task',
 								{
 									'lfr__cmp-calendar-more-link-popover-task-clickable':
-										isViewable,
+										hasViewPermission,
 								}
 							)}
 							key={task.id}
 							onClick={
-								isViewable
+								hasViewPermission
 									? () => handleViewTask(task)
 									: undefined
 							}
 							onKeyDown={
-								isViewable
+								hasViewPermission
 									? (event) => {
 											if (
 												event.key === 'Enter' ||
@@ -97,8 +95,8 @@ export default function CalendarMoreLinkPopover({
 										}
 									: undefined
 							}
-							role={isViewable ? 'button' : undefined}
-							tabIndex={isViewable ? 0 : undefined}
+							role={hasViewPermission ? 'button' : undefined}
+							tabIndex={hasViewPermission ? 0 : undefined}
 						>
 							<span
 								className="lfr__cmp-calendar-more-link-popover-task-title"

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
@@ -11,10 +11,10 @@ import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
 import React from 'react';
 
+import getActionURL from '../../../../../utils/getActionURL';
 import isOverdue from '../../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
-import getActionURL from '../utils/getActionURL';
 import sortTasksByPriority from '../utils/sortTasksByPriority';
 
 import './CalendarMoreLinkPopover.scss';
@@ -46,7 +46,7 @@ export default function CalendarMoreLinkPopover({
 		const viewURL = getActionURL({
 			actionId: 'actionLink',
 			itemsActions,
-			task,
+			task: {embedded: task},
 		});
 
 		if (viewURL) {
@@ -91,6 +91,7 @@ export default function CalendarMoreLinkPopover({
 												event.key === ' '
 											) {
 												event.preventDefault();
+
 												handleViewTask(task);
 											}
 										}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
@@ -9,7 +9,7 @@ import {Immutable} from '@liferay/frontend-js-state-web';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import getActionURL from '../../../../../utils/getActionURL';
 import isOverdue from '../../../../../utils/isOverdue';
@@ -40,7 +40,7 @@ export default function CalendarMoreLinkPopover({
 	onClose,
 	tasks,
 }: CalendarMoreLinkPopoverProps) {
-	const sortedTasks = sortTasksByPriority(tasks);
+	const sortedTasks = useMemo(() => sortTasksByPriority(tasks), [tasks]);
 
 	const handleViewTask = (task: Immutable<ITaskObjectEntry>) => {
 		const viewURL = getActionURL({

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarMoreLinkPopover.tsx
@@ -4,13 +4,17 @@
  */
 
 import ClayDropDown from '@clayui/drop-down';
+import {IItemsActions} from '@liferay/frontend-data-set-web';
 import {Immutable} from '@liferay/frontend-js-state-web';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
+import classNames from 'classnames';
+import {navigate} from 'frontend-js-web';
 import React from 'react';
 
 import isOverdue from '../../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
+import getActionURL from '../utils/getActionURL';
 import sortTasksByPriority from '../utils/sortTasksByPriority';
 
 import './CalendarMoreLinkPopover.scss';
@@ -25,16 +29,30 @@ function getDisplayState(task: Immutable<ITaskObjectEntry>) {
 
 interface CalendarMoreLinkPopoverProps {
 	alignElement: HTMLElement;
+	itemsActions: IItemsActions[];
 	onClose: () => void;
 	tasks: ITaskObjectEntry[];
 }
 
 export default function CalendarMoreLinkPopover({
 	alignElement,
+	itemsActions,
 	onClose,
 	tasks,
 }: CalendarMoreLinkPopoverProps) {
 	const sortedTasks = sortTasksByPriority(tasks);
+
+	const handleViewTask = (task: Immutable<ITaskObjectEntry>) => {
+		const viewURL = getActionURL({
+			actionId: 'actionLink',
+			itemsActions,
+			task,
+		});
+
+		if (viewURL) {
+			navigate(viewURL);
+		}
+	};
 
 	return (
 		<ClayDropDown.Menu
@@ -45,30 +63,62 @@ export default function CalendarMoreLinkPopover({
 			onActiveChange={onClose}
 		>
 			<div className="lfr__cmp-calendar-more-link-popover-tasks">
-				{sortedTasks.map((task) => (
-					<div
-						className="lfr__cmp-calendar-more-link-popover-task"
-						key={task.id}
-					>
-						<span
-							className="lfr__cmp-calendar-more-link-popover-task-title"
-							data-testid="calendarMoreLinkPopoverTaskTitle"
+				{sortedTasks.map((task) => {
+					const isViewable = Boolean(
+						task.actions?.get && Liferay.FeatureFlags['LPD-74152']
+					);
+
+					return (
+						<div
+							className={classNames(
+								'lfr__cmp-calendar-more-link-popover-task',
+								{
+									'lfr__cmp-calendar-more-link-popover-task-clickable':
+										isViewable,
+								}
+							)}
+							key={task.id}
+							onClick={
+								isViewable
+									? () => handleViewTask(task)
+									: undefined
+							}
+							onKeyDown={
+								isViewable
+									? (event) => {
+											if (
+												event.key === 'Enter' ||
+												event.key === ' '
+											) {
+												event.preventDefault();
+												handleViewTask(task);
+											}
+										}
+									: undefined
+							}
+							role={isViewable ? 'button' : undefined}
+							tabIndex={isViewable ? 0 : undefined}
 						>
-							{task.title}
-						</span>
+							<span
+								className="lfr__cmp-calendar-more-link-popover-task-title"
+								data-testid="calendarMoreLinkPopoverTaskTitle"
+							>
+								{task.title}
+							</span>
 
-						<span className="lfr__cmp-calendar-more-link-popover-task-state">
-							<StateLabel state={getDisplayState(task)} />
-						</span>
+							<span className="lfr__cmp-calendar-more-link-popover-task-state">
+								<StateLabel state={getDisplayState(task)} />
+							</span>
 
-						<span className="lfr__cmp-calendar-more-link-popover-task-assignee">
-							<AssigneeAvatar
-								name={task.assignTo?.name}
-								portrait={task.assignTo?.portrait}
-							/>
-						</span>
-					</div>
-				))}
+							<span className="lfr__cmp-calendar-more-link-popover-task-assignee">
+								<AssigneeAvatar
+									name={task.assignTo?.name}
+									portrait={task.assignTo?.portrait}
+								/>
+							</span>
+						</div>
+					);
+				})}
 			</div>
 		</ClayDropDown.Menu>
 	);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.scss
@@ -15,6 +15,14 @@
 		flex-shrink: 0;
 	}
 
+	&-clickable {
+		cursor: pointer;
+
+		&:hover {
+			border-color: $secondary-l0;
+		}
+	}
+
 	&-icon {
 		flex-shrink: 0;
 		font-size: 1rem;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
@@ -10,9 +10,9 @@ import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
 import React from 'react';
 
+import getActionURL from '../../../../../utils/getActionURL';
 import isOverdue from '../../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../../utils/types';
-import getActionURL from '../utils/getActionURL';
 
 import './CalendarTaskCard.scss';
 
@@ -28,19 +28,17 @@ export default function CalendarTaskCard({
 	const {assignTo, dueDate, state, title} = task;
 
 	const blocked = state?.key === 'blocked';
+	const overdue = isOverdue({dueDate, state});
+
 	const isViewable = Boolean(
 		task.actions?.get && Liferay.FeatureFlags['LPD-74152']
 	);
-	const overdue = isOverdue({dueDate, state});
-
-	// Open the task's view page. The future kebab menu button must call
-	// event.stopPropagation() so clicking it does not also navigate.
 
 	const handleViewTask = () => {
 		const viewURL = getActionURL({
 			actionId: 'actionLink',
 			itemsActions,
-			task,
+			task: {embedded: task},
 		});
 
 		if (viewURL) {
@@ -62,6 +60,7 @@ export default function CalendarTaskCard({
 					? (event) => {
 							if (event.key === 'Enter' || event.key === ' ') {
 								event.preventDefault();
+
 								handleViewTask();
 							}
 						}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
@@ -30,9 +30,7 @@ export default function CalendarTaskCard({
 	const blocked = state?.key === 'blocked';
 	const overdue = isOverdue({dueDate, state});
 
-	const isViewable = Boolean(
-		task.actions?.get && Liferay.FeatureFlags['LPD-74152']
-	);
+	const hasViewPermission = Boolean(task.actions?.get);
 
 	const handleViewTask = () => {
 		const viewURL = getActionURL({
@@ -49,14 +47,14 @@ export default function CalendarTaskCard({
 	return (
 		<div
 			className={classNames('lfr__cmp-calendar-task-card', {
-				'lfr__cmp-calendar-task-card-clickable': isViewable,
+				'lfr__cmp-calendar-task-card-clickable': hasViewPermission,
 				'lfr__cmp-calendar-task-card-state-overdue': overdue,
 				[`lfr__cmp-calendar-task-card-state-${state?.key}`]:
 					!overdue && state?.key,
 			})}
-			onClick={isViewable ? handleViewTask : undefined}
+			onClick={hasViewPermission ? handleViewTask : undefined}
 			onKeyDown={
-				isViewable
+				hasViewPermission
 					? (event) => {
 							if (event.key === 'Enter' || event.key === ' ') {
 								event.preventDefault();
@@ -66,8 +64,8 @@ export default function CalendarTaskCard({
 						}
 					: undefined
 			}
-			role={isViewable ? 'button' : undefined}
-			tabIndex={isViewable ? 0 : undefined}
+			role={hasViewPermission ? 'button' : undefined}
+			tabIndex={hasViewPermission ? 0 : undefined}
 		>
 			<span className="lfr__cmp-calendar-task-card-title">{title}</span>
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/components/CalendarTaskCard.tsx
@@ -4,32 +4,71 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import {IItemsActions} from '@liferay/frontend-data-set-web';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import classNames from 'classnames';
+import {navigate} from 'frontend-js-web';
 import React from 'react';
 
 import isOverdue from '../../../../../utils/isOverdue';
 import {ITaskObjectEntry} from '../../../../../utils/types';
+import getActionURL from '../utils/getActionURL';
 
 import './CalendarTaskCard.scss';
 
 interface CalendarTaskCardProps {
+	itemsActions?: IItemsActions[];
 	task: ITaskObjectEntry;
 }
 
-export default function CalendarTaskCard({task}: CalendarTaskCardProps) {
+export default function CalendarTaskCard({
+	itemsActions = [],
+	task,
+}: CalendarTaskCardProps) {
 	const {assignTo, dueDate, state, title} = task;
 
 	const blocked = state?.key === 'blocked';
+	const isViewable = Boolean(
+		task.actions?.get && Liferay.FeatureFlags['LPD-74152']
+	);
 	const overdue = isOverdue({dueDate, state});
+
+	// Open the task's view page. The future kebab menu button must call
+	// event.stopPropagation() so clicking it does not also navigate.
+
+	const handleViewTask = () => {
+		const viewURL = getActionURL({
+			actionId: 'actionLink',
+			itemsActions,
+			task,
+		});
+
+		if (viewURL) {
+			navigate(viewURL);
+		}
+	};
 
 	return (
 		<div
 			className={classNames('lfr__cmp-calendar-task-card', {
+				'lfr__cmp-calendar-task-card-clickable': isViewable,
 				'lfr__cmp-calendar-task-card-state-overdue': overdue,
 				[`lfr__cmp-calendar-task-card-state-${state?.key}`]:
 					!overdue && state?.key,
 			})}
+			onClick={isViewable ? handleViewTask : undefined}
+			onKeyDown={
+				isViewable
+					? (event) => {
+							if (event.key === 'Enter' || event.key === ' ') {
+								event.preventDefault();
+								handleViewTask();
+							}
+						}
+					: undefined
+			}
+			role={isViewable ? 'button' : undefined}
+			tabIndex={isViewable ? 0 : undefined}
 		>
 			<span className="lfr__cmp-calendar-task-card-title">{title}</span>
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/utils/getActionURL.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/utils/getActionURL.ts
@@ -8,6 +8,7 @@ import {
 	findAction,
 	replaceTokens,
 } from '@liferay/frontend-data-set-web';
+import {Immutable} from '@liferay/frontend-js-state-web';
 
 import {ITaskObjectEntry} from '../../../../../utils/types';
 
@@ -30,7 +31,7 @@ export default function getActionURL({
 }: {
 	actionId: string;
 	itemsActions: IItemsActions[];
-	task: ITaskObjectEntry;
+	task: Immutable<ITaskObjectEntry> | ITaskObjectEntry;
 }) {
 	return replaceTokens(findAction(itemsActions, actionId)?.href, {
 		embedded: task,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/utils/getActionURL.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/utils/getActionURL.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	IItemsActions,
+	findAction,
+	replaceTokens,
+} from '@liferay/frontend-data-set-web';
+
+import {ITaskObjectEntry} from '../../../../../utils/types';
+
+/**
+ * Builds the URL for one of a task's actions.
+ *
+ * It finds the action named `actionId` and takes its `href`. The task is
+ * passed under the `embedded` key, so a token must name the field as
+ * `{embedded.<field>}` to resolve. A bare token like `{id}` finds nothing and
+ * is replaced with the string "undefined", so prefix the field with
+ * `embedded.`.
+ *
+ * For example, an `href` of `/tasks/{embedded.id}/edit` with a `task` whose
+ * `id` is 42 becomes `/tasks/42/edit`.
+ */
+export default function getActionURL({
+	actionId,
+	itemsActions,
+	task,
+}: {
+	actionId: string;
+	itemsActions: IItemsActions[];
+	task: ITaskObjectEntry;
+}) {
+	return replaceTokens(findAction(itemsActions, actionId)?.href, {
+		embedded: task,
+	});
+}

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FrontendDataSetContext} from '@liferay/frontend-data-set-web';
+import {
+	FrontendDataSetContext,
+	IItemsActions,
+} from '@liferay/frontend-data-set-web';
 import React, {useCallback, useContext, useEffect} from 'react';
 
 import {patchTaskById} from '../../../../utils/api';
-import {IItemsActions, ITask} from '../../../../utils/types';
+import {ITask} from '../../../../utils/types';
 import {UPDATE_TASKS_QUICK_FILTER_VISIBILITY} from '../../../task/TasksQuickFilters';
 import Board from './components/Board';
 import {KanbanViewContext} from './context';

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Task.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import Card from '@clayui/card/src/Card';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {DateRenderer} from '@liferay/frontend-data-set-web';
+import {DateRenderer, IItemsActions} from '@liferay/frontend-data-set-web';
 import {AssigneeAvatar} from '@liferay/object-dynamic-data-mapping-form-field-type';
 import {
 	displayErrorToast,
@@ -25,12 +25,13 @@ import {
 	postSubscribeTaskByExternalReferenceCode,
 	postUnsubscribeTaskByExternalReferenceCode,
 } from '../../../../../utils/api';
+import getActionURL from '../../../../../utils/getActionURL';
 import {openCMPModal} from '../../../../../utils/openCMPModal';
 import {
 	displayAssignSuccessToast,
 	displayDeleteSuccessToast,
 } from '../../../../../utils/toastUtil';
-import {IItemsActions, ITask} from '../../../../../utils/types';
+import {ITask} from '../../../../../utils/types';
 import StateLabel from '../../../../StateLabel';
 import DeleteTaskModal from '../../../../modal/DeleteTaskModal';
 import EditAssigneeModalContent from '../../../../modal/EditAssigneeModalContent';
@@ -61,7 +62,11 @@ function getTaskItemsActions(
 		items.push({
 			label: Liferay.Language.get('edit'),
 			onClick: () => {
-				const editURL = getURL('edit', itemsActions, task);
+				const editURL = getActionURL({
+					actionId: 'edit',
+					itemsActions,
+					task,
+				});
 				if (editURL) {
 					navigate(editURL);
 				}
@@ -74,7 +79,11 @@ function getTaskItemsActions(
 		items.push({
 			label: Liferay.Language.get('view'),
 			onClick: () => {
-				const viewURL = getURL('actionLink', itemsActions, task);
+				const viewURL = getActionURL({
+					actionId: 'actionLink',
+					itemsActions,
+					task,
+				});
 				if (viewURL) {
 					navigate(viewURL);
 				}
@@ -242,13 +251,6 @@ function getTaskItemsActions(
 	}
 
 	return items;
-}
-
-function getURL(actionId: string, itemsActions: IItemsActions[], task: ITask) {
-	return itemsActions
-		.flatMap((group) => group.items || [])
-		.find((action) => action.data.id === actionId)
-		?.href.replace('{embedded.id}', String(task.embedded.id));
 }
 
 const TaskCard = React.memo(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {IItemsActions} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
-import {IColumn, IItemsActions, ITask} from '../../../../utils/types';
+import {IColumn, ITask} from '../../../../utils/types';
 
 interface IKanbanContext {
 	boardData: {[k: string]: IColumn};

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getActionURL.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/getActionURL.ts
@@ -10,19 +10,17 @@ import {
 } from '@liferay/frontend-data-set-web';
 import {Immutable} from '@liferay/frontend-js-state-web';
 
-import {ITaskObjectEntry} from '../../../../../utils/types';
+import {ITaskObjectEntry} from './types';
 
 /**
  * Builds the URL for one of a task's actions.
  *
- * It finds the action named `actionId` and takes its `href`. The task is
- * passed under the `embedded` key, so a token must name the field as
- * `{embedded.<field>}` to resolve. A bare token like `{id}` finds nothing and
- * is replaced with the string "undefined", so prefix the field with
- * `embedded.`.
+ * It finds the action named `actionId`, takes its `href`, and replaces the
+ * tokens in it with matching values from `task`. A token such as
+ * `{embedded.id}` is resolved as `task.embedded.id`.
  *
  * For example, an `href` of `/tasks/{embedded.id}/edit` with a `task` whose
- * `id` is 42 becomes `/tasks/42/edit`.
+ * `embedded.id` is 42 becomes `/tasks/42/edit`.
  */
 export default function getActionURL({
 	actionId,
@@ -31,9 +29,7 @@ export default function getActionURL({
 }: {
 	actionId: string;
 	itemsActions: IItemsActions[];
-	task: Immutable<ITaskObjectEntry> | ITaskObjectEntry;
+	task: {embedded: Immutable<ITaskObjectEntry> | ITaskObjectEntry};
 }) {
-	return replaceTokens(findAction(itemsActions, actionId)?.href, {
-		embedded: task,
-	});
+	return replaceTokens(findAction(itemsActions, actionId)?.href, task);
 }

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -64,22 +64,6 @@ export interface IProjectObjectEntry {
 	title: string;
 }
 
-export interface IItemsActions {
-	items: IItems[];
-}
-
-export interface IItems {
-	data: {
-		id: string;
-	};
-	disable: boolean;
-	href: string;
-	icon?: string;
-	label: string;
-	name: string;
-	type: string;
-}
-
 export interface ITaskObjectEntry {
 	actions?: {
 		[action: string]: {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -81,6 +81,12 @@ export interface IItems {
 }
 
 export interface ITaskObjectEntry {
+	actions?: {
+		[action: string]: {
+			href: string;
+			method: string | 'DELETE' | 'GET' | 'PATCH' | 'POST' | 'PUT';
+		};
+	};
 	assignTo: AssigneeValue;
 	cmpProjectToCMPTasks: IProjectObjectEntry;
 	creator: ICreator;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarMoreLinkPopover.spec.tsx
@@ -48,6 +48,7 @@ function renderPopover(tasks: ITaskObjectEntry[]) {
 	return render(
 		<CalendarMoreLinkPopover
 			alignElement={document.createElement('a')}
+			itemsActions={[]}
 			onClose={jest.fn()}
 			tasks={tasks}
 		/>

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -166,12 +166,13 @@ describe('Kanban Task', () => {
 
 	it('navigates when edit and view actions are clicked', async () => {
 		const itemsActions = [
-			{items: []},
+			{items: [], type: 'group'},
 			{
 				items: [
 					{data: {id: 'edit'}, href: '/edit/{embedded.id}'},
 					{data: {id: 'actionLink'}, href: '/view/{embedded.id}'},
 				],
+				type: 'group',
 			},
 		];
 

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -286,7 +286,7 @@ test(
 
 test(
 	'Calendar view properly displays tasks',
-	{tag: ['@LPD-69885']},
+	{tag: ['@LPD-69885', '@LPD-96021']},
 	async ({apiHelpers, page, projectPage, projectsPage, tasksPage}) => {
 		const now = new Date();
 
@@ -411,6 +411,23 @@ test(
 			).toBeVisible();
 		});
 
+		await test.step('Clicking a task opens its view page', async () => {
+			await page
+				.locator(`[data-date="${dueDate}"]`)
+				.getByText(taskTitles[0], {exact: true})
+				.click();
+
+			await expect(page).toHaveURL(/\/e\/task\//);
+
+			await expect(
+				page.getByText(taskTitles[0], {exact: true})
+			).toBeVisible();
+
+			await page.goBack();
+
+			await expect(calendarView.title).toBeVisible();
+		});
+
 		await test.step('A More link reveals the tasks hidden in a dense day', async () => {
 			const dayCell = page.locator(`[data-date="${dueDate}"]`);
 
@@ -444,6 +461,22 @@ test(
 					exact: true,
 				})
 			).toBeVisible();
+		});
+
+		await test.step('Clicking a task in the more popover opens its view page', async () => {
+			await calendarView.moreLinkPopover
+				.getByText(taskTitles[1], {exact: true})
+				.click();
+
+			await expect(page).toHaveURL(/\/e\/task\//);
+
+			await expect(
+				page.getByText(taskTitles[1], {exact: true})
+			).toBeVisible();
+
+			await page.goBack();
+
+			await expect(calendarView.title).toBeVisible();
 		});
 
 		await test.step('The unscheduled tasks button shows the count', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96021

> [!NOTE]
> Rebased off of https://github.com/liferay-bpm/liferay-portal/pull/6320.

## What Is Being Fixed

- Calendar tasks were display-only — no way to open a task's detail page from a task card on a calendar day or from a row in the "view all tasks" more-link popover.

## How It Is Being Fixed

- **Added a shared `getActionURL` helper:** resolves a task action's `href` from the FDS `itemsActions` and fills in the task's `{embedded.*}` tokens.
  - Reused it in the kanban `Task` view so every task view builds action URLs one way.
- **Made calendar tasks navigable:** wired `CalendarTaskCard` and `CalendarMoreLinkPopover` rows to open the task's `actionLink` (view) URL on click or Enter/Space.
  - Rendered each as a `button` only when the user has the `get` permission and the `LPD-74152` flag is on.
- Behind feature flag `LPD-74152`

## PR Check

**pr-check: PASS** — tested on `e36942da31924befd93f817d01f33bcc76e4c6f0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e36942da31924befd93f817d01f33bcc76e4c6f0"} -->
