### PR TITLE
LPD-96561 Drop the emphasis style from disabled bulk actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.tsx
@@ -291,7 +291,9 @@ function BulkActions({
 												<ClayButton
 													className={classNames(
 														'bulk-action-btn nav-link',
-														highlightedBulkAction.className
+														!highlightedBulkAction
+															.data?.disabled &&
+															highlightedBulkAction.className
 													)}
 													disabled={
 														highlightedBulkAction
@@ -352,7 +354,10 @@ function BulkActions({
 												(actionDefinition) => (
 													<DropDown.Item
 														className={
-															actionDefinition.className
+															actionDefinition
+																.data?.disabled
+																? undefined
+																: actionDefinition.className
 														}
 														disabled={
 															actionDefinition

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/BulkActions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/BulkActions.tsx
@@ -85,4 +85,45 @@ describe('BulkActions className propagation', () => {
 			'text-danger'
 		);
 	});
+
+	it('does not apply data.className to the highlighted bulk action button when it is disabled', () => {
+		const bulkActions: IBulkActionItem[] = [
+			{
+				className: 'text-danger',
+				data: {
+					disabled: true,
+					highlighted: true,
+					id: 'delete',
+				},
+				icon: 'trash',
+				label: 'Delete',
+			},
+		];
+
+		renderBulkActions(bulkActions);
+
+		const button = screen.getByRole('button', {name: /delete/i});
+
+		expect(button).toBeDisabled();
+		expect(button).not.toHaveClass('text-danger');
+	});
+
+	it('does not apply data.className to the overflow dropdown item when it is disabled', async () => {
+		const bulkActions: IBulkActionItem[] = [
+			{
+				className: 'text-danger',
+				data: {disabled: true, id: 'delete'},
+				icon: 'trash',
+				label: 'Delete',
+			},
+		];
+
+		renderBulkActions(bulkActions);
+
+		await userEvent.click(screen.getByRole('button', {name: /actions/i}));
+
+		expect(screen.getByRole('menuitem', {name: /delete/i})).not.toHaveClass(
+			'text-danger'
+		);
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96561

## What Is Being Fixed

On the CMP All Tasks tab, the bulk "Delete" action stayed bright red while disabled, unlike the other bulk actions (Update Due Date, Assign To, Update State), which fade to a muted gray. The Delete action carries the `text-danger` emphasis class, and because that utility sets the color with `!important`, it overrode the disabled button's faded appearance — so a disabled Delete still looked active.

## How It Is Being Fixed

The frontend data set management bar now applies a bulk action's custom emphasis className only while the action is enabled. When `data.disabled` is true, the className (e.g. `text-danger`) is dropped for both the highlighted button and the overflow dropdown item, so the action falls back to the standard disabled button styling and fades like every other action. The fix lives in `BulkActions`, so it applies generically to any disabled bulk action with an emphasis class rather than special-casing delete.

## PR Check

**pr-check: PASS** — tested on `9dd801dcd3067015e84b5e9d8edb103e8d2985ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9dd801dcd3067015e84b5e9d8edb103e8d2985ac"} -->
