### PR TITLE
LPD-96960 Fix 0-byte form CSV export when an options field is deleted

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldValueUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldValueUtil.java
@@ -167,6 +167,10 @@ public class DDMFormFieldValueUtil {
 
 		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
 
+		if (ddmFormField == null) {
+			return new DDMFormFieldOptions();
+		}
+
 		return ddmFormField.getDDMFormFieldOptions();
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRenderer.java
@@ -82,6 +82,10 @@ public class GridDDMFormFieldValueRenderer
 
 		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
 
+		if (ddmFormField == null) {
+			return new DDMFormFieldOptions();
+		}
+
 		return (DDMFormFieldOptions)ddmFormField.getProperty(optionType);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRendererTest.java
@@ -86,6 +86,27 @@ public class CheckboxMultipleDDMFormFieldValueRendererTest {
 				ddmFormFieldValue, LocaleUtil.US));
 	}
 
+	@Test
+	public void testRenderWithDeletedDDMFormField() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"CheckboxMultiple", new UnlocalizedValue("[\"value 1\"]"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		Assert.assertEquals(
+			"value 1",
+			_checkboxMultipleDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
+	}
+
 	private CheckboxMultipleDDMFormFieldValueRenderer
 		_checkboxMultipleDDMFormFieldValueRenderer;
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRendererTest.java
@@ -13,6 +13,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -74,6 +75,31 @@ public class GridDDMFormFieldValueRendererTest {
 
 		Assert.assertEquals(
 			"rowLabel 1: columnLabel 1",
+			gridDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
+	}
+
+	@Test
+	public void testRenderWithDeletedDDMFormField() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"Grid",
+				new UnlocalizedValue("{\"rowValue 1\":\"columnValue 1\"}"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		GridDDMFormFieldValueRenderer gridDDMFormFieldValueRenderer =
+			_createGridDDMFormFieldValueRenderer();
+
+		Assert.assertEquals(
+			StringPool.BLANK,
 			gridDDMFormFieldValueRenderer.render(
 				ddmFormFieldValue, LocaleUtil.US));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/radio/RadioDDMFormFieldValueRendererTest.java
@@ -66,4 +66,28 @@ public class RadioDDMFormFieldValueRendererTest {
 				ddmFormFieldValue, LocaleUtil.US));
 	}
 
+	@Test
+	public void testRenderWithDeletedDDMFormField() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"Radio", new UnlocalizedValue("value 1"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		RadioDDMFormFieldValueRenderer radioDDMFormFieldValueRenderer =
+			new RadioDDMFormFieldValueRenderer();
+
+		Assert.assertEquals(
+			"value 1",
+			radioDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
+	}
+
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRendererTest.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.form.field.type.internal.select;
+
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Victor Kammerer
+ */
+public class SelectDDMFormFieldValueRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testRenderWithDeletedDDMFormField() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"Select", new UnlocalizedValue("[\"value 1\"]"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		SelectDDMFormFieldValueRenderer selectDDMFormFieldValueRenderer =
+			new SelectDDMFormFieldValueRenderer();
+
+		Assert.assertEquals(
+			"value 1",
+			selectDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96960

## What Is Being Fixed

Exporting a form's entries as CSV produced a 0-byte file when the form had an options-based field (Radio, Select, or Checkbox Multiple) that was later deleted. The export threw a NullPointerException that the portlet's resource command swallowed, streaming an empty byte array to the browser as the downloaded file.

## How It Is Being Fixed

The CSV exporter renders each option field's value through DDMFormFieldValueUtil, which resolves the field's options from the DDMFormFieldValue's back-reference to its DDMFormField. Once the field is deleted from the form's structure that back-reference resolves to null, so _getDDMFormFieldOptions dereferenced null and threw. The fix guards the null field and returns an empty DDMFormFieldOptions, mirroring the null handling already present in getFieldReference; the export then falls back to the raw stored value instead of crashing. Because the three option-based renderers share this helper, the fix covers all of them. A regression test in RadioDDMFormFieldValueRendererTest renders a value whose field is absent from the form and asserts the render no longer throws.

## PR Check

**pr-check: PASS** — tested on `cc32c2943f87fab750e7320fabf96c5b5f8d7501`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cc32c2943f87fab750e7320fabf96c5b5f8d7501"} -->






