### PR TITLE
LPD-96415 Fix bulk actions for workflow tasks in the All Tasks tab

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
@@ -5,6 +5,7 @@
 
 import {
 	DateRenderer,
+	FDS_EVENT,
 	IInternalRenderer,
 	IView,
 } from '@liferay/frontend-data-set-web';
@@ -34,6 +35,8 @@ import StateLabel from '../StateLabel';
 import BulkEditAssigneeModalContent from '../modal/BulkEditAssigneeModalContent';
 import BulkEditDueDateModalContent from '../modal/BulkEditDueDateModalContent';
 import BulkEditStateModalContent from '../modal/BulkEditStateModalContent';
+import BulkEditWorkflowAssigneeModalContent from '../modal/BulkEditWorkflowAssigneeModalContent';
+import BulkEditWorkflowDueDateModalContent from '../modal/BulkEditWorkflowDueDateModalContent';
 import EditAssigneeModalContent from '../modal/EditAssigneeModalContent';
 import ACTIONS from './actions/creationMenuActions';
 import AssigneeRenderer from './cell_renderers/AssigneeRenderer';
@@ -47,6 +50,20 @@ const isWorkflowTask = (
 	itemData: ProjectTaskItemData | WorkflowTaskItemData
 ): itemData is WorkflowTaskItemData =>
 	itemData.entryClassName === _CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN;
+
+type BulkModalProps = {
+	closeModal: () => void;
+	loadData: () => void;
+	selectedData: any;
+};
+
+const WORKFLOW_BULK_ACTION_MODALS: Record<
+	string,
+	React.ComponentType<BulkModalProps>
+> = {
+	'assign-to': BulkEditWorkflowAssigneeModalContent,
+	'update-due-date': BulkEditWorkflowDueDateModalContent,
+};
 
 export default function AllTasksFDSPropsTransformer({
 	additionalProps,
@@ -86,6 +103,18 @@ export default function AllTasksFDSPropsTransformer({
 				allItemsSelectedActive: boolean;
 				selectedItems: any[];
 			}) => {
+				const actionId = action?.data?.id;
+
+				if (actionId === 'update-state' || actionId === 'delete') {
+					if (allItemsSelectedActive) {
+						return true;
+					}
+
+					if (selectedItems?.some(isWorkflowTask)) {
+						return true;
+					}
+				}
+
 				if (allItemsSelectedActive || !selectedItems?.length) {
 					return false;
 				}
@@ -267,6 +296,42 @@ export default function AllTasksFDSPropsTransformer({
 			action: any;
 			selectedData: any;
 		}) => {
+			const selectedItems = selectedData?.items ?? [];
+
+			if (
+				!selectedData?.selectAll &&
+				selectedItems.length &&
+				selectedItems.every(isWorkflowTask)
+			) {
+				const ContentComponent =
+					WORKFLOW_BULK_ACTION_MODALS[action?.data?.id];
+
+				if (!ContentComponent) {
+					return;
+				}
+
+				const loadData = () =>
+					Liferay.fire(FDS_EVENT.UPDATE_DISPLAY, {id});
+
+				await openCMPModal({
+					center: true,
+					contentComponent: ({
+						closeModal,
+					}: {
+						closeModal: () => void;
+					}) => (
+						<ContentComponent
+							closeModal={closeModal}
+							loadData={loadData}
+							selectedData={selectedData}
+						/>
+					),
+					size: 'md',
+				});
+
+				return;
+			}
+
 			if (action?.data?.id === 'assign-to') {
 				await openCMPModal({
 					center: true,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/AllTasksFDSPropsTransformer.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/AllTasksFDSPropsTransformer.spec.tsx
@@ -1,0 +1,192 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import BulkEditWorkflowAssigneeModalContent from '../../js/components/modal/BulkEditWorkflowAssigneeModalContent';
+import BulkEditWorkflowDueDateModalContent from '../../js/components/modal/BulkEditWorkflowDueDateModalContent';
+import AllTasksFDSPropsTransformer from '../../js/components/props_transformer/AllTasksFDSPropsTransformer';
+
+const mockOpenCMPModal = jest.fn();
+
+jest.mock('../../js/utils/openCMPModal', () => ({
+	openCMPModal: (...args: any[]) => mockOpenCMPModal(...args),
+}));
+
+// The project-task assignee modals pull in the item selector, which is not
+// importable under jsdom; stub them since these tests exercise only the
+// workflow-task path.
+
+jest.mock('../../js/components/modal/BulkEditAssigneeModalContent', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('../../js/components/modal/EditAssigneeModalContent', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+const _CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN =
+	'com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken';
+
+const baseProps = {
+	additionalProps: {states: []},
+	apiURL: '/o/search/v1.0/search',
+	bulkActions: [
+		{data: {id: 'assign-to'}, label: 'Assign To'},
+		{data: {id: 'delete'}, label: 'Delete'},
+		{data: {id: 'update-due-date'}, label: 'Update Due Date'},
+		{data: {id: 'update-state'}, label: 'Update State'},
+	],
+	creationMenu: {primaryItems: []},
+	id: 'test-fds',
+	itemsActions: [],
+	views: [{default: true, initialPaginationDelta: 20, name: 'table'}],
+};
+
+const getBulkAction = (id: string) => {
+	const result = AllTasksFDSPropsTransformer(baseProps as any);
+
+	return (result.bulkActions as any[]).find(
+		(action) => action.data.id === id
+	);
+};
+
+const workflowItem = {
+	embedded: {id: 1},
+	entryClassName: _CLASS_NAME_KALEO_TASK_INSTANCE_TOKEN,
+};
+const projectItem = {
+	embedded: {id: 1},
+	entryClassName: 'com.liferay.object.model.ObjectEntry',
+};
+
+describe('AllTasksFDSPropsTransformer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('disables all bulk actions when a mixed selection of workflow and project tasks is selected', () => {
+		const selectedItems = [workflowItem, projectItem];
+
+		expect(
+			getBulkAction('update-state').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+		expect(
+			getBulkAction('delete').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+		expect(
+			getBulkAction('assign-to').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+		expect(
+			getBulkAction('update-due-date').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+	});
+
+	it('disables update-state and delete bulk actions when a workflow task is selected', () => {
+		const selectedItems = [workflowItem];
+
+		expect(
+			getBulkAction('update-state').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+		expect(
+			getBulkAction('delete').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(true);
+
+		expect(
+			getBulkAction('assign-to').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(false);
+		expect(
+			getBulkAction('update-due-date').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(false);
+	});
+
+	it('disables update-state and delete bulk actions when all items are selected', () => {
+		expect(
+			getBulkAction('update-state').isDisabled({
+				allItemsSelectedActive: true,
+			})
+		).toBe(true);
+		expect(
+			getBulkAction('delete').isDisabled({allItemsSelectedActive: true})
+		).toBe(true);
+
+		expect(
+			getBulkAction('assign-to').isDisabled({
+				allItemsSelectedActive: true,
+			})
+		).toBe(false);
+	});
+
+	it('keeps update-state and delete bulk actions enabled when a project task is selected', () => {
+		const selectedItems = [projectItem];
+
+		expect(
+			getBulkAction('update-state').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(false);
+		expect(
+			getBulkAction('delete').isDisabled({
+				allItemsSelectedActive: false,
+				selectedItems,
+			})
+		).toBe(false);
+	});
+
+	it('opens BulkEditWorkflowAssigneeModalContent when assign-to is clicked for workflow tasks', async () => {
+		const result = AllTasksFDSPropsTransformer(baseProps as any);
+
+		await (result as any).onBulkActionItemClick({
+			action: {data: {id: 'assign-to'}},
+			selectedData: {items: [workflowItem], selectAll: false},
+		});
+
+		const {contentComponent} = mockOpenCMPModal.mock.calls[0][0];
+
+		expect(contentComponent({closeModal: jest.fn()}).type).toBe(
+			BulkEditWorkflowAssigneeModalContent
+		);
+	});
+
+	it('opens BulkEditWorkflowDueDateModalContent when update-due-date is clicked for workflow tasks', async () => {
+		const result = AllTasksFDSPropsTransformer(baseProps as any);
+
+		await (result as any).onBulkActionItemClick({
+			action: {data: {id: 'update-due-date'}},
+			selectedData: {items: [workflowItem], selectAll: false},
+		});
+
+		const {contentComponent} = mockOpenCMPModal.mock.calls[0][0];
+
+		expect(contentComponent({closeModal: jest.fn()}).type).toBe(
+			BulkEditWorkflowDueDateModalContent
+		);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96415

## What Is Being Fixed

In the CMP Global Tasks "All Tasks" tab, selecting only workflow tasks and triggering a bulk action (Update Due Date or Assign to) failed. That tab mixes workflow tasks (KaleoTaskInstanceToken) with project tasks, but its bulk-action handler always routed to the project-task endpoints, which do not apply to workflow tasks. Update State and Delete were also offered for workflow tasks even though they are not supported for them.

## How It Is Being Fixed

The All Tasks props transformer now detects when a bulk selection consists of workflow tasks and routes Assign to and Update Due Date to the workflow-specific bulk modals (BulkEditWorkflowAssigneeModalContent and BulkEditWorkflowDueDateModalContent), mirroring how the dedicated Workflow Tasks tab already wires them. Update State and Delete are disabled whenever the selection contains a workflow task, including under "select all", which can span both task types. Project-task selections keep their existing behavior. A new Jest spec mirrors the Workflow Tasks transformer test, asserting the disable logic and that workflow selections open the workflow bulk modals.

## PR Check

**pr-check: PASS** — tested on `637da715515004a71573b744e43247517f8483a2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "637da715515004a71573b744e43247517f8483a2"} -->
