### PR TITLE
LPD-97075 Fix category scope for shared CMS vocabularies via the info panel

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -147,7 +147,19 @@ public class ServiceContextUtil {
 			taxonomyCategoryBrief.getParentTaxonomyVocabulary();
 
 		if (parentTaxonomyVocabulary == null) {
-			return null;
+			AssetCategory assetCategory =
+				AssetCategoryLocalServiceUtil.
+					fetchAssetCategoryByExternalReferenceCode(
+						taxonomyCategoryBrief.
+							getTaxonomyCategoryExternalReferenceCode(),
+						groupId);
+
+			if (assetCategory == null) {
+				return null;
+			}
+
+			return AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
+				assetCategory.getVocabularyId());
 		}
 
 		return AssetVocabularyLocalServiceUtil.

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -6,8 +6,12 @@
 package com.liferay.object.rest.internal.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.object.comment.ObjectEntryComment;
 import com.liferay.object.exception.ObjectEntryGroupIdException;
@@ -23,6 +27,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -135,6 +140,21 @@ public class ServiceContextUtil {
 		return serviceContext;
 	}
 
+	private static AssetVocabulary _fetchBriefAssetVocabulary(
+		long groupId, TaxonomyCategoryBrief taxonomyCategoryBrief) {
+
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			taxonomyCategoryBrief.getParentTaxonomyVocabulary();
+
+		if (parentTaxonomyVocabulary == null) {
+			return null;
+		}
+
+		return AssetVocabularyLocalServiceUtil.
+			fetchAssetVocabularyByExternalReferenceCode(
+				parentTaxonomyVocabulary.getExternalReferenceCode(), groupId);
+	}
+
 	private static long[] _getAllowedGroupIds(long companyId, long groupId)
 		throws PortalException {
 
@@ -188,6 +208,27 @@ public class ServiceContextUtil {
 		return status.getCode();
 	}
 
+	private static boolean _isAssetVocabularyAvailable(
+		long assetVocabularyId, long groupId) {
+
+		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
+			AssetVocabularyGroupRelLocalServiceUtil.
+				getAssetVocabularyGroupRelsByVocabularyId(assetVocabularyId);
+
+		for (AssetVocabularyGroupRel assetVocabularyGroupRel :
+				assetVocabularyGroupRels) {
+
+			if ((assetVocabularyGroupRel.getGroupId() ==
+					GroupConstants.ANY_PARENT_GROUP_ID) ||
+				(assetVocabularyGroupRel.getGroupId() == groupId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static boolean _isObjectEntryDraft(Status status) {
 		if ((status != null) &&
 			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
@@ -231,8 +272,17 @@ public class ServiceContextUtil {
 				taxonomyCategoryBrief);
 
 			if (!ArrayUtil.contains(groupIds, scopeGroupId)) {
-				throw new ObjectEntryGroupIdException.
-					InvalidGroupIdForAssetCategoryBrief(externalReferenceCode);
+				AssetVocabulary assetVocabulary = _fetchBriefAssetVocabulary(
+					scopeGroupId, taxonomyCategoryBrief);
+
+				if ((assetVocabulary == null) ||
+					!_isAssetVocabularyAvailable(
+						assetVocabulary.getVocabularyId(), groupId)) {
+
+					throw new ObjectEntryGroupIdException.
+						InvalidGroupIdForAssetCategoryBrief(
+							externalReferenceCode);
+				}
 			}
 
 			try {
@@ -297,7 +347,9 @@ public class ServiceContextUtil {
 					assetCategoryId);
 
 			if ((assetCategory == null) ||
-				!ArrayUtil.contains(groupIds, assetCategory.getGroupId())) {
+				(!ArrayUtil.contains(groupIds, assetCategory.getGroupId()) &&
+				 !_isAssetVocabularyAvailable(
+					 assetCategory.getVocabularyId(), groupId))) {
 
 				throw new ObjectEntryGroupIdException.
 					InvalidGroupIdForAssetCategory(assetCategoryId);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -14,6 +14,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.constants.DepotConstants;
@@ -20829,6 +20830,120 @@ public class ObjectEntryResourceTest {
 			));
 
 		_groupLocalService.deleteGroup(childGroup);
+
+		// Can add a category whose vocabulary is shared to all spaces
+
+		AssetVocabulary allSpacesAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			allSpacesAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory allSpacesTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				allSpacesAssetVocabulary.getGroupId(),
+				allSpacesAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.put(allSpacesTaxonomyCategory.getId())
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(allSpacesAssetVocabulary);
+
+		// Can add a category whose vocabulary is shared to the entry group
+
+		AssetVocabulary sharedAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			_testGroupId, sharedAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory sharedTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				sharedAssetVocabulary.getGroupId(),
+				sharedAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.put(sharedTaxonomyCategory.getId())
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(sharedAssetVocabulary);
+
+		// Can add a category by brief whose vocabulary is shared to all spaces
+
+		AssetVocabulary briefAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			briefAssetVocabulary.getVocabularyId(), DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory briefTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				briefAssetVocabulary.getGroupId(),
+				briefAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"parentTaxonomyVocabulary",
+							JSONUtil.put(
+								"externalReferenceCode",
+								briefAssetVocabulary.getExternalReferenceCode())
+						).put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							briefTaxonomyCategory.getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(briefAssetVocabulary);
 
 		// Cannot add a category to a company-scoped entry
 

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -20945,6 +20945,54 @@ public class ObjectEntryResourceTest {
 
 		_assetVocabularyLocalService.deleteVocabulary(briefAssetVocabulary);
 
+		// Can add a category by brief without a parent vocabulary whose
+		// vocabulary is shared to all spaces
+
+		AssetVocabulary parentlessBriefAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			parentlessBriefAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory parentlessBriefTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				parentlessBriefAssetVocabulary.getGroupId(),
+				parentlessBriefAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							parentlessBriefTaxonomyCategory.
+								getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(
+			parentlessBriefAssetVocabulary);
+
 		// Cannot add a category to a company-scoped entry
 
 		Assert.assertEquals(


### PR DESCRIPTION
## What is being fixed

Follow-up to LPD-74644. That change fixed the asset category scope validation for the REST **ids** path, but the CMS UI publish flow still failed: creating/editing a Basic Web Content in a Space and assigning a category from a vocabulary shared to the spaces returned the generic "An error occurred while sending the form information", with the underlying request returning `400 "Asset category ... does not belong to the object entry's scope"`. Removing the category let it publish.

## Root cause

`ServiceContextUtil` resolves taxonomy categories through two paths: an **ids** path (`taxonomyCategoryIds`) and a **briefs** path (`taxonomyCategoryBriefs`). LPD-74644 fixed only the ids path — for a category whose group is outside the entry's connected groups, it accepts the category when its vocabulary is shared to the entry group, resolving the vocabulary from the category itself.

The briefs path relied instead on `_fetchBriefAssetVocabulary`, which returned `null` when the brief carried no `parentTaxonomyVocabulary`, throwing `InvalidGroupIdForAssetCategoryBrief` before vocabulary availability was ever checked. And the CMS info item editor save flow (`ObjectEntryInfoItemFieldValuesUpdater._toTaxonomyCategoryBriefs`, object-web) builds each `TaxonomyCategoryBrief` with only a scope and the category external reference code — never a `parentTaxonomyVocabulary`. So the shared category was rejected.

## How it is being fixed

`_fetchBriefAssetVocabulary` now falls back to resolving the vocabulary from the category itself (`AssetCategoryLocalServiceUtil.fetchAssetCategoryByExternalReferenceCode` then `AssetVocabularyLocalServiceUtil.fetchAssetVocabulary`) when the brief has no parent vocabulary, mirroring the ids path.

## Why this approach (and not fixing the origin)

The brief reaches the validation from more than one origin, so the fix belongs in the **consumer** (`ServiceContextUtil`), not in the caller that happens to build an incomplete brief:

- **Info item editor** (`ObjectEntryInfoItemFieldValuesUpdater`) — builds briefs without a parent vocabulary. This is the origin the reported bug came through.
- **Direct REST clients** — a `POST`/`PUT` may carry `taxonomyCategoryBriefs` in its body with only a scope and the category external reference code (a minimal, valid brief). These deserialize straight into the DTO and reach the same validation, never touching the updater.

Fixing the origin (populating `parentTaxonomyVocabulary` in `_toTaxonomyCategoryBriefs`) would only cover the first case and leave direct REST clients failing. Fixing the consumer covers every origin at once and makes the briefs path **symmetric with the ids path** — both now resolve the vocabulary from the category when it is not otherwise provided. The existing cross-site rejection is preserved: a category whose vocabulary is neither group-scoped to the entry nor shared to it is still rejected.

## Commits

- LPD-74644 (2 commits) — the original ids-path fix + coverage (from #6350).
- LPD-97075 (2 commits) — the briefs-path fix + integration coverage.

## How can it be tested

**Integration test:**
```
cd modules
../gradlew :apps:object:object-rest-test:testIntegration --tests 'com.liferay.object.rest.internal.resource.v1_0.test.ObjectEntryResourceTest.testPostObjectEntryWithTaxonomyCategories'
```
A new case in `_testPostObjectEntryWithCrossSiteTaxonomyCategories` asserts that a category brief **without** a parent vocabulary, whose vocabulary is shared to all spaces, is accepted on a space-scoped entry.

**Manual:** in the CMS, create a Space, create a vocabulary shared to all spaces with a category, create a Basic Web Content in the Space, assign the category, and Publish — it now saves without the generic error.
