### PR TITLE
LPD-96330 Restore predefined value when a rule reveals a hidden field

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -84,7 +84,8 @@ export function mergePages(
 				field.visible &&
 				viewMode
 			) {
-				fieldValue = '';
+				fieldValue =
+					field.predefinedValue ?? sourceField.predefinedValue ?? '';
 			}
 
 			let newField = {

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/utils/evaluation.es.js
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergePages} from '../../../src/main/resources/META-INF/resources/js/utils/evaluation.es';
+import {PagesVisitor} from '../../../src/main/resources/META-INF/resources/js/utils/visitors.es';
+
+// The "select" field is localizable. The value the server validates comes from
+// the field's `value` property, so these tests assert on `value`.
+
+const buildPages = (fieldProps) => [
+	{
+		rows: [
+			{
+				columns: [
+					{
+						fields: [
+							{
+								fieldName: 'select',
+								localizable: true,
+								name: 'select',
+								type: 'select',
+								...fieldProps,
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+];
+
+const mergeField = ({sourceVisible, viewMode = true, ...fieldProps}) => {
+	const mergedPages = mergePages(
+		'en_US',
+		'en_US',
+		'select',
+		buildPages({...fieldProps, visible: true}),
+		buildPages({...fieldProps, visible: sourceVisible}),
+		viewMode
+	);
+
+	return new PagesVisitor(mergedPages).findField(
+		(field) => field.fieldName === 'select'
+	);
+};
+
+describe('evaluation', () => {
+	describe('mergePages', () => {
+		it('clears the value when a field without a predefined value becomes visible in view mode', () => {
+			const field = mergeField({
+				predefinedValue: '',
+				sourceVisible: false,
+				value: 'stale',
+			});
+
+			expect(field.value).toEqual('');
+		});
+
+		it('does not reset the value when not in view mode', () => {
+			const field = mergeField({
+				predefinedValue: ['option2'],
+				sourceVisible: false,
+				value: ['option1'],
+				viewMode: false,
+			});
+
+			expect(field.value).toEqual(['option1']);
+		});
+
+		it('keeps the value when the field visibility does not change', () => {
+			const field = mergeField({
+				predefinedValue: ['option2'],
+				sourceVisible: true,
+				value: ['option1'],
+			});
+
+			expect(field.value).toEqual(['option1']);
+		});
+
+		it('restores the predefined value when a field becomes visible in view mode', () => {
+			const field = mergeField({
+				predefinedValue: ['option2'],
+				sourceVisible: false,
+				value: '',
+			});
+
+			expect(field.value).toEqual(['option2']);
+		});
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96330

## What Is Being Fixed

A required "Select from list" field with a predefined value triggers a spurious "this field is required" validation error when a visibility rule reveals it. After the rule shows the field — with its predefined value visibly selected — submitting the form fails even though a value appears chosen.

## How It Is Being Fixed

When a field transitions from hidden to visible in view mode, `mergePages` reset its value to an empty string, discarding the predefined value while the field kept displaying it. The submitted value was therefore empty and server-side required validation flagged the field. The reset now restores the field's predefined value instead of blanking it, keeping the stored value aligned with what is displayed. The fix lives on the client because the reset-on-reveal only exists there; the server validates the serialized `value`, which the fix now populates correctly.

## PR Check

**pr-check: PASS** — tested on `f9df9aeb49a9c3bd9d9a8a5c5ee90205d9694cb6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f9df9aeb49a9c3bd9d9a8a5c5ee90205d9694cb6"} -->
