### PR TITLE
LPD-97537 Scroll the first invalid rich text field into view

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/pageValidationReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/pageValidationReducer.es.js
@@ -20,6 +20,7 @@ export default function pageValidationReducer(state, action) {
 			let firstInvalidFieldLabel = null;
 			let firstInvalidFieldInput = null;
 			let firstInvalidFieldName;
+			let firstInvalidRichTextFieldWrapper = null;
 
 			const pages = visitor.mapFields(
 				(
@@ -42,13 +43,14 @@ export default function pageValidationReducer(state, action) {
 						firstInvalidFieldLabel = field.label;
 
 						if (field.type === 'rich_text') {
-							if (!Liferay.FeatureFlags['LPD-11235']) {
-								const fieldWrapper = document.querySelector(
+							firstInvalidRichTextFieldWrapper =
+								document.querySelector(
 									`[data-field-name='${field.name}']`
 								);
 
+							if (!Liferay.FeatureFlags['LPD-11235']) {
 								firstInvalidFieldInput =
-									fieldWrapper?.querySelector(
+									firstInvalidRichTextFieldWrapper?.querySelector(
 										'.ck-editor__editable[contenteditable="true"]'
 									);
 							}
@@ -82,6 +84,11 @@ export default function pageValidationReducer(state, action) {
 
 			if (firstInvalidFieldInput) {
 				if (firstInvalidFieldInput.type !== 'hidden') {
+					firstInvalidRichTextFieldWrapper?.scrollIntoView({
+						behavior: 'smooth',
+						block: 'center',
+					});
+
 					firstInvalidFieldInput.focus();
 				}
 				else {

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/pageValidationReducer.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/pageValidationReducer.js
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EVENT_TYPES} from '../../../../src/main/resources/META-INF/resources/js/core/actions/eventTypes.es';
+import reducer from '../../../../src/main/resources/META-INF/resources/js/core/reducers/pageValidationReducer.es';
+
+const createAction = (fields) => ({
+	payload: {
+		newPages: [{rows: [{columns: [{fields}]}]}],
+		pageIndex: 0,
+	},
+	type: EVENT_TYPES.PAGE.VALIDATION_FAILED,
+});
+
+const createField = (name, type) => ({
+	errorMessage: 'This field is required.',
+	label: 'Field Label',
+	name,
+	type,
+	valid: false,
+});
+
+describe('page validation failed', () => {
+	afterEach(() => {
+		Liferay.FeatureFlags['LPD-11235'] = false;
+
+		document.body.innerHTML = '';
+
+		delete window.CKEDITOR;
+	});
+
+	it('focuses the input when a regular field is invalid', () => {
+		document.body.innerHTML = `
+			<input name="textField" type="text">
+		`;
+
+		const input = document.querySelector("[name='textField']");
+
+		input.focus = jest.fn();
+
+		reducer({}, createAction([createField('textField', 'text')]));
+
+		expect(input.focus).toHaveBeenCalled();
+	});
+
+	it('scrolls the field into view and focuses the CKEditor 4 instance when a rich text field is invalid', () => {
+		Liferay.FeatureFlags['LPD-11235'] = true;
+
+		document.body.innerHTML = `
+			<div data-field-name="richTextField"></div>
+		`;
+
+		const editor = {focus: jest.fn()};
+
+		window.CKEDITOR = {instances: {richTextField: editor}};
+
+		const wrapper = document.querySelector(
+			"[data-field-name='richTextField']"
+		);
+
+		wrapper.scrollIntoView = jest.fn();
+
+		reducer({}, createAction([createField('richTextField', 'rich_text')]));
+
+		expect(wrapper.scrollIntoView).toHaveBeenCalledWith({
+			behavior: 'smooth',
+			block: 'center',
+		});
+
+		expect(editor.focus).toHaveBeenCalled();
+	});
+
+	it('scrolls the field into view and focuses the CKEditor 5 editable when a rich text field is invalid', () => {
+		document.body.innerHTML = `
+			<div data-field-name="richTextField">
+				<div class="ck-editor__editable" contenteditable="true"></div>
+			</div>
+		`;
+
+		const editable = document.querySelector('.ck-editor__editable');
+		const wrapper = document.querySelector(
+			"[data-field-name='richTextField']"
+		);
+
+		editable.focus = jest.fn();
+		wrapper.scrollIntoView = jest.fn();
+
+		reducer({}, createAction([createField('richTextField', 'rich_text')]));
+
+		expect(wrapper.scrollIntoView).toHaveBeenCalledWith({
+			behavior: 'smooth',
+			block: 'center',
+		});
+
+		expect(editable.focus).toHaveBeenCalled();
+	});
+
+	it('scrolls the parent element into view when the invalid field input is hidden', () => {
+		document.body.innerHTML = `
+			<div><input name="hiddenField" type="hidden"></div>
+		`;
+
+		const parentElement = document.querySelector('div');
+
+		parentElement.scrollIntoView = jest.fn();
+
+		reducer({}, createAction([createField('hiddenField', 'text')]));
+
+		expect(parentElement.scrollIntoView).toHaveBeenCalled();
+	});
+});

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/pageValidationReducer.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/pageValidationReducer.js
@@ -4,15 +4,12 @@
  */
 
 import {EVENT_TYPES} from '../../../../src/main/resources/META-INF/resources/js/core/actions/eventTypes.es';
-import reducer from '../../../../src/main/resources/META-INF/resources/js/core/reducers/pageValidationReducer.es';
+import pageValidationReducer from '../../../../src/main/resources/META-INF/resources/js/core/reducers/pageValidationReducer.es';
 
-const createAction = (fields) => ({
-	payload: {
-		newPages: [{rows: [{columns: [{fields}]}]}],
-		pageIndex: 0,
-	},
+const action = {
+	payload: {pageIndex: 0},
 	type: EVENT_TYPES.PAGE.VALIDATION_FAILED,
-});
+};
 
 const createField = (name, type) => ({
 	errorMessage: 'This field is required.',
@@ -20,6 +17,10 @@ const createField = (name, type) => ({
 	name,
 	type,
 	valid: false,
+});
+
+const createState = (fields) => ({
+	pages: [{rows: [{columns: [{fields}]}]}],
 });
 
 describe('page validation failed', () => {
@@ -40,7 +41,9 @@ describe('page validation failed', () => {
 
 		input.focus = jest.fn();
 
-		reducer({}, createAction([createField('textField', 'text')]));
+		const state = createState([createField('textField', 'text')]);
+
+		pageValidationReducer(state, action);
 
 		expect(input.focus).toHaveBeenCalled();
 	});
@@ -62,7 +65,9 @@ describe('page validation failed', () => {
 
 		wrapper.scrollIntoView = jest.fn();
 
-		reducer({}, createAction([createField('richTextField', 'rich_text')]));
+		const state = createState([createField('richTextField', 'rich_text')]);
+
+		pageValidationReducer(state, action);
 
 		expect(wrapper.scrollIntoView).toHaveBeenCalledWith({
 			behavior: 'smooth',
@@ -87,7 +92,9 @@ describe('page validation failed', () => {
 		editable.focus = jest.fn();
 		wrapper.scrollIntoView = jest.fn();
 
-		reducer({}, createAction([createField('richTextField', 'rich_text')]));
+		const state = createState([createField('richTextField', 'rich_text')]);
+
+		pageValidationReducer(state, action);
 
 		expect(wrapper.scrollIntoView).toHaveBeenCalledWith({
 			behavior: 'smooth',
@@ -106,7 +113,9 @@ describe('page validation failed', () => {
 
 		parentElement.scrollIntoView = jest.fn();
 
-		reducer({}, createAction([createField('hiddenField', 'text')]));
+		const state = createState([createField('hiddenField', 'text')]);
+
+		pageValidationReducer(state, action);
 
 		expect(parentElement.scrollIntoView).toHaveBeenCalled();
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97537

## What Is Being Fixed

When page validation fails on a form rendered by data engine (Web Content, Forms, Objects), the first invalid rich text field is focused but not always scrolled into view. A native focus() only reveals the caret line, so when a tall editor already peeks into the viewport nothing scrolls and the validation message below the editor stays hidden — clicking Publish appears to do nothing. Reported in LPP-64617 for Web Content structures with multiple required rich text fields, where regular Text fields scroll correctly but rich text fields do not.

## How It Is Being Fixed

pageValidationReducer now resolves the invalid rich text field's wrapper ([data-field-name]) for both editor paths (CKEditor 4 and CKEditor 5) and explicitly scrolls it into view with block: 'center' before focusing. This brings the label, the editor, and the validation message into view, and makes the subsequent native focus scroll a no-op. Other field types are untouched — the wrapper is only resolved for rich text, so the new scroll is a no-op for them. The fix is scoped to rich text per the LPP report; other tall field types share the underlying focus-does-not-scroll behavior and can be generalized in a follow-up.

A new jest suite covers the four paths through the reducer: the CKEditor 5 editable, the CKEditor 4 instance, the regular input focus, and the hidden-input fallback scroll.

## PR Check

**pr-check: PASS** — tested on `21739955e689c33056a70411b31ce5b8a14d0331`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "21739955e689c33056a70411b31ce5b8a14d0331"} -->
