### PR TITLE
LPD-96936 Preserve hidden form field values when editing an entry

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -30,6 +30,7 @@ import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -55,6 +56,7 @@ import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 import jakarta.portlet.PortletSession;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -150,11 +152,29 @@ public class AddFormInstanceRecordMVCActionCommand
 
 		DDMStructure ddmStructure = ddmFormInstance.getStructure();
 
+		long formInstanceRecordId = ParamUtil.getLong(
+			actionRequest, "formInstanceRecordId");
+
+		Map<String, List<DDMFormFieldValue>> existingDDMFormFieldValuesMap =
+			null;
+
+		if (formInstanceRecordId != 0) {
+			DDMFormInstanceRecord ddmFormInstanceRecord =
+				_ddmFormInstanceRecordService.getFormInstanceRecord(
+					formInstanceRecordId);
+
+			DDMFormValues existingDDMFormValues =
+				ddmFormInstanceRecord.getDDMFormValues();
+
+			existingDDMFormFieldValuesMap =
+				existingDDMFormValues.getDDMFormFieldValuesMap(true);
+		}
+
 		AddFormInstanceRecordMVCCommandUtil.updateNonevaluableDDMFormFields(
 			ddmForm.getDDMFormFieldsMap(true),
 			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges(),
 			ddmFormValues.getDDMFormFieldValuesMap(true),
-			ddmStructure.getDDMFormLayout(),
+			existingDDMFormFieldValuesMap, ddmStructure.getDDMFormLayout(),
 			ddmFormEvaluatorEvaluateResponse.getDisabledPagesIndexes());
 
 		AddFormInstanceRecordMVCCommandUtil.updateReadOnlyDDMFormFields(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -45,6 +47,7 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
 				ddmFormFieldsPropertyChanges,
 			Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap,
+			Map<String, List<DDMFormFieldValue>> existingDDMFormFieldValuesMap,
 			DDMFormLayout ddmFormLayout, Set<Integer> disabledPagesIndexes)
 		throws Exception {
 
@@ -102,7 +105,13 @@ public class AddFormInstanceRecordMVCCommandUtil {
 					continue;
 				}
 
-				if (ddmFormField.isLocalizable()) {
+				Value existingValue = _getExistingValue(
+					existingDDMFormFieldValuesMap, ddmFormFieldValue);
+
+				if (existingValue != null) {
+					ddmFormFieldValue.setValue(existingValue);
+				}
+				else if (ddmFormField.isLocalizable()) {
 					LocalizedValue localizedValue = new LocalizedValue(
 						value.getDefaultLocale());
 
@@ -180,6 +189,42 @@ public class AddFormInstanceRecordMVCCommandUtil {
 					" has already submitted an entry in form instance ",
 					ddmFormInstance.getFormInstanceId()));
 		}
+	}
+
+	private static Value _getExistingValue(
+		Map<String, List<DDMFormFieldValue>> existingDDMFormFieldValuesMap,
+		DDMFormFieldValue ddmFormFieldValue) {
+
+		if (existingDDMFormFieldValuesMap == null) {
+			return null;
+		}
+
+		List<DDMFormFieldValue> existingDDMFormFieldValues =
+			existingDDMFormFieldValuesMap.get(ddmFormFieldValue.getName());
+
+		if (ListUtil.isEmpty(existingDDMFormFieldValues)) {
+			return null;
+		}
+
+		for (DDMFormFieldValue existingDDMFormFieldValue :
+				existingDDMFormFieldValues) {
+
+			if (Objects.equals(
+					existingDDMFormFieldValue.getInstanceId(),
+					ddmFormFieldValue.getInstanceId())) {
+
+				return existingDDMFormFieldValue.getValue();
+			}
+		}
+
+		if (existingDDMFormFieldValues.size() == 1) {
+			DDMFormFieldValue existingDDMFormFieldValue =
+				existingDDMFormFieldValues.get(0);
+
+			return existingDDMFormFieldValue.getValue();
+		}
+
+		return null;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.ActionRequest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -114,6 +115,20 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 	}
 
 	@Test
+	public void testInvisibleFieldWithExistingValue() throws Exception {
+		_updateNonevaluableDDMFormFields(
+			HashMapBuilder.<String, Object>put(
+				"visible", false
+			).build(),
+			false, RandomTestUtil.randomBoolean(),
+			new UnlocalizedValue(StringPool.BLANK),
+			_createExistingDDMFormFieldValuesMap(
+				new UnlocalizedValue(_STRING_VALUE)));
+
+		_assertDDMFormFields(false, new UnlocalizedValue(_STRING_VALUE));
+	}
+
+	@Test
 	public void testInvisibleFieldWithNullValue() throws Exception {
 		_updateNonevaluableDDMFormFields(
 			HashMapBuilder.<String, Object>put(
@@ -123,6 +138,32 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			null);
 
 		_assertDDMFormFields(false, null);
+	}
+
+	@Test
+	public void testInvisibleFieldWithUnmatchedRepeatableExistingValues()
+		throws Exception {
+
+		_updateNonevaluableDDMFormFields(
+			HashMapBuilder.<String, Object>put(
+				"visible", false
+			).build(),
+			false, RandomTestUtil.randomBoolean(),
+			new UnlocalizedValue(_STRING_VALUE),
+			HashMapBuilder.<String, List<DDMFormFieldValue>>put(
+				_FIELD_NAME,
+				Arrays.asList(
+					DDMFormValuesTestUtil.createDDMFormFieldValue(
+						RandomTestUtil.randomString(), _FIELD_NAME,
+						new UnlocalizedValue(RandomTestUtil.randomString())),
+					DDMFormValuesTestUtil.createDDMFormFieldValue(
+						RandomTestUtil.randomString(), _FIELD_NAME,
+						new UnlocalizedValue(RandomTestUtil.randomString())))
+			).build());
+
+		Assert.assertEquals(
+			new UnlocalizedValue(StringPool.BLANK),
+			_getFieldValue(_FIELD_NAME));
 	}
 
 	@Test(expected = FormInstanceExpiredException.class)
@@ -210,6 +251,22 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 				_NESTED_FIELD_INSTANCE_ID, _NESTED_FIELD_NAME, value));
 
 		_ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+	}
+
+	private Map<String, List<DDMFormFieldValue>>
+		_createExistingDDMFormFieldValuesMap(Value value) {
+
+		return HashMapBuilder.<String, List<DDMFormFieldValue>>put(
+			_FIELD_NAME,
+			Collections.singletonList(
+				DDMFormValuesTestUtil.createDDMFormFieldValue(
+					_FIELD_INSTANCE_ID, _FIELD_NAME, value))
+		).put(
+			_NESTED_FIELD_NAME,
+			Collections.singletonList(
+				DDMFormValuesTestUtil.createDDMFormFieldValue(
+					_NESTED_FIELD_INSTANCE_ID, _NESTED_FIELD_NAME, value))
+		).build();
 	}
 
 	private Value _getFieldValue(String fieldName) {
@@ -304,6 +361,16 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 			boolean required, Value value)
 		throws Exception {
 
+		_updateNonevaluableDDMFormFields(
+			fieldChangesProperties, localizable, required, value, null);
+	}
+
+	private void _updateNonevaluableDDMFormFields(
+			Map<String, Object> fieldChangesProperties, boolean localizable,
+			boolean required, Value value,
+			Map<String, List<DDMFormFieldValue>> existingDDMFormFieldValuesMap)
+		throws Exception {
+
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
 
 		_createDDMFormFields(ddmForm, localizable, required);
@@ -321,7 +388,8 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 					_NESTED_FIELD_NAME, _NESTED_FIELD_INSTANCE_ID),
 				fieldChangesProperties
 			).build(),
-			_ddmFormValues.getDDMFormFieldValuesMap(true), new DDMFormLayout(),
+			_ddmFormValues.getDDMFormFieldValuesMap(true),
+			existingDDMFormFieldValuesMap, new DDMFormLayout(),
 			Collections.emptySet());
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
@@ -17,6 +17,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -137,6 +138,93 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 			ddmFormInstanceRecords.get(0);
 
 		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(false);
+
+		_assertValue("TextField1", ddmFormFieldValuesMap, value1);
+		_assertValue("TextField2", ddmFormFieldValuesMap, value2);
+	}
+
+	@Test
+	public void testProcessActionPreservesInvisibleFieldValue()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(
+				LocaleUtil.BRAZIL, LocaleUtil.US),
+			LocaleUtil.US);
+
+		DDMFormTestUtil.addDDMFormRule(
+			Collections.singletonList("setVisible('TextField2', false)"),
+			"not(isEmpty(getValue('TextField1')))", ddmForm);
+		DDMFormTestUtil.addTextDDMFormFields(
+			ddmForm, "TextField1", "TextField2");
+
+		DDMFormInstance ddmFormInstance =
+			DDMFormInstanceTestUtil.addDDMFormInstance(
+				ddmForm, _group,
+				DDMFormInstanceTestUtil.createSettingsDDMFormValues(false),
+				TestPropsValues.getUserId());
+
+		String value2 = RandomTestUtil.randomString();
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value2);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<DDMFormInstanceRecord> ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecords.get(0);
+
+		String value1 = RandomTestUtil.randomString();
+
+		mockLiferayPortletActionRequest = _getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", value1);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceRecordId",
+			String.valueOf(ddmFormInstanceRecord.getFormInstanceRecordId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		Assert.assertEquals(
+			String.valueOf(ddmFormInstanceRecords), 1,
+			ddmFormInstanceRecords.size());
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecords.get(
+			0
+		).getDDMFormValues();
 
 		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
 			ddmFormValues.getDDMFormFieldValuesMap(false);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96936

## What Is Being Fixed

On a form with a field-visibility rule (for example, "show FirstName only if
the user is in role Submitter"), a user for whom a field is not visible could
edit an existing entry, change other fields, and save — and the previously
stored value of the hidden field was erased. The value belonged to a field the
acting user could neither see nor edit, yet the save destroyed it.

A form-record update writes the submitted values into a fresh per-version
storage, so any field missing from (or blanked in) the submission is lost.
Because a hidden field is submitted with an empty value, its stored value was
overwritten with a blank on save.

## How It Is Being Fixed

On an existing-record edit, before persisting, the value of each non-evaluable
field (hidden by a visibility rule, on a page-flow-disabled page, or read-only)
is replaced with the value already stored in the record, instead of being
blanked. The decision lives in the form-web action, which is the only layer
that has the evaluator's visibility verdict and can tell a field the user
intentionally cleared from one that was hidden from them. The stored value is
used rather than the submitted one, so a user still cannot inject a value into
a field they cannot see. New submissions have no prior record, so hidden fields
in them still store blank, exactly as before.

For a non-repeatable field the stored value is matched by instance id, falling
back to its single stored value; for a repeatable field with no matching
instance id the value is left blank rather than risking copying another
instance's value.

## PR Check

**pr-check: PASS** — tested on `b99993fa562a07ea27ada2e8c53b7a89b14edc34`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b99993fa562a07ea27ada2e8c53b7a89b14edc34"} -->
