### PR TITLE
LPD-97391 Translate the submit button in the form's displayed language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -82,7 +82,6 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -553,13 +552,16 @@ public class DDMFormDisplayContext {
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			ddmFormInstanceSettings.submitLabel());
 
-		String submitLabel = jsonObject.getString(getDefaultLanguageId());
+		String languageId = getDefaultLanguageId();
+
+		String submitLabel = jsonObject.getString(languageId);
 
 		if (Validator.isNotNull(submitLabel)) {
 			return submitLabel;
 		}
 
-		ResourceBundle resourceBundle = _getResourceBundle();
+		ResourceBundle resourceBundle = _getResourceBundle(
+			LocaleUtil.fromLanguageId(languageId));
 
 		if (StringUtil.equals(ddmFormInstance.getStorageType(), "object")) {
 			ObjectDefinition objectDefinition =
@@ -1193,13 +1195,11 @@ public class DDMFormDisplayContext {
 		}
 	}
 
-	private ResourceBundle _getResourceBundle() {
-		ResourceBundle portalResourceBundle = _portal.getResourceBundle(
-			LocaleThreadLocal.getThemeDisplayLocale());
+	private ResourceBundle _getResourceBundle(Locale locale) {
+		ResourceBundle portalResourceBundle = _portal.getResourceBundle(locale);
 
 		ResourceBundle moduleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
-			getClass());
+			"content.Language", locale, getClass());
 
 		return new AggregateResourceBundle(
 			moduleResourceBundle, portalResourceBundle);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -581,11 +582,26 @@ public class DDMFormDisplayContextTest {
 
 		_mockWorkflowDefinitionLinkLocalService(false);
 
-		DDMFormDisplayContext ddmFormDisplayContext =
-			_createDDMFormDisplayContext();
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
 
-		Assert.assertEquals(
-			submitLabel, ddmFormDisplayContext.getSubmitLabel());
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		try {
+			DDMFormDisplayContext ddmFormDisplayContext =
+				_createDDMFormDisplayContext();
+
+			Assert.assertEquals(
+				submitLabel, ddmFormDisplayContext.getSubmitLabel());
+
+			Mockito.verify(
+				_portal
+			).getResourceBundle(
+				LocaleUtil.SPAIN
+			);
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
 	}
 
 	@Test
@@ -952,8 +968,8 @@ public class DDMFormDisplayContextTest {
 			Mockito.mock(DDMFormValuesMerger.class), _ddmFormWebConfiguration,
 			Mockito.mock(DDMStorageAdapterRegistry.class),
 			_ddmStructureLocalService, _groupLocalService,
-			new JSONFactoryImpl(), null, null, null, null, null,
-			Mockito.mock(Portal.class), renderRequest, new MockRenderResponse(),
+			new JSONFactoryImpl(), null, null, null, null, null, _portal,
+			renderRequest, new MockRenderResponse(),
 			Mockito.mock(RoleLocalService.class),
 			Mockito.mock(UserLocalService.class),
 			_workflowDefinitionLinkLocalService);
@@ -1356,6 +1372,7 @@ public class DDMFormDisplayContextTest {
 		new MockHttpServletRequest();
 	private final MockHttpServletRequest _mockHttpServletRequest2 =
 		new MockHttpServletRequest();
+	private final Portal _portal = Mockito.mock(Portal.class);
 	private MockedStatic<PortletPermissionUtil>
 		_portletPermissionUtilMockedStatic;
 	private final MockedStatic<PrefsParamUtil> _prefsParamUtilMockedStatic =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97391

## What Is Being Fixed

On a shared form, switching the display language with the form's language selector left the submit button in the previous language. In the default configuration (propagate-language-selection off), the selector reloads the form with the chosen languageId but does not change the user's session locale, so the field labels switched while the submit button stayed behind. This happened even on a form with no custom submit label configured.

## How It Is Being Fixed

DDMFormDisplayContext.getSubmitLabel() resolved its default label against the user's session (theme display) locale instead of the form's displayed locale. It now builds the fallback resource bundle from the displayed locale (getDefaultLanguageId()), so both the generic default and a per-locale custom label follow the language the form is actually showing. The now-unused no-argument _getResourceBundle() helper and its LocaleThreadLocal import were removed.

The DDMFormDisplayContextTest.testGetSubmitLabel unit test was extended to assert that, when the form's display locale differs from the user's theme display locale, the default submit label is resolved in the display locale.

## PR Check

**pr-check: PASS (3/4) — Java Unit Tests could not run in the local environment**

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | NOT RUN (local environment) |

The three runnable validations pass. Java Unit Tests (`DDMFormDisplayContextTest`) could not execute locally: every test in the class — including the ones this branch does not touch — fails at construction with

```
java.lang.NullPointerException: Cannot invoke "com.liferay.portal.kernel.util.Portal.getPortalServerPort(boolean)" because "com.liferay.portal.kernel.util.PortalUtil._portal" is null
```

Root cause: the `_renderRequest` instance-field initializer calls `PortalUtil.getPortalServerPort(...)` (via `_mockThemeDisplay`) at test-instance construction, which runs before `@Before setUp()` wires `PortalUtil`. This is a local test-harness initialization issue, not a defect in the change — checking out the pristine `master` version of the test class reproduces the identical 29/29 failure. CI runs this class normally and is the authoritative runner for the unit test.

<!-- pr-check {"result": "success", "sha": "96e8d79ab520ff52aeaf2d03a2bfb33588d39f74"} -->
