### PR TITLE
LPD-96123 Publish and expire object entries missed during downtime

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -723,16 +723,16 @@ public class ObjectEntryLocalServiceImpl
 
 		Date date = new Date();
 
-		long checkInterval = _getObjectEntryCheckInterval(companyId);
+		Date previousCheckDate = _companyIdPreviousCheckDate.computeIfAbsent(
+			companyId,
+			key -> new Date(
+				date.getTime() - _getObjectEntryCheckInterval(companyId)));
 
-		_companyIdPreviousCheckDate.computeIfAbsent(
-			companyId, key -> new Date(date.getTime() - checkInterval));
+		_checkObjectEntriesByDisplayDate(companyId, date);
 
-		_checkObjectEntriesByDisplayDate(companyId, date, checkInterval);
+		_checkObjectEntriesByExpirationDate(companyId, date);
 
-		_checkObjectEntriesByExpirationDate(companyId, date, checkInterval);
-
-		_checkObjectEntriesByReviewDate(companyId, date);
+		_checkObjectEntriesByReviewDate(companyId, date, previousCheckDate);
 
 		_companyIdPreviousCheckDate.put(companyId, date);
 	}
@@ -3204,32 +3204,23 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _checkObjectEntriesByDisplayDate(
-			long companyId, Date date, long checkInterval)
+	private void _checkObjectEntriesByDisplayDate(long companyId, Date date)
 		throws PortalException {
-
-		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property displayDateProperty = PropertyFactoryUtil.forName(
-					"displayDate");
-
-				dynamicQuery.add(displayDateProperty.lt(date));
-
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.le("displayDate", date));
 				dynamicQuery.add(
 					RestrictionsFactoryUtil.or(
 						RestrictionsFactoryUtil.isNull("expirationDate"),
-						RestrictionsFactoryUtil.ge(
-							"expirationDate", nextExpirationDate)));
-
-				Property statusProperty = PropertyFactoryUtil.forName("status");
-
+						RestrictionsFactoryUtil.gt("expirationDate", date)));
 				dynamicQuery.add(
-					statusProperty.eq(WorkflowConstants.STATUS_SCHEDULED));
+					RestrictionsFactoryUtil.eq(
+						"status", WorkflowConstants.STATUS_SCHEDULED));
 			});
 		actionableDynamicQuery.setCompanyId(companyId);
 		actionableDynamicQuery.setPerformActionMethod(
@@ -3255,28 +3246,21 @@ public class ObjectEntryLocalServiceImpl
 		actionableDynamicQuery.performActions();
 	}
 
-	private void _checkObjectEntriesByExpirationDate(
-			long companyId, Date date, long checkInterval)
+	private void _checkObjectEntriesByExpirationDate(long companyId, Date date)
 		throws PortalException {
-
-		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property expirationDateProperty = PropertyFactoryUtil.forName(
-					"expirationDate");
-
-				dynamicQuery.add(expirationDateProperty.le(nextExpirationDate));
-
-				Property statusProperty = PropertyFactoryUtil.forName("status");
-
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.le("expirationDate", date));
 				dynamicQuery.add(
 					RestrictionsFactoryUtil.not(
-						statusProperty.in(
-							new int[] {
+						RestrictionsFactoryUtil.in(
+							"status",
+							new Integer[] {
 								WorkflowConstants.STATUS_DRAFT,
 								WorkflowConstants.STATUS_EXPIRED,
 								WorkflowConstants.STATUS_IN_TRASH,
@@ -3306,21 +3290,20 @@ public class ObjectEntryLocalServiceImpl
 		actionableDynamicQuery.performActions();
 	}
 
-	private void _checkObjectEntriesByReviewDate(long companyId, Date date)
+	private void _checkObjectEntriesByReviewDate(
+			long companyId, Date date, Date previousCheckDate)
 		throws PortalException {
-
-		Date previousCheckDate = _companyIdPreviousCheckDate.get(companyId);
 
 		ActionableDynamicQuery actionableDynamicQuery =
 			getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property reviewDateProperty = PropertyFactoryUtil.forName(
-					"reviewDate");
-
-				dynamicQuery.add(reviewDateProperty.ge(previousCheckDate));
-				dynamicQuery.add(reviewDateProperty.le(date));
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.ge(
+						"reviewDate", previousCheckDate));
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.le("reviewDate", date));
 			});
 		actionableDynamicQuery.setCompanyId(companyId);
 		actionableDynamicQuery.setPerformActionMethod(
@@ -3333,11 +3316,15 @@ public class ObjectEntryLocalServiceImpl
 					"notificationMessageKey", "x-has-reached-its-review-date"
 				);
 
-				for (ObjectEntryReviewNotificationContributor contributor :
-						_objectEntryReviewNotificationContributors) {
+				for (ObjectEntryReviewNotificationContributor
+						objectEntryReviewNotificationContributor :
+							_objectEntryReviewNotificationContributors) {
 
-					if (contributor.isApplicable(objectEntry)) {
-						contributor.contribute(objectEntry, payloadJSONObject);
+					if (objectEntryReviewNotificationContributor.isApplicable(
+							objectEntry)) {
+
+						objectEntryReviewNotificationContributor.contribute(
+							objectEntry, payloadJSONObject);
 					}
 				}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -176,10 +176,12 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.DefaultActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -3208,33 +3210,49 @@ public class ObjectEntryLocalServiceImpl
 
 		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.displayDate.lt(date)
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.isNull(
-					).or(
-						ObjectEntryTable.INSTANCE.expirationDate.gte(
-							nextExpirationDate)
-					)
-				).and(
-					ObjectEntryTable.INSTANCE.status.eq(
-						WorkflowConstants.STATUS_SCHEDULED)
-				)
-			));
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			updateStatus(
-				objectEntry.getUserId(), objectEntry,
-				WorkflowConstants.STATUS_APPROVED, new ServiceContext());
-		}
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property displayDateProperty = PropertyFactoryUtil.forName(
+					"displayDate");
+
+				dynamicQuery.add(displayDateProperty.lt(date));
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.or(
+						RestrictionsFactoryUtil.isNull("expirationDate"),
+						RestrictionsFactoryUtil.ge(
+							"expirationDate", nextExpirationDate)));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(
+					statusProperty.eq(WorkflowConstants.STATUS_SCHEDULED));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				try {
+					updateStatus(
+						objectEntry.getUserId(), objectEntry,
+						WorkflowConstants.STATUS_APPROVED,
+						new ServiceContext());
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to publish object entry " +
+								objectEntry.getObjectEntryId(),
+							portalException);
+					}
+				}
+			});
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _checkObjectEntriesByExpirationDate(
@@ -3243,80 +3261,97 @@ public class ObjectEntryLocalServiceImpl
 
 		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.lte(
-						nextExpirationDate)
-				).and(
-					ObjectEntryTable.INSTANCE.status.notIn(
-						new Integer[] {
-							WorkflowConstants.STATUS_DRAFT,
-							WorkflowConstants.STATUS_EXPIRED,
-							WorkflowConstants.STATUS_IN_TRASH,
-							WorkflowConstants.STATUS_PENDING
-						})
-				)
-			));
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			expireObjectEntry(
-				objectEntry.getUserId(), objectEntry.getObjectEntryId(),
-				new ServiceContext());
-		}
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property expirationDateProperty = PropertyFactoryUtil.forName(
+					"expirationDate");
+
+				dynamicQuery.add(expirationDateProperty.le(nextExpirationDate));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.not(
+						statusProperty.in(
+							new int[] {
+								WorkflowConstants.STATUS_DRAFT,
+								WorkflowConstants.STATUS_EXPIRED,
+								WorkflowConstants.STATUS_IN_TRASH,
+								WorkflowConstants.STATUS_PENDING
+							})));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				try {
+					expireObjectEntry(
+						objectEntry.getUserId(), objectEntry.getObjectEntryId(),
+						new ServiceContext());
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to expire object entry " +
+								objectEntry.getObjectEntryId(),
+							portalException);
+					}
+				}
+			});
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _checkObjectEntriesByReviewDate(long companyId, Date date)
 		throws PortalException {
 
-		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
-			DSLQueryFactoryUtil.select(
-				ObjectEntryTable.INSTANCE
-			).from(
-				ObjectEntryTable.INSTANCE
-			).where(
-				ObjectEntryTable.INSTANCE.companyId.eq(
-					companyId
-				).and(
-					ObjectEntryTable.INSTANCE.reviewDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
-				).and(
-					ObjectEntryTable.INSTANCE.reviewDate.lte(date)
-				)
-			));
+		Date previousCheckDate = _companyIdPreviousCheckDate.get(companyId);
 
-		for (ObjectEntry objectEntry : objectEntries) {
-			JSONObject payloadJSONObject = JSONUtil.put(
-				"classPK", objectEntry.getObjectEntryId()
-			).put(
-				"notificationMessageArg", objectEntry.getTitleValue()
-			).put(
-				"notificationMessageKey", "x-has-reached-its-review-date"
-			);
+		ActionableDynamicQuery actionableDynamicQuery =
+			getActionableDynamicQuery();
 
-			for (ObjectEntryReviewNotificationContributor contributor :
-					_objectEntryReviewNotificationContributors) {
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property reviewDateProperty = PropertyFactoryUtil.forName(
+					"reviewDate");
 
-				if (contributor.isApplicable(objectEntry)) {
-					contributor.contribute(objectEntry, payloadJSONObject);
+				dynamicQuery.add(reviewDateProperty.ge(previousCheckDate));
+				dynamicQuery.add(reviewDateProperty.le(date));
+			});
+		actionableDynamicQuery.setCompanyId(companyId);
+		actionableDynamicQuery.setPerformActionMethod(
+			(ObjectEntry objectEntry) -> {
+				JSONObject payloadJSONObject = JSONUtil.put(
+					"classPK", objectEntry.getObjectEntryId()
+				).put(
+					"notificationMessageArg", objectEntry.getTitleValue()
+				).put(
+					"notificationMessageKey", "x-has-reached-its-review-date"
+				);
+
+				for (ObjectEntryReviewNotificationContributor contributor :
+						_objectEntryReviewNotificationContributors) {
+
+					if (contributor.isApplicable(objectEntry)) {
+						contributor.contribute(objectEntry, payloadJSONObject);
+					}
 				}
-			}
 
-			ObjectDefinition objectDefinition =
-				_objectDefinitionPersistence.fetchByPrimaryKey(
-					objectEntry.getObjectDefinitionId());
+				ObjectDefinition objectDefinition =
+					_objectDefinitionPersistence.fetchByPrimaryKey(
+						objectEntry.getObjectDefinitionId());
 
-			_userNotificationEventLocalService.sendUserNotificationEvents(
-				objectEntry.getUserId(), objectDefinition.getPortletId(),
-				UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-				payloadJSONObject);
-		}
+				_userNotificationEventLocalService.sendUserNotificationEvents(
+					objectEntry.getUserId(), objectDefinition.getPortletId(),
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+					payloadJSONObject);
+			});
+
+		actionableDynamicQuery.performActions();
 	}
 
 	private void _contributeValues(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -3308,35 +3308,51 @@ public class ObjectEntryLocalServiceImpl
 		actionableDynamicQuery.setCompanyId(companyId);
 		actionableDynamicQuery.setPerformActionMethod(
 			(ObjectEntry objectEntry) -> {
-				JSONObject payloadJSONObject = JSONUtil.put(
-					"classPK", objectEntry.getObjectEntryId()
-				).put(
-					"notificationMessageArg", objectEntry.getTitleValue()
-				).put(
-					"notificationMessageKey", "x-has-reached-its-review-date"
-				);
+				try {
+					JSONObject payloadJSONObject = JSONUtil.put(
+						"classPK", objectEntry.getObjectEntryId()
+					).put(
+						"notificationMessageArg", objectEntry.getTitleValue()
+					).put(
+						"notificationMessageKey",
+						"x-has-reached-its-review-date"
+					);
 
-				for (ObjectEntryReviewNotificationContributor
-						objectEntryReviewNotificationContributor :
-							_objectEntryReviewNotificationContributors) {
+					for (ObjectEntryReviewNotificationContributor
+							objectEntryReviewNotificationContributor :
+								_objectEntryReviewNotificationContributors) {
 
-					if (objectEntryReviewNotificationContributor.isApplicable(
-							objectEntry)) {
+						if (objectEntryReviewNotificationContributor.
+								isApplicable(objectEntry)) {
 
-						objectEntryReviewNotificationContributor.contribute(
-							objectEntry, payloadJSONObject);
+							objectEntryReviewNotificationContributor.contribute(
+								objectEntry, payloadJSONObject);
+						}
+					}
+
+					ObjectDefinition objectDefinition =
+						_objectDefinitionPersistence.fetchByPrimaryKey(
+							objectEntry.getObjectDefinitionId());
+
+					_userNotificationEventLocalService.
+						sendUserNotificationEvents(
+							objectEntry.getUserId(),
+							objectDefinition.getPortletId(),
+							UserNotificationDeliveryConstants.TYPE_WEBSITE,
+							false, payloadJSONObject);
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Unable to send user notification events for " +
+								"object entry " +
+									objectEntry.getObjectEntryId(),
+							portalException);
 					}
 				}
-
-				ObjectDefinition objectDefinition =
-					_objectDefinitionPersistence.fetchByPrimaryKey(
-						objectEntry.getObjectDefinitionId());
-
-				_userNotificationEventLocalService.sendUserNotificationEvents(
-					objectEntry.getUserId(), objectDefinition.getPortletId(),
-					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-					payloadJSONObject);
 			});
+		actionableDynamicQuery.setTransactionConfig(
+			DefaultActionableDynamicQuery.REQUIRES_NEW_TRANSACTION_CONFIG);
 
 		actionableDynamicQuery.performActions();
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -721,14 +721,14 @@ public class ObjectEntryLocalServiceImpl
 
 		Date date = new Date();
 
+		long checkInterval = _getObjectEntryCheckInterval(companyId);
+
 		_companyIdPreviousCheckDate.computeIfAbsent(
-			companyId,
-			key -> new Date(
-				date.getTime() - _getObjectEntryCheckInterval(companyId)));
+			companyId, key -> new Date(date.getTime() - checkInterval));
 
-		_checkObjectEntriesByDisplayDate(companyId, date);
+		_checkObjectEntriesByDisplayDate(companyId, date, checkInterval);
 
-		_checkObjectEntriesByExpirationDate(companyId, date);
+		_checkObjectEntriesByExpirationDate(companyId, date, checkInterval);
 
 		_checkObjectEntriesByReviewDate(companyId, date);
 
@@ -3202,8 +3202,11 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _checkObjectEntriesByDisplayDate(long companyId, Date date)
+	private void _checkObjectEntriesByDisplayDate(
+			long companyId, Date date, long checkInterval)
 		throws PortalException {
+
+		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -3214,10 +3217,13 @@ public class ObjectEntryLocalServiceImpl
 				ObjectEntryTable.INSTANCE.companyId.eq(
 					companyId
 				).and(
-					ObjectEntryTable.INSTANCE.displayDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
+					ObjectEntryTable.INSTANCE.displayDate.lt(date)
 				).and(
-					ObjectEntryTable.INSTANCE.displayDate.lte(date)
+					ObjectEntryTable.INSTANCE.expirationDate.isNull(
+					).or(
+						ObjectEntryTable.INSTANCE.expirationDate.gte(
+							nextExpirationDate)
+					)
 				).and(
 					ObjectEntryTable.INSTANCE.status.eq(
 						WorkflowConstants.STATUS_SCHEDULED)
@@ -3231,8 +3237,11 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private void _checkObjectEntriesByExpirationDate(long companyId, Date date)
+	private void _checkObjectEntriesByExpirationDate(
+			long companyId, Date date, long checkInterval)
 		throws PortalException {
+
+		Date nextExpirationDate = new Date(date.getTime() + checkInterval);
 
 		List<ObjectEntry> objectEntries = objectEntryPersistence.dslQuery(
 			DSLQueryFactoryUtil.select(
@@ -3243,10 +3252,8 @@ public class ObjectEntryLocalServiceImpl
 				ObjectEntryTable.INSTANCE.companyId.eq(
 					companyId
 				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.gte(
-						_companyIdPreviousCheckDate.get(companyId))
-				).and(
-					ObjectEntryTable.INSTANCE.expirationDate.lte(date)
+					ObjectEntryTable.INSTANCE.expirationDate.lte(
+						nextExpirationDate)
 				).and(
 					ObjectEntryTable.INSTANCE.status.notIn(
 						new Integer[] {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
@@ -147,15 +147,8 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 
 		Assert.assertTrue(objectEntry1.isApproved());
 		Assert.assertTrue(objectEntry2.isScheduled());
-	}
 
-	@Test
-	public void testCheckObjectEntryDisplayDateAfterMissedInterval()
-		throws Exception {
-
-		Date date = new Date();
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+		ObjectEntry objectEntry3 = ObjectEntryTestUtil.addObjectEntry(
 			0, _objectDefinition.getObjectDefinitionId(),
 			HashMapBuilder.<String, Serializable>put(
 				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
@@ -164,17 +157,17 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 				new Date(date.getTime() + TimeUnit.DAY.toMillis(1))
 			).build());
 
-		Assert.assertTrue(objectEntry.isScheduled());
+		Assert.assertTrue(objectEntry3.isScheduled());
 
 		_updateDisplayDate(
-			new Date(date.getTime() - TimeUnit.DAY.toMillis(1)), objectEntry);
+			new Date(date.getTime() - TimeUnit.DAY.toMillis(1)), objectEntry3);
 
 		_jobExecutorUnsafeRunnable.run();
 
-		objectEntry = _objectEntryLocalService.getObjectEntry(
-			objectEntry.getObjectEntryId());
+		objectEntry3 = _objectEntryLocalService.getObjectEntry(
+			objectEntry3.getObjectEntryId());
 
-		Assert.assertTrue(objectEntry.isApproved());
+		Assert.assertTrue(objectEntry3.isApproved());
 	}
 
 	@Test
@@ -208,7 +201,8 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			).build());
 
 		_updateExpirationDate(
-			new Date(date.getTime() + TimeUnit.DAY.toMillis(1)), objectEntry2);
+			new Date(date.getTime() + TimeUnit.MINUTE.toMillis(5)),
+			objectEntry2);
 
 		_jobExecutorUnsafeRunnable.run();
 
@@ -250,6 +244,27 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 
 		Assert.assertFalse(objectEntry3.isExpired());
 		Assert.assertTrue(objectEntry3.isInTrash());
+
+		ObjectEntry objectEntry4 = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).put(
+				"expirationDate",
+				new Date(date.getTime() + TimeUnit.DAY.toMillis(1))
+			).build());
+
+		Assert.assertTrue(objectEntry4.isApproved());
+
+		_updateExpirationDate(
+			new Date(date.getTime() - TimeUnit.DAY.toMillis(1)), objectEntry4);
+
+		_jobExecutorUnsafeRunnable.run();
+
+		objectEntry4 = _objectEntryLocalService.getObjectEntry(
+			objectEntry4.getObjectEntryId());
+
+		Assert.assertTrue(objectEntry4.isExpired());
 	}
 
 	@Test

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/entries/scheduler/test/CheckObjectEntrySchedulerJobConfigurationTest.java
@@ -150,6 +150,34 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 	}
 
 	@Test
+	public void testCheckObjectEntryDisplayDateAfterMissedInterval()
+		throws Exception {
+
+		Date date = new Date();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).put(
+				"displayDate",
+				new Date(date.getTime() + TimeUnit.DAY.toMillis(1))
+			).build());
+
+		Assert.assertTrue(objectEntry.isScheduled());
+
+		_updateDisplayDate(
+			new Date(date.getTime() - TimeUnit.DAY.toMillis(1)), objectEntry);
+
+		_jobExecutorUnsafeRunnable.run();
+
+		objectEntry = _objectEntryLocalService.getObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(objectEntry.isApproved());
+	}
+
+	@Test
 	public void testCheckObjectEntryExpirationDate() throws Exception {
 		Date date = new Date();
 
@@ -180,8 +208,7 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			).build());
 
 		_updateExpirationDate(
-			new Date(date.getTime() + TimeUnit.MINUTE.toMillis(5)),
-			objectEntry2);
+			new Date(date.getTime() + TimeUnit.DAY.toMillis(1)), objectEntry2);
 
 		_jobExecutorUnsafeRunnable.run();
 
@@ -372,6 +399,12 @@ public class CheckObjectEntrySchedulerJobConfigurationTest {
 			).minusMonths(
 				months
 			));
+	}
+
+	private void _updateDisplayDate(Date displayDate, ObjectEntry objectEntry) {
+		objectEntry.setDisplayDate(displayDate);
+
+		_objectEntryLocalService.updateObjectEntry(objectEntry);
 	}
 
 	private void _updateExpirationDate(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96123

## What Is Being Fixed

Scheduled object entries were not published or expired when a scheduler interval was missed — for example when the server was down longer than one check interval, or when the in-memory previous-check date reset on restart. The publish and expire checks only matched display and expiration dates falling between the previous check and now, so any date that passed during the gap was skipped and the entry stayed scheduled or unexpired indefinitely. Separately, the checks looked ahead by a full interval, so with a large check interval live entries were expired well before their expiration date. The checks also loaded every matching entry for a company into a single in-memory list, risking unbounded heap on a large backlog.

## How It Is Being Fixed

The object entry scheduler checks are aligned with the journal article scheduler. The publish and expire queries drop the bounded lower bound and act on any entry whose display or expiration date has been reached, relying on the workflow status as the guard against reprocessing, so the checks self-heal across missed intervals. The display check adopts the journal guard that skips entries about to expire, and entries are expired only once their expiration date is actually reached rather than a full interval early. Review-date notifications stay windowed, carrying over the previous check date to avoid re-sending. Finally, the three checks were converted from a single dslQuery list to an ActionableDynamicQuery that streams rows in primary-key batches, running each publish and expire in its own transaction and isolating per-entry failures.

## PR Check

**pr-check: PASS** — tested on `23608a97c91dba7309c9e45ee631c221b0e5f797`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "23608a97c91dba7309c9e45ee631c221b0e5f797"} -->
