### PR TITLE
LPD-96138 Stop showing paragraph placeholder for empty CMP descriptions

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/site-initializer/layout-page-templates/display-page-templates/project-view/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/site-initializer/layout-page-templates/display-page-templates/project-view/page-definition.json
@@ -223,6 +223,9 @@
 																						"fragmentLink": {
 																						},
 																						"text": {
+																							"defaultFragmentInlineValue": {
+																								"value": ""
+																							},
 																							"mapping": {
 																								"fieldKey": "ObjectField_description",
 																								"itemReference": {

--- a/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/site-initializer/layout-page-templates/display-page-templates/task-view/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cmp/src/main/resources/site-initializer/layout-page-templates/display-page-templates/task-view/page-definition.json
@@ -173,6 +173,9 @@
 																				"fragmentLink": {
 																				},
 																				"text": {
+																					"defaultFragmentInlineValue": {
+																						"value": ""
+																					},
 																					"mapping": {
 																						"fieldKey": "ObjectField_description",
 																						"itemReference": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96138

## What Is Being Fixed

On the Liferay CMS (CMP) Task and Project detail views, the Description field
displayed a predefined placeholder ("A paragraph is a self-contained unit of a
discourse in writing dealing with a particular point or idea...") when the entry
had no description. Nothing should be shown in that case.

## How It Is Being Fixed

The detail views are display page templates that map the description to a
paragraph fragment. During site-initializer import, the fragment's own
design-time default text is merged into the stored editable values alongside the
mapping, so when an entry's description is empty the mapped field resolves to
null and the fragment renders its default placeholder. This adds an explicit
empty default to the mapped description in both the task-view and project-view
page definitions. Because the per-field value wins over the fragment default
during the import merge, an empty description now renders nothing, while a
populated description is unaffected.

## Why Are There No Tests?

The change is limited to site-initializer page-definition JSON consumed at
site-provisioning time; there is no Java or JS code path a unit or integration
test could exercise. It was verified manually on a freshly provisioned CMP site:
a Task and a Project created without a description show an empty Description, and
entries with a description still render it.

## PR Check

**pr-check: PASS** — tested on `79a72c7f0373f9202df84164872861b3c7b30a42`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "79a72c7f0373f9202df84164872861b3c7b30a42"} -->
