### PR TITLE
LPD-96960 Fix 0-byte form CSV export when a field is deleted

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldValueUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormFieldValueUtil.java
@@ -167,6 +167,10 @@ public class DDMFormFieldValueUtil {
 
 		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
 
+		if (ddmFormField == null) {
+			return new DDMFormFieldOptions();
+		}
+
 		return ddmFormField.getDDMFormFieldOptions();
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRenderer.java
@@ -82,6 +82,10 @@ public class GridDDMFormFieldValueRenderer
 
 		DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
 
+		if (ddmFormField == null) {
+			return new DDMFormFieldOptions();
+		}
+
 		return (DDMFormFieldOptions)ddmFormField.getProperty(optionType);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/checkbox/multiple/CheckboxMultipleDDMFormFieldValueRendererTest.java
@@ -84,6 +84,22 @@ public class CheckboxMultipleDDMFormFieldValueRendererTest {
 			"option 1, option with &amp;",
 			_checkboxMultipleDDMFormFieldValueRenderer.render(
 				ddmFormFieldValue, LocaleUtil.US));
+
+		ddmForm = DDMFormTestUtil.createDDMForm();
+
+		ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
+
+		ddmFormFieldValue = DDMFormValuesTestUtil.createDDMFormFieldValue(
+			"CheckboxMultiple", new UnlocalizedValue("[\"value 1\"]"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		Assert.assertEquals(
+			"value 1",
+			_checkboxMultipleDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
 	}
 
 	private CheckboxMultipleDDMFormFieldValueRenderer

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/grid/GridDDMFormFieldValueRendererTest.java
@@ -13,6 +13,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -74,6 +75,22 @@ public class GridDDMFormFieldValueRendererTest {
 
 		Assert.assertEquals(
 			"rowLabel 1: columnLabel 1",
+			gridDDMFormFieldValueRenderer.render(
+				ddmFormFieldValue, LocaleUtil.US));
+
+		ddmForm = DDMFormTestUtil.createDDMForm();
+
+		ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
+
+		ddmFormFieldValue = DDMFormValuesTestUtil.createDDMFormFieldValue(
+			"Grid", new UnlocalizedValue("{\"rowValue 1\":\"columnValue 1\"}"));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		Assert.assertNull(ddmFormFieldValue.getDDMFormField());
+
+		Assert.assertEquals(
+			StringPool.BLANK,
 			gridDDMFormFieldValueRenderer.render(
 				ddmFormFieldValue, LocaleUtil.US));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldValueRendererTest.java
@@ -1,9 +1,9 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.dynamic.data.mapping.form.field.type.internal.radio;
+package com.liferay.dynamic.data.mapping.form.field.type.internal.select;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -22,9 +22,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * @author Renato Rego
+ * @author Victor Kammerer
  */
-public class RadioDDMFormFieldValueRendererTest {
+public class SelectDDMFormFieldValueRendererTest {
 
 	@ClassRule
 	@Rule
@@ -36,15 +36,13 @@ public class RadioDDMFormFieldValueRendererTest {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
 
 		DDMFormField ddmFormField = DDMFormTestUtil.createDDMFormField(
-			"Radio", "Radio", "radio", "string", false, false, false);
+			"Select", "Select", "select", "string", false, false, false);
 
 		DDMFormFieldOptions ddmFormFieldOptions =
 			ddmFormField.getDDMFormFieldOptions();
 
 		ddmFormFieldOptions.addOptionLabel(
 			"value 1", LocaleUtil.US, "option with &");
-		ddmFormFieldOptions.addOptionLabel(
-			"value 2", LocaleUtil.US, "option 2");
 
 		ddmForm.addDDMFormField(ddmFormField);
 
@@ -53,16 +51,16 @@ public class RadioDDMFormFieldValueRendererTest {
 
 		DDMFormFieldValue ddmFormFieldValue =
 			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"Radio", new UnlocalizedValue("value 1"));
+				"Select", new UnlocalizedValue("[\"value 1\"]"));
 
 		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
 
-		RadioDDMFormFieldValueRenderer radioDDMFormFieldValueRenderer =
-			new RadioDDMFormFieldValueRenderer();
+		SelectDDMFormFieldValueRenderer selectDDMFormFieldValueRenderer =
+			new SelectDDMFormFieldValueRenderer();
 
 		Assert.assertEquals(
 			"option with &amp;",
-			radioDDMFormFieldValueRenderer.render(
+			selectDDMFormFieldValueRenderer.render(
 				ddmFormFieldValue, LocaleUtil.US));
 
 		ddmForm = DDMFormTestUtil.createDDMForm();
@@ -70,7 +68,7 @@ public class RadioDDMFormFieldValueRendererTest {
 		ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
 
 		ddmFormFieldValue = DDMFormValuesTestUtil.createDDMFormFieldValue(
-			"Radio", new UnlocalizedValue("value 1"));
+			"Select", new UnlocalizedValue("[\"value 1\"]"));
 
 		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
 
@@ -78,7 +76,7 @@ public class RadioDDMFormFieldValueRendererTest {
 
 		Assert.assertEquals(
 			"value 1",
-			radioDDMFormFieldValueRenderer.render(
+			selectDDMFormFieldValueRenderer.render(
 				ddmFormFieldValue, LocaleUtil.US));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96960

## What Is Being Fixed

Exporting a form's records to CSV produced a 0-byte file whenever a form field that had stored data was later deleted from the form definition. During export the field-value renderers looked up the (now missing) `DDMFormField` and dereferenced a null, throwing before any content was written and leaving an empty file.

## How It Is Being Fixed

The option-resolving paths now guard against a missing field. `DDMFormFieldValueUtil.getDDMFormFieldOptions` and the option lookup in `GridDDMFormFieldValueRenderer` return an empty `DDMFormFieldOptions` when the `DDMFormField` no longer exists, so a value whose field was deleted renders from its stored raw value (or blank for grid) instead of aborting the export. Unit tests for the checkbox-multiple, grid, radio, and select renderers assert the render output when `getDDMFormField()` is null.

## PR Check

**pr-check: PASS** — tested on `0f89d78be51d3618e5448f763480950c43d6e68b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0f89d78be51d3618e5448f763480950c43d6e68b"} -->
