### PR TITLE
LPD-96708 | Fix stale system object external reference codes on upgrade

### DIFF
--- a/modules/apps/object/object-service/bnd.bnd
+++ b/modules/apps/object/object-service/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-Name: Liferay Object Service
 Bundle-SymbolicName: com.liferay.object.service
 Bundle-Version: 1.0.248
 Liferay-Client-Extension-Batch: com/liferay/object/internal/batch
-Liferay-Require-SchemaVersion: 13.0.0
+Liferay-Require-SchemaVersion: 13.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -718,6 +718,12 @@ public class ObjectServiceUpgradeStepRegistrator
 			"12.1.1", "13.0.0",
 			new com.liferay.object.internal.upgrade.v13_0_0.
 				ObjectEntryIndexedColumnSizeUpgradeProcess());
+
+		registry.register(
+			"13.0.0", "13.1.0",
+			new com.liferay.object.internal.upgrade.v13_1_0.
+				ObjectDefinitionExternalReferenceCodeUpgradeProcess(
+					_systemObjectDefinitionManagerRegistry));
 	}
 
 	@Reference

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v13_1_0/ObjectDefinitionExternalReferenceCodeUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v13_1_0/ObjectDefinitionExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v13_1_0;
+
+import com.liferay.object.system.SystemObjectDefinitionManager;
+import com.liferay.object.system.SystemObjectDefinitionManagerRegistry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+public class ObjectDefinitionExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	public ObjectDefinitionExternalReferenceCodeUpgradeProcess(
+		SystemObjectDefinitionManagerRegistry
+			systemObjectDefinitionManagerRegistry) {
+
+		_systemObjectDefinitionManagerRegistry =
+			systemObjectDefinitionManagerRegistry;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<Long, Set<String>> externalReferenceCodesByCompanyId =
+			_getExternalReferenceCodesByCompanyId();
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				SQLTransformer.transform(
+					StringBundler.concat(
+						"select externalReferenceCode, objectDefinitionId, ",
+						"companyId, name from ObjectDefinition where ",
+						"modifiable = [$FALSE$] and system_ = [$TRUE$]")));
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update ObjectDefinition set externalReferenceCode = ? " +
+						"where objectDefinitionId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			while (resultSet.next()) {
+				SystemObjectDefinitionManager systemObjectDefinitionManager =
+					_systemObjectDefinitionManagerRegistry.
+						getSystemObjectDefinitionManager(
+							resultSet.getString("name"));
+
+				if (systemObjectDefinitionManager == null) {
+					continue;
+				}
+
+				String externalReferenceCode =
+					systemObjectDefinitionManager.getExternalReferenceCode();
+				String oldExternalReferenceCode = resultSet.getString(
+					"externalReferenceCode");
+
+				if (Validator.isNull(externalReferenceCode) ||
+					externalReferenceCode.equals(oldExternalReferenceCode)) {
+
+					continue;
+				}
+
+				long companyId = resultSet.getLong("companyId");
+				long objectDefinitionId = resultSet.getLong(
+					"objectDefinitionId");
+
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesByCompanyId.get(companyId);
+
+				if ((externalReferenceCodes != null) &&
+					externalReferenceCodes.contains(externalReferenceCode)) {
+
+					throw new UpgradeException(
+						StringBundler.concat(
+							"Unable to update object definition ",
+							objectDefinitionId,
+							" because external reference code \"",
+							externalReferenceCode,
+							"\" is already used by another object definition ",
+							"in company ", companyId));
+				}
+
+				preparedStatement2.setString(1, externalReferenceCode);
+				preparedStatement2.setLong(2, objectDefinitionId);
+
+				preparedStatement2.addBatch();
+
+				externalReferenceCodes.remove(oldExternalReferenceCode);
+				externalReferenceCodes.add(externalReferenceCode);
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private Map<Long, Set<String>> _getExternalReferenceCodesByCompanyId()
+		throws Exception {
+
+		Map<Long, Set<String>> externalReferenceCodesByCompanyId =
+			new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select externalReferenceCode, companyId from " +
+					"ObjectDefinition");
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				String externalReferenceCode = resultSet.getString(
+					"externalReferenceCode");
+
+				if (Validator.isNull(externalReferenceCode)) {
+					continue;
+				}
+
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesByCompanyId.computeIfAbsent(
+						resultSet.getLong("companyId"),
+						companyId -> new HashSet<>());
+
+				externalReferenceCodes.add(externalReferenceCode);
+			}
+		}
+
+		return externalReferenceCodesByCompanyId;
+	}
+
+	private final SystemObjectDefinitionManagerRegistry
+		_systemObjectDefinitionManagerRegistry;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_1_0/test/ObjectDefinitionExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_1_0/test/ObjectDefinitionExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.upgrade.v13_1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jhosseph Gonzalez
+ */
+@RunWith(Arquillian.class)
+public class ObjectDefinitionExternalReferenceCodeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_userObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
+				TestPropsValues.getCompanyId(), User.class.getName());
+
+		_userObjectDefinition.setExternalReferenceCode(
+			RandomTestUtil.randomString());
+
+		_userObjectDefinition =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_userObjectDefinition);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_userObjectDefinition.setExternalReferenceCode("L_USER");
+
+		_userObjectDefinition =
+			_objectDefinitionLocalService.updateObjectDefinition(
+				_userObjectDefinition);
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_objectDefinition =
+			ObjectDefinitionTestUtil.addUnmodifiableSystemObjectDefinition(
+				null, TestPropsValues.getUserId(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"Test" + ObjectDefinitionTestUtil.getRandomName(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionConstants.SCOPE_SITE, null, 1,
+				Collections.emptyList());
+
+		String externalReferenceCode =
+			_objectDefinition.getExternalReferenceCode();
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		_multiVMPool.clear();
+
+		_userObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				_userObjectDefinition.getObjectDefinitionId());
+
+		Assert.assertEquals(
+			"L_USER", _userObjectDefinition.getExternalReferenceCode());
+
+		_objectDefinition = _objectDefinitionLocalService.fetchObjectDefinition(
+			_objectDefinition.getObjectDefinitionId());
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			_objectDefinition.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testUpgradeWithDuplicateExternalReferenceCode()
+		throws Exception {
+
+		try {
+			_objectDefinition =
+				ObjectDefinitionTestUtil.addCustomObjectDefinition();
+
+			_objectDefinition.setExternalReferenceCode("L_USER");
+
+			_objectDefinition =
+				_objectDefinitionLocalService.updateObjectDefinition(
+					_objectDefinition);
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			Assert.assertThrows(
+				UpgradeException.class, upgradeProcess::upgrade);
+		}
+		finally {
+			if (_objectDefinition != null) {
+				_objectDefinition.setExternalReferenceCode(
+					RandomTestUtil.randomString());
+
+				_objectDefinitionLocalService.updateObjectDefinition(
+					_objectDefinition);
+			}
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.internal.upgrade.v13_1_0." +
+			"ObjectDefinitionExternalReferenceCodeUpgradeProcess";
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.object.internal.upgrade.registry.ObjectServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	private ObjectDefinition _userObjectDefinition;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96708

## What Is Being Fixed

Portals upgraded from versions older than LPS-183792 (e.g. 7.4.13-u85) never migrate the externalReferenceCode of pre-existing system object definitions to the canonical L_-prefixed convention. addOrUpdateSystemObjectDefinition only sets the ERC on the create path; the update path taken by every already-provisioned system object on subsequent startups never touches it. This breaks lookups by canonical ERC, including CMS/CMP site initializers that depend on the newer naming (L_USER, L_POSTAL_ADDRESS, L_COMMERCE_PRODUCT_DEFINITION, etc.).

## How It Is Being Fixed

Add a one-time upgrade process, ObjectDefinitionExternalReferenceCodeUpgradeProcess, registered at schema 12.2.0 -> 12.3.0, that scans every system, non-modifiable ObjectDefinition row, resolves its SystemObjectDefinitionManager by name, and corrects the stored externalReferenceCode to the manager's canonical value when they differ. Rows without a registered manager are skipped. The existing external reference codes are preloaded per company before the update loop (skipping rows with a null ERC, which is possible for non-system object definitions) and kept up to date as each row is corrected, so a row whose canonical ERC is already held by another object definition in the same company is detected without a nested query against the still-open result set; when that happens, the upgrade throws an UpgradeException rather than silently leaving the conflicting row uncorrected, since this migration exists specifically to fix broken canonical-ERC lookups. The approach mirrors the existing v10_8_1/ObjectEntryAssetEntryTitleUpgradeProcess pattern already used in this module. Integration tests cover the correction path, the no-manager-registered skip, and the duplicate-ERC failure.

## PR Check

**pr-check: PASS** — tested on `cb516bc52cbe15606d0b6fd1578bebaea11209cd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cb516bc52cbe15606d0b6fd1578bebaea11209cd"} -->
