### PR TITLE
LPD-96626 Register Many-to-Many related info collection providers

### DIFF
--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalService.java
@@ -423,7 +423,7 @@ public interface ObjectRelationshipLocalService
 		throws PortalException;
 
 	public void registerObjectRelationshipsRelatedInfoCollectionProviders(
-		ObjectDefinition objectDefinition1,
+		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		List<ObjectRelationship> objectRelationships);
 
@@ -452,4 +452,4 @@ public interface ObjectRelationshipLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:146478146
+// LIFERAY-SERVICE-BUILDER-HASH:900104349

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceUtil.java
@@ -557,12 +557,12 @@ public class ObjectRelationshipLocalServiceUtil {
 
 	public static void
 		registerObjectRelationshipsRelatedInfoCollectionProviders(
-			com.liferay.object.model.ObjectDefinition objectDefinition1,
+			com.liferay.object.model.ObjectDefinition objectDefinition,
 			ObjectDefinitionLocalService objectDefinitionLocalService,
 			List<ObjectRelationship> objectRelationships) {
 
 		getService().registerObjectRelationshipsRelatedInfoCollectionProviders(
-			objectDefinition1, objectDefinitionLocalService,
+			objectDefinition, objectDefinitionLocalService,
 			objectRelationships);
 	}
 
@@ -611,4 +611,4 @@ public class ObjectRelationshipLocalServiceUtil {
 			ObjectRelationshipLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-320288305
+// LIFERAY-SERVICE-BUILDER-HASH:2142959521

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/service/ObjectRelationshipLocalServiceWrapper.java
@@ -652,14 +652,14 @@ public class ObjectRelationshipLocalServiceWrapper
 
 	@Override
 	public void registerObjectRelationshipsRelatedInfoCollectionProviders(
-		com.liferay.object.model.ObjectDefinition objectDefinition1,
+		com.liferay.object.model.ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		java.util.List<com.liferay.object.model.ObjectRelationship>
 			objectRelationships) {
 
 		_objectRelationshipLocalService.
 			registerObjectRelationshipsRelatedInfoCollectionProviders(
-				objectDefinition1, objectDefinitionLocalService,
+				objectDefinition, objectDefinitionLocalService,
 				objectRelationships);
 	}
 
@@ -722,4 +722,4 @@ public class ObjectRelationshipLocalServiceWrapper
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1817623923
+// LIFERAY-SERVICE-BUILDER-HASH:-2013795293

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectRelationshipLocalServiceImpl.java
@@ -909,11 +909,11 @@ public class ObjectRelationshipLocalServiceImpl
 
 	@Override
 	public void registerObjectRelationshipsRelatedInfoCollectionProviders(
-		ObjectDefinition objectDefinition1,
+		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		List<ObjectRelationship> objectRelationships) {
 
-		long objectDefinitionId = objectDefinition1.getObjectDefinitionId();
+		long objectDefinitionId = objectDefinition.getObjectDefinitionId();
 
 		if (objectRelationships == null) {
 			objectRelationships =
@@ -929,37 +929,36 @@ public class ObjectRelationshipLocalServiceImpl
 			}
 
 			try {
+				ObjectDefinition objectDefinition1;
+				ObjectDefinition objectDefinition2;
+
 				if (objectRelationship.getObjectDefinitionId1() ==
 						objectDefinitionId) {
 
-					ObjectDefinition objectDefinition2 =
+					objectDefinition1 = objectDefinition;
+					objectDefinition2 =
 						objectDefinitionLocalService.getObjectDefinition(
 							objectRelationship.getObjectDefinitionId2());
-
-					_registerRelatedInfoItemCollectionProvider(
-						objectDefinition1, objectDefinition2,
-						objectRelationship);
-
-					if (Objects.equals(
-							objectRelationship.getType(),
-							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
-
-						_registerRelatedInfoItemCollectionProvider(
-							objectDefinition2, objectDefinition1,
-							objectRelationshipLocalService.
-								getObjectRelationship(
-									objectRelationship.getObjectDefinitionId2(),
-									objectRelationship.getName()));
-					}
 				}
-				else if (!Objects.equals(
-							objectRelationship.getType(),
-							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+				else {
+					objectDefinition1 =
+						objectDefinitionLocalService.getObjectDefinition(
+							objectRelationship.getObjectDefinitionId1());
+					objectDefinition2 = objectDefinition;
+				}
+
+				_registerRelatedInfoItemCollectionProvider(
+					objectDefinition1, objectDefinition2, objectRelationship);
+
+				if (Objects.equals(
+						objectRelationship.getType(),
+						ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
 
 					_registerRelatedInfoItemCollectionProvider(
-						objectDefinitionLocalService.getObjectDefinition(
-							objectRelationship.getObjectDefinitionId1()),
-						objectDefinition1, objectRelationship);
+						objectDefinition2, objectDefinition1,
+						objectRelationshipLocalService.getObjectRelationship(
+							objectRelationship.getObjectDefinitionId2(),
+							objectRelationship.getName()));
 				}
 			}
 			catch (PortalException portalException) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96626

## What Is Being Fixed

When two custom objects are linked by a Many-to-Many relationship, the related items of the second object to be published were not offered as a collection in a Collection Display. Publishing the second object of the pair failed to register its related info item collection provider, so the "Related Items Collection Providers" list was missing the related object.

## How It Is Being Fixed

When an object definition is published, its object relationships are walked to register the related info item collection providers. For the side of the relationship that is not objectDefinitionId1, the previous code skipped registration entirely for Many-to-Many relationships. It now always registers the provider for that side and, for Many-to-Many relationships, additionally registers the reverse-direction provider using the reverse relationship row, so both objects expose the related collection regardless of publish order.

## Why Are There No Tests?

The fix is already covered by the existing integration test `testRegisterObjectRelationshipsRelatedInfoItemCollectionProviders` in ObjectRelationshipLocalServiceTest. It creates two draft object definitions linked by a Many-to-Many relationship, publishes them one at a time, and asserts that both related info item collection providers are registered after the second publish -- the exact path this change repairs. The test failed before the change and passes after it, so no new test is warranted.

## PR Check

**pr-check: PASS** -- tested on `7d9c4d5af5c07fd49cd01b1fbee1bc41c27e696e`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7d9c4d5af5c07fd49cd01b1fbee1bc41c27e696e"} -->
