### PR TITLE
LPD-96936 Preserve hidden form field values when editing an entry

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -91,6 +91,7 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			}
 
 			ddmFormField.setDDMFormFieldValidation(null);
+			ddmFormField.setProperty("persistNonevaluableValue", true);
 			ddmFormField.setRequired(false);
 
 			for (DDMFormFieldValue ddmFormFieldValue :

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -20,12 +20,14 @@ import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormLayoutTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -62,7 +64,32 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			false, RandomTestUtil.randomBoolean(),
 			new UnlocalizedValue(_STRING_VALUE));
 
-		_assertDDMFormFields(false, new UnlocalizedValue(StringPool.BLANK));
+		_assertDDMFormFields(
+			false, new UnlocalizedValue(StringPool.BLANK), true);
+	}
+
+	@Test
+	public void testDisabledPageField() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		_createDDMFormFields(ddmForm, false, RandomTestUtil.randomBoolean());
+
+		_createDDMFormValues(ddmForm, new UnlocalizedValue(_STRING_VALUE));
+
+		AddFormInstanceRecordMVCCommandUtil.updateNonevaluableDDMFormFields(
+			ddmForm.getDDMFormFieldsMap(true), Collections.emptyMap(),
+			_ddmFormValues.getDDMFormFieldValuesMap(true),
+			DDMFormLayoutTestUtil.createDDMFormLayout(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new String[] {_FIELD_NAME, _NESTED_FIELD_NAME}),
+			Collections.singleton(0));
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				_ddmFormField.getProperty("persistNonevaluableValue")));
+		Assert.assertEquals(
+			new UnlocalizedValue(StringPool.BLANK),
+			_getFieldValue(_FIELD_NAME));
 	}
 
 	@Test
@@ -75,7 +102,8 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			).build(),
 			false, required, new UnlocalizedValue(_STRING_VALUE));
 
-		_assertDDMFormFields(required, new UnlocalizedValue(_STRING_VALUE));
+		_assertDDMFormFields(
+			required, new UnlocalizedValue(_STRING_VALUE), false);
 	}
 
 	@Test
@@ -99,6 +127,10 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 		Assert.assertEquals(
 			StringPool.BLANK, value.getString(LocaleUtil.BRAZIL));
 		Assert.assertEquals(StringPool.BLANK, value.getString(LocaleUtil.US));
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				_ddmFormField.getProperty("persistNonevaluableValue")));
 	}
 
 	@Test
@@ -110,7 +142,8 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			false, RandomTestUtil.randomBoolean(),
 			new UnlocalizedValue(_STRING_VALUE));
 
-		_assertDDMFormFields(false, new UnlocalizedValue(StringPool.BLANK));
+		_assertDDMFormFields(
+			false, new UnlocalizedValue(StringPool.BLANK), true);
 	}
 
 	@Test
@@ -122,7 +155,7 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			RandomTestUtil.randomBoolean(), RandomTestUtil.randomBoolean(),
 			null);
 
-		_assertDDMFormFields(false, null);
+		_assertDDMFormFields(false, null, true);
 	}
 
 	@Test(expected = FormInstanceExpiredException.class)
@@ -164,13 +197,19 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			).build(),
 			false, required, new UnlocalizedValue(_STRING_VALUE));
 
-		_assertDDMFormFields(required, new UnlocalizedValue(_STRING_VALUE));
+		_assertDDMFormFields(
+			required, new UnlocalizedValue(_STRING_VALUE), false);
 	}
 
 	private void _assertDDMFormFields(
-		boolean expectedRequired, Value expectedValue) {
+		boolean expectedRequired, Value expectedValue,
+		boolean expectedPersistNonevaluableValue) {
 
 		Assert.assertEquals(expectedRequired, _ddmFormField.isRequired());
+		Assert.assertEquals(
+			expectedPersistNonevaluableValue,
+			GetterUtil.getBoolean(
+				_ddmFormField.getProperty("persistNonevaluableValue")));
 		Assert.assertEquals(expectedValue, _getFieldValue(_FIELD_NAME));
 		Assert.assertEquals(expectedValue, _getFieldValue(_NESTED_FIELD_NAME));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFieldLocalServiceImpl.java
@@ -868,7 +868,7 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 
 			DDMField ddmField = ddmFieldEntry.getKey();
 
-			if (_persistReadOnlyValues(
+			if (_persistFieldValues(
 					ddmField, ddmFieldAttributeEntries, ddmFieldInfosMap,
 					ddmFieldsAttributesMap, ddmFormFieldsMap)) {
 
@@ -1096,7 +1096,7 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 		return jsonObject.toString();
 	}
 
-	private boolean _persistReadOnlyValues(
+	private boolean _persistFieldValues(
 		DDMField ddmField,
 		List<Map.Entry<DDMFieldAttribute, DDMFieldAttributeInfo>>
 			ddmFieldAttributeEntries,
@@ -1114,8 +1114,10 @@ public class DDMFieldLocalServiceImpl extends DDMFieldLocalServiceBaseImpl {
 			ddmField.getFieldName());
 
 		if ((ddmFormField == null) ||
-			!GetterUtil.getBoolean(
-				ddmFormField.getProperty("persistReadOnlyValue"))) {
+			(!GetterUtil.getBoolean(
+				ddmFormField.getProperty("persistNonevaluableValue")) &&
+			 !GetterUtil.getBoolean(
+				 ddmFormField.getProperty("persistReadOnlyValue")))) {
 
 			return false;
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
@@ -17,6 +17,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -137,6 +138,93 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 			ddmFormInstanceRecords.get(0);
 
 		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(false);
+
+		_assertValue("TextField1", ddmFormFieldValuesMap, value1);
+		_assertValue("TextField2", ddmFormFieldValuesMap, value2);
+	}
+
+	@Test
+	public void testProcessActionPreservesInvisibleFieldValue()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(
+				LocaleUtil.BRAZIL, LocaleUtil.US),
+			LocaleUtil.US);
+
+		DDMFormTestUtil.addDDMFormRule(
+			Collections.singletonList("setVisible('TextField2', false)"),
+			"not(isEmpty(getValue('TextField1')))", ddmForm);
+		DDMFormTestUtil.addTextDDMFormFields(
+			ddmForm, "TextField1", "TextField2");
+
+		DDMFormInstance ddmFormInstance =
+			DDMFormInstanceTestUtil.addDDMFormInstance(
+				ddmForm, _group,
+				DDMFormInstanceTestUtil.createSettingsDDMFormValues(false),
+				TestPropsValues.getUserId());
+
+		String value2 = RandomTestUtil.randomString();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value2);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<DDMFormInstanceRecord> ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecords.get(0);
+
+		String value1 = RandomTestUtil.randomString();
+
+		mockLiferayPortletActionRequest = _getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", value1);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceRecordId",
+			String.valueOf(ddmFormInstanceRecord.getFormInstanceRecordId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		Assert.assertEquals(
+			String.valueOf(ddmFormInstanceRecords), 1,
+			ddmFormInstanceRecords.size());
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecords.get(
+			0
+		).getDDMFormValues();
 
 		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
 			ddmFormValues.getDDMFormFieldValuesMap(false);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96936

## What Is Being Fixed

On a form with a field-visibility rule (for example, "show FirstName only if
the user is in role Submitter"), a user for whom a field is not visible could
edit an existing entry, change other fields, and save — and the previously
stored value of the hidden field was erased. The value belonged to a field the
acting user could neither see nor edit, yet the save destroyed it.

A form-record update writes the submitted values into a fresh per-version
storage, so any field missing from (or blanked in) the submission is lost.
Because a hidden field is submitted with an empty value, its stored value was
overwritten with a blank on save.

## How It Is Being Fixed

On an existing-record edit, before persisting, the value of each non-evaluable
field (hidden by a visibility rule, on a page-flow-disabled page, or read-only)
is replaced with the value already stored in the record, instead of being
blanked. The decision lives in the form-web action, which is the only layer
that has the evaluator's visibility verdict and can tell a field the user
intentionally cleared from one that was hidden from them. The stored value is
used rather than the submitted one, so a user still cannot inject a value into
a field they cannot see. New submissions have no prior record, so hidden fields
in them still store blank, exactly as before.

## PR Check

**pr-check: PASS** — tested on `f27803f6b92c6ea52af378e8a658777331a20297`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f27803f6b92c6ea52af378e8a658777331a20297"} -->
