### PR TITLE
LPP-64476 Hide non-default translations and sort untranslated object entries last

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/petra/sql/dsl/DynamicObjectDefinitionLocalizationTable.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/petra/sql/dsl/DynamicObjectDefinitionLocalizationTable.java
@@ -67,6 +67,18 @@ public class DynamicObjectDefinitionLocalizationTable
 			});
 	}
 
+	@Override
+	public DynamicObjectDefinitionLocalizationTable as(String alias) {
+		DynamicObjectDefinitionLocalizationTable
+			dynamicObjectDefinitionLocalizationTable =
+				new DynamicObjectDefinitionLocalizationTable(
+					_objectDefinition, _objectFields);
+
+		dynamicObjectDefinitionLocalizationTable.setAlias(alias);
+
+		return dynamicObjectDefinitionLocalizationTable;
+	}
+
 	public String getCreateTableSQL() {
 		StringBundler sb = new StringBundler();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/BaseSortDSLQueryVisitor.java
@@ -12,6 +12,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.sql.dsl.query.JoinStep;
 import com.liferay.petra.sql.dsl.spi.ast.BaseASTNode;
@@ -44,6 +45,13 @@ public abstract class BaseSortDSLQueryVisitor {
 		Column<?, Long> column1, Column<?, Long> column2, DSLQuery dslQuery,
 		Table<?> table) {
 
+		return addLeftJoin(column1, column2, dslQuery, table, null);
+	}
+
+	protected DSLQuery addLeftJoin(
+		Column<?, Long> column1, Column<?, Long> column2, DSLQuery dslQuery,
+		Table<?> table, Predicate onPredicate) {
+
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(
 			JoinStep.class, dslQuery);
 
@@ -53,8 +61,14 @@ public abstract class BaseSortDSLQueryVisitor {
 			column2 = getPrimaryKeyColumn(getTable(joinStep));
 		}
 
+		Predicate predicate = column1.eq(column2);
+
+		if (onPredicate != null) {
+			predicate = predicate.and(onPredicate);
+		}
+
 		BaseASTNode baseASTNode = (BaseASTNode)joinStep.leftJoinOn(
-			table, column1.eq(column2));
+			table, predicate);
 
 		return updateParents(baseASTNode, allBaseASTNodes);
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/sort/ObjectEntryFieldSortDSLQueryVisitor.java
@@ -7,7 +7,9 @@ package com.liferay.object.internal.sort;
 
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionLocalizationTable;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
@@ -23,11 +25,14 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.Clob;
 import java.sql.Types;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Stack;
 
@@ -53,6 +58,7 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 
 		Expression<?> columnExpression = null;
 		Table fieldTable = null;
+		boolean localized = false;
 		String prefix = StringPool.BLANK;
 
 		if (objectField == null) {
@@ -65,13 +71,55 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 			columnExpression = fieldTable.getColumn(fieldName);
 		}
 		else {
-			fieldTable = getAliasedTable(
-				_getSuffix(sort),
-				objectFieldLocalService.getTable(
-					objectDefinition.getObjectDefinitionId(),
-					objectField.getName()));
+			Table objectFieldTable = objectFieldLocalService.getTable(
+				objectDefinition.getObjectDefinitionId(),
+				objectField.getName());
+
+			fieldTable = getAliasedTable(_getSuffix(sort), objectFieldTable);
 
 			columnExpression = _getColumnExpression(objectField, fieldTable);
+
+			if (objectField.isLocalized() && !_isParentComplexField(sort) &&
+				(objectFieldTable instanceof
+					DynamicObjectDefinitionLocalizationTable)) {
+
+				// The base query joins only the requested-locale localized
+				// value. Sort by the value the entry displays: fall back from
+				// the requested locale to the site default language, and to
+				// NULL when neither is present. The nulls-last term below then
+				// pushes untranslated entries to the end.
+
+				localized = true;
+
+				Table defaultLanguageIdFieldTable = getAliasedTable(
+					"defaultLanguageId", objectFieldTable);
+
+				if (!contains(dslQuery, defaultLanguageIdFieldTable)) {
+					dslQuery = addLeftJoin(
+						getPrimaryKeyColumn(defaultLanguageIdFieldTable),
+						ObjectEntryTable.INSTANCE.objectEntryId, dslQuery,
+						defaultLanguageIdFieldTable,
+						_getLanguageIdColumn(
+							defaultLanguageIdFieldTable
+						).eq(
+							_getDefaultLanguageId()
+						));
+				}
+
+				Expression<String> activeExpression =
+					(Expression<String>)columnExpression;
+				Expression<String> defaultExpression =
+					(Expression<String>)_getColumnExpression(
+						objectField, defaultLanguageIdFieldTable);
+
+				columnExpression = DSLFunctionFactoryUtil.caseWhenThen(
+					activeExpression.isNotNull(), activeExpression
+				).whenThen(
+					defaultExpression.isNotNull(), defaultExpression
+				).elseEnd(
+					activeExpression
+				);
+			}
 
 			if (Objects.equals(
 					objectField.getDBType(),
@@ -90,6 +138,28 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 			_isParentComplexField(sort), columnExpression, prefix,
 			sort.isReverse());
 
+		OrderByExpression[] orderByExpressions = {orderByExpression};
+
+		if (localized) {
+
+			// MySQL has no NULLS LAST syntax and sorts NULL first when
+			// ascending. Emulate NULLS LAST with a leading term that is 0 for a
+			// present value and 1 for a null value, always ascending, so that
+			// untranslated entries stay at the end for both ascending and
+			// descending sorts.
+
+			OrderByExpression nullOrderByExpression =
+				DSLFunctionFactoryUtil.caseWhenThen(
+					columnExpression.isNull(), 1
+				).elseEnd(
+					0
+				).ascending();
+
+			orderByExpressions = new OrderByExpression[] {
+				nullOrderByExpression, orderByExpression
+			};
+		}
+
 		Stack<BaseASTNode> allBaseASTNodes = getAllBaseASTNodes(
 			OrderByStep.class, dslQuery);
 
@@ -101,13 +171,12 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 			BaseASTNode baseASTNode = new OrderBy(
 				(OrderByStep)orderBy.getChild(),
 				ArrayUtil.append(
-					orderBy.getOrderByExpressions(), orderByExpression));
+					orderBy.getOrderByExpressions(), orderByExpressions));
 
 			return updateParents(baseASTNode, allBaseASTNodes);
 		}
 
-		BaseASTNode baseASTNode = new OrderBy(
-			orderByStep, new OrderByExpression[] {orderByExpression});
+		BaseASTNode baseASTNode = new OrderBy(orderByStep, orderByExpressions);
 
 		return updateParents(baseASTNode, allBaseASTNodes);
 	}
@@ -129,6 +198,20 @@ public class ObjectEntryFieldSortDSLQueryVisitor
 		}
 
 		return column;
+	}
+
+	private String _getDefaultLanguageId() {
+		Locale locale = LocaleThreadLocal.getSiteDefaultLocale();
+
+		if (locale == null) {
+			locale = LocaleUtil.getDefault();
+		}
+
+		return LocaleUtil.toLanguageId(locale);
+	}
+
+	private Column<?, String> _getLanguageIdColumn(Table<?> table) {
+		return (Column<?, String>)table.getColumn("languageId");
 	}
 
 	private OrderByExpression _getOrderByExpression(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalizedFieldSortTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalizedFieldSortTest.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Guilherme Camacho
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryLocalizedFieldSortTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_availableLocales = LanguageUtil.getAvailableLocales(
+			TestPropsValues.getCompanyId());
+		_defaultLocale = LocaleUtil.getDefault();
+
+		Set<Locale> locales = new HashSet<>(_availableLocales);
+
+		locales.add(LocaleUtil.BRAZIL);
+		locales.add(LocaleUtil.GERMANY);
+		locales.add(LocaleUtil.US);
+
+		CompanyTestUtil.resetCompanyLocales(
+			TestPropsValues.getCompanyId(), locales, LocaleUtil.US);
+
+		_objectFieldName = "a" + RandomTestUtil.randomString();
+
+		ObjectField objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, _objectFieldName,
+			_objectFieldName);
+
+		objectField.setLocalized(true);
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Arrays.asList(objectField), ObjectDefinitionConstants.SCOPE_SITE);
+
+		// Every entry defaults to English. Entry 1 is translated in English and
+		// Portuguese, entry 2 in English only, entry 3 in Portuguese only, and
+		// entry 4 in German only.
+
+		_objectEntry1 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"en_US", "alpha"
+			).put(
+				"pt_BR", "zulu"
+			).build());
+		_objectEntry2 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"en_US", "bravo"
+			).build());
+		_objectEntry3 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"pt_BR", "charlie"
+			).build());
+		_objectEntry4 = _addObjectEntry(
+			HashMapBuilder.<String, Serializable>put(
+				"de_DE", "delta"
+			).build());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		CompanyTestUtil.resetCompanyLocales(
+			TestPropsValues.getCompanyId(), _availableLocales, _defaultLocale);
+	}
+
+	@Test
+	public void testGetPrimaryKeysSortsBySiteDefaultLanguageValue()
+		throws Exception {
+
+		// The active language is Portuguese and the site default is English.
+		// Entry 2 has no Portuguese value and falls back to its English value
+		// "bravo"; entry 4 has neither Portuguese nor English and sorts last.
+
+		_assertPrimaryKeys(
+			LocaleUtil.BRAZIL, false,
+			Arrays.asList(_objectEntry2, _objectEntry3, _objectEntry1),
+			new HashSet<>(Arrays.asList(_objectEntry4)));
+	}
+
+	@Test
+	public void testGetPrimaryKeysSortsUntranslatedEntriesLast()
+		throws Exception {
+
+		// The active language and site default are both English. Entries 1 and
+		// 2 have an English value; entries 3 and 4 do not, so they sort last
+		// for both ascending and descending order.
+
+		_assertPrimaryKeys(
+			LocaleUtil.US, false, Arrays.asList(_objectEntry1, _objectEntry2),
+			new HashSet<>(Arrays.asList(_objectEntry3, _objectEntry4)));
+		_assertPrimaryKeys(
+			LocaleUtil.US, true, Arrays.asList(_objectEntry2, _objectEntry1),
+			new HashSet<>(Arrays.asList(_objectEntry3, _objectEntry4)));
+	}
+
+	private ObjectEntry _addObjectEntry(
+			Map<String, Serializable> localizedValues)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0, "en_US",
+			HashMapBuilder.<String, Serializable>put(
+				_objectFieldName + "_i18n", (Serializable)localizedValues
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertPrimaryKeys(
+			Locale locale, boolean reverse,
+			List<ObjectEntry> orderedObjectEntries,
+			Set<ObjectEntry> unorderedObjectEntries)
+		throws Exception {
+
+		Locale siteDefaultLocale = LocaleThreadLocal.getSiteDefaultLocale();
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		try {
+			LocaleThreadLocal.setSiteDefaultLocale(LocaleUtil.US);
+			LocaleThreadLocal.setThemeDisplayLocale(locale);
+
+			List<Long> actualPrimaryKeys =
+				_objectEntryLocalService.getPrimaryKeys(
+					new Long[] {TestPropsValues.getGroupId()},
+					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+					_objectDefinition.getObjectDefinitionId(),
+					ObjectEntryTable.INSTANCE.objectEntryId.isNotNull(), false,
+					null, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					new Sort[] {
+						new Sort(_objectFieldName, Sort.STRING_TYPE, reverse)
+					});
+
+			List<Long> expectedOrderedPrimaryKeys = TransformUtil.transform(
+				orderedObjectEntries, ObjectEntry::getObjectEntryId);
+
+			Assert.assertEquals(
+				actualPrimaryKeys.toString(), expectedOrderedPrimaryKeys,
+				actualPrimaryKeys.subList(
+					0, expectedOrderedPrimaryKeys.size()));
+
+			Set<Long> expectedUnorderedPrimaryKeys = new HashSet<>(
+				TransformUtil.transform(
+					new ArrayList<>(unorderedObjectEntries),
+					ObjectEntry::getObjectEntryId));
+
+			Assert.assertEquals(
+				actualPrimaryKeys.toString(), expectedUnorderedPrimaryKeys,
+				new HashSet<>(
+					actualPrimaryKeys.subList(
+						expectedOrderedPrimaryKeys.size(),
+						actualPrimaryKeys.size())));
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+			LocaleThreadLocal.setSiteDefaultLocale(siteDefaultLocale);
+		}
+	}
+
+	private Set<Locale> _availableLocales;
+	private Locale _defaultLocale;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	private ObjectEntry _objectEntry1;
+	private ObjectEntry _objectEntry2;
+	private ObjectEntry _objectEntry3;
+	private ObjectEntry _objectEntry4;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private String _objectFieldName;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
@@ -394,8 +394,9 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 
 		if (Validator.isNull(objectField.getRelationshipType())) {
 			_addFDSTableSchemaField(
-				objectField.getBusinessType(), null, objectField.getDBType(),
-				fdsTableSchemaBuilder,
+				objectField.getBusinessType(),
+				_getLocalizedTextContentRenderer(objectField),
+				objectField.getDBType(), fdsTableSchemaBuilder,
 				_getFieldName(
 					objectField.getBusinessType(), objectField.getName()),
 				label, false, objectField.getObjectFieldSettings(),
@@ -514,6 +515,20 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 		}
 
 		return defaultLabel;
+	}
+
+	private String _getLocalizedTextContentRenderer(ObjectField objectField) {
+
+		// A localized field displays the value in the request locale, falling
+		// back to the site default language and then to nothing. Render the
+		// value the REST layer already resolved for the entry instead of
+		// letting the data set fall back to any available translation.
+
+		if (objectField.isLocalized()) {
+			return "localizedTextDataRenderer";
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/FDSPropsTransformer/FDSDataRenderers/LocalizedTextDataRenderer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/FDSPropsTransformer/FDSDataRenderers/LocalizedTextDataRenderer.tsx
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+interface LocalizedTextDataRendererProps {
+	itemData: {[key: string]: any};
+	options: {fieldName: string};
+}
+
+export default function LocalizedTextDataRenderer({
+	itemData,
+	options,
+}: LocalizedTextDataRendererProps) {
+
+	// Render the value the REST layer already resolved for the request locale
+	// (which falls back to the site default language and then to nothing),
+	// rather than letting the data set fall back to any available translation.
+
+	return itemData?.[options?.fieldName] ?? '';
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/FDSPropsTransformer/ViewObjectEntriesFDSPropsTransformer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/FDSPropsTransformer/ViewObjectEntriesFDSPropsTransformer.tsx
@@ -7,6 +7,7 @@ import {IBulkActionItem} from '@liferay/frontend-data-set-web';
 import React from 'react';
 
 import DecimalDataRenderer from './FDSDataRenderers/DecimalDataRenderer';
+import LocalizedTextDataRenderer from './FDSDataRenderers/LocalizedTextDataRenderer';
 import MultiselectPicklistDataRenderer from './FDSDataRenderers/MultiselectPicklistDataRenderer';
 import ObjectEntryStatusDataRenderer from './FDSDataRenderers/ObjectEntryStatusDataRenderer';
 import transformFDSBulkActions from './utils/transformFDSBulkActions';
@@ -29,6 +30,7 @@ export default function ViewObjectEntriesFDSPropsTransformer({
 			bulkActions && transformFDSBulkActions<ObjectEntry>(bulkActions),
 		customDataRenderers: {
 			decimalDataRenderer: DecimalDataRenderer,
+			localizedTextDataRenderer: LocalizedTextDataRenderer,
 			multiselectPicklistDataRenderer: MultiselectPicklistDataRenderer,
 			statusDataRenderer: (props: ObjectEntryStatusDataRendererProps) => (
 				<ObjectEntryStatusDataRenderer

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformers/FDSDataRenderers/LocalizedTextDataRenderer.spec.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/tests/FDSPropsTransformers/FDSDataRenderers/LocalizedTextDataRenderer.spec.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import LocalizedTextDataRenderer from '../../../components/FDSPropsTransformer/FDSDataRenderers/LocalizedTextDataRenderer';
+
+describe('The LocalizedTextDataRenderer component', () => {
+	it('renders the value the REST layer resolved for the request locale', () => {
+		const {container} = render(
+			<LocalizedTextDataRenderer
+				itemData={{
+					name: 'alpha',
+					name_i18n: {en_US: 'alpha', pt_BR: 'zulu'},
+				}}
+				options={{fieldName: 'name'}}
+			/>
+		);
+
+		expect(container).toHaveTextContent('alpha');
+	});
+
+	it('renders nothing when the request and default languages have no value', () => {
+		const {container} = render(
+			<LocalizedTextDataRenderer
+				itemData={{name: '', name_i18n: {de_DE: 'delta'}}}
+				options={{fieldName: 'name'}}
+			/>
+		);
+
+		expect(container.textContent).toBe('');
+		expect(container).not.toHaveTextContent('delta');
+	});
+});


### PR DESCRIPTION
### What

Sorting a translatable Object field in the entries table produced a chaotic order (and a misleading cell value) when some entries had no translation in the current display language (LPP-64476). The base query joins only the requested-locale value, so untranslated entries collapse to `null` and cluster arbitrarily, while the cell fell back to any available translation.

This aligns the entries table with the behavior expected by the product (consistent with the Commerce products screen): show only the current or site-default value, and order entries with no such value to the end.

### Behavior

For a translatable column in the object entries table:

- **Display** — shows the value in the current display language, falling back to the **site default language**, and to **nothing** when neither is present. It no longer falls back to an arbitrary other translation.
- **Sort** — orders entries by that same displayed value, and pushes entries with **no current-or-default value to the end** (nulls-last), for both ascending and descending order.

### Implementation

- **object-api** — `DynamicObjectDefinitionLocalizationTable` gains an `as()` override so the localization table can be aliased for the fallback join (its inherited supplier was a no-op that returned `null`).
- **object-service** — `ObjectEntryFieldSortDSLQueryVisitor` sorts a localized field by `CASE active -> site default -> NULL`, then emits a leading nulls-last flag term. MySQL has no `NULLS LAST` syntax and sorts `null` first when ascending, so the placement is emulated with `CASE WHEN value IS NULL THEN 1 ELSE 0 END ASC` (direction-independent). The site default is resolved via `LocaleThreadLocal.getSiteDefaultLocale()` — the same source the base active-locale join uses — so display and sort stay consistent. The fallback join is guarded to dynamic localization tables, so sorting a localized *system* field cannot NPE.
- **object-web** — `ObjectEntriesTableFDSView` renders localized text columns with a new `localizedTextDataRenderer`, which shows the value the REST layer already resolved (current -> site default -> nothing) instead of the data set's first-available fallback. The schema field name stays plain so sorting keeps working.

### Testing

- **object-test** — integration test asserts untranslated entries sort last (both directions) and that a missing current-locale value falls back to the site default.
- **object-web** — jest spec asserts the renderer shows the resolved value and renders nothing (not a foreign translation) when the current and default languages have no value.
- Compiles, `formatSource` is clean, and the change was validated manually and via the integration test on MySQL.
