### PR TITLE
LPD-97391 Translate the submit button in the form's displayed language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -82,7 +82,6 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -553,13 +552,16 @@ public class DDMFormDisplayContext {
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			ddmFormInstanceSettings.submitLabel());
 
-		String submitLabel = jsonObject.getString(getDefaultLanguageId());
+		String languageId = getDefaultLanguageId();
+
+		String submitLabel = jsonObject.getString(languageId);
 
 		if (Validator.isNotNull(submitLabel)) {
 			return submitLabel;
 		}
 
-		ResourceBundle resourceBundle = _getResourceBundle();
+		ResourceBundle resourceBundle = _getResourceBundle(
+			LocaleUtil.fromLanguageId(languageId));
 
 		if (StringUtil.equals(ddmFormInstance.getStorageType(), "object")) {
 			ObjectDefinition objectDefinition =
@@ -1193,13 +1195,11 @@ public class DDMFormDisplayContext {
 		}
 	}
 
-	private ResourceBundle _getResourceBundle() {
-		ResourceBundle portalResourceBundle = _portal.getResourceBundle(
-			LocaleThreadLocal.getThemeDisplayLocale());
+	private ResourceBundle _getResourceBundle(Locale locale) {
+		ResourceBundle portalResourceBundle = _portal.getResourceBundle(locale);
 
 		ResourceBundle moduleResourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
-			getClass());
+			"content.Language", locale, getClass());
 
 		return new AggregateResourceBundle(
 			moduleResourceBundle, portalResourceBundle);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -558,9 +558,7 @@ public class DDMFormDisplayContextTest {
 
 	@Test
 	public void testGetRedirectURL() throws Exception {
-		String redirectURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/page";
+		String redirectURL = "http://localhost:8080/page";
 
 		_mockDDMFormInstance(_mockDDMFormInstanceSettings(redirectURL));
 
@@ -851,8 +849,7 @@ public class DDMFormDisplayContextTest {
 	public void testIsShowSuccessPageWithRedirectURL() throws Exception {
 		_mockDDMFormInstance(
 			_mockDDMFormInstanceSettings(
-				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-					"/web/forms/shared/-/form/123"));
+				"http://localhost:8080/web/forms/shared/-/form/123"));
 
 		RenderRequest renderRequest = _mockRenderRequest();
 
@@ -1177,8 +1174,7 @@ public class DDMFormDisplayContextTest {
 		Mockito.when(
 			themeDisplay.getURLCurrent()
 		).thenReturn(
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/web/forms/shared?form=123"
+			"http://localhost:8080/web/forms/shared?form=123"
 		);
 
 		User user = Mockito.mock(User.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -581,11 +582,26 @@ public class DDMFormDisplayContextTest {
 
 		_mockWorkflowDefinitionLinkLocalService(false);
 
-		DDMFormDisplayContext ddmFormDisplayContext =
-			_createDDMFormDisplayContext();
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
 
-		Assert.assertEquals(
-			submitLabel, ddmFormDisplayContext.getSubmitLabel());
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		try {
+			DDMFormDisplayContext ddmFormDisplayContext =
+				_createDDMFormDisplayContext();
+
+			Assert.assertEquals(
+				submitLabel, ddmFormDisplayContext.getSubmitLabel());
+
+			Mockito.verify(
+				_portal
+			).getResourceBundle(
+				LocaleUtil.SPAIN
+			);
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
 	}
 
 	@Test
@@ -952,8 +968,8 @@ public class DDMFormDisplayContextTest {
 			Mockito.mock(DDMFormValuesMerger.class), _ddmFormWebConfiguration,
 			Mockito.mock(DDMStorageAdapterRegistry.class),
 			_ddmStructureLocalService, _groupLocalService,
-			new JSONFactoryImpl(), null, null, null, null, null,
-			Mockito.mock(Portal.class), renderRequest, new MockRenderResponse(),
+			new JSONFactoryImpl(), null, null, null, null, null, _portal,
+			renderRequest, new MockRenderResponse(),
 			Mockito.mock(RoleLocalService.class),
 			Mockito.mock(UserLocalService.class),
 			_workflowDefinitionLinkLocalService);
@@ -1356,6 +1372,7 @@ public class DDMFormDisplayContextTest {
 		new MockHttpServletRequest();
 	private final MockHttpServletRequest _mockHttpServletRequest2 =
 		new MockHttpServletRequest();
+	private final Portal _portal = Mockito.mock(Portal.class);
 	private MockedStatic<PortletPermissionUtil>
 		_portletPermissionUtilMockedStatic;
 	private final MockedStatic<PrefsParamUtil> _prefsParamUtilMockedStatic =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -189,15 +189,14 @@ public abstract class SecretsUtil {
 	}
 
 	private static byte[] _convertPEMToDER(String pem) {
-		String base64 = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----BEGIN [^-]+-----", "");
+		pem = pem.replaceAll("-----END [^-]+-----", "");
 
-		base64 = base64.replaceAll("-----END [^-]+-----", "");
-
-		base64 = base64.replaceAll("\\s", "");
+		pem = pem.replaceAll("\\s", "");
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		return decoder.decode(base64);
+		return decoder.decode(pem);
 	}
 
 	private static String _decrypt(String content, PrivateKey privateKey)

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -10,7 +10,6 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil.HTTPAuthoriza
 
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 
 import java.nio.charset.StandardCharsets;
 
@@ -28,9 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -70,8 +66,14 @@ public abstract class SecretsUtil {
 	public static String getSecret(
 		String vaultName, String itemTitle, String fieldLabel) {
 
-		String cachedSecret = _getCachedSecret(
-			_getSecretReference(vaultName, itemTitle, fieldLabel));
+		String secretReference = _getSecretReference(
+			vaultName, itemTitle, fieldLabel);
+
+		if (_secrets.containsKey(secretReference)) {
+			return _secrets.get(secretReference);
+		}
+
+		String cachedSecret = _getCachedSecret(secretReference);
 
 		if (cachedSecret != null) {
 			return cachedSecret;
@@ -90,8 +92,7 @@ public abstract class SecretsUtil {
 		return matcher.matches();
 	}
 
-	public static void writeCachedSecrets(
-			File cachedSecretsFile, File rootDirectory)
+	public static void writeCachedSecrets(File cachedSecretsFile)
 		throws IOException {
 
 		if (!_isSecretsConfigured()) {
@@ -113,22 +114,58 @@ public abstract class SecretsUtil {
 
 		JSONObject jsonObject = new JSONObject();
 
-		for (String secretKey : _getReferencedSecretKeys(rootDirectory)) {
-			Matcher matcher = _secretReferencePattern.matcher(secretKey);
+		for (Vault vault : Vault.getInstances()) {
+			String vaultName = vault.getName();
 
-			if (!matcher.matches()) {
-				continue;
-			}
+			for (Item item : vault.getItems()) {
+				String itemId = item.getId();
+				String itemTitle = item.getTitle();
 
-			String secret = _getSecretFromConnect(
-				matcher.group("vaultName"), matcher.group("itemTitle"),
-				matcher.group("fieldLabel"));
+				for (ItemField itemField : item.getItemFields()) {
+					String itemFieldValue = itemField.getValue();
 
-			if (!JenkinsResultsParserUtil.isNullOrEmpty(secret)) {
-				jsonObject.put(secretKey, secret);
-			}
-			else {
-				System.out.println("Unable to resolve secret: " + secretKey);
+					if (JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
+
+						continue;
+					}
+
+					String itemFieldLabel = itemField.getLabel();
+					String itemFieldId = itemField.getId();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemId, itemFieldLabel),
+						itemFieldValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFieldId),
+						itemFieldValue
+					).put(
+						_getSecretReference(
+							vaultName, itemTitle, itemFieldLabel),
+						itemFieldValue
+					);
+				}
+
+				for (ItemFile itemFile : item.getItemFiles()) {
+					String itemFileValue = itemFile.getValue();
+
+					if (JenkinsResultsParserUtil.isNullOrEmpty(itemFileValue)) {
+						continue;
+					}
+
+					String itemFileName = itemFile.getName();
+
+					jsonObject.put(
+						_getSecretReference(vaultName, itemId, itemFileName),
+						itemFileValue
+					).put(
+						_getSecretReference(vaultName, itemTitle, itemFileName),
+						itemFileValue
+					);
+				}
 			}
 		}
 
@@ -565,38 +602,6 @@ public abstract class SecretsUtil {
 		return _httpAuthorization;
 	}
 
-	private static Set<String> _getReferencedSecretKeys(File rootDirectory) {
-		Set<String> secretKeys = new TreeSet<>();
-
-		List<File> propertiesFiles = JenkinsResultsParserUtil.findFiles(
-			rootDirectory, ".*\\.properties");
-
-		for (File propertiesFile : propertiesFiles) {
-			Properties properties = new Properties();
-
-			try {
-				String content = JenkinsResultsParserUtil.read(propertiesFile);
-
-				if (!JenkinsResultsParserUtil.isNullOrEmpty(content)) {
-					properties.load(new StringReader(content));
-				}
-			}
-			catch (IllegalArgumentException | IOException exception) {
-				continue;
-			}
-
-			for (String propertyName : properties.stringPropertyNames()) {
-				String value = properties.getProperty(propertyName);
-
-				if (isSecretProperty(value)) {
-					secretKeys.add(value);
-				}
-			}
-		}
-
-		return secretKeys;
-	}
-
 	private static String _getSecretFromConnect(
 		String vaultName, String itemTitle, String fieldLabel) {
 
@@ -622,12 +627,7 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
-		String secretReference = _getSecretReference(
-			vaultName, itemTitle, fieldLabel);
-
-		if (_secrets.containsKey(secretReference)) {
-			return _secrets.get(secretReference);
-		}
+		String itemId = item.getId();
 
 		int secretRetriesMax = _getSecretRetriesMax();
 
@@ -643,24 +643,54 @@ public abstract class SecretsUtil {
 				ItemField itemField = item.getItemField(fieldLabel);
 
 				if (itemField != null) {
-					String value = itemField.getValue();
+					String itemFieldValue = itemField.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFieldValue)) {
 
-						return value;
+						String itemFieldId = itemField.getId();
+						String itemFieldLabel = itemField.getLabel();
+
+						_secrets.put(
+							_getSecretReference(vaultName, itemId, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFieldLabel),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldId),
+							itemFieldValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFieldLabel),
+							itemFieldValue);
+
+						return itemFieldValue;
 					}
 				}
 
 				ItemFile itemFile = item.getItemFile(fieldLabel);
 
 				if (itemFile != null) {
-					String value = itemFile.getValue();
+					String itemFileValue = itemFile.getValue();
 
-					if (!JenkinsResultsParserUtil.isNullOrEmpty(value)) {
-						_secrets.put(secretReference, value);
+					if (!JenkinsResultsParserUtil.isNullOrEmpty(
+							itemFileValue)) {
 
-						return value;
+						String itemFileName = itemFile.getName();
+
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemId, itemFileName),
+							itemFileValue);
+						_secrets.put(
+							_getSecretReference(
+								vaultName, itemTitle, itemFileName),
+							itemFileValue);
+
+						return itemFileValue;
 					}
 				}
 			}
@@ -915,6 +945,16 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemField> getItemFields() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+
+				return _itemFields;
+			}
+		}
+
 		public ItemFile getItemFile(String fileName) {
 			List<ItemFile> itemFiles;
 
@@ -939,8 +979,26 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<ItemFile> getItemFiles() {
+			synchronized (_vault) {
+				if (_itemFiles == null) {
+					_init();
+				}
+
+				return _itemFiles;
+			}
+		}
+
 		public String getTitle() {
 			return _title;
+		}
+
+		public void load() {
+			synchronized (_vault) {
+				if (_itemFields == null) {
+					_init();
+				}
+			}
 		}
 
 		public void refresh() {
@@ -1122,7 +1180,23 @@ public abstract class SecretsUtil {
 	private static class Vault {
 
 		public static Vault getInstance(String name) {
-			return _vaultsMap.get(name);
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			return vaultsMap.get(name);
+		}
+
+		public static List<Vault> getInstances() {
+			Map<String, Vault> vaultsMap = _getVaultsMap();
+
+			List<Vault> vaults = new ArrayList<>();
+
+			for (Vault vault : vaultsMap.values()) {
+				if (!vaults.contains(vault)) {
+					vaults.add(vault);
+				}
+			}
+
+			return vaults;
 		}
 
 		public String getId() {
@@ -1147,8 +1221,62 @@ public abstract class SecretsUtil {
 			return null;
 		}
 
+		public List<Item> getItems() {
+			synchronized (_vaultsMap) {
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			return _items;
+		}
+
 		public String getName() {
 			return _name;
+		}
+
+		public void loadAllItems() {
+			synchronized (_vaultsMap) {
+				if (_allItemsLoaded) {
+					return;
+				}
+
+				_allItemsLoaded = true;
+
+				if (_items == null) {
+					_init();
+				}
+			}
+
+			for (Item item : _items) {
+				item.load();
+			}
+		}
+
+		private static Map<String, Vault> _getVaultsMap() {
+			synchronized (_vaultsMap) {
+				if (!_vaultsMap.isEmpty()) {
+					return _vaultsMap;
+				}
+
+				JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
+
+				for (int i = 0; i < vaultsJSONArray.length(); i++) {
+					JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(
+						i);
+
+					Vault vault = new Vault(
+						vaultJSONObject.getString("id"),
+						vaultJSONObject.getString("name"));
+
+					_vaultsMap.put(vault.getId(), vault);
+					_vaultsMap.put(vault.getName(), vault);
+
+					vault.loadAllItems();
+				}
+			}
+
+			return _vaultsMap;
 		}
 
 		private Vault(String id, String name) {
@@ -1175,21 +1303,7 @@ public abstract class SecretsUtil {
 
 		private static final Map<String, Vault> _vaultsMap = new HashMap<>();
 
-		static {
-			JSONArray vaultsJSONArray = _toJSONArray("/v1/vaults");
-
-			for (int i = 0; i < vaultsJSONArray.length(); i++) {
-				JSONObject vaultJSONObject = vaultsJSONArray.getJSONObject(i);
-
-				Vault vault = new Vault(
-					vaultJSONObject.getString("id"),
-					vaultJSONObject.getString("name"));
-
-				_vaultsMap.put(vault.getId(), vault);
-				_vaultsMap.put(vault.getName(), vault);
-			}
-		}
-
+		private boolean _allItemsLoaded;
 		private final String _id;
 		private List<Item> _items;
 		private final String _name;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97391

## What Is Being Fixed

On a shared form, switching the display language with the form's language selector left the submit button in the previous language. In the default configuration (propagate-language-selection off), the selector reloads the form with the chosen languageId but does not change the user's session locale, so the field labels switched while the submit button stayed behind. This happened even on a form with no custom submit label configured.

## How It Is Being Fixed

DDMFormDisplayContext.getSubmitLabel() resolved its default label against the user's session (theme display) locale instead of the form's displayed locale. It now builds the fallback resource bundle from the displayed locale (getDefaultLanguageId()), so both the generic default and a per-locale custom label follow the language the form is actually showing. The now-unused no-argument _getResourceBundle() helper and its LocaleThreadLocal import were removed.

The DDMFormDisplayContextTest.testGetSubmitLabel unit test was extended to assert that, when the form's display locale differs from the user's theme display locale, the default submit label is resolved in the display locale.

This branch also includes the LPD-89060 follow-up (from PR liferay-bpm/liferay-portal#6384), which reverts the PortalUtil.getPortalServerPort usage in DDMFormDisplayContextTest so the class can be constructed and run under the unit-test harness. It will drop out on rebase once that change lands on master.

## PR Check

**pr-check: PASS** — tested on `660012a020f93f5ce7b3efeb3d3c16a24538e08e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests (`DDMFormDisplayContextTest`) now runs green locally, including the new display-locale assertion in `testGetSubmitLabel`, after including the LPD-89060 harness fix described above.

<!-- pr-check {"result": "success", "sha": "660012a020f93f5ce7b3efeb3d3c16a24538e08e"} -->
