### PR TITLE
LPD-96252 Fix object definition tabs sticky positioning for large browser font sizes

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.scss
@@ -1,13 +1,7 @@
 @import 'atlas-custom-properties/_variables';
 
 .lfr__management-toolbar {
-	position: sticky;
 	width: 100%;
-	z-index: 2;
-
-	.has-control-menu & {
-		top: var(--control-menu-container-height);
-	}
 
 	&--box-shadow {
 		box-shadow: 0 0.125rem 0.75rem

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
@@ -32,7 +32,8 @@
 
 		.data-set .management-bar-wrapper {
 			top: calc(
-				var(--control-menu-container-height, 56px) + 1.5rem + 4rem + 48px
+				var(--control-menu-container-height, 56px) + 1.5rem + 4rem +
+					48px
 			);
 		}
 
@@ -43,7 +44,9 @@
 		}
 
 		.page-header {
-			top: calc(var(--control-menu-container-height, 56px) + 1.5rem + 4rem);
+			top: calc(
+				var(--control-menu-container-height, 56px) + 1.5rem + 4rem
+			);
 		}
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/_management-toolbar.scss
@@ -9,12 +9,12 @@
 	.data-set {
 		.management-bar-wrapper {
 			background-color: #fff;
-			top: 168px;
+			top: calc(var(--control-menu-container-height, 56px) + 4rem + 48px);
 		}
 	}
 
 	> .lfr-tooltip-scope {
-		top: 56px;
+		top: var(--control-menu-container-height, 56px);
 	}
 
 	.navbar {
@@ -22,26 +22,28 @@
 	}
 
 	.page-header {
-		top: 120px;
+		top: calc(var(--control-menu-container-height, 56px) + 4rem);
 	}
 
 	&.publication {
 		& > .lfr-tooltip-scope {
-			top: 80px;
+			top: calc(var(--control-menu-container-height, 56px) + 1.5rem);
 		}
 
 		.data-set .management-bar-wrapper {
-			top: 192px;
+			top: calc(
+				var(--control-menu-container-height, 56px) + 1.5rem + 4rem + 48px
+			);
 		}
 
 		.lfr-objects__object-definition-details-management-toolbar {
 			.lfr__management-toolbar {
-				margin-top: 24px;
+				margin-top: 1.5rem;
 			}
 		}
 
 		.page-header {
-			top: 144px;
+			top: calc(var(--control-menu-container-height, 56px) + 1.5rem + 4rem);
 		}
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ObjectDetails.scss
@@ -1,11 +1,11 @@
 .edit-object-definition-wrapper {
 	position: relative;
-	top: -3.5rem;
+	top: calc(-1 * var(--control-menu-container-height, 56px));
 }
 
 .lfr-objects__object-definition-details {
 	margin-bottom: 25px;
-	margin-top: 5.5rem;
+	margin-top: calc(var(--control-menu-container-height, 56px) + 4rem);
 
 	&-configuration {
 		display: flex;
@@ -15,13 +15,9 @@
 
 .lfr-objects__object-definition-details-management-toolbar {
 	position: sticky;
-	top: 3.5rem;
+	top: var(--control-menu-container-height, 56px);
 	width: 100%;
 	z-index: 1;
-
-	.has-control-menu & .lfr__management-toolbar {
-		top: 0;
-	}
 }
 
 .lfr__object-web-edit-object-details-external-data-source-container {


### PR DESCRIPTION
# What is this trying to solve?

[LPD-96252](https://liferay.atlassian.net/browse/LPD-96252) | [LPP-64610](https://liferay.atlassian.net/browse/LPP-64610)

In Control Panel → Objects → any object definition, the navigation tabs (Details, Fields, Relationships, Actions, Validations) are hidden behind the sticky management toolbar when the browser font size is set to Large in chrome://settings/appearance.

# How am I fixing it?

The root cause is that sticky `top` values were hardcoded in `px` or `rem`, assuming a fixed 16px root font size. At Large font (20px), the management toolbar grows taller via `min-height: 4rem`, but the sticky offsets below it did not account for that growth — causing nav tabs and content to scroll behind the toolbar.

Three files updated:

1. `index.scss` — Removed `position: sticky` and `top` from the inner `<nav>` (`.lfr__management-toolbar`). The inner nav was fighting the outer wrapper's sticky position, causing a double-sticky conflict that misaligned the toolbar on scroll.

2. `ObjectDetails.scss` — Replaced 3 hardcoded `rem` values with `var(--control-menu-container-height, 56px)`. The Details tab toolbar was sticking at `3.5rem` (70px at Large font) instead of the correct 56px, and the form content margin was not compensating for the toolbar's actual rendered height.

3. `_management-toolbar.scss` — Replaced 6 hardcoded `px` sticky-top values with `calc(var(--control-menu-container-height, 56px) + 4rem)` and variants. This ensures the nav tabs bar and data-set search bar always stack flush below the management toolbar regardless of the browser font size setting, including in publication mode.

# How can you verify that it works?

1. Go to `chrome://settings/appearance` and set Font Size to **Large**
2. Navigate to Control Panel → Objects → any object definition
3. Click through all tabs: Details, Fields, Relationships, Actions, Validations
4. Scroll down on each tab — the toolbar, nav tabs, and search bar should stack without overlapping
5. Repeat at **Medium** font size to confirm no regression

[LPD-96252]: https://liferay.atlassian.net/browse/LPD-96252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPP-64610]: https://liferay.atlassian.net/browse/LPP-64610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# PR Check

**pr-check: PASS** — tested on `a05d25701a3714787b82431e428332d5e1908637`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a05d25701a3714787b82431e428332d5e1908637"} -->