### PR TITLE
LPD-96749 Prevent guest form upload deletion when the field is clicked

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/DocumentLibrary/DocumentLibrary.es.js
@@ -697,6 +697,10 @@ const Main = ({
 	};
 
 	const handleUploadSelectButtonClicked = (event, currentValue) => {
+		if (!event.target.files?.length) {
+			return;
+		}
+
 		onFocus(event);
 
 		stagePendingDeletion(getFileEntryId(currentValue));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/DocumentLibrary.es.js
@@ -742,6 +742,24 @@ describe('Field DocumentLibrary', () => {
 			expectNoDeletes();
 		});
 
+		it('does not delete the uploaded file when the guest clicks the field before submitting (LPP-64664)', () => {
+			Liferay.ThemeDisplay.isSignedIn = jest.fn(() => false);
+
+			renderField({allowGuestUsers: true, value: '{}'});
+
+			triggerGuestUpload();
+
+			completeUpload(99);
+
+			act(() => {
+				fireEvent.click(document.getElementById('uploadField'));
+			});
+
+			fireGlobal('paginationControlsSubmitButtonClicked');
+
+			expectNoDeletes();
+		});
+
 		it('does not delete when Clear is followed by Cancel (LPP-63917)', () => {
 			renderField({value: valueWithFileEntry(42)});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96749

## What Is Being Fixed

Guest submissions to a public form with a Documents and Media field could silently lose the uploaded file: the entry saved but the field showed "Content is temporarily unavailable". After uploading a file, clicking the read-only file-name text field staged the just-uploaded file for deletion and then threw "TypeError: event.target.files is null" before uploading anything. On submit, the pending-deletions flush deleted the staged file, so the record committed a reference to a deleted file. This is a regression from LPD-89027, which moved deletions to a flush-on-submit model and ran the staging call on the line before the throw.

Reported through LPP-64664, and the cause of the customer data loss in LPP-64542 / LRHC-151597.

## How It Is Being Fixed

handleUploadSelectButtonClicked is bound to both the file input's onChange and the read-only text field's onClick. It now returns early when the event carries no selected file, so a text-field click no longer stages the current file for deletion and no longer throws, while a real file selection still stages the previous file and uploads the new one. A Jest regression test uploads a file as a guest, clicks the field, submits, and asserts the uploaded file is not deleted.

## PR Check

**pr-check: PASS** — tested on `50658cd227c2b3bb8ce5a645f227c2d5459917af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "50658cd227c2b3bb8ce5a645f227c2d5459917af"} -->


