### PR TITLE
LPD-96741 Block disabling script execution while scripts are in use

### DIFF
--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-permission-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/groovy/script/uses/factory/test/ObjectActionGroovyScriptUsesFactoryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/groovy/script/uses/factory/test/ObjectActionGroovyScriptUsesFactoryTest.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.groovy.script.uses.factory.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectActionExecutorConstants;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectActionTestUtil;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
+import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Fábio Alves
+ */
+@RunWith(Arquillian.class)
+public class ObjectActionGroovyScriptUsesFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			ScriptManagementConfigurationTestRule.INSTANCE);
+
+	@Test
+	public void testHasUses() throws Exception {
+		Assert.assertFalse(_groovyScriptUsesFactory.hasUses());
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectActionTestUtil.addObjectAction(
+			ObjectActionExecutorConstants.KEY_GROOVY,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, _objectDefinition,
+			UnicodePropertiesBuilder.put(
+				"script", "return true;"
+			).build());
+
+		Assert.assertTrue(_groovyScriptUsesFactory.hasUses());
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.object.web.internal.groovy.script.uses.factory.ObjectActionGroovyScriptUsesFactory"
+	)
+	private GroovyScriptUsesFactory _groovyScriptUsesFactory;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/groovy/script/uses/factory/test/ObjectValidationRuleGroovyScriptUsesFactoryTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/groovy/script/uses/factory/test/ObjectValidationRuleGroovyScriptUsesFactoryTest.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.groovy.script.uses.factory.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectValidationRuleConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectValidationRuleLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
+import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Fábio Alves
+ */
+@RunWith(Arquillian.class)
+public class ObjectValidationRuleGroovyScriptUsesFactoryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			ScriptManagementConfigurationTestRule.INSTANCE);
+
+	@Test
+	public void testHasUses() throws Exception {
+		Assert.assertFalse(_groovyScriptUsesFactory.hasUses());
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectValidationRuleLocalService.addObjectValidationRule(
+			null, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), true,
+			ObjectValidationRuleConstants.ENGINE_TYPE_GROOVY,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectValidationRuleConstants.OUTPUT_TYPE_FULL_VALIDATION,
+			"return true;", false, Collections.emptyList());
+
+		Assert.assertTrue(_groovyScriptUsesFactory.hasUses());
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.object.web.internal.groovy.script.uses.factory.ObjectValidationRuleGroovyScriptUsesFactory"
+	)
+	private GroovyScriptUsesFactory _groovyScriptUsesFactory;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectValidationRuleLocalService _objectValidationRuleLocalService;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/groovy/script/uses/factory/ObjectActionGroovyScriptUsesFactory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/groovy/script/uses/factory/ObjectActionGroovyScriptUsesFactory.java
@@ -12,6 +12,7 @@ import com.liferay.object.web.internal.object.definitions.constants.ObjectDefini
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.security.script.management.groovy.script.use.GroovyScriptUse;
 import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
@@ -47,6 +48,13 @@ public class ObjectActionGroovyScriptUsesFactory
 						ObjectDefinitionsScreenNavigationEntryConstants.
 							CATEGORY_KEY_ACTIONS));
 			});
+	}
+
+	@Override
+	public boolean hasUses() {
+		return ListUtil.isNotEmpty(
+			_objectActionLocalService.getObjectActions(
+				true, ObjectActionExecutorConstants.KEY_GROOVY));
 	}
 
 	@Reference

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/groovy/script/uses/factory/ObjectValidationRuleGroovyScriptUsesFactory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/groovy/script/uses/factory/ObjectValidationRuleGroovyScriptUsesFactory.java
@@ -12,6 +12,7 @@ import com.liferay.object.web.internal.object.definitions.constants.ObjectDefini
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.security.script.management.groovy.script.use.GroovyScriptUse;
 import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
@@ -48,6 +49,13 @@ public class ObjectValidationRuleGroovyScriptUsesFactory
 						ObjectDefinitionsScreenNavigationEntryConstants.
 							CATEGORY_KEY_VALIDATIONS));
 			});
+	}
+
+	@Override
+	public boolean hasUses() {
+		return ListUtil.isNotEmpty(
+			_objectValidationRuleLocalService.getObjectValidationRules(
+				true, ObjectValidationRuleConstants.ENGINE_TYPE_GROOVY));
 	}
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-script-management-api/src/main/java/com/liferay/portal/security/script/management/groovy/script/uses/factory/GroovyScriptUsesFactory.java
+++ b/modules/apps/portal-security/portal-security-script-management-api/src/main/java/com/liferay/portal/security/script/management/groovy/script/uses/factory/GroovyScriptUsesFactory.java
@@ -19,4 +19,6 @@ public interface GroovyScriptUsesFactory {
 	public List<GroovyScriptUse> create(ResourceRequest resourceRequest)
 		throws Exception;
 
+	public boolean hasUses() throws Exception;
+
 }

--- a/modules/apps/portal-security/portal-security-script-management-api/src/main/resources/com/liferay/portal/security/script/management/groovy/script/uses/factory/packageinfo
+++ b/modules/apps/portal-security/portal-security-script-management-api/src/main/resources/com/liferay/portal/security/script/management/groovy/script/uses/factory/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/portal-security/portal-security-script-management-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-script-management-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-definition-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-script-management-test/src/testIntegration/java/com/liferay/portal/security/script/management/web/internal/configuration/persistence/listener/test/ScriptManagementConfigurationModelListenerTest.java
+++ b/modules/apps/portal-security/portal-security-script-management-test/src/testIntegration/java/com/liferay/portal/security/script/management/web/internal/configuration/persistence/listener/test/ScriptManagementConfigurationModelListenerTest.java
@@ -1,0 +1,155 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.script.management.web.internal.configuration.persistence.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.security.script.management.configuration.ScriptManagementConfiguration;
+import com.liferay.portal.security.script.management.groovy.script.use.GroovyScriptUse;
+import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.portlet.ResourceRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Yuri Monteiro
+ */
+@RunWith(Arquillian.class)
+public class ScriptManagementConfigurationModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ScriptManagementConfigurationModelListenerTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		_locale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		_serviceRegistration = _registerGroovyScriptUsesFactory();
+	}
+
+	@After
+	public void tearDown() {
+		_serviceRegistration.unregister();
+
+		LocaleThreadLocal.setThemeDisplayLocale(_locale);
+	}
+
+	@Test
+	public void testOnBeforeDelete() throws Exception {
+		try {
+			_configurationModelListener.onBeforeDelete(
+				ScriptManagementConfiguration.class.getName());
+
+			Assert.fail();
+		}
+		catch (ConfigurationModelListenerException
+					configurationModelListenerException) {
+
+			Assert.assertEquals(
+				_language.get(LocaleUtil.US, _MESSAGE_KEY),
+				configurationModelListenerException.causeMessage);
+		}
+	}
+
+	@Test
+	public void testOnBeforeSave() throws Exception {
+		_configurationModelListener.onBeforeSave(
+			ScriptManagementConfiguration.class.getName(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"allowScriptContentToBeExecutedOrIncluded", true
+			).build());
+
+		try {
+			_configurationModelListener.onBeforeSave(
+				ScriptManagementConfiguration.class.getName(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"allowScriptContentToBeExecutedOrIncluded", false
+				).build());
+
+			Assert.fail();
+		}
+		catch (ConfigurationModelListenerException
+					configurationModelListenerException) {
+
+			Assert.assertEquals(
+				_language.get(LocaleUtil.US, _MESSAGE_KEY),
+				configurationModelListenerException.causeMessage);
+		}
+	}
+
+	private ServiceRegistration<GroovyScriptUsesFactory>
+		_registerGroovyScriptUsesFactory() {
+
+		return _bundleContext.registerService(
+			GroovyScriptUsesFactory.class,
+			new GroovyScriptUsesFactory() {
+
+				@Override
+				public List<GroovyScriptUse> create(
+					ResourceRequest resourceRequest) {
+
+					return Collections.emptyList();
+				}
+
+				@Override
+				public boolean hasUses() {
+					return true;
+				}
+
+			},
+			null);
+	}
+
+	private static final String _MESSAGE_KEY =
+		"resolve-all-active-scripting-uses-before-proceeding-you-can-" +
+			"deactivate-the-source-entity-or-remove-the-script";
+
+	private BundleContext _bundleContext;
+
+	@Inject(
+		filter = "model.class.name=com.liferay.portal.security.script.management.configuration.ScriptManagementConfiguration"
+	)
+	private ConfigurationModelListener _configurationModelListener;
+
+	@Inject
+	private Language _language;
+
+	private Locale _locale;
+	private ServiceRegistration<GroovyScriptUsesFactory> _serviceRegistration;
+
+}

--- a/modules/apps/portal-security/portal-security-script-management-web/build.gradle
+++ b/modules/apps/portal-security/portal-security-script-management-web/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:portal-settings:portal-settings-api")
 	compileOnly project(":apps:portal-workflow:portal-workflow-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/portal-security/portal-security-script-management-web/src/main/java/com/liferay/portal/security/script/management/web/internal/configuration/persistence/listener/ScriptManagementConfigurationModelListener.java
+++ b/modules/apps/portal-security/portal-security-script-management-web/src/main/java/com/liferay/portal/security/script/management/web/internal/configuration/persistence/listener/ScriptManagementConfigurationModelListener.java
@@ -1,0 +1,145 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.script.management.web.internal.configuration.persistence.listener;
+
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.security.script.management.configuration.ScriptManagementConfiguration;
+import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
+
+import java.util.Dictionary;
+import java.util.Locale;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Yuri Monteiro
+ */
+@Component(
+	property = "model.class.name=com.liferay.portal.security.script.management.configuration.ScriptManagementConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class ScriptManagementConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeDelete(String pid)
+		throws ConfigurationModelListenerException {
+
+		_checkActiveGroovyScriptUses();
+	}
+
+	@Override
+	public void onBeforeSave(String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+
+		if (GetterUtil.getBoolean(
+				properties.get("allowScriptContentToBeExecutedOrIncluded"))) {
+
+			return;
+		}
+
+		_checkActiveGroovyScriptUses();
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerList = ServiceTrackerListFactory.open(
+			bundleContext, GroovyScriptUsesFactory.class);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTrackerList.close();
+	}
+
+	private void _checkActiveGroovyScriptUses()
+		throws ConfigurationModelListenerException {
+
+		boolean activeGroovyScriptUses = false;
+
+		try {
+			activeGroovyScriptUses = _hasGroovyScriptUses();
+		}
+		catch (Exception exception) {
+			throw new ConfigurationModelListenerException(
+				exception, ScriptManagementConfiguration.class, getClass(),
+				null);
+		}
+
+		if (!activeGroovyScriptUses) {
+			return;
+		}
+
+		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		if (locale == null) {
+			locale = LocaleUtil.getDefault();
+		}
+
+		String message = _language.get(
+			locale,
+			"resolve-all-active-scripting-uses-before-proceeding-you-can-" +
+				"deactivate-the-source-entity-or-remove-the-script");
+
+		throw new ConfigurationModelListenerException(
+			message, ScriptManagementConfiguration.class, getClass(), null);
+	}
+
+	private boolean _hasGroovyScriptUses() throws Exception {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			boolean[] activeGroovyScriptUses = {false};
+
+			_companyLocalService.forEachCompanyId(
+				companyId -> {
+					if (activeGroovyScriptUses[0]) {
+						return;
+					}
+
+					if (_hasGroovyScriptUsesInCurrentCompany()) {
+						activeGroovyScriptUses[0] = true;
+					}
+				});
+
+			return activeGroovyScriptUses[0];
+		}
+
+		return _hasGroovyScriptUsesInCurrentCompany();
+	}
+
+	private boolean _hasGroovyScriptUsesInCurrentCompany() throws Exception {
+		for (GroovyScriptUsesFactory groovyScriptUsesFactory :
+				_serviceTrackerList) {
+
+			if (groovyScriptUsesFactory.hasUses()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private Language _language;
+
+	private ServiceTrackerList<GroovyScriptUsesFactory> _serviceTrackerList;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-script-management-test-util")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-api")

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionGroovyScriptUsesFactoryTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowDefinitionGroovyScriptUsesFactoryTest.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.workflow.kaleo.internal.runtime.integration.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
+import com.liferay.portal.security.script.management.test.rule.ScriptManagementConfigurationTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.workflow.manager.WorkflowDefinitionManager;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Fábio Alves
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class WorkflowDefinitionGroovyScriptUsesFactoryTest
+	extends BaseWorkflowManagerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			ScriptManagementConfigurationTestRule.INSTANCE);
+
+	@Test
+	public void testHasUses() throws Exception {
+		Assert.assertFalse(_groovyScriptUsesFactory.hasUses());
+
+		_workflowDefinitionManager.deployWorkflowDefinition(
+			FileUtil.getBytes(
+				getResourceInputStream(
+					"single-approver-site-member-workflow-definition.xml")),
+			TestPropsValues.getCompanyId(), RandomTestUtil.randomString(),
+			"Site Member Single Approver", StringPool.BLANK,
+			TestPropsValues.getUserId());
+
+		Assert.assertTrue(_groovyScriptUsesFactory.hasUses());
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.workflow.web.internal.groovy.script.uses.factory.WorkflowDefinitionGroovyScriptUsesFactory"
+	)
+	private GroovyScriptUsesFactory _groovyScriptUsesFactory;
+
+	@Inject
+	private WorkflowDefinitionManager _workflowDefinitionManager;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/groovy/script/uses/factory/WorkflowDefinitionGroovyScriptUsesFactory.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/groovy/script/uses/factory/WorkflowDefinitionGroovyScriptUsesFactory.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.workflow.WorkflowDefinition;
 import com.liferay.portal.security.script.management.groovy.script.use.GroovyScriptUse;
 import com.liferay.portal.security.script.management.groovy.script.uses.factory.GroovyScriptUsesFactory;
 import com.liferay.portal.workflow.constants.WorkflowDefinitionConstants;
@@ -66,6 +67,26 @@ public class WorkflowDefinitionGroovyScriptUsesFactory
 						workflowDefinition.getVersion(),
 						_workflowPortletTabRegistry));
 			});
+	}
+
+	@Override
+	public boolean hasUses() throws Exception {
+		for (WorkflowDefinition workflowDefinition :
+				_workflowDefinitionManager.getActiveWorkflowDefinitions(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			if (WorkflowDefinitionGroovyScriptUseDetector.detect(
+					workflowDefinition.getContent(), _jsonFactory) &&
+				!Objects.equals(
+					workflowDefinition.getName(),
+					WorkflowDefinitionConstants.
+						NAME_MESSAGE_BOARDS_USER_STATS_MODERATION)) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96741

## What Is Being Fixed

Disabling script execution (the "Allow script content to be executed or included" configuration) could be turned off while Groovy scripts registered through the script management framework were still actively in use — for example, by an active object action, object validation rule, or workflow definition. Turning off script execution in that state left those entities referencing scripts the portal could no longer run.

## How It Is Being Fixed

`GroovyScriptUsesFactory` gains a request-free `hasUses()` method, since the existing `create(ResourceRequest)` method can't be called from the configuration-persistence path where no `ResourceRequest` is available. Adding a method to this provider-implemented interface is a breaking change, so the `groovy.script.uses.factory` package and the module's bundle version bump accordingly. `ObjectActionGroovyScriptUsesFactory`, `ObjectValidationRuleGroovyScriptUsesFactory`, and `WorkflowDefinitionGroovyScriptUsesFactory` each implement it.

A new `ScriptManagementConfigurationModelListener` tracks every `GroovyScriptUsesFactory` and enforces the check: `onBeforeSave` blocks turning off script execution while any factory reports active uses, and `onBeforeDelete` blocks removing the configuration entirely for the same reason. Integration tests cover both the factories' `hasUses()` behavior and the listener's enforcement.

## PR Check

**pr-check: PASS** — tested on `86431e66220f109fd591d12bdd6f42f4861cdcd7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "86431e66220f109fd591d12bdd6f42f4861cdcd7"} -->
