### PR TITLE
LPD-96952 Avoid NPE when rendering a notification without a request

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/template/CommerceOrderHttpHelperTemplateContextContributor.java
@@ -7,6 +7,7 @@ package com.liferay.commerce.order.content.web.internal.template;
 
 import com.liferay.commerce.order.CommerceOrderHttpHelper;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -33,10 +34,16 @@ public class CommerceOrderHttpHelperTemplateContextContributor
 		HttpServletRequest httpServletRequest) {
 
 		contextObjects.put("commerceOrderHttpHelper", _commerceOrderHttpHelper);
+
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (httpServletRequest != null) {
+			companyId = _portal.getCompanyId(httpServletRequest);
+		}
+
 		contextObjects.put(
 			"commerceReturnsEnabled",
-			FeatureFlagManagerUtil.isEnabled(
-				_portal.getCompanyId(httpServletRequest), "LPD-10562"));
+			FeatureFlagManagerUtil.isEnabled(companyId, "LPD-10562"));
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96952

## What Is Being Fixed

Creating a CMP task fires an email notification. While formatting the notification body, the portal logged a NullPointerException, though the task itself was still created.

## How It Is Being Fixed

Email notifications are formatted outside of any HTTP request, so EmailNotificationType passes a null request to every global template context contributor. CommerceOrderHttpHelperTemplateContextContributor, introduced in LPD-93811, dereferenced that request through Portal.getCompanyId to resolve a feature flag, which threw. The contributor now reads the company from CompanyThreadLocal when there is no request, and only calls Portal.getCompanyId when a request is present.

## Why Are There No Tests?

The regression is already covered by EmailNotificationTypeTest. Its FreeMarker tests exercise the global contributor during email rendering with a null request; they fail on the NullPointerException before this fix and pass after it.

## PR Check

**pr-check: PASS** — tested on `c62f7203418a70e45a329a44a6d70616944f6770`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c62f7203418a70e45a329a44a6d70616944f6770"} -->
