### PR TITLE
LPD-89588 Document major bump

### DIFF
--- a/modules/apps/changeset/changeset-service/bnd.bnd
+++ b/modules/apps/changeset/changeset-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Changeset Service
 Bundle-SymbolicName: com.liferay.changeset.service
 Bundle-Version: 4.0.40
-Liferay-Require-SchemaVersion: 2.2.0
+Liferay-Require-SchemaVersion: 3.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/registry/ChangesetServiceUpgradeStepRegistrator.java
@@ -36,8 +36,8 @@ public class ChangesetServiceUpgradeStepRegistrator
 				"classExternalReferenceCode VARCHAR(1000) null"));
 
 		registry.register(
-			"2.1.0", "2.2.0",
-			new com.liferay.changeset.internal.upgrade.v2_2_0.
+			"2.1.0", "3.0.0",
+			new com.liferay.changeset.internal.upgrade.v3_0_0.
 				ChangesetEntryIndexedColumnSizeUpgradeProcess());
 	}
 

--- a/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v3_0_0/ChangesetEntryIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/changeset/changeset-service/src/main/java/com/liferay/changeset/internal/upgrade/v3_0_0/ChangesetEntryIndexedColumnSizeUpgradeProcess.java
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.oauth2.provider.internal.upgrade.v4_3_0;
+package com.liferay.changeset.internal.upgrade.v3_0_0;
 
 import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
 
 /**
  * @author Roselaine Marques
  */
-public class OAuth2ApplicationIndexedColumnSizeUpgradeProcess
+public class ChangesetEntryIndexedColumnSizeUpgradeProcess
 	extends BaseIndexedColumnSizeUpgradeProcess {
 
 	@Override
 	protected String getColumnName() {
-		return "externalReferenceCode";
+		return "classExternalReferenceCode";
 	}
 
 	@Override
 	protected String[] getGroupByColumnNames() {
-		return new String[] {"companyId"};
+		return new String[] {"changesetCollectionId", "classNameId"};
 	}
 
 	@Override
@@ -30,7 +30,7 @@ public class OAuth2ApplicationIndexedColumnSizeUpgradeProcess
 
 	@Override
 	protected String getTableName() {
-		return "OAuth2Application";
+		return "ChangesetEntry";
 	}
 
 }

--- a/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v3_0_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/changeset/changeset-test/src/testIntegration/java/com/liferay/changeset/internal/upgrade/v3_0_0/test/ChangesetEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.changeset.internal.upgrade.v2_2_0.test;
+package com.liferay.changeset.internal.upgrade.v3_0_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.112
-Liferay-Require-SchemaVersion: 4.3.0
+Liferay-Require-SchemaVersion: 5.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -151,8 +151,8 @@ public class OAuth2ServiceUpgradeStepRegistrator
 				"OAuth2Authorization", "audiences TEXT null"));
 
 		registry.register(
-			"4.2.8", "4.3.0",
-			new com.liferay.oauth2.provider.internal.upgrade.v4_3_0.
+			"4.2.8", "5.0.0",
+			new com.liferay.oauth2.provider.internal.upgrade.v5_0_0.
 				OAuth2ApplicationIndexedColumnSizeUpgradeProcess());
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v5_0_0/OAuth2ApplicationIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v5_0_0/OAuth2ApplicationIndexedColumnSizeUpgradeProcess.java
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.changeset.internal.upgrade.v2_2_0;
+package com.liferay.oauth2.provider.internal.upgrade.v5_0_0;
 
 import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
 
 /**
  * @author Roselaine Marques
  */
-public class ChangesetEntryIndexedColumnSizeUpgradeProcess
+public class OAuth2ApplicationIndexedColumnSizeUpgradeProcess
 	extends BaseIndexedColumnSizeUpgradeProcess {
 
 	@Override
 	protected String getColumnName() {
-		return "classExternalReferenceCode";
+		return "externalReferenceCode";
 	}
 
 	@Override
 	protected String[] getGroupByColumnNames() {
-		return new String[] {"changesetCollectionId", "classNameId"};
+		return new String[] {"companyId"};
 	}
 
 	@Override
@@ -30,7 +30,7 @@ public class ChangesetEntryIndexedColumnSizeUpgradeProcess
 
 	@Override
 	protected String getTableName() {
-		return "ChangesetEntry";
+		return "OAuth2Application";
 	}
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v5_0_0/test/OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/internal/upgrade/v5_0_0/test/OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.oauth2.provider.internal.upgrade.v4_3_0.test;
+package com.liferay.oauth2.provider.internal.upgrade.v5_0_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;

--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.248
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 12.2.0
+Liferay-Require-SchemaVersion: 13.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -715,8 +715,8 @@ public class ObjectServiceUpgradeStepRegistrator
 				ObjectEntryPicklistDefaultValueUpgradeProcess());
 
 		registry.register(
-			"12.1.1", "12.2.0",
-			new com.liferay.object.internal.upgrade.v12_2_0.
+			"12.1.1", "13.0.0",
+			new com.liferay.object.internal.upgrade.v13_0_0.
 				ObjectEntryIndexedColumnSizeUpgradeProcess());
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v13_0_0/ObjectEntryIndexedColumnSizeUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v13_0_0/ObjectEntryIndexedColumnSizeUpgradeProcess.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.object.internal.upgrade.v12_2_0;
+package com.liferay.object.internal.upgrade.v13_0_0;
 
 import com.liferay.portal.kernel.upgrade.BaseIndexedColumnSizeUpgradeProcess;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_0_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_0_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.object.internal.upgrade.v12_2_0.test;
+package com.liferay.object.internal.upgrade.v13_0_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89588

## What Is Being Fixed

The fix for LPD-89588 (PR #176223) added upgrade processes that resize the unique ERC indexes on ChangesetEntry, OAuth2Application, and ObjectEntry to avoid SQL Server warning 1945. Those upgrade steps were registered as minor schema bumps (2.2.0, 4.3.0, 12.2.0). Because they alter database structure, they need to be documented as major schema version bumps.

## How It Is Being Fixed

Each affected -service module's Liferay-Require-SchemaVersion is raised to the next major version (3.0.0, 5.0.0, 13.0.0), the upgrade step registration target is changed to match, and the upgrade process class along with its integration test is moved into the corresponding v3_0_0 / v5_0_0 / v13_0_0 package.

## Why Are There No Tests?

This change only promotes the existing upgrade steps' schema versions from minor to major and relocates the existing integration tests to match the new version packages. There is no runtime behavior change, so the existing integration test coverage still applies.

## PR Check

**pr-check: PASS** — tested on `43534d600707373d662ae44e722bdafb884d246c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "43534d600707373d662ae44e722bdafb884d246c"} -->
