### PR TITLE
LPD-89060 Follow up PR - Revert getPortalServerPort in DDM form unit test

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -557,9 +557,7 @@ public class DDMFormDisplayContextTest {
 
 	@Test
 	public void testGetRedirectURL() throws Exception {
-		String redirectURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/page";
+		String redirectURL = "http://localhost:8080/page";
 
 		_mockDDMFormInstance(_mockDDMFormInstanceSettings(redirectURL));
 
@@ -835,8 +833,7 @@ public class DDMFormDisplayContextTest {
 	public void testIsShowSuccessPageWithRedirectURL() throws Exception {
 		_mockDDMFormInstance(
 			_mockDDMFormInstanceSettings(
-				"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-					"/web/forms/shared/-/form/123"));
+				"http://localhost:8080/web/forms/shared/-/form/123"));
 
 		RenderRequest renderRequest = _mockRenderRequest();
 
@@ -1161,8 +1158,7 @@ public class DDMFormDisplayContextTest {
 		Mockito.when(
 			themeDisplay.getURLCurrent()
 		).thenReturn(
-			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
-				"/web/forms/shared?form=123"
+			"http://localhost:8080/web/forms/shared?form=123"
 		);
 
 		User user = Mockito.mock(User.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89060

## What is being done

Follow-up to LPD-89060. DDMFormDisplayContextTest fails on all 29 test methods because the class cannot be constructed: the _renderRequest field initializer calls _mockRenderRequest, which calls _mockThemeDisplay, which calls PortalUtil.getPortalServerPort(false) before @Before setUp runs _setUpPortalUtil. At construction time PortalUtil._portal is still null, so every test throws NullPointerException.

Introduced by commit f8dbf220, which replaced hardcoded http://localhost:8080 with PortalUtil.getPortalServerPort(false) across tests. That replacement is only valid for integration tests: TestClassHardcodedPortCheck is scoped to /testIntegration/ only, and LPD-89060 already reverted the same pattern for the same PortalUtil._portal is null reason in commit 97fa077. This unit test was missed by that revert.

---

## How it is being done

Reverts the three call sites in DDMFormDisplayContextTest back to the hardcoded http://localhost:8080 form, restoring the file to its pre-f8dbf220 state and matching the revert done in commit 97fa077. Unit tests are exempt from the hardcoded-port check, so the literals are not re-flagged.

---

## How can it be tested

The affected test now passes:

**Unit test:** com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormDisplayContextTest

```bash
cd modules
../gradlew :apps:dynamic-data-mapping:dynamic-data-mapping-form-web:test --tests com.liferay.dynamic.data.mapping.form.web.internal.display.context.DDMFormDisplayContextTest
```

All 29 test methods pass. Before this change they fail at construction with NullPointerException.
