### PR TITLE
LPP-64665 Keep hidden field values when editing a form entry

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -161,6 +161,9 @@ public class AddFormInstanceRecordMVCActionCommand
 			ddmForm.getDDMFormFieldsMap(true),
 			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges());
 
+		_updateInvisibleDDMFormFieldValues(
+			actionRequest, ddmFormEvaluatorEvaluateResponse, ddmFormValues);
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DDMFormInstanceRecord.class.getName(), actionRequest);
 
@@ -287,6 +290,28 @@ public class AddFormInstanceRecordMVCActionCommand
 					false, ddmFormValues, serviceContext);
 			}
 		}
+	}
+
+	private void _updateInvisibleDDMFormFieldValues(
+			ActionRequest actionRequest,
+			DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse,
+			DDMFormValues ddmFormValues)
+		throws Exception {
+
+		long ddmFormInstanceRecordId = ParamUtil.getLong(
+			actionRequest, "formInstanceRecordId");
+
+		if (ddmFormInstanceRecordId == 0) {
+			return;
+		}
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			_ddmFormInstanceRecordService.getFormInstanceRecord(
+				ddmFormInstanceRecordId);
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges(),
+			ddmFormValues, ddmFormInstanceRecord.getDDMFormValues());
 	}
 
 	private void _validateCaptcha(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -21,6 +21,7 @@ import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.PortletRequest;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -39,6 +41,56 @@ import java.util.Set;
  * @author Leonardo Barros
  */
 public class AddFormInstanceRecordMVCCommandUtil {
+
+	public static void updateInvisibleDDMFormFieldValues(
+		Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
+			ddmFormFieldsPropertyChanges,
+		DDMFormValues ddmFormValues, DDMFormValues persistedDDMFormValues) {
+
+		Set<String> invisibleDDMFormFieldNames = new HashSet<>();
+
+		for (Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
+				entry : ddmFormFieldsPropertyChanges.entrySet()) {
+
+			if (MapUtil.getBoolean(entry.getValue(), "visible", true)) {
+				continue;
+			}
+
+			DDMFormEvaluatorFieldContextKey ddmFormEvaluatorFieldContextKey =
+				entry.getKey();
+
+			invisibleDDMFormFieldNames.add(
+				ddmFormEvaluatorFieldContextKey.getName());
+		}
+
+		if (invisibleDDMFormFieldNames.isEmpty()) {
+			return;
+		}
+
+		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
+
+		for (DDMFormFieldValue ddmFormFieldValue :
+				ddmFormValues.getDDMFormFieldValues()) {
+
+			if (!invisibleDDMFormFieldNames.contains(
+					ddmFormFieldValue.getName())) {
+
+				newDDMFormFieldValues.add(ddmFormFieldValue);
+			}
+		}
+
+		for (DDMFormFieldValue persistedDDMFormFieldValue :
+				persistedDDMFormValues.getDDMFormFieldValues()) {
+
+			if (invisibleDDMFormFieldNames.contains(
+					persistedDDMFormFieldValue.getName())) {
+
+				newDDMFormFieldValues.add(persistedDDMFormFieldValue);
+			}
+		}
+
+		ddmFormValues.setDDMFormFieldValues(newDDMFormFieldValues);
+	}
 
 	public static void updateNonevaluableDDMFormFields(
 			Map<String, DDMFormField> ddmFormFieldsMap,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -67,29 +67,16 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			return;
 		}
 
-		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
+		// Keep every field a rule has hidden exactly as it was persisted,
+		// dropping whatever was submitted for it, so editing an entry does not
+		// blank a hidden field (LPP-64665). Nested fields are handled
+		// recursively and the original field order is preserved.
 
-		for (DDMFormFieldValue ddmFormFieldValue :
-				ddmFormValues.getDDMFormFieldValues()) {
-
-			if (!invisibleDDMFormFieldNames.contains(
-					ddmFormFieldValue.getName())) {
-
-				newDDMFormFieldValues.add(ddmFormFieldValue);
-			}
-		}
-
-		for (DDMFormFieldValue persistedDDMFormFieldValue :
-				persistedDDMFormValues.getDDMFormFieldValues()) {
-
-			if (invisibleDDMFormFieldNames.contains(
-					persistedDDMFormFieldValue.getName())) {
-
-				newDDMFormFieldValues.add(persistedDDMFormFieldValue);
-			}
-		}
-
-		ddmFormValues.setDDMFormFieldValues(newDDMFormFieldValues);
+		ddmFormValues.setDDMFormFieldValues(
+			_restoreInvisibleDDMFormFieldValues(
+				invisibleDDMFormFieldNames,
+				ddmFormValues.getDDMFormFieldValues(),
+				persistedDDMFormValues.getDDMFormFieldValues()));
 	}
 
 	public static void updateNonevaluableDDMFormFields(
@@ -232,6 +219,108 @@ public class AddFormInstanceRecordMVCCommandUtil {
 					" has already submitted an entry in form instance ",
 					ddmFormInstance.getFormInstanceId()));
 		}
+	}
+
+	private static void _addDDMFormFieldValuesByName(
+		List<DDMFormFieldValue> ddmFormFieldValues,
+		List<DDMFormFieldValue> sourceDDMFormFieldValues, String name) {
+
+		for (DDMFormFieldValue sourceDDMFormFieldValue :
+				sourceDDMFormFieldValues) {
+
+			if (name.equals(sourceDDMFormFieldValue.getName())) {
+				ddmFormFieldValues.add(sourceDDMFormFieldValue);
+			}
+		}
+	}
+
+	private static DDMFormFieldValue _getDDMFormFieldValueByInstanceId(
+		List<DDMFormFieldValue> ddmFormFieldValues, String instanceId) {
+
+		if (instanceId == null) {
+			return null;
+		}
+
+		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			if (instanceId.equals(ddmFormFieldValue.getInstanceId())) {
+				return ddmFormFieldValue;
+			}
+		}
+
+		return null;
+	}
+
+	private static List<DDMFormFieldValue> _restoreInvisibleDDMFormFieldValues(
+		Set<String> invisibleDDMFormFieldNames,
+		List<DDMFormFieldValue> ddmFormFieldValues,
+		List<DDMFormFieldValue> persistedDDMFormFieldValues) {
+
+		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
+
+		Set<String> restoredDDMFormFieldNames = new HashSet<>();
+
+		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			String name = ddmFormFieldValue.getName();
+
+			if (invisibleDDMFormFieldNames.contains(name)) {
+				if (!restoredDDMFormFieldNames.contains(name)) {
+					_addDDMFormFieldValuesByName(
+						newDDMFormFieldValues, persistedDDMFormFieldValues,
+						name);
+
+					restoredDDMFormFieldNames.add(name);
+				}
+
+				continue;
+			}
+
+			DDMFormFieldValue persistedDDMFormFieldValue =
+				_getDDMFormFieldValueByInstanceId(
+					persistedDDMFormFieldValues,
+					ddmFormFieldValue.getInstanceId());
+
+			if (persistedDDMFormFieldValue != null) {
+				List<DDMFormFieldValue> nestedDDMFormFieldValues =
+					ddmFormFieldValue.getNestedDDMFormFieldValues();
+
+				if (!nestedDDMFormFieldValues.isEmpty()) {
+					List<DDMFormFieldValue> newNestedDDMFormFieldValues =
+						_restoreInvisibleDDMFormFieldValues(
+							invisibleDDMFormFieldNames,
+							nestedDDMFormFieldValues,
+							persistedDDMFormFieldValue.
+								getNestedDDMFormFieldValues());
+
+					nestedDDMFormFieldValues.clear();
+
+					for (DDMFormFieldValue newNestedDDMFormFieldValue :
+							newNestedDDMFormFieldValues) {
+
+						ddmFormFieldValue.addNestedDDMFormFieldValue(
+							newNestedDDMFormFieldValue);
+					}
+				}
+			}
+
+			newDDMFormFieldValues.add(ddmFormFieldValue);
+		}
+
+		for (DDMFormFieldValue persistedDDMFormFieldValue :
+				persistedDDMFormFieldValues) {
+
+			String name = persistedDDMFormFieldValue.getName();
+
+			if (invisibleDDMFormFieldNames.contains(name) &&
+				!restoredDDMFormFieldNames.contains(name)) {
+
+				_addDDMFormFieldValuesByName(
+					newDDMFormFieldValues, persistedDDMFormFieldValues, name);
+
+				restoredDDMFormFieldNames.add(name);
+			}
+		}
+
+		return newDDMFormFieldValues;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -282,14 +282,17 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			if (persistedDDMFormFieldValue != null) {
 				List<DDMFormFieldValue> nestedDDMFormFieldValues =
 					ddmFormFieldValue.getNestedDDMFormFieldValues();
+				List<DDMFormFieldValue> persistedNestedDDMFormFieldValues =
+					persistedDDMFormFieldValue.getNestedDDMFormFieldValues();
 
-				if (!nestedDDMFormFieldValues.isEmpty()) {
+				if (!nestedDDMFormFieldValues.isEmpty() ||
+					!persistedNestedDDMFormFieldValues.isEmpty()) {
+
 					List<DDMFormFieldValue> newNestedDDMFormFieldValues =
 						_restoreInvisibleDDMFormFieldValues(
 							invisibleDDMFormFieldNames,
 							nestedDDMFormFieldValues,
-							persistedDDMFormFieldValue.
-								getNestedDDMFormFieldValues());
+							persistedNestedDDMFormFieldValues);
 
 					nestedDDMFormFieldValues.clear();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -67,11 +67,6 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			return;
 		}
 
-		// Keep every field a rule has hidden exactly as it was persisted,
-		// dropping whatever was submitted for it, so editing an entry does not
-		// blank a hidden field (LPP-64665). Nested fields are handled
-		// recursively and the original field order is preserved.
-
 		ddmFormValues.setDDMFormFieldValues(
 			_restoreInvisibleDDMFormFieldValues(
 				invisibleDDMFormFieldNames,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -126,6 +126,66 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 	}
 
 	@Test
+	public void testInvisibleNestedFieldKeepsPersistedValue() throws Exception {
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"parentInstanceId", "parent", new UnlocalizedValue(""));
+
+		ddmFormFieldValue.addNestedDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"childInstanceId", "child",
+				new UnlocalizedValue(StringPool.BLANK)));
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			DDMFormTestUtil.createDDMForm());
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		DDMFormFieldValue persistedDDMFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"parentInstanceId", "parent", new UnlocalizedValue(""));
+
+		persistedDDMFormFieldValue.addNestedDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"childInstanceId", "child", new UnlocalizedValue("kept")));
+
+		DDMFormValues persistedDDMFormValues =
+			DDMFormValuesTestUtil.createDDMFormValues(
+				DDMFormTestUtil.createDDMForm());
+
+		persistedDDMFormValues.addDDMFormFieldValue(persistedDDMFormFieldValue);
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			HashMapBuilder.put(
+				new DDMFormEvaluatorFieldContextKey("child", "childInstanceId"),
+				HashMapBuilder.<String, Object>put(
+					"visible", false
+				).build()
+			).build(),
+			ddmFormValues, persistedDDMFormValues);
+
+		DDMFormFieldValue parentDDMFormFieldValue =
+			ddmFormValues.getDDMFormFieldValues(
+			).get(
+				0
+			);
+
+		List<DDMFormFieldValue> nestedDDMFormFieldValues =
+			parentDDMFormFieldValue.getNestedDDMFormFieldValues();
+
+		Assert.assertEquals(
+			nestedDDMFormFieldValues.toString(), 1,
+			nestedDDMFormFieldValues.size());
+
+		DDMFormFieldValue childDDMFormFieldValue = nestedDDMFormFieldValues.get(
+			0);
+
+		Value value = childDDMFormFieldValue.getValue();
+
+		Assert.assertEquals("kept", value.getString(LocaleUtil.US));
+	}
+
+	@Test
 	public void testInvisibleRepeatableFieldKeepsAllPersistedInstances()
 		throws Exception {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -125,6 +125,68 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 		_assertDDMFormFields(false, null);
 	}
 
+	@Test
+	public void testInvisibleRepeatableFieldKeepsAllPersistedInstances()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
+			_FIELD_NAME, false, false, false);
+
+		ddmFormField.setRepeatable(true);
+
+		ddmForm.addDDMFormField(ddmFormField);
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		ddmFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId0", _FIELD_NAME,
+				new UnlocalizedValue(StringPool.BLANK)));
+
+		DDMFormValues persistedDDMFormValues =
+			DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
+
+		persistedDDMFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId0", _FIELD_NAME, new UnlocalizedValue("value0")));
+		persistedDDMFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId1", _FIELD_NAME, new UnlocalizedValue("value1")));
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			HashMapBuilder.put(
+				new DDMFormEvaluatorFieldContextKey(_FIELD_NAME, "instanceId0"),
+				HashMapBuilder.<String, Object>put(
+					"visible", false
+				).build()
+			).build(),
+			ddmFormValues, persistedDDMFormValues);
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(false);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			_FIELD_NAME);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 2, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Value value = ddmFormFieldValue.getValue();
+
+		Assert.assertEquals("value0", value.getString(LocaleUtil.US));
+
+		ddmFormFieldValue = ddmFormFieldValues.get(1);
+
+		value = ddmFormFieldValue.getValue();
+
+		Assert.assertEquals("value1", value.getString(LocaleUtil.US));
+	}
+
 	@Test(expected = FormInstanceExpiredException.class)
 	public void testValidateExpirationStatus() throws Exception {
 		ThemeDisplay themeDisplay = _mockThemeDisplay();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
@@ -17,6 +17,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -143,6 +144,86 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 
 		_assertValue("TextField1", ddmFormFieldValuesMap, value1);
 		_assertValue("TextField2", ddmFormFieldValuesMap, value2);
+	}
+
+	@Test
+	public void testProcessActionKeepsInvisibleFieldValueOnEdit()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(
+				LocaleUtil.BRAZIL, LocaleUtil.US),
+			LocaleUtil.US);
+
+		DDMFormTestUtil.addDDMFormRule(
+			Collections.singletonList("setVisible('TextField2', true)"),
+			"not(isEmpty(getValue('TextField1')))", ddmForm);
+		DDMFormTestUtil.addTextDDMFormFields(
+			ddmForm, "TextField1", "TextField2");
+
+		DDMFormInstance ddmFormInstance =
+			DDMFormInstanceTestUtil.addDDMFormInstance(
+				ddmForm, _group,
+				DDMFormInstanceTestUtil.createSettingsDDMFormValues(false),
+				TestPropsValues.getUserId());
+
+		String value1 = RandomTestUtil.randomString();
+		String value2 = RandomTestUtil.randomString();
+
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", value1);
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value2);
+		_mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		_mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			_mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<DDMFormInstanceRecord> ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecords.get(0);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		String value3 = RandomTestUtil.randomString();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value3);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceRecordId",
+			String.valueOf(ddmFormInstanceRecord.getFormInstanceRecordId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		ddmFormInstanceRecord = ddmFormInstanceRecords.get(0);
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		_assertValue(
+			"TextField2", ddmFormValues.getDDMFormFieldValuesMap(false),
+			value2);
 	}
 
 	private void _assertValue(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-64665

## What Is Being Fixed

When an administrator edits an existing form entry, any field currently hidden by a show/hide form rule loses its stored value on save. On the save path, a field that a rule has made invisible is treated as non-evaluable and its submitted value is blanked, so a field that holds a value but is hidden at edit time is silently cleared. 

## How It Is Being Fixed

On the save path, and only when editing an existing record (`formInstanceRecordId != 0`), each invisible field's value is restored from the persisted record before the entry is saved. Adding a new entry is unaffected, since there is no prior value to preserve.

The restore is built in complementary layers, each covering a broader shape of form data:

- **Core restore** — for every field a rule has hidden, the persisted value is kept and the submitted (blanked) value is dropped, so editing an entry can no longer blank a hidden field.
- **Repeatable fields** — the complete persisted set for a hidden field is restored rather than a positional copy, so a hidden repeatable field keeps all of its instances.
- **Nested fields and ordering** — the restore recurses into nested field values (fieldsets and grids), matching submitted values to persisted values by instance id, and preserves the original field order.

## Tests

- **Unit** — `AddFormInstanceRecordMVCCommandUtilTest`: a hidden repeatable field keeps all of its persisted instances, and a hidden nested field keeps its persisted value.
- **Integration** — `AddFormInstanceRecordMVCActionCommandTest`: adding an entry then editing it so that a rule hides a field keeps that field's stored value after save.

## PR Check

**pr-check: SKIPPED** — Source formatting was validated locally with `format-source-current-branch` (PASS) and the changed module compiles cleanly. The full premerge suite (integration and unit compile and execution) is left to CI, as it cannot be run in full from this local checkout.

<!-- pr-check {"reason": "Source format validated locally (PASS) and module compiles; full suite left to CI, not runnable in full locally", "result": "skipped", "sha": "8116b3063a50854db3e2bf77f6f8c16b83df7779"} -->
