### PR TITLE
LPD-90360 Add a dummy upgrade step to reserve object schema 12.0.1

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -704,8 +704,10 @@ public class ObjectServiceUpgradeStepRegistrator
 			new com.liferay.object.internal.upgrade.v12_0_0.
 				ObjectFieldUpgradeProcess());
 
+		registry.register("12.0.0", "12.0.1", new DummyUpgradeStep());
+
 		registry.register(
-			"12.0.0", "12.1.0",
+			"12.0.1", "12.1.0",
 			new com.liferay.object.internal.upgrade.v12_1_0.
 				ObjectDefinitionSettingUpgradeProcess());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90360

## What Is Being Fixed

The object service upgrade registry advanced directly from schema version 12.0.0 to 12.1.0 through ObjectDefinitionSettingUpgradeProcess, leaving no 12.0.1 entry in the schema version sequence.

## How It Is Being Fixed

A DummyUpgradeStep is registered for the 12.0.0 to 12.0.1 range, and ObjectDefinitionSettingUpgradeProcess now runs from 12.0.1 to 12.1.0. This reserves schema version 12.0.1 in the upgrade sequence without touching any data.

## Why Are There No Tests?

A DummyUpgradeStep carries no logic. It only advances the module's schema version, so there is nothing to assert.

## PR Check

**pr-check: PASS** — tested on `e8d63778204e2ed1bce46be139744d4a2b0339d8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "e8d63778204e2ed1bce46be139744d4a2b0339d8"} -->
