### PR TITLE
LPD-74644 Follow up PR - Fix category scope for shared CMS vocabularies

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/util/ServiceContextUtil.java
@@ -6,8 +6,12 @@
 package com.liferay.object.rest.internal.util;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyGroupRel;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.object.comment.ObjectEntryComment;
 import com.liferay.object.exception.ObjectEntryGroupIdException;
@@ -23,6 +27,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -135,6 +140,34 @@ public class ServiceContextUtil {
 		return serviceContext;
 	}
 
+	private static AssetVocabulary _fetchAssetVocabulary(
+		long groupId, TaxonomyCategoryBrief taxonomyCategoryBrief) {
+
+		ParentTaxonomyVocabulary parentTaxonomyVocabulary =
+			taxonomyCategoryBrief.getParentTaxonomyVocabulary();
+
+		if (parentTaxonomyVocabulary != null) {
+			return AssetVocabularyLocalServiceUtil.
+				fetchAssetVocabularyByExternalReferenceCode(
+					parentTaxonomyVocabulary.getExternalReferenceCode(),
+					groupId);
+		}
+
+		AssetCategory assetCategory =
+			AssetCategoryLocalServiceUtil.
+				fetchAssetCategoryByExternalReferenceCode(
+					taxonomyCategoryBrief.
+						getTaxonomyCategoryExternalReferenceCode(),
+					groupId);
+
+		if (assetCategory == null) {
+			return null;
+		}
+
+		return AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
+			assetCategory.getVocabularyId());
+	}
+
 	private static long[] _getAllowedGroupIds(long companyId, long groupId)
 		throws PortalException {
 
@@ -188,6 +221,27 @@ public class ServiceContextUtil {
 		return status.getCode();
 	}
 
+	private static boolean _isAssetVocabularyAvailable(
+		long assetVocabularyId, long groupId) {
+
+		List<AssetVocabularyGroupRel> assetVocabularyGroupRels =
+			AssetVocabularyGroupRelLocalServiceUtil.
+				getAssetVocabularyGroupRelsByVocabularyId(assetVocabularyId);
+
+		for (AssetVocabularyGroupRel assetVocabularyGroupRel :
+				assetVocabularyGroupRels) {
+
+			if ((assetVocabularyGroupRel.getGroupId() ==
+					GroupConstants.ANY_PARENT_GROUP_ID) ||
+				(assetVocabularyGroupRel.getGroupId() == groupId)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static boolean _isObjectEntryDraft(Status status) {
 		if ((status != null) &&
 			(status.getCode() == WorkflowConstants.STATUS_DRAFT)) {
@@ -231,8 +285,17 @@ public class ServiceContextUtil {
 				taxonomyCategoryBrief);
 
 			if (!ArrayUtil.contains(groupIds, scopeGroupId)) {
-				throw new ObjectEntryGroupIdException.
-					InvalidGroupIdForAssetCategoryBrief(externalReferenceCode);
+				AssetVocabulary assetVocabulary = _fetchAssetVocabulary(
+					scopeGroupId, taxonomyCategoryBrief);
+
+				if ((assetVocabulary == null) ||
+					!_isAssetVocabularyAvailable(
+						assetVocabulary.getVocabularyId(), groupId)) {
+
+					throw new ObjectEntryGroupIdException.
+						InvalidGroupIdForAssetCategoryBrief(
+							externalReferenceCode);
+				}
 			}
 
 			try {
@@ -297,7 +360,9 @@ public class ServiceContextUtil {
 					assetCategoryId);
 
 			if ((assetCategory == null) ||
-				!ArrayUtil.contains(groupIds, assetCategory.getGroupId())) {
+				(!ArrayUtil.contains(groupIds, assetCategory.getGroupId()) &&
+				 !_isAssetVocabularyAvailable(
+					 assetCategory.getVocabularyId(), groupId))) {
 
 				throw new ObjectEntryGroupIdException.
 					InvalidGroupIdForAssetCategory(assetCategoryId);

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -11,9 +11,11 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyGroupRelLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.depot.constants.DepotConstants;
@@ -231,6 +233,7 @@ import com.liferay.portal.vulcan.resource.NestedFieldsContextResource;
 import com.liferay.portal.vulcan.scope.Scope;
 import com.liferay.portal.vulcan.util.GroupUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 import com.liferay.portlet.documentlibrary.constants.DLConstants;
 import com.liferay.sharing.model.SharingEntry;
 import com.liferay.sharing.security.permission.SharingEntryAction;
@@ -20829,6 +20832,182 @@ public class ObjectEntryResourceTest {
 			));
 
 		_groupLocalService.deleteGroup(childGroup);
+
+		// Can add a category from an all-spaces vocabulary
+
+		AssetVocabulary allSpacesAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			allSpacesAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory allSpacesTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				allSpacesAssetVocabulary.getGroupId(),
+				allSpacesAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryIds",
+					JSONUtil.put(allSpacesTaxonomyCategory.getId())
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(allSpacesAssetVocabulary);
+
+		// Can add a category from a space-associated vocabulary
+
+		AssetVocabulary sharedAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			_testGroupId, sharedAssetVocabulary.getVocabularyId(),
+			DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory sharedTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				sharedAssetVocabulary.getGroupId(),
+				sharedAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"parentTaxonomyVocabulary",
+							JSONUtil.put(
+								"externalReferenceCode",
+								sharedAssetVocabulary.
+									getExternalReferenceCode())
+						).put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							sharedTaxonomyCategory.getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(sharedAssetVocabulary);
+
+		// Can add a category from a system vocabulary
+
+		AssetVocabularySettingsHelper assetVocabularySettingsHelper =
+			new AssetVocabularySettingsHelper();
+
+		assetVocabularySettingsHelper.setSystem(true);
+
+		AssetVocabulary systemAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), null,
+				HashMapBuilder.put(
+					LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+				).build(),
+				null, assetVocabularySettingsHelper.toString(),
+				AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC,
+				new ServiceContext());
+
+		AssetVocabularyGroupRelLocalServiceUtil.addAssetVocabularyGroupRel(
+			GroupConstants.ANY_PARENT_GROUP_ID,
+			systemAssetVocabulary.getVocabularyId(), DepotConstants.TYPE_SPACE);
+
+		TaxonomyCategory systemTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				systemAssetVocabulary.getGroupId(),
+				systemAssetVocabulary.getVocabularyId());
+
+		Assert.assertNotNull(
+			HTTPTestUtil.invokeToJSONObject(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							systemTaxonomyCategory.getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST
+			).get(
+				"id"
+			));
+
+		_assetVocabularyLocalService.deleteVocabulary(systemAssetVocabulary);
+
+		// Cannot add a category from an unassociated vocabulary
+
+		AssetVocabulary foreignAssetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		TaxonomyCategory foreignTaxonomyCategory =
+			_postTaxonomyVocabularyTaxonomyCategory(
+				foreignAssetVocabulary.getGroupId(),
+				foreignAssetVocabulary.getVocabularyId());
+
+		Assert.assertEquals(
+			400,
+			HTTPTestUtil.invokeToHttpCode(
+				JSONUtil.put(
+					_OBJECT_FIELD_NAME_1, RandomTestUtil.randomString()
+				).put(
+					"taxonomyCategoryBriefs",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"scope",
+							JSONUtil.put(
+								"externalReferenceCode",
+								_group.getExternalReferenceCode()
+							).put(
+								"type", "Site"
+							)
+						).put(
+							"taxonomyCategoryExternalReferenceCode",
+							foreignTaxonomyCategory.getExternalReferenceCode()
+						))
+				).toString(),
+				_getEndpoint(_siteScopedObjectDefinition1, _testGroupId),
+				Http.Method.POST));
+
+		_assetVocabularyLocalService.deleteVocabulary(foreignAssetVocabulary);
 
 		// Cannot add a category to a company-scoped entry
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74644

Follow-up for the CMS categorization scope regression. Widens the asset-category scope validation in ServiceContextUtil into a union: a category is accepted when its group is in the object entry's allowed set OR its vocabulary is available to the entry group via AssetVocabularyGroupRel (the all-spaces sentinel or the entry group itself). This covers space-scoped CMS content (all-spaces and space-shared vocabularies) and the system-vocabulary path used by CMP (briefs sent without a parent vocabulary, resolved through the category), while categories from unrelated sites stay rejected.

Continues the work from #6350 (closed).

## Tests

Adds four cases to _testPostObjectEntryWithCrossSiteTaxonomyCategories in ObjectEntryResourceTest: an all-spaces vocabulary (ids path), a space-shared vocabulary (brief with a parent), a system vocabulary (brief without a parent), and the negative case where an unshared vocabulary is rejected with a 400.

pr-check: PASS. Source formatting clean, per-module, cross-module and integration-test compile all green. The integration test was verified green on a local bundle.