### PR TITLE
LPD-97165 Make clickAndExpectToBeVisible retry toggle-safe

### DIFF
--- a/modules/test/playwright/utils/clickAndExpectToBeVisible.ts
+++ b/modules/test/playwright/utils/clickAndExpectToBeVisible.ts
@@ -17,14 +17,11 @@ export async function clickAndExpectToBeVisible({
 	trigger: Locator;
 }) {
 	await expect(async () => {
-		try {
-			await expect(target).toBeVisible({timeout});
-		}
-		catch {
+		if (!(await target.isVisible())) {
 			await trigger.click({timeout});
-
-			await expect(target).toBeVisible({timeout});
 		}
+
+		await expect(target).toBeVisible({timeout});
 
 		if (autoClick) {
 			await target.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97165

## What Is Being Fixed

The shared Playwright helper clickAndExpectToBeVisible re-clicked the trigger on every retry. Since LPD-93937 made the frontend data set item actions menu correctly close on a repeated trigger click, that retry turned into an open/close oscillation that never settled, timing out tests such as site-cmp-site-initializer/main/projects.spec.ts > Project view tab navigation.

## How It Is Being Fixed

The helper now clicks the trigger only when the target is not already visible, so an open menu is never closed by a retry click. Behavior is unchanged for the normal closed-to-open path (and slightly faster, since it no longer waits before the first click).

## Why Are There No Tests?

The change is confined to shared test infrastructure (a Playwright helper used by ~179 specs and ~124 page classes), so there is no product code to cover. It was validated by running the originally failing test plus a sample of consumers across modules, all passing:

| Module | Test |
| --- | --- |
| site-cmp-site-initializer | projects.spec.ts > Project view tab navigation |
| site-cms-site-initializer | folders.spec.ts > Can edit a folder |
| document-library-web | fileEntry.spec.ts > Check View Usage in Action Menu |
| message-boards-web | mbThreadActions.spec.ts > Can lock and unlock a thread |
| fragment-web | fragmentsAdmin.spec.ts > Can delete fragment set |
| style-book-web | styleBookAdmin.spec.ts > A warning message appears when deleting a style book |
| calendar-web | calendarEvent.spec.ts > assert that past events have respective class within the click more dropdown |
| layout-page-template-admin-web | masterPagesEdition.spec.ts > Categories field can be used in a master page |
| object-web | objectRelationship.spec.ts > can create multiple object relationships between the same objects |

## PR Check

**pr-check: PASS** — tested on `350c0786b63a763452581045649966905e069d95`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "350c0786b63a763452581045649966905e069d95"} -->
