### PR TITLE
LPD-77906: Task statistics card loses the active state when users perform searches

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksQuickFilters.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/task/TasksQuickFilters.tsx
@@ -101,9 +101,14 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 	const [visible, setVisible] = useState(true);
 
 	const isQuickFilterChangeRef = useRef(false);
+	const activeQuickFilterSelectionsRef = useRef<Record<
+		string,
+		IBaseFilterState['selectedData']
+	> | null>(null);
 
 	const handleTotalTasksClick = useCallback(() => {
 		setActiveQuickFilter(TASK_QUICK_FILTER_TYPES.TOTAL);
+		activeQuickFilterSelectionsRef.current = null;
 
 		setTasksFDSState({
 			...tasksFDSState,
@@ -125,6 +130,35 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 	const handleOverdueClick = useCallback(() => {
 		setActiveQuickFilter(TASK_QUICK_FILTER_TYPES.OVERDUE);
 
+		const cmpStateSelectedData: IBaseFilterState['selectedData'] = {
+			exclude: true,
+			selectedItems: [
+				{
+					label: Liferay.Language.get('done'),
+					value: 'done',
+				},
+			],
+		};
+
+		const currentDate = new Date();
+
+		currentDate.setDate(currentDate.getDate() - 1);
+
+		const cmpDueDateSelectedData: IBaseFilterState['selectedData'] = {
+			exclude: false,
+			from: null,
+			to: {
+				day: currentDate.getDate(),
+				month: currentDate.getMonth() + 1,
+				year: currentDate.getFullYear(),
+			},
+		};
+
+		activeQuickFilterSelectionsRef.current = {
+			cmpDueDate: cmpDueDateSelectedData,
+			cmpState: cmpStateSelectedData,
+		};
+
 		setTasksFDSState({
 			...tasksFDSState,
 			filters: tasksFDSState.filters.map((filter: IBaseFilterState) => {
@@ -132,35 +166,15 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 					return {
 						...filter,
 						active: true,
-						selectedData: {
-							exclude: true,
-							selectedItems: [
-								{
-									label: Liferay.Language.get('done'),
-									value: 'done',
-								},
-							],
-						},
+						selectedData: cmpStateSelectedData,
 					};
 				}
 
 				if (filter.id === 'cmpDueDate') {
-					const currentDate = new Date();
-
-					currentDate.setDate(currentDate.getDate() - 1);
-
 					return {
 						...filter,
 						active: true,
-						selectedData: {
-							exclude: false,
-							from: null,
-							to: {
-								day: currentDate.getDate(),
-								month: currentDate.getMonth() + 1,
-								year: currentDate.getFullYear(),
-							},
-						},
+						selectedData: cmpDueDateSelectedData,
 					};
 				}
 
@@ -181,6 +195,20 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 	const handleBlockedClick = useCallback(() => {
 		setActiveQuickFilter(TASK_QUICK_FILTER_TYPES.BLOCKED);
 
+		const cmpStateSelectedData: IBaseFilterState['selectedData'] = {
+			exclude: false,
+			selectedItems: [
+				{
+					label: Liferay.Language.get('blocked'),
+					value: 'blocked',
+				},
+			],
+		};
+
+		activeQuickFilterSelectionsRef.current = {
+			cmpState: cmpStateSelectedData,
+		};
+
 		setTasksFDSState({
 			...tasksFDSState,
 			filters: tasksFDSState.filters.map((filter: IBaseFilterState) => {
@@ -188,15 +216,7 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 					return {
 						...filter,
 						active: true,
-						selectedData: {
-							exclude: false,
-							selectedItems: [
-								{
-									label: Liferay.Language.get('blocked'),
-									value: 'blocked',
-								},
-							],
-						},
+						selectedData: cmpStateSelectedData,
 					};
 				}
 
@@ -217,6 +237,20 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 	const handleInProgressClick = useCallback(() => {
 		setActiveQuickFilter(TASK_QUICK_FILTER_TYPES.IN_PROGRESS);
 
+		const cmpStateSelectedData: IBaseFilterState['selectedData'] = {
+			exclude: false,
+			selectedItems: [
+				{
+					label: Liferay.Language.get('in-progress'),
+					value: 'inProgress',
+				},
+			],
+		};
+
+		activeQuickFilterSelectionsRef.current = {
+			cmpState: cmpStateSelectedData,
+		};
+
 		setTasksFDSState({
 			...tasksFDSState,
 			filters: tasksFDSState.filters.map((filter: IBaseFilterState) => {
@@ -224,15 +258,7 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 					return {
 						...filter,
 						active: true,
-						selectedData: {
-							exclude: false,
-							selectedItems: [
-								{
-									label: Liferay.Language.get('in-progress'),
-									value: 'inProgress',
-								},
-							],
-						},
+						selectedData: cmpStateSelectedData,
 					};
 				}
 
@@ -278,6 +304,10 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 	 * Clear the active quick filter if the filters in the FDS changes.
 	 * `isQuickFilterChangeRef` is used to prevent the active quick filter from
 	 * immediately clearing when one of the quick filters are clicked.
+	 * `activeQuickFilterSelectionsRef` tracks the exact `selectedData` the
+	 * active quick filter set for each filter ID, so unrelated filter changes
+	 * (e.g. a text search) do not reset it, but changing the selection within
+	 * a tracked filter (e.g. adding "Done" to the State dropdown) does.
 	 */
 	useEffect(() => {
 		if (isQuickFilterChangeRef.current) {
@@ -286,7 +316,37 @@ export default function TasksQuickFilters({projectId}: {projectId?: string}) {
 			return;
 		}
 
-		setActiveQuickFilter(null);
+		// null = TOTAL: valid while all quick-filter dimensions remain inactive
+
+		const isFilterActive = (filterId: string) =>
+			tasksFDSState.filters.some(
+				(filter: IBaseFilterState) =>
+					filter.id === filterId && filter.active
+			);
+
+		const isFilterMatchingSelection = (filterId: string) => {
+			const expectedSelectedData =
+				activeQuickFilterSelectionsRef.current?.[filterId];
+
+			return tasksFDSState.filters.some(
+				(filter: IBaseFilterState) =>
+					filter.id === filterId &&
+					filter.active &&
+					JSON.stringify(filter.selectedData) ===
+						JSON.stringify(expectedSelectedData)
+			);
+		};
+
+		const quickFilterStillActive =
+			activeQuickFilterSelectionsRef.current === null
+				? !isFilterActive('cmpState') && !isFilterActive('cmpDueDate')
+				: Object.keys(activeQuickFilterSelectionsRef.current).every(
+						isFilterMatchingSelection
+					);
+
+		if (!quickFilterStillActive) {
+			setActiveQuickFilter(null);
+		}
 	}, [tasksFDSState.filters]);
 
 	/**

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
@@ -5,18 +5,40 @@
 
 import '@testing-library/jest-dom';
 import {act, cleanup, render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {fetch} from 'frontend-js-web';
 import React from 'react';
 
 import TasksQuickFilters from '../../js/components/task/TasksQuickFilters';
 
-describe('TasksQuickFilters', () => {
-	afterEach(() => {
-		cleanup();
-		(fetch as jest.Mock).mockClear();
-	});
+const mockSetTasksFDSState = jest.fn();
 
-	it('renders the appropriate counts when a projectId is provided', async () => {
+let mockTasksFDSState: any = {
+	filters: [
+		{active: false, id: 'cmpState', selectedData: {selectedItems: []}},
+		{active: false, id: 'cmpDueDate', selectedData: {}},
+	],
+};
+
+jest.mock('@liferay/frontend-js-state-web/react', () => ({
+	useLiferayState: () => [mockTasksFDSState, mockSetTasksFDSState],
+}));
+
+describe('TasksQuickFilters', () => {
+	beforeEach(() => {
+		mockSetTasksFDSState.mockClear();
+
+		mockTasksFDSState = {
+			filters: [
+				{
+					active: false,
+					id: 'cmpState',
+					selectedData: {selectedItems: []},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
 		(fetch as jest.Mock).mockResolvedValue({
 			json: () =>
 				Promise.resolve({
@@ -27,7 +49,14 @@ describe('TasksQuickFilters', () => {
 				}),
 			ok: true,
 		});
+	});
 
+	afterEach(() => {
+		cleanup();
+		(fetch as jest.Mock).mockClear();
+	});
+
+	it('renders the appropriate counts when a projectId is provided', async () => {
 		await act(async () => {
 			render(<TasksQuickFilters projectId="123" />);
 		});
@@ -54,17 +83,6 @@ describe('TasksQuickFilters', () => {
 	});
 
 	it('renders the appropriate counts from multiple API calls', async () => {
-		(fetch as jest.Mock).mockResolvedValueOnce({
-			json: () =>
-				Promise.resolve({
-					blockedCount: 1,
-					inProgressCount: 2,
-					overdueCount: 3,
-					totalCount: 4,
-				}),
-			ok: true,
-		});
-
 		await act(async () => {
 			render(<TasksQuickFilters />);
 		});
@@ -86,5 +104,184 @@ describe('TasksQuickFilters', () => {
 		expect(
 			screen.getByText('total-tasks').previousSibling
 		).toHaveTextContent('4');
+	});
+
+	it('keeps the quick filter button active when an unrelated filter changes', async () => {
+		const {rerender} = render(<TasksQuickFilters />);
+
+		await screen.findByText('blocked');
+
+		await userEvent.click(
+			screen.getByText('blocked').closest('button') as HTMLButtonElement
+		);
+
+		expect(screen.getByText('blocked').closest('button')).toHaveClass(
+			'active'
+		);
+
+		// Simulate FDS applying the quick filter state (consumes isQuickFilterChangeRef)
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [{label: 'blocked', value: 'blocked'}],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		// Simulate a search that triggers a new filters reference but leaves cmpState active
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [{label: 'blocked', value: 'blocked'}],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		expect(screen.getByText('blocked').closest('button')).toHaveClass(
+			'active'
+		);
+	});
+
+	it('clears the quick filter button when the selection changes within the same filter', async () => {
+		const {rerender} = render(<TasksQuickFilters />);
+
+		await screen.findByText('blocked');
+
+		await userEvent.click(
+			screen.getByText('blocked').closest('button') as HTMLButtonElement
+		);
+
+		expect(screen.getByText('blocked').closest('button')).toHaveClass(
+			'active'
+		);
+
+		// Simulate FDS applying the quick filter state (consumes isQuickFilterChangeRef)
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [{label: 'blocked', value: 'blocked'}],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		// Simulate the State dropdown adding "done" to the selection while cmpState stays active
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [
+							{label: 'blocked', value: 'blocked'},
+							{label: 'done', value: 'done'},
+						],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		expect(screen.getByText('blocked').closest('button')).not.toHaveClass(
+			'active'
+		);
+	});
+
+	it('keeps the total tasks button active when an unrelated filter changes', async () => {
+		const {rerender} = render(<TasksQuickFilters />);
+
+		await screen.findByText('total-tasks');
+
+		await userEvent.click(
+			screen
+				.getByText('total-tasks')
+				.closest('button') as HTMLButtonElement
+		);
+
+		expect(screen.getByText('total-tasks').closest('button')).toHaveClass(
+			'active'
+		);
+
+		// Simulate FDS applying the quick filter state (consumes isQuickFilterChangeRef)
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: false,
+					id: 'cmpState',
+					selectedData: {exclude: false, selectedItems: []},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		// Simulate a search that adds a new filter reference but leaves cmpState and cmpDueDate inactive
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: false,
+					id: 'cmpState',
+					selectedData: {exclude: false, selectedItems: []},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		expect(screen.getByText('total-tasks').closest('button')).toHaveClass(
+			'active'
+		);
 	});
 });

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/TasksQuickFilters.spec.tsx
@@ -56,116 +56,6 @@ describe('TasksQuickFilters', () => {
 		(fetch as jest.Mock).mockClear();
 	});
 
-	it('renders the appropriate counts when a projectId is provided', async () => {
-		await act(async () => {
-			render(<TasksQuickFilters projectId="123" />);
-		});
-
-		expect(fetch).toHaveBeenCalledWith(
-			'/o/headless-cmp/v1.0/projects/123/task-statistics/',
-			{
-				method: 'GET',
-			}
-		);
-
-		expect(screen.getByText('blocked').previousSibling).toHaveTextContent(
-			'1'
-		);
-		expect(
-			screen.getByText('in-progress').previousSibling
-		).toHaveTextContent('2');
-		expect(screen.getByText('overdue').previousSibling).toHaveTextContent(
-			'3'
-		);
-		expect(
-			screen.getByText('total-tasks').previousSibling
-		).toHaveTextContent('4');
-	});
-
-	it('renders the appropriate counts from multiple API calls', async () => {
-		await act(async () => {
-			render(<TasksQuickFilters />);
-		});
-
-		expect(fetch).toHaveBeenCalledWith(
-			'/o/headless-cmp/v1.0/task-statistics/',
-			{method: 'GET'}
-		);
-
-		expect(screen.getByText('blocked').previousSibling).toHaveTextContent(
-			'1'
-		);
-		expect(
-			screen.getByText('in-progress').previousSibling
-		).toHaveTextContent('2');
-		expect(screen.getByText('overdue').previousSibling).toHaveTextContent(
-			'3'
-		);
-		expect(
-			screen.getByText('total-tasks').previousSibling
-		).toHaveTextContent('4');
-	});
-
-	it('keeps the quick filter button active when an unrelated filter changes', async () => {
-		const {rerender} = render(<TasksQuickFilters />);
-
-		await screen.findByText('blocked');
-
-		await userEvent.click(
-			screen.getByText('blocked').closest('button') as HTMLButtonElement
-		);
-
-		expect(screen.getByText('blocked').closest('button')).toHaveClass(
-			'active'
-		);
-
-		// Simulate FDS applying the quick filter state (consumes isQuickFilterChangeRef)
-
-		mockTasksFDSState = {
-			...mockTasksFDSState,
-			filters: [
-				{
-					active: true,
-					id: 'cmpState',
-					selectedData: {
-						exclude: false,
-						selectedItems: [{label: 'blocked', value: 'blocked'}],
-					},
-				},
-				{active: false, id: 'cmpDueDate', selectedData: {}},
-			],
-		};
-
-		await act(async () => {
-			rerender(<TasksQuickFilters />);
-		});
-
-		// Simulate a search that triggers a new filters reference but leaves cmpState active
-
-		mockTasksFDSState = {
-			...mockTasksFDSState,
-			filters: [
-				{
-					active: true,
-					id: 'cmpState',
-					selectedData: {
-						exclude: false,
-						selectedItems: [{label: 'blocked', value: 'blocked'}],
-					},
-				},
-				{active: false, id: 'cmpDueDate', selectedData: {}},
-			],
-		};
-
-		await act(async () => {
-			rerender(<TasksQuickFilters />);
-		});
-
-		expect(screen.getByText('blocked').closest('button')).toHaveClass(
-			'active'
-		);
-	});
-
 	it('clears the quick filter button when the selection changes within the same filter', async () => {
 		const {rerender} = render(<TasksQuickFilters />);
 
@@ -229,6 +119,66 @@ describe('TasksQuickFilters', () => {
 		);
 	});
 
+	it('keeps the quick filter button active when an unrelated filter changes', async () => {
+		const {rerender} = render(<TasksQuickFilters />);
+
+		await screen.findByText('blocked');
+
+		await userEvent.click(
+			screen.getByText('blocked').closest('button') as HTMLButtonElement
+		);
+
+		expect(screen.getByText('blocked').closest('button')).toHaveClass(
+			'active'
+		);
+
+		// Simulate FDS applying the quick filter state (consumes isQuickFilterChangeRef)
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [{label: 'blocked', value: 'blocked'}],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		// Simulate a search that triggers a new filters reference but leaves cmpState active
+
+		mockTasksFDSState = {
+			...mockTasksFDSState,
+			filters: [
+				{
+					active: true,
+					id: 'cmpState',
+					selectedData: {
+						exclude: false,
+						selectedItems: [{label: 'blocked', value: 'blocked'}],
+					},
+				},
+				{active: false, id: 'cmpDueDate', selectedData: {}},
+			],
+		};
+
+		await act(async () => {
+			rerender(<TasksQuickFilters />);
+		});
+
+		expect(screen.getByText('blocked').closest('button')).toHaveClass(
+			'active'
+		);
+	});
+
 	it('keeps the total tasks button active when an unrelated filter changes', async () => {
 		const {rerender} = render(<TasksQuickFilters />);
 
@@ -283,5 +233,55 @@ describe('TasksQuickFilters', () => {
 		expect(screen.getByText('total-tasks').closest('button')).toHaveClass(
 			'active'
 		);
+	});
+
+	it('renders the appropriate counts from multiple API calls', async () => {
+		await act(async () => {
+			render(<TasksQuickFilters />);
+		});
+
+		expect(fetch).toHaveBeenCalledWith(
+			'/o/headless-cmp/v1.0/task-statistics/',
+			{method: 'GET'}
+		);
+
+		expect(screen.getByText('blocked').previousSibling).toHaveTextContent(
+			'1'
+		);
+		expect(
+			screen.getByText('in-progress').previousSibling
+		).toHaveTextContent('2');
+		expect(screen.getByText('overdue').previousSibling).toHaveTextContent(
+			'3'
+		);
+		expect(
+			screen.getByText('total-tasks').previousSibling
+		).toHaveTextContent('4');
+	});
+
+	it('renders the appropriate counts when a projectId is provided', async () => {
+		await act(async () => {
+			render(<TasksQuickFilters projectId="123" />);
+		});
+
+		expect(fetch).toHaveBeenCalledWith(
+			'/o/headless-cmp/v1.0/projects/123/task-statistics/',
+			{
+				method: 'GET',
+			}
+		);
+
+		expect(screen.getByText('blocked').previousSibling).toHaveTextContent(
+			'1'
+		);
+		expect(
+			screen.getByText('in-progress').previousSibling
+		).toHaveTextContent('2');
+		expect(screen.getByText('overdue').previousSibling).toHaveTextContent(
+			'3'
+		);
+		expect(
+			screen.getByText('total-tasks').previousSibling
+		).toHaveTextContent('4');
 	});
 });


### PR DESCRIPTION
[https://liferay.atlassian.net/browse/LPD-77906](https://liferay.atlassian.net/browse/LPD-77906)

**What Is Being Fixed**
Task statistics card loses the active state when users perform searches

**How It Is Being Fixed**
 activeQuickFilterIdsRef tracks which filter IDs the active quick filter set, so unrelated filter changes (e.g. a text search) do not reset it.