### PR TITLE
LPD-74644 Follow up PR - Fix category scope for shared CMS vocabularies

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -6,8 +6,12 @@
 package com.liferay.object.rest.internal.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.object.comment.ObjectEntryComment;
 import com.liferay.object.exception.ObjectEntryGroupIdException;
@@ -23,6 +27,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -135,6 +140,21 @@ public class ServiceContextUtil {
 		return serviceContext;
 	}
 
+	private static AssetVocabulary _fetchBriefAssetVocabulary(
+		long groupId, TaxonomyCategoryBrief taxonomyCategoryBrief) {
+
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			taxonomyCategoryBrief.getParentTaxonomyVocabulary();
+
+		if (parentTaxonomyVocabulary == null) {
+			return null;
+		}
+
+		return AssetVocabularyLocalServiceUtil.
+			fetchAssetVocabularyByExternalReferenceCode(
+				parentTaxonomyVocabulary.getExternalReferenceCode(), groupId);
+	}
+
 	private static long[] _getAllowedGroupIds(long companyId, long groupId)
 		throws PortalException {
 
@@ -188,6 +208,27 @@ public class ServiceContextUtil {
 		return status.getCode();
 	}
 
+	private static boolean _isAssetVocabularyAvailable(
+		long assetVocabularyId, long groupId) {
+
+		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
+			AssetVocabularyGroupRelLocalServiceUtil.
+				getAssetVocabularyGroupRelsByVocabularyId(assetVocabularyId);
+
+		for (AssetVocabularyGroupRel assetVocabularyGroupRel :
+				assetVocabularyGroupRels) {
+
+			if ((assetVocabularyGroupRel.getGroupId() ==
+					GroupConstants.ANY_PARENT_GROUP_ID) ||
+				(assetVocabularyGroupRel.getGroupId() == groupId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static boolean _isObjectEntryDraft(Status status) {
 		if ((status != null) &&
 			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
@@ -231,8 +272,17 @@ public class ServiceContextUtil {
 				taxonomyCategoryBrief);
 
 			if (!ArrayUtil.contains(groupIds, scopeGroupId)) {
-				throw new ObjectEntryGroupIdException.
-					InvalidGroupIdForAssetCategoryBrief(externalReferenceCode);
+				AssetVocabulary assetVocabulary = _fetchBriefAssetVocabulary(
+					scopeGroupId, taxonomyCategoryBrief);
+
+				if ((assetVocabulary == null) ||
+					!_isAssetVocabularyAvailable(
+						assetVocabulary.getVocabularyId(), groupId)) {
+
+					throw new ObjectEntryGroupIdException.
+						InvalidGroupIdForAssetCategoryBrief(
+							externalReferenceCode);
+				}
 			}
 
 			try {
@@ -297,7 +347,9 @@ public class ServiceContextUtil {
 					assetCategoryId);
 
 			if ((assetCategory == null) ||
-				!ArrayUtil.contains(groupIds, assetCategory.getGroupId())) {
+				(!ArrayUtil.contains(groupIds, assetCategory.getGroupId()) &&
+				 !_isAssetVocabularyAvailable(
+					 assetCategory.getVocabularyId(), groupId))) {
 
 				throw new ObjectEntryGroupIdException.
 					InvalidGroupIdForAssetCategory(assetCategoryId);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.constants.DepotConstants;
@@ -20829,6 +20830,120 @@ public class ObjectEntryResourceTest {
 			));
 
 		_groupLocalService.deleteGroup(childGroup);
+
+		// Can add a category whose vocabulary is shared to all spaces
+
+		AssetVocabulary allSpacesAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			allSpacesAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory allSpacesTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				allSpacesAssetVocabulary.getGroupId(),
+				allSpacesAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.put(allSpacesTaxonomyCategory.getId())
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(allSpacesAssetVocabulary);
+
+		// Can add a category whose vocabulary is shared to the entry group
+
+		AssetVocabulary sharedAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			_testGroupId, sharedAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory sharedTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				sharedAssetVocabulary.getGroupId(),
+				sharedAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.put(sharedTaxonomyCategory.getId())
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(sharedAssetVocabulary);
+
+		// Can add a category by brief whose vocabulary is shared to all spaces
+
+		AssetVocabulary briefAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			briefAssetVocabulary.getVocabularyId(), DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory briefTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				briefAssetVocabulary.getGroupId(),
+				briefAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"parentTaxonomyVocabulary",
+							JSONUtil.put(
+								"externalReferenceCode",
+								briefAssetVocabulary.getExternalReferenceCode())
+						).put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							briefTaxonomyCategory.getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(briefAssetVocabulary);
 
 		// Cannot add a category to a company-scoped entry
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74644

## What is being fixed

The asset category scope validation added under LPD-74644 broke CMS content categorization. CMS content is space-scoped (depot) and its vocabularies live in the CMS site group but are shared to the spaces through the assetLibraries association (AssetVocabularyGroupRel, including the -1 all-spaces sentinel). The new validation only accepted a category whose group was in the entry's connected site and depot groups, so selecting such a shared category in the CMS Info Panel returned a 400 "Asset category does not belong to the object entry's scope".

---

## How it is being fixed

Both scope-validation paths in ServiceContextUtil (the ids path in _validateAssetCategoryGroupIds and the briefs path in _setObjectEntryTaxonomyCategoryIds) are widened into a union: a category is rejected only when its group is outside the allowed set AND its vocabulary is not available to the entry group. Availability is resolved through AssetVocabularyGroupRel, mirroring ObjectEntryLocalServiceImpl._filterAssetCategoryIds. The original cross-site rejection is preserved because such a vocabulary is neither group-scoped to the entry nor shared to it.

---

## How can it be tested

**Integration test:** ObjectEntryResourceTest.testPostObjectEntryWithTaxonomyCategories

```bash
cd modules
../gradlew :apps:object:object-rest-test:testIntegration --tests 'com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest.testPostObjectEntryWithTaxonomyCategories'
```

New cases in _testPostObjectEntryWithCrossSiteTaxonomyCategories assert that a category whose vocabulary is shared to all spaces (-1) or to the entry group is accepted on a space-scoped entry (ids and briefs paths), while the existing cross-site rejection cases still return 400.

Manual: in CMS, open a space-scoped content item's Info Panel Categorization tab, select a category from a vocabulary shared to all spaces, and confirm it attaches without a 400.