### PR TITLE
LPD-95523 Map objectDefinitionExternalReferenceCode as a keyword

### DIFF
--- a/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/search/spi/index/configuration/contributor/dependencies/additional-type-mappings.json
+++ b/modules/apps/object/object-service/src/main/resources/com/liferay/object/internal/search/spi/index/configuration/contributor/dependencies/additional-type-mappings.json
@@ -9,6 +9,9 @@
 		"objectActionId": {
 			"type": "keyword"
 		},
+		"objectDefinitionExternalReferenceCode": {
+			"type": "keyword"
+		},
 		"objectDefinitionId": {
 			"type": "keyword"
 		},

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/search/test/ObjectEntryIndexerIndexedFieldsTest.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.filter.ComplexQueryPartBuilderFactory;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryIndexerIndexedFieldsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Test
+	public void testSearchByObjectDefinitionExternalReferenceCode()
+		throws Exception {
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"able", RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		SearchResponse searchResponse = _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				_objectDefinition.getClassName()
+			).addComplexQueryPart(
+				_complexQueryPartBuilderFactory.builder(
+				).query(
+					QueriesUtil.term(
+						"objectDefinitionExternalReferenceCode",
+						_objectDefinition.getExternalReferenceCode())
+				).build()
+			).build());
+
+		Assert.assertEquals(1, searchResponse.getTotalHits());
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	@Inject
+	private ComplexQueryPartBuilderFactory _complexQueryPartBuilderFactory;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95523

## What Is Being Fixed

Filtering object entries by their object definition's external reference code returned no results. The `objectDefinitionExternalReferenceCode` field was indexed as `text`, so the analyzer tokenized the value (a default external reference code is a UUID, which the analyzer splits on its hyphens) and an exact term query never matched.

## How It Is Being Fixed

Map `objectDefinitionExternalReferenceCode` as a `keyword` in the object entry index's additional type mappings, so the value is stored as a single, non-analyzed term and an exact term query matches it. An integration test publishes an object definition, indexes an entry, and asserts that a term search on the external reference code returns the entry.

## PR Check

**pr-check: PASS** — tested on `632c9868c3d73f30e613cf793503c8e761d93254`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "632c9868c3d73f30e613cf793503c8e761d93254"} -->
