### PR TITLE
LPD-97139 Fix task creation from the Kanban view

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseTasksSectionDisplayContextTestCase.java
+++ b/modules/apps/site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/display/context/test/BaseTasksSectionDisplayContextTestCase.java
@@ -91,12 +91,18 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 		Map<String, Object> additionalProps = getAdditionalProps(null);
 
 		Assert.assertNull(additionalProps.get("projectId"));
+		Assert.assertEquals(
+			projectObjectDefinition.getObjectDefinitionId(),
+			additionalProps.get("projectObjectDefinitionId"));
 		Assert.assertNotNull(additionalProps.get("states"));
 
 		additionalProps = getAdditionalProps(assetEntry);
 
 		Assert.assertEquals(
 			assetEntry.getClassPK(), additionalProps.get("projectId"));
+		Assert.assertEquals(
+			projectObjectDefinition.getObjectDefinitionId(),
+			additionalProps.get("projectObjectDefinitionId"));
 		Assert.assertNotNull(additionalProps.get("states"));
 	}
 
@@ -153,6 +159,9 @@ public abstract class BaseTasksSectionDisplayContextTestCase
 		Assert.assertEquals(
 			String.valueOf(objectDefinition.getObjectDefinitionId()),
 			getValue(dropdownItem, "objectDefinitionId"));
+		Assert.assertEquals(
+			String.valueOf(projectObjectDefinition.getObjectDefinitionId()),
+			getValue(dropdownItem, "projectObjectDefinitionId"));
 		Assert.assertEquals(
 			StringBundler.concat(
 				themeDisplay.getPortalURL(), themeDisplay.getPathMain(),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/BaseTasksSectionDisplayContext.java
@@ -97,6 +97,9 @@ public abstract class BaseTasksSectionDisplayContext
 				return assetEntry.getClassPK();
 			}
 		).put(
+			"projectObjectDefinitionId",
+			projectObjectDefinition.getObjectDefinitionId()
+		).put(
 			"states",
 			() -> {
 				JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
@@ -207,6 +210,10 @@ public abstract class BaseTasksSectionDisplayContext
 				dropdownItem.putData(
 					"objectDefinitionId",
 					String.valueOf(objectDefinition.getObjectDefinitionId()));
+				dropdownItem.putData(
+					"projectObjectDefinitionId",
+					String.valueOf(
+						projectObjectDefinition.getObjectDefinitionId()));
 
 				if (assetEntry != null) {
 					dropdownItem.putData(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/CreateTaskModal.tsx
@@ -32,6 +32,7 @@ type CreateTaskModalProps = {
 	dueDate?: string;
 	loadData: Function;
 	projectId?: string;
+	projectObjectDefinitionId: number;
 	state: string;
 };
 
@@ -40,6 +41,7 @@ export default function CreateTaskModal({
 	dueDate = '',
 	loadData,
 	projectId,
+	projectObjectDefinitionId,
 	state,
 }: CreateTaskModalProps) {
 	const [states, setStates] = useState([]);
@@ -113,7 +115,7 @@ export default function CreateTaskModal({
 
 			const {
 				data: {items},
-			} = (await getAllProjects()) as {
+			} = (await getAllProjects(projectObjectDefinitionId)) as {
 				data: {
 					items: {
 						embedded: IProjectObjectEntry;
@@ -143,7 +145,7 @@ export default function CreateTaskModal({
 		};
 
 		makeFetch();
-	}, [projectId]);
+	}, [projectId, projectObjectDefinitionId]);
 
 	return (
 		<ClayForm

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/SelectProjectModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/SelectProjectModalContent.tsx
@@ -26,10 +26,12 @@ export default function SelectProjectModalContent({
 	addProjectURL,
 	addTaskURL,
 	closeModal,
+	projectObjectDefinitionId,
 }: {
 	addProjectURL: string;
 	addTaskURL: string;
 	closeModal: () => void;
+	projectObjectDefinitionId: number;
 }) {
 	const [errorMessage, setErrorMessage] = useState<string>('');
 	const [selectedProject, setSelectedProject] = useState<Project | null>();
@@ -47,7 +49,7 @@ export default function SelectProjectModalContent({
 			method: 'GET',
 		},
 		fetchPolicy: FetchPolicy.CacheFirst,
-		link: `${Liferay.ThemeDisplay.getPortalURL()}/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionExternalReferenceCode eq 'L_CMP_PROJECT'&nestedFields=embedded`,
+		link: `${Liferay.ThemeDisplay.getPortalURL()}/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${projectObjectDefinitionId}&nestedFields=embedded`,
 	});
 
 	const projects: Project[] = resource?.items?.length

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/AllTasksFDSPropsTransformer.tsx
@@ -358,17 +358,21 @@ export default function AllTasksFDSPropsTransformer({
 					getCustomBulkDeleteMessage: (selectedData) => {
 						if (selectedData.selectAll) {
 							return {
-								confirmationMessage: Liferay.Language.get(
-									'delete-tasks-confirmation'
-								),
+								messages: [
+									Liferay.Language.get(
+										'delete-tasks-confirmation'
+									),
+								],
 								title: Liferay.Language.get('delete-all-tasks'),
 							};
 						}
 						else if (selectedData.items.length > 1) {
 							return {
-								confirmationMessage: Liferay.Language.get(
-									'delete-tasks-confirmation'
-								),
+								messages: [
+									Liferay.Language.get(
+										'delete-tasks-confirmation'
+									),
+								],
 								title: sub(
 									Liferay.Language.get('delete-x-tasks'),
 									[selectedData.items.length]
@@ -377,9 +381,11 @@ export default function AllTasksFDSPropsTransformer({
 						}
 
 						return {
-							confirmationMessage: Liferay.Language.get(
-								'delete-tasks-confirmation'
-							),
+							messages: [
+								Liferay.Language.get(
+									'delete-tasks-confirmation'
+								),
+							],
 							title: Liferay.Language.get('delete-task'),
 						};
 					},

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -69,6 +69,8 @@ export default function ProjectTasksFDSPropsTransformer({
 			CalendarView({
 				...props,
 				projectId: additionalProps.projectId,
+				projectObjectDefinitionId:
+					additionalProps.projectObjectDefinitionId,
 			}),
 		default: false,
 		initialPaginationDelta: FDS_PAGINATION_DELTA_ALL,
@@ -88,7 +90,12 @@ export default function ProjectTasksFDSPropsTransformer({
 
 	const kanbanView: IView = {
 		component: (props: any) =>
-			KanbanView({...props, projectId: additionalProps.projectId}),
+			KanbanView({
+				...props,
+				projectId: additionalProps.projectId,
+				projectObjectDefinitionId:
+					additionalProps.projectObjectDefinitionId,
+			}),
 		default: false,
 		initialPaginationDelta: FDS_PAGINATION_DELTA_ALL,
 		label: Liferay.Language.get('kanban'),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -248,17 +248,21 @@ export default function ProjectTasksFDSPropsTransformer({
 					getCustomBulkDeleteMessage: (selectedData) => {
 						if (selectedData.selectAll) {
 							return {
-								confirmationMessage: Liferay.Language.get(
-									'delete-tasks-confirmation'
-								),
+								messages: [
+									Liferay.Language.get(
+										'delete-tasks-confirmation'
+									),
+								],
 								title: Liferay.Language.get('delete-all-tasks'),
 							};
 						}
 						else if (selectedData.items.length > 1) {
 							return {
-								confirmationMessage: Liferay.Language.get(
-									'delete-tasks-confirmation'
-								),
+								messages: [
+									Liferay.Language.get(
+										'delete-tasks-confirmation'
+									),
+								],
 								title: sub(
 									Liferay.Language.get('delete-x-tasks'),
 									[selectedData.items.length]
@@ -267,9 +271,11 @@ export default function ProjectTasksFDSPropsTransformer({
 						}
 
 						return {
-							confirmationMessage: Liferay.Language.get(
-								'delete-tasks-confirmation'
-							),
+							messages: [
+								Liferay.Language.get(
+									'delete-tasks-confirmation'
+								),
+							],
 							title: Liferay.Language.get('delete-task'),
 						};
 					},

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/actions/createTaskAction.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/actions/createTaskAction.ts
@@ -11,10 +11,12 @@ import SelectProjectModalContent from '../../modal/SelectProjectModalContent';
 export default function createTaskAction({
 	addProjectURL,
 	addTaskURL,
+	projectObjectDefinitionId,
 	redirect,
 }: {
 	addProjectURL: string;
 	addTaskURL: string;
+	projectObjectDefinitionId: number;
 	redirect?: string;
 }) {
 	if (redirect) {
@@ -32,6 +34,7 @@ export default function createTaskAction({
 				addProjectURL,
 				addTaskURL,
 				closeModal,
+				projectObjectDefinitionId,
 			}),
 		size: 'md',
 	});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -35,6 +35,7 @@ interface CalendarViewProps {
 	items: ITask[];
 	itemsActions: IItemsActions[];
 	projectId?: string;
+	projectObjectDefinitionId: number;
 }
 
 interface MoreLinkPopover {
@@ -47,6 +48,7 @@ export default function CalendarView({
 	items,
 	itemsActions,
 	projectId,
+	projectObjectDefinitionId,
 }: CalendarViewProps) {
 	const {loadData, onInfoPanelToggleButtonClick} = useContext(
 		FrontendDataSetContext
@@ -139,6 +141,7 @@ export default function CalendarView({
 					dueDate={dueDate}
 					loadData={loadData}
 					projectId={projectId}
+					projectObjectDefinitionId={projectObjectDefinitionId}
 					state={DEFAULT_TASK_STATE_KEY}
 				/>
 			),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/KanbanView.tsx
@@ -20,6 +20,7 @@ interface KanbanViewProps {
 	items: ITask[];
 	itemsActions: IItemsActions[];
 	projectId: string;
+	projectObjectDefinitionId: number;
 }
 
 function KanbanView(props: KanbanViewProps) {
@@ -63,6 +64,7 @@ function KanbanView(props: KanbanViewProps) {
 				itemsActions: props.itemsActions,
 				loadData,
 				projectId: props.projectId,
+				projectObjectDefinitionId: props.projectObjectDefinitionId,
 			}}
 		>
 			<Board />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/components/Column.tsx
@@ -43,7 +43,7 @@ export function ColumnView({
 	column: {icon, key, name, tasks},
 	stateFlow,
 }: IColumnViewProps) {
-	const {changeTaskStatus, loadData, projectId} =
+	const {changeTaskStatus, loadData, projectId, projectObjectDefinitionId} =
 		useContext(KanbanViewContext);
 
 	const canTransition = (taskStateKey: string) => {
@@ -129,6 +129,9 @@ export function ColumnView({
 										closeModal={closeModal}
 										loadData={loadData}
 										projectId={projectId}
+										projectObjectDefinitionId={
+											projectObjectDefinitionId
+										}
 										state={key}
 									/>
 								),

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/kanban_view/context.ts
@@ -20,6 +20,7 @@ interface IKanbanContext {
 	itemsActions: IItemsActions[];
 	loadData: Function;
 	projectId: string;
+	projectObjectDefinitionId: number;
 }
 
 export const KanbanViewContext = React.createContext({} as IKanbanContext);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/api.ts
@@ -34,9 +34,9 @@ export async function deleteTaskById({taskId}: {taskId: string}) {
 	return await ApiHelper.delete(`/o/cmp/tasks/${taskId}`);
 }
 
-export async function getAllProjects() {
+export async function getAllProjects(projectObjectDefinitionId: number) {
 	return await ApiHelper.get(
-		`/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionExternalReferenceCode eq 'L_CMP_PROJECT'&nestedFields=embedded`
+		`/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq ${projectObjectDefinitionId}&nestedFields=embedded`
 	);
 }
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CreateTaskModal.spec.tsx
@@ -130,6 +130,7 @@ describe('CreateTaskModal', () => {
 				closeModal={() => {}}
 				loadData={() => {}}
 				projectId={projectId}
+				projectObjectDefinitionId={123}
 				state=""
 			/>
 		);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/KanbanView.spec.tsx
@@ -42,7 +42,12 @@ describe('KanbanView mapping and lifecycle', () => {
 		] as any;
 
 		const {unmount} = render(
-			<KanbanView items={items} itemsActions={[]} projectId="" />
+			<KanbanView
+				items={items}
+				itemsActions={[]}
+				projectId=""
+				projectObjectDefinitionId={123}
+			/>
 		);
 
 		expect((global as any).Liferay.fire).toHaveBeenCalledWith(

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/SelectProjectModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/SelectProjectModalContent.spec.tsx
@@ -26,6 +26,7 @@ const defaultProps = {
 	addProjectURL: 'http://localhost/add-project',
 	addTaskURL: 'http://localhost/add-task',
 	closeModal: mockCloseModal,
+	projectObjectDefinitionId: 123,
 };
 
 describe('SelectProjectModalContent', () => {
@@ -93,7 +94,7 @@ describe('SelectProjectModalContent', () => {
 			expect(mockUseResource).toHaveBeenCalledWith(
 				expect.objectContaining({
 					link: expect.stringContaining(
-						"/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionExternalReferenceCode eq 'L_CMP_PROJECT'&nestedFields=embedded"
+						'/o/search/v1.0/search?emptySearch=true&filter=objectDefinitionId eq 123&nestedFields=embedded'
 					),
 				})
 			);

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/Task.spec.tsx
@@ -109,6 +109,7 @@ describe('Kanban Task', () => {
 					itemsActions,
 					loadData: mockLoadData,
 					projectId,
+					projectObjectDefinitionId: 123,
 				}}
 			>
 				<Task {...task} />
@@ -218,6 +219,7 @@ describe('Kanban Task', () => {
 					itemsActions: [],
 					loadData: mockLoadData,
 					projectId: '123',
+					projectObjectDefinitionId: 123,
 				}}
 			>
 				<Task {...taskWithDueDate} />
@@ -286,6 +288,7 @@ describe('Kanban Task', () => {
 						itemsActions: [],
 						loadData: mockLoadData,
 						projectId: '',
+						projectObjectDefinitionId: 123,
 					}}
 				>
 					<Task {...taskWithSubscription} />
@@ -319,6 +322,7 @@ describe('Kanban Task', () => {
 						itemsActions: [],
 						loadData: mockLoadData,
 						projectId: '',
+						projectObjectDefinitionId: 123,
 					}}
 				>
 					<Task {...taskWithSubscription} />

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
@@ -27,6 +27,7 @@ describe('createTaskAction', () => {
 			createTaskAction({
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
+				projectObjectDefinitionId: 123,
 			});
 
 			expect(mockNavigate).not.toHaveBeenCalled();
@@ -49,6 +50,7 @@ describe('createTaskAction', () => {
 			createTaskAction({
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
+				projectObjectDefinitionId: 123,
 				redirect: 'http://localhost/redirect-url',
 			});
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/createTaskAction.spec.ts
@@ -41,6 +41,7 @@ describe('createTaskAction', () => {
 				addProjectURL: '/add-project',
 				addTaskURL: '/add-task',
 				closeModal: mockCloseModal,
+				projectObjectDefinitionId: 123,
 			});
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97139

## What Is Being Fixed

Creating a task from the Kanban view failed because the project selector came up empty. The project lookup queried the `/o/search` endpoint with an OData filter on `objectDefinitionExternalReferenceCode`, which no longer matches: that field is indexed as a case-sensitive `keyword`, while the OData filter lowercases the literal, so the uppercase `L_CMP_PROJECT` external reference code never matched and no projects were returned.

## How It Is Being Fixed

Project entries are now filtered by `objectDefinitionId`, which is indexed as a numeric keyword and is unaffected by the OData lowercasing, so the lookup returns the expected projects again. The project object definition id is threaded from the backend display context through the task-creation flow on the frontend (`CreateTaskModal`, `SelectProjectModalContent`, the view props transformers, and `createTaskAction`), and the frontend unit tests and backend integration tests are updated to match.

While rebasing onto the latest master, two adjustments were required. The task delete bulk actions were migrated to the shared confirmation modal's new message API, since LPD-90341 replaced the `confirmationMessage` return value with a `messages` array. The `createTaskAction` unit test was updated to assert the new `projectObjectDefinitionId` prop passed to the modal.

## PR Check

**pr-check: PASS** — tested on `3c9e17cbec7e6797aeb90134f768b9e1a9588fb8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3c9e17cbec7e6797aeb90134f768b9e1a9588fb8"} -->
