### PR TITLE
LPD-96215 Fix mapped object entry fields not rendering on content pages

### DIFF
--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.info.item.util;
 
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryVersion;
 import com.liferay.object.model.ObjectField;
@@ -89,6 +90,11 @@ public class ObjectEntryInfoItemUtil {
 				"objectEntryVersion", objectEntryVersion);
 		}
 
+		boolean skipObjectEntryResourcePermission =
+			ObjectEntryThreadLocal.isSkipObjectEntryResourcePermission();
+
+		ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
+
 		try {
 			if (serviceBuilderObjectEntry.isRootDescendantNode() &&
 				(objectEntryManager instanceof DefaultObjectEntryManager)) {
@@ -135,6 +141,10 @@ public class ObjectEntryInfoItemUtil {
 			}
 
 			return null;
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(
+				skipObjectEntryResourcePermission);
 		}
 	}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/translationFallback.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/translationFallback.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	ObjectDefinition,
+	ObjectDefinitionAPI,
+} from '@liferay/object-admin-rest-client-js';
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {displayPageTemplatesPagesTest} from '../../../fixtures/displayPageTemplatesPagesTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+
+const test = mergeTests(
+	dataApiHelpersTest,
+	displayPageTemplatesPagesTest,
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'Mapped object entry field values are visible to guest users on a display page',
+	{tag: '@LPD-96215'},
+	async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create object definition with a localized field
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const objectName = `Sample${getRandomInt()}`;
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.postObjectDefinition({
+				label: {en_US: objectName},
+				name: objectName,
+				objectFields: [
+					{
+						DBType: 'String',
+						businessType: 'Text',
+						indexed: true,
+						indexedAsKeyword: false,
+						indexedLanguageId: 'en_US',
+						label: {en_US: 'Title'},
+						localized: true,
+						name: 'title',
+						objectFieldSettings: [],
+						required: true,
+					},
+				] as ObjectDefinition['objectFields'],
+				pluralLabel: {en_US: `${objectName}s`},
+				scope: 'company',
+				status: {code: 0},
+			} as ObjectDefinition);
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		// Create entry with en_US only
+
+		const applicationName = `c/${objectName.toLowerCase()}s`;
+
+		const entry = await apiHelpers.objectEntry.postObjectEntry(
+			{title_i18n: {en_US: 'English Title'}},
+			applicationName
+		);
+
+		// Get the classNameId required for the DPT URL and creation
+
+		const className =
+			await apiHelpers.jsonWebServicesClassName.fetchClassName(
+				objectDefinition.className
+			);
+
+		// Create a display page template for the object type
+
+		const displayPageTemplateName = getRandomString();
+
+		await apiHelpers.jsonWebServicesLayoutPageTemplateEntry.addDisplayPageLayoutPageTemplateEntry(
+			{
+				classNameId: className.classNameId,
+				groupId: site.id,
+				name: displayPageTemplateName,
+			}
+		);
+
+		// Open the DPT editor and map a Heading fragment to the Title field
+
+		await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+		await displayPageTemplatesPage.editTemplate(displayPageTemplateName);
+
+		await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+		const headingId = await pageEditorPage.getFragmentId('Heading');
+
+		await pageEditorPage.selectEditable(headingId, 'element-text');
+
+		await page.getByLabel('Field').selectOption('Title');
+
+		await pageEditorPage.waitForChangesSaved();
+
+		// Publish the display page template
+
+		await displayPageTemplatesPage.publishTemplate();
+
+		// Navigate to the display page as a guest (no authentication)
+
+		await page.context().clearCookies();
+
+		await page.goto(
+			`/web${site.friendlyUrlPath}/e/${displayPageTemplateName}/${className.classNameId}/${entry.id}`
+		);
+
+		// The field value must be visible even without an authenticated session
+
+		await expect(
+			page.getByRole('heading', {name: 'English Title'})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
**Guest users see no field values**

The info item rendering path re-fetches the object entry as a REST DTO via ObjectEntryManager.getObjectEntry, which routes through ObjectEntryService and checks VIEW permission against the thread-local permission checker (the guest user's checker). 

When the guest has no explicit VIEW permission on the entry, the service throws, the exception is swallowed silently, and all
  mapped fields render blank. The SB entity is already fetched earlier in the pipeline without a permission check, so this re-check is redundant. Fixed by wrapping the manager call with ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true) (save and restore pattern).
