### PR TITLE
LPD-96936 Keep hidden field values when editing a form entry

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -161,6 +161,9 @@ public class AddFormInstanceRecordMVCActionCommand
 			ddmForm.getDDMFormFieldsMap(true),
 			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges());
 
+		_updateInvisibleDDMFormFieldValues(
+			actionRequest, ddmFormEvaluatorEvaluateResponse, ddmFormValues);
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DDMFormInstanceRecord.class.getName(), actionRequest);
 
@@ -287,6 +290,28 @@ public class AddFormInstanceRecordMVCActionCommand
 					false, ddmFormValues, serviceContext);
 			}
 		}
+	}
+
+	private void _updateInvisibleDDMFormFieldValues(
+			ActionRequest actionRequest,
+			DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse,
+			DDMFormValues ddmFormValues)
+		throws Exception {
+
+		long ddmFormInstanceRecordId = ParamUtil.getLong(
+			actionRequest, "formInstanceRecordId");
+
+		if (ddmFormInstanceRecordId == 0) {
+			return;
+		}
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			_ddmFormInstanceRecordService.getFormInstanceRecord(
+				ddmFormInstanceRecordId);
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges(),
+			ddmFormValues, ddmFormInstanceRecord.getDDMFormValues());
 	}
 
 	private void _validateCaptcha(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -27,6 +27,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
@@ -157,12 +158,28 @@ public class AddFormInstanceRecordMVCActionCommand
 			ddmStructure.getDDMFormLayout(),
 			ddmFormEvaluatorEvaluateResponse.getDisabledPagesIndexes());
 
+		long ddmFormInstanceRecordId = ParamUtil.getLong(
+			actionRequest, "formInstanceRecordId");
+
+		if (ddmFormInstanceRecordId > 0) {
+			DDMFormInstanceRecord ddmFormInstanceRecord =
+				_ddmFormInstanceRecordLocalService.getFormInstanceRecord(
+					ddmFormInstanceRecordId);
+
+			DDMFormValues persistedDDMFormValues =
+				ddmFormInstanceRecord.getDDMFormValues();
+
+			AddFormInstanceRecordMVCCommandUtil.
+				updateInvisibleDDMFormFieldValues(
+					ddmFormEvaluatorEvaluateResponse.
+						getDDMFormFieldsPropertyChanges(),
+					ddmFormValues.getDDMFormFieldValuesMap(true),
+					persistedDDMFormValues.getDDMFormFieldValuesMap(true));
+		}
+
 		AddFormInstanceRecordMVCCommandUtil.updateReadOnlyDDMFormFields(
 			ddmForm.getDDMFormFieldsMap(true),
 			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges());
-
-		_updateInvisibleDDMFormFieldValues(
-			actionRequest, ddmFormEvaluatorEvaluateResponse, ddmFormValues);
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			DDMFormInstanceRecord.class.getName(), actionRequest);
@@ -292,28 +309,6 @@ public class AddFormInstanceRecordMVCActionCommand
 		}
 	}
 
-	private void _updateInvisibleDDMFormFieldValues(
-			ActionRequest actionRequest,
-			DDMFormEvaluatorEvaluateResponse ddmFormEvaluatorEvaluateResponse,
-			DDMFormValues ddmFormValues)
-		throws Exception {
-
-		long ddmFormInstanceRecordId = ParamUtil.getLong(
-			actionRequest, "formInstanceRecordId");
-
-		if (ddmFormInstanceRecordId == 0) {
-			return;
-		}
-
-		DDMFormInstanceRecord ddmFormInstanceRecord =
-			_ddmFormInstanceRecordService.getFormInstanceRecord(
-				ddmFormInstanceRecordId);
-
-		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
-			ddmFormEvaluatorEvaluateResponse.getDDMFormFieldsPropertyChanges(),
-			ddmFormValues, ddmFormInstanceRecord.getDDMFormValues());
-	}
-
 	private void _validateCaptcha(
 			ActionRequest actionRequest, DDMFormInstance ddmFormInstance)
 		throws Exception {
@@ -356,6 +351,10 @@ public class AddFormInstanceRecordMVCActionCommand
 
 	@Reference
 	private DDMFormInstanceLocalService _ddmFormInstanceLocalService;
+
+	@Reference
+	private DDMFormInstanceRecordLocalService
+		_ddmFormInstanceRecordLocalService;
 
 	@Reference
 	private DDMFormInstanceRecordService _ddmFormInstanceRecordService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -21,16 +21,16 @@ import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
-import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.PortletRequest;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -45,9 +45,8 @@ public class AddFormInstanceRecordMVCCommandUtil {
 	public static void updateInvisibleDDMFormFieldValues(
 		Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
 			ddmFormFieldsPropertyChanges,
-		DDMFormValues ddmFormValues, DDMFormValues persistedDDMFormValues) {
-
-		Set<String> invisibleDDMFormFieldNames = new HashSet<>();
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap,
+		Map<String, List<DDMFormFieldValue>> persistedDDMFormFieldValuesMap) {
 
 		for (Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
 				entry : ddmFormFieldsPropertyChanges.entrySet()) {
@@ -59,19 +58,35 @@ public class AddFormInstanceRecordMVCCommandUtil {
 			DDMFormEvaluatorFieldContextKey ddmFormEvaluatorFieldContextKey =
 				entry.getKey();
 
-			invisibleDDMFormFieldNames.add(
-				ddmFormEvaluatorFieldContextKey.getName());
-		}
+			for (DDMFormFieldValue ddmFormFieldValue :
+					ListUtil.fromCollection(
+						ddmFormFieldValuesMap.get(
+							ddmFormEvaluatorFieldContextKey.getName()))) {
 
-		if (invisibleDDMFormFieldNames.isEmpty()) {
-			return;
-		}
+				if (!StringUtil.equals(
+						ddmFormFieldValue.getInstanceId(),
+						ddmFormEvaluatorFieldContextKey.getInstanceId())) {
 
-		ddmFormValues.setDDMFormFieldValues(
-			_restoreInvisibleDDMFormFieldValues(
-				invisibleDDMFormFieldNames,
-				ddmFormValues.getDDMFormFieldValues(),
-				persistedDDMFormValues.getDDMFormFieldValues()));
+					continue;
+				}
+
+				for (DDMFormFieldValue persistedDDMFormFieldValue :
+						ListUtil.fromCollection(
+							persistedDDMFormFieldValuesMap.get(
+								ddmFormEvaluatorFieldContextKey.getName()))) {
+
+					if (!StringUtil.equals(
+							ddmFormFieldValue.getInstanceId(),
+							persistedDDMFormFieldValue.getInstanceId())) {
+
+						continue;
+					}
+
+					ddmFormFieldValue.setValue(
+						persistedDDMFormFieldValue.getValue());
+				}
+			}
+		}
 	}
 
 	public static void updateNonevaluableDDMFormFields(
@@ -214,111 +229,6 @@ public class AddFormInstanceRecordMVCCommandUtil {
 					" has already submitted an entry in form instance ",
 					ddmFormInstance.getFormInstanceId()));
 		}
-	}
-
-	private static void _addDDMFormFieldValuesByName(
-		List<DDMFormFieldValue> ddmFormFieldValues,
-		List<DDMFormFieldValue> sourceDDMFormFieldValues, String name) {
-
-		for (DDMFormFieldValue sourceDDMFormFieldValue :
-				sourceDDMFormFieldValues) {
-
-			if (name.equals(sourceDDMFormFieldValue.getName())) {
-				ddmFormFieldValues.add(sourceDDMFormFieldValue);
-			}
-		}
-	}
-
-	private static DDMFormFieldValue _getDDMFormFieldValueByInstanceId(
-		List<DDMFormFieldValue> ddmFormFieldValues, String instanceId) {
-
-		if (instanceId == null) {
-			return null;
-		}
-
-		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
-			if (instanceId.equals(ddmFormFieldValue.getInstanceId())) {
-				return ddmFormFieldValue;
-			}
-		}
-
-		return null;
-	}
-
-	private static List<DDMFormFieldValue> _restoreInvisibleDDMFormFieldValues(
-		Set<String> invisibleDDMFormFieldNames,
-		List<DDMFormFieldValue> ddmFormFieldValues,
-		List<DDMFormFieldValue> persistedDDMFormFieldValues) {
-
-		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
-
-		Set<String> restoredDDMFormFieldNames = new HashSet<>();
-
-		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
-			String name = ddmFormFieldValue.getName();
-
-			if (invisibleDDMFormFieldNames.contains(name)) {
-				if (!restoredDDMFormFieldNames.contains(name)) {
-					_addDDMFormFieldValuesByName(
-						newDDMFormFieldValues, persistedDDMFormFieldValues,
-						name);
-
-					restoredDDMFormFieldNames.add(name);
-				}
-
-				continue;
-			}
-
-			DDMFormFieldValue persistedDDMFormFieldValue =
-				_getDDMFormFieldValueByInstanceId(
-					persistedDDMFormFieldValues,
-					ddmFormFieldValue.getInstanceId());
-
-			if (persistedDDMFormFieldValue != null) {
-				List<DDMFormFieldValue> nestedDDMFormFieldValues =
-					ddmFormFieldValue.getNestedDDMFormFieldValues();
-				List<DDMFormFieldValue> persistedNestedDDMFormFieldValues =
-					persistedDDMFormFieldValue.getNestedDDMFormFieldValues();
-
-				if (!nestedDDMFormFieldValues.isEmpty() ||
-					!persistedNestedDDMFormFieldValues.isEmpty()) {
-
-					List<DDMFormFieldValue> newNestedDDMFormFieldValues =
-						_restoreInvisibleDDMFormFieldValues(
-							invisibleDDMFormFieldNames,
-							nestedDDMFormFieldValues,
-							persistedNestedDDMFormFieldValues);
-
-					nestedDDMFormFieldValues.clear();
-
-					for (DDMFormFieldValue newNestedDDMFormFieldValue :
-							newNestedDDMFormFieldValues) {
-
-						ddmFormFieldValue.addNestedDDMFormFieldValue(
-							newNestedDDMFormFieldValue);
-					}
-				}
-			}
-
-			newDDMFormFieldValues.add(ddmFormFieldValue);
-		}
-
-		for (DDMFormFieldValue persistedDDMFormFieldValue :
-				persistedDDMFormFieldValues) {
-
-			String name = persistedDDMFormFieldValue.getName();
-
-			if (invisibleDDMFormFieldNames.contains(name) &&
-				!restoredDDMFormFieldNames.contains(name)) {
-
-				_addDDMFormFieldValuesByName(
-					newDDMFormFieldValues, persistedDDMFormFieldValues, name);
-
-				restoredDDMFormFieldNames.add(name);
-			}
-		}
-
-		return newDDMFormFieldValues;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/util/AddFormInstanceRecordMVCCommandUtil.java
@@ -21,6 +21,7 @@ import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordVersionLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.portlet.PortletRequest;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -39,6 +41,38 @@ import java.util.Set;
  * @author Leonardo Barros
  */
 public class AddFormInstanceRecordMVCCommandUtil {
+
+	public static void updateInvisibleDDMFormFieldValues(
+		Map<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
+			ddmFormFieldsPropertyChanges,
+		DDMFormValues ddmFormValues, DDMFormValues persistedDDMFormValues) {
+
+		Set<String> invisibleDDMFormFieldNames = new HashSet<>();
+
+		for (Map.Entry<DDMFormEvaluatorFieldContextKey, Map<String, Object>>
+				entry : ddmFormFieldsPropertyChanges.entrySet()) {
+
+			if (MapUtil.getBoolean(entry.getValue(), "visible", true)) {
+				continue;
+			}
+
+			DDMFormEvaluatorFieldContextKey ddmFormEvaluatorFieldContextKey =
+				entry.getKey();
+
+			invisibleDDMFormFieldNames.add(
+				ddmFormEvaluatorFieldContextKey.getName());
+		}
+
+		if (invisibleDDMFormFieldNames.isEmpty()) {
+			return;
+		}
+
+		ddmFormValues.setDDMFormFieldValues(
+			_restoreInvisibleDDMFormFieldValues(
+				invisibleDDMFormFieldNames,
+				ddmFormValues.getDDMFormFieldValues(),
+				persistedDDMFormValues.getDDMFormFieldValues()));
+	}
 
 	public static void updateNonevaluableDDMFormFields(
 			Map<String, DDMFormField> ddmFormFieldsMap,
@@ -180,6 +214,111 @@ public class AddFormInstanceRecordMVCCommandUtil {
 					" has already submitted an entry in form instance ",
 					ddmFormInstance.getFormInstanceId()));
 		}
+	}
+
+	private static void _addDDMFormFieldValuesByName(
+		List<DDMFormFieldValue> ddmFormFieldValues,
+		List<DDMFormFieldValue> sourceDDMFormFieldValues, String name) {
+
+		for (DDMFormFieldValue sourceDDMFormFieldValue :
+				sourceDDMFormFieldValues) {
+
+			if (name.equals(sourceDDMFormFieldValue.getName())) {
+				ddmFormFieldValues.add(sourceDDMFormFieldValue);
+			}
+		}
+	}
+
+	private static DDMFormFieldValue _getDDMFormFieldValueByInstanceId(
+		List<DDMFormFieldValue> ddmFormFieldValues, String instanceId) {
+
+		if (instanceId == null) {
+			return null;
+		}
+
+		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			if (instanceId.equals(ddmFormFieldValue.getInstanceId())) {
+				return ddmFormFieldValue;
+			}
+		}
+
+		return null;
+	}
+
+	private static List<DDMFormFieldValue> _restoreInvisibleDDMFormFieldValues(
+		Set<String> invisibleDDMFormFieldNames,
+		List<DDMFormFieldValue> ddmFormFieldValues,
+		List<DDMFormFieldValue> persistedDDMFormFieldValues) {
+
+		List<DDMFormFieldValue> newDDMFormFieldValues = new ArrayList<>();
+
+		Set<String> restoredDDMFormFieldNames = new HashSet<>();
+
+		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			String name = ddmFormFieldValue.getName();
+
+			if (invisibleDDMFormFieldNames.contains(name)) {
+				if (!restoredDDMFormFieldNames.contains(name)) {
+					_addDDMFormFieldValuesByName(
+						newDDMFormFieldValues, persistedDDMFormFieldValues,
+						name);
+
+					restoredDDMFormFieldNames.add(name);
+				}
+
+				continue;
+			}
+
+			DDMFormFieldValue persistedDDMFormFieldValue =
+				_getDDMFormFieldValueByInstanceId(
+					persistedDDMFormFieldValues,
+					ddmFormFieldValue.getInstanceId());
+
+			if (persistedDDMFormFieldValue != null) {
+				List<DDMFormFieldValue> nestedDDMFormFieldValues =
+					ddmFormFieldValue.getNestedDDMFormFieldValues();
+				List<DDMFormFieldValue> persistedNestedDDMFormFieldValues =
+					persistedDDMFormFieldValue.getNestedDDMFormFieldValues();
+
+				if (!nestedDDMFormFieldValues.isEmpty() ||
+					!persistedNestedDDMFormFieldValues.isEmpty()) {
+
+					List<DDMFormFieldValue> newNestedDDMFormFieldValues =
+						_restoreInvisibleDDMFormFieldValues(
+							invisibleDDMFormFieldNames,
+							nestedDDMFormFieldValues,
+							persistedNestedDDMFormFieldValues);
+
+					nestedDDMFormFieldValues.clear();
+
+					for (DDMFormFieldValue newNestedDDMFormFieldValue :
+							newNestedDDMFormFieldValues) {
+
+						ddmFormFieldValue.addNestedDDMFormFieldValue(
+							newNestedDDMFormFieldValue);
+					}
+				}
+			}
+
+			newDDMFormFieldValues.add(ddmFormFieldValue);
+		}
+
+		for (DDMFormFieldValue persistedDDMFormFieldValue :
+				persistedDDMFormFieldValues) {
+
+			String name = persistedDDMFormFieldValue.getName();
+
+			if (invisibleDDMFormFieldNames.contains(name) &&
+				!restoredDDMFormFieldNames.contains(name)) {
+
+				_addDDMFormFieldValuesByName(
+					newDDMFormFieldValues, persistedDDMFormFieldValues, name);
+
+				restoredDDMFormFieldNames.add(name);
+			}
+		}
+
+		return newDDMFormFieldValues;
 	}
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -125,6 +125,132 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 		_assertDDMFormFields(false, null);
 	}
 
+	@Test
+	public void testInvisibleNestedFieldKeepsPersistedValue() throws Exception {
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"parentInstanceId", "parent", new UnlocalizedValue(""));
+
+		ddmFormFieldValue.addNestedDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"childInstanceId", "child",
+				new UnlocalizedValue(StringPool.BLANK)));
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			DDMFormTestUtil.createDDMForm());
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		DDMFormFieldValue persistedDDMFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"parentInstanceId", "parent", new UnlocalizedValue(""));
+
+		persistedDDMFormFieldValue.addNestedDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"childInstanceId", "child", new UnlocalizedValue("kept")));
+
+		DDMFormValues persistedDDMFormValues =
+			DDMFormValuesTestUtil.createDDMFormValues(
+				DDMFormTestUtil.createDDMForm());
+
+		persistedDDMFormValues.addDDMFormFieldValue(persistedDDMFormFieldValue);
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			HashMapBuilder.
+				<DDMFormEvaluatorFieldContextKey, Map<String, Object>>put(
+					new DDMFormEvaluatorFieldContextKey(
+						"child", "childInstanceId"),
+					HashMapBuilder.<String, Object>put(
+						"visible", false
+					).build()
+				).build(),
+			ddmFormValues, persistedDDMFormValues);
+
+		DDMFormFieldValue parentDDMFormFieldValue =
+			ddmFormValues.getDDMFormFieldValues(
+			).get(
+				0
+			);
+
+		List<DDMFormFieldValue> nestedDDMFormFieldValues =
+			parentDDMFormFieldValue.getNestedDDMFormFieldValues();
+
+		Assert.assertEquals(
+			nestedDDMFormFieldValues.toString(), 1,
+			nestedDDMFormFieldValues.size());
+
+		DDMFormFieldValue childDDMFormFieldValue = nestedDDMFormFieldValues.get(
+			0);
+
+		Value value = childDDMFormFieldValue.getValue();
+
+		Assert.assertEquals("kept", value.getString(LocaleUtil.US));
+	}
+
+	@Test
+	public void testInvisibleRepeatableFieldKeepsAllPersistedInstances()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
+
+		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
+			_FIELD_NAME, false, false, false);
+
+		ddmFormField.setRepeatable(true);
+
+		ddmForm.addDDMFormField(ddmFormField);
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmForm);
+
+		ddmFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId0", _FIELD_NAME,
+				new UnlocalizedValue(StringPool.BLANK)));
+
+		DDMFormValues persistedDDMFormValues =
+			DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
+
+		persistedDDMFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId0", _FIELD_NAME, new UnlocalizedValue("value0")));
+		persistedDDMFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId1", _FIELD_NAME, new UnlocalizedValue("value1")));
+
+		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
+			HashMapBuilder.
+				<DDMFormEvaluatorFieldContextKey, Map<String, Object>>put(
+					new DDMFormEvaluatorFieldContextKey(
+						_FIELD_NAME, "instanceId0"),
+					HashMapBuilder.<String, Object>put(
+						"visible", false
+					).build()
+				).build(),
+			ddmFormValues, persistedDDMFormValues);
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(false);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			_FIELD_NAME);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), 2, ddmFormFieldValues.size());
+
+		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Value value = ddmFormFieldValue.getValue();
+
+		Assert.assertEquals("value0", value.getString(LocaleUtil.US));
+
+		ddmFormFieldValue = ddmFormFieldValues.get(1);
+
+		value = ddmFormFieldValue.getValue();
+
+		Assert.assertEquals("value1", value.getString(LocaleUtil.US));
+	}
+
 	@Test(expected = FormInstanceExpiredException.class)
 	public void testValidateExpirationStatus() throws Exception {
 		ThemeDisplay themeDisplay = _mockThemeDisplay();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/helper/AddFormInstanceRecordMVCCommandUtilTest.java
@@ -126,129 +126,55 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 	}
 
 	@Test
-	public void testInvisibleNestedFieldKeepsPersistedValue() throws Exception {
-		DDMFormFieldValue ddmFormFieldValue =
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"parentInstanceId", "parent", new UnlocalizedValue(""));
-
-		ddmFormFieldValue.addNestedDDMFormFieldValue(
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"childInstanceId", "child",
-				new UnlocalizedValue(StringPool.BLANK)));
-
-		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
-			DDMFormTestUtil.createDDMForm());
-
-		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
-
-		DDMFormFieldValue persistedDDMFormFieldValue =
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"parentInstanceId", "parent", new UnlocalizedValue(""));
-
-		persistedDDMFormFieldValue.addNestedDDMFormFieldValue(
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"childInstanceId", "child", new UnlocalizedValue("kept")));
-
-		DDMFormValues persistedDDMFormValues =
-			DDMFormValuesTestUtil.createDDMFormValues(
-				DDMFormTestUtil.createDDMForm());
-
-		persistedDDMFormValues.addDDMFormFieldValue(persistedDDMFormFieldValue);
+	public void testUpdateInvisibleDDMFormFieldValues() throws Exception {
+		DDMFormValues ddmFormValues = _createDDMFormValues(
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK);
+		DDMFormValues persistedDDMFormValues = _createDDMFormValues(
+			"value1", "value2", "nestedValue");
 
 		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
 			HashMapBuilder.
 				<DDMFormEvaluatorFieldContextKey, Map<String, Object>>put(
+					new DDMFormEvaluatorFieldContextKey("field", "instanceId1"),
+					HashMapBuilder.<String, Object>put(
+						"visible", false
+					).build()
+				).put(
+					new DDMFormEvaluatorFieldContextKey("field", "instanceId2"),
+					HashMapBuilder.<String, Object>put(
+						"visible", false
+					).build()
+				).put(
 					new DDMFormEvaluatorFieldContextKey(
-						"child", "childInstanceId"),
+						"nestedField", "nestedInstanceId"),
 					HashMapBuilder.<String, Object>put(
 						"visible", false
 					).build()
 				).build(),
-			ddmFormValues, persistedDDMFormValues);
+			ddmFormValues.getDDMFormFieldValuesMap(true),
+			persistedDDMFormValues.getDDMFormFieldValuesMap(true));
 
-		DDMFormFieldValue parentDDMFormFieldValue =
-			ddmFormValues.getDDMFormFieldValues(
-			).get(
-				0
-			);
-
-		List<DDMFormFieldValue> nestedDDMFormFieldValues =
-			parentDDMFormFieldValue.getNestedDDMFormFieldValues();
-
-		Assert.assertEquals(
-			nestedDDMFormFieldValues.toString(), 1,
-			nestedDDMFormFieldValues.size());
-
-		DDMFormFieldValue childDDMFormFieldValue = nestedDDMFormFieldValues.get(
-			0);
-
-		Value value = childDDMFormFieldValue.getValue();
-
-		Assert.assertEquals("kept", value.getString(LocaleUtil.US));
-	}
-
-	@Test
-	public void testInvisibleRepeatableFieldKeepsAllPersistedInstances()
-		throws Exception {
-
-		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
-
-		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
-			_FIELD_NAME, false, false, false);
-
-		ddmFormField.setRepeatable(true);
-
-		ddmForm.addDDMFormField(ddmFormField);
-
-		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
-			ddmForm);
-
-		ddmFormValues.addDDMFormFieldValue(
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"instanceId0", _FIELD_NAME,
-				new UnlocalizedValue(StringPool.BLANK)));
-
-		DDMFormValues persistedDDMFormValues =
-			DDMFormValuesTestUtil.createDDMFormValues(ddmForm);
-
-		persistedDDMFormValues.addDDMFormFieldValue(
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"instanceId0", _FIELD_NAME, new UnlocalizedValue("value0")));
-		persistedDDMFormValues.addDDMFormFieldValue(
-			DDMFormValuesTestUtil.createDDMFormFieldValue(
-				"instanceId1", _FIELD_NAME, new UnlocalizedValue("value1")));
-
-		AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues(
-			HashMapBuilder.
-				<DDMFormEvaluatorFieldContextKey, Map<String, Object>>put(
-					new DDMFormEvaluatorFieldContextKey(
-						_FIELD_NAME, "instanceId0"),
-					HashMapBuilder.<String, Object>put(
-						"visible", false
-					).build()
-				).build(),
-			ddmFormValues, persistedDDMFormValues);
-
-		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
-			ddmFormValues.getDDMFormFieldValuesMap(false);
-
-		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
-			_FIELD_NAME);
+		List<DDMFormFieldValue> ddmFormFieldValues =
+			ddmFormValues.getDDMFormFieldValues();
 
 		Assert.assertEquals(
 			ddmFormFieldValues.toString(), 2, ddmFormFieldValues.size());
 
 		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
 
-		Value value = ddmFormFieldValue.getValue();
+		_assertDDMFormFieldValue("value1", ddmFormFieldValue);
 
-		Assert.assertEquals("value0", value.getString(LocaleUtil.US));
+		List<DDMFormFieldValue> nestedDDMFormFieldValues =
+			ddmFormFieldValue.getNestedDDMFormFieldValues();
 
-		ddmFormFieldValue = ddmFormFieldValues.get(1);
+		Assert.assertEquals(
+			nestedDDMFormFieldValues.toString(), 1,
+			nestedDDMFormFieldValues.size());
 
-		value = ddmFormFieldValue.getValue();
+		_assertDDMFormFieldValue(
+			"nestedValue", nestedDDMFormFieldValues.get(0));
 
-		Assert.assertEquals("value1", value.getString(LocaleUtil.US));
+		_assertDDMFormFieldValue("value2", ddmFormFieldValues.get(1));
 	}
 
 	@Test(expected = FormInstanceExpiredException.class)
@@ -301,6 +227,14 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 		Assert.assertEquals(expectedValue, _getFieldValue(_NESTED_FIELD_NAME));
 	}
 
+	private void _assertDDMFormFieldValue(
+		String expectedFieldValue, DDMFormFieldValue ddmFormFieldValue) {
+
+		Value value = ddmFormFieldValue.getValue();
+
+		Assert.assertEquals(expectedFieldValue, value.getString(LocaleUtil.US));
+	}
+
 	private void _createDDMFormFields(
 		DDMForm ddmForm, boolean localizable, boolean required) {
 
@@ -336,6 +270,30 @@ public class AddFormInstanceRecordMVCCommandUtilTest {
 				_NESTED_FIELD_INSTANCE_ID, _NESTED_FIELD_NAME, value));
 
 		_ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+	}
+
+	private DDMFormValues _createDDMFormValues(
+		String fieldValue1, String fieldValue2, String nestedFieldValue) {
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			DDMFormTestUtil.createDDMForm());
+
+		DDMFormFieldValue ddmFormFieldValue =
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId1", "field", new UnlocalizedValue(fieldValue1));
+
+		ddmFormFieldValue.addNestedDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"nestedInstanceId", "nestedField",
+				new UnlocalizedValue(nestedFieldValue)));
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		ddmFormValues.addDDMFormFieldValue(
+			DDMFormValuesTestUtil.createDDMFormFieldValue(
+				"instanceId2", "field", new UnlocalizedValue(fieldValue2)));
+
+		return ddmFormValues;
 	}
 
 	private Value _getFieldValue(String fieldName) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
@@ -17,6 +17,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormInstanceTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -143,6 +144,86 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 
 		_assertValue("TextField1", ddmFormFieldValuesMap, value1);
 		_assertValue("TextField2", ddmFormFieldValuesMap, value2);
+	}
+
+	@Test
+	public void testProcessActionKeepsInvisibleFieldValueOnEdit()
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			DDMFormTestUtil.createAvailableLocales(
+				LocaleUtil.BRAZIL, LocaleUtil.US),
+			LocaleUtil.US);
+
+		DDMFormTestUtil.addDDMFormRule(
+			Collections.singletonList("setVisible('TextField2', true)"),
+			"not(isEmpty(getValue('TextField1')))", ddmForm);
+		DDMFormTestUtil.addTextDDMFormFields(
+			ddmForm, "TextField1", "TextField2");
+
+		DDMFormInstance ddmFormInstance =
+			DDMFormInstanceTestUtil.addDDMFormInstance(
+				ddmForm, _group,
+				DDMFormInstanceTestUtil.createSettingsDDMFormValues(false),
+				TestPropsValues.getUserId());
+
+		String value1 = RandomTestUtil.randomString();
+		String value2 = RandomTestUtil.randomString();
+
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", value1);
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value2);
+		_mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		_mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			_mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<DDMFormInstanceRecord> ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			ddmFormInstanceRecords.get(0);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		String value3 = RandomTestUtil.randomString();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$$0$$pt_BR", StringPool.BLANK);
+		mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$$0$$pt_BR", value3);
+		mockLiferayPortletActionRequest.addParameter(
+			"defaultLanguageId", "pt_BR");
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceId",
+			String.valueOf(ddmFormInstance.getFormInstanceId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"formInstanceRecordId",
+			String.valueOf(ddmFormInstanceRecord.getFormInstanceRecordId()));
+
+		_addFormInstanceRecordMVCActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		ddmFormInstanceRecords =
+			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
+				ddmFormInstance.getFormInstanceId());
+
+		ddmFormInstanceRecord = ddmFormInstanceRecords.get(0);
+
+		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+
+		_assertValue(
+			"TextField2", ddmFormValues.getDDMFormFieldValuesMap(false),
+			value2);
 	}
 
 	private void _assertValue(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/test/AddFormInstanceRecordMVCActionCommandTest.java
@@ -109,12 +109,14 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 				TestPropsValues.getUserId());
 
 		String value1 = RandomTestUtil.randomString();
+
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField1$1$0$$pt_BR", value1);
+
 		String value2 = RandomTestUtil.randomString();
 
 		_mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField1$$0$$pt_BR", value1);
-		_mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField2$$0$$pt_BR", value2);
+			"ddm$$TextField2$2$0$$pt_BR", value2);
 
 		_mockLiferayPortletActionRequest.addParameter(
 			"defaultLanguageId", "pt_BR");
@@ -144,73 +146,21 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 
 		_assertValue("TextField1", ddmFormFieldValuesMap, value1);
 		_assertValue("TextField2", ddmFormFieldValuesMap, value2);
-	}
-
-	@Test
-	public void testProcessActionKeepsInvisibleFieldValueOnEdit()
-		throws Exception {
-
-		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
-			DDMFormTestUtil.createAvailableLocales(
-				LocaleUtil.BRAZIL, LocaleUtil.US),
-			LocaleUtil.US);
-
-		DDMFormTestUtil.addDDMFormRule(
-			Collections.singletonList("setVisible('TextField2', true)"),
-			"not(isEmpty(getValue('TextField1')))", ddmForm);
-		DDMFormTestUtil.addTextDDMFormFields(
-			ddmForm, "TextField1", "TextField2");
-
-		DDMFormInstance ddmFormInstance =
-			DDMFormInstanceTestUtil.addDDMFormInstance(
-				ddmForm, _group,
-				DDMFormInstanceTestUtil.createSettingsDDMFormValues(false),
-				TestPropsValues.getUserId());
-
-		String value1 = RandomTestUtil.randomString();
-		String value2 = RandomTestUtil.randomString();
 
 		_mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField1$$0$$pt_BR", value1);
-		_mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField2$$0$$pt_BR", value2);
-		_mockLiferayPortletActionRequest.addParameter(
-			"defaultLanguageId", "pt_BR");
-		_mockLiferayPortletActionRequest.addParameter(
-			"formInstanceId",
-			String.valueOf(ddmFormInstance.getFormInstanceId()));
-
-		_addFormInstanceRecordMVCActionCommand.processAction(
-			_mockLiferayPortletActionRequest,
-			new MockLiferayPortletActionResponse());
-
-		List<DDMFormInstanceRecord> ddmFormInstanceRecords =
-			_ddmFormInstanceRecordLocalService.getFormInstanceRecords(
-				ddmFormInstance.getFormInstanceId());
-
-		DDMFormInstanceRecord ddmFormInstanceRecord =
-			ddmFormInstanceRecords.get(0);
-
-		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-			_getMockLiferayPortletActionRequest();
+			"ddm$$TextField1$1$0$$pt_BR", StringPool.BLANK);
 
 		String value3 = RandomTestUtil.randomString();
 
-		mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField1$$0$$pt_BR", StringPool.BLANK);
-		mockLiferayPortletActionRequest.addParameter(
-			"ddm$$TextField2$$0$$pt_BR", value3);
-		mockLiferayPortletActionRequest.addParameter(
-			"defaultLanguageId", "pt_BR");
-		mockLiferayPortletActionRequest.addParameter(
-			"formInstanceId",
-			String.valueOf(ddmFormInstance.getFormInstanceId()));
-		mockLiferayPortletActionRequest.addParameter(
+		_mockLiferayPortletActionRequest.addParameter(
+			"ddm$$TextField2$2$0$$pt_BR", value3);
+
+		_mockLiferayPortletActionRequest.addParameter(
 			"formInstanceRecordId",
 			String.valueOf(ddmFormInstanceRecord.getFormInstanceRecordId()));
 
 		_addFormInstanceRecordMVCActionCommand.processAction(
-			mockLiferayPortletActionRequest,
+			_mockLiferayPortletActionRequest,
 			new MockLiferayPortletActionResponse());
 
 		ddmFormInstanceRecords =
@@ -219,7 +169,7 @@ public class AddFormInstanceRecordMVCActionCommandTest {
 
 		ddmFormInstanceRecord = ddmFormInstanceRecords.get(0);
 
-		DDMFormValues ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
+		ddmFormValues = ddmFormInstanceRecord.getDDMFormValues();
 
 		_assertValue(
 			"TextField2", ddmFormValues.getDDMFormFieldValuesMap(false),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96936

cc @igor-franca 

## What Is Being Fixed

When an administrator edits an existing form entry, any field currently hidden by a show/hide form rule loses its stored value on save. On the save path, a field that a rule has made invisible is treated as non-evaluable and its submitted value is blanked, so a field that holds a value but is hidden at edit time is silently cleared. Reported by a customer on 2025.Q1.20-lts.

## How It Is Being Fixed

On the save path, and only when editing an existing record (`formInstanceRecordId > 0`), each invisible field's value is restored from the persisted record before the entry is saved. Adding a new entry is unaffected, since there is no prior value to preserve.

A new `AddFormInstanceRecordMVCCommandUtil.updateInvisibleDDMFormFieldValues` helper walks the evaluator's field property changes, skips fields that remain visible, and for every field a rule has hidden restores the persisted value onto the submitted (blanked) value. Submitted and persisted values are matched by instance id, so repeatable and nested field values keep the correct instances.

## PR Check

**pr-check: PASS** — tested on `1f1079a8ebef801bcd861ef380ddb6094625461e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1f1079a8ebef801bcd861ef380ddb6094625461e"} -->
