### PR TITLE
LPD-95997 Sort object field picklist options by the rendering locale

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
@@ -34,8 +34,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.CollatorUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -273,15 +271,8 @@ public class SelectDDMFormFieldTemplateContextContributor
 			ddmFormField, ddmFormFieldOptions, objectField);
 
 		if (ListUtil.isNotEmpty(objectFieldOptions)) {
-			ServiceContext serviceContext =
-				ServiceContextThreadLocal.getServiceContext();
-
-			Locale serviceContextLocale = LocaleUtil.fromLanguageId(
-				serviceContext.getLanguageId());
-
-			if (alphabeticalOrder && (locale != serviceContextLocale)) {
-				return _getSortedOptions(
-					serviceContextLocale, objectFieldOptions);
+			if (alphabeticalOrder) {
+				return _getSortedOptions(locale, objectFieldOptions);
 			}
 
 			return objectFieldOptions;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
@@ -322,6 +322,43 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 			expectedOptions,
 			_getActualOptions(
 				ddmFormField, ddmFormFieldOptions, LocaleUtil.US));
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		long listTypeDefinitionId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectField.getListTypeDefinitionId()
+		).thenReturn(
+			listTypeDefinitionId
+		);
+
+		List<ListTypeEntry> listTypeEntries = Arrays.asList(
+			_getListTypeEntry("Reference 3", "Label 3"),
+			_getListTypeEntry("Reference 1", "Label 1"),
+			_getListTypeEntry("Reference 2", "Label 2"));
+
+		Mockito.when(
+			_listTypeEntryLocalService.getListTypeEntries(
+				Mockito.eq(listTypeDefinitionId), Mockito.eq(QueryUtil.ALL_POS),
+				Mockito.eq(QueryUtil.ALL_POS), Mockito.any())
+		).thenReturn(
+			listTypeEntries
+		);
+
+		ddmFormField.setProperty("alphabeticalOrder", "false");
+
+		Assert.assertNotEquals(
+			expectedOptions,
+			_selectDDMFormFieldTemplateContextContributor.getOptions(
+				ddmFormField, ddmFormFieldOptions, LocaleUtil.US, objectField));
+
+		ddmFormField.setProperty("alphabeticalOrder", "true");
+
+		Assert.assertEquals(
+			expectedOptions,
+			_selectDDMFormFieldTemplateContextContributor.getOptions(
+				ddmFormField, ddmFormFieldOptions, LocaleUtil.US, objectField));
 	}
 
 	@Test
@@ -610,12 +647,17 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 	}
 
 	private ListTypeEntry _getListTypeEntry(String name) {
+		return _getListTypeEntry(
+			StringUtil.removeChars(name, CharPool.SPACE), name);
+	}
+
+	private ListTypeEntry _getListTypeEntry(String key, String name) {
 		ListTypeEntry listTypeEntry = Mockito.mock(ListTypeEntry.class);
 
 		Mockito.when(
 			listTypeEntry.getKey()
 		).thenReturn(
-			StringUtil.removeChars(name, CharPool.SPACE)
+			key
 		);
 
 		Mockito.when(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95997

## What Is Being Fixed

When a Select (picklist) field backed by an Object field has alphabetical
order enabled, the options were not sorted by the labels shown to the user.
Viewing the form in a non-default locale (for example pt_BR) rendered the
options in the default-locale (en_US) order rather than alphabetically by the
displayed labels.

## How It Is Being Fixed

The previous logic only re-sorted the object field options when the service
context language differed from the rendering locale, and it sorted by the
service context locale. That left the common case unsorted and ignored the
locale actually used to render the field. The fix sorts the object field
options by the rendering locale whenever alphabetical order is enabled, and
drops the now-unused ServiceContextThreadLocal lookup.

## PR Check

**pr-check: PASS** — tested on `3f824d4d39a021a776dd53242bae123952024f53`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3f824d4d39a021a776dd53242bae123952024f53"} -->
