### PR TITLE
LPD-97186 Allow saving a root model descendant object definition

### DIFF
--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 125.2.0
+Bundle-Version: 126.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
@@ -146,6 +146,9 @@ public class ObjectDefinitionTreeUtil {
 			}
 		}
 		else {
+			_addAllowStandaloneObjectEntrySetting(
+				objectDefinition2, objectDefinitionSettingLocalService);
+
 			if (ArrayUtil.isNotEmpty(
 					getRootObjectDefinitionIds(
 						objectDefinition2.getObjectDefinitionId(),

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/constants/packageinfo
@@ -1,1 +1,1 @@
-version 11.3.0
+version 11.4.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/exception/packageinfo
@@ -1,1 +1,1 @@
-version 35.4.0
+version 35.5.0

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -9,7 +9,6 @@ import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
-import com.liferay.batch.engine.thread.local.BatchEngineThreadLocal;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
@@ -1847,6 +1846,12 @@ public class ObjectDefinitionLocalServiceImpl
 				objectDefinitionSetting.getValue());
 		}
 
+		if (!_hasEdgeObjectRelationship(objectDefinition)) {
+			objectDefinitionSettingsValuesMap.remove(
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+		}
+
 		_validateObjectDefinitionSettings(
 			objectDefinition, objectDefinitionSettingsValuesMap);
 
@@ -1898,6 +1903,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 			if (!objectDefinitionSettingsValuesMap.containsKey(
 					oldObjectDefinitionSetting.getName())) {
+
+				if (StringUtil.equals(
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
+						oldObjectDefinitionSetting.getName())) {
+
+					continue;
+				}
 
 				_objectDefinitionSettingLocalService.
 					deleteObjectDefinitionSetting(oldObjectDefinitionSetting);
@@ -2475,6 +2488,19 @@ public class ObjectDefinitionLocalServiceImpl
 		ObjectDefinitionValidationThreadLocal.addValidationError(
 			ObjectDefinition.class.getName(), exception, propertyName,
 			propertyValue);
+	}
+
+	private boolean _hasEdgeObjectRelationship(
+		ObjectDefinition objectDefinition) {
+
+		int count = _objectRelationshipPersistence.countByODI2_E(
+			objectDefinition.getObjectDefinitionId(), true);
+
+		if (count > 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasObjectField(
@@ -3600,21 +3626,6 @@ public class ObjectDefinitionLocalServiceImpl
 			Map<String, String> objectDefinitionSettingsValuesMap)
 		throws PortalException {
 
-		if (!BatchEngineThreadLocal.isBatchImportInProcess() &&
-			objectDefinition.isRootDescendantNode() &&
-			!objectDefinitionSettingsValuesMap.containsKey(
-				ObjectDefinitionSettingConstants.
-					NAME_ALLOW_STANDALONE_OBJECT_ENTRY)) {
-
-			_handleException(
-				new ObjectDefinitionSettingNameException.RequiredNames(
-					objectDefinition.getShortName(),
-					Set.of(
-						ObjectDefinitionSettingConstants.
-							NAME_ALLOW_STANDALONE_OBJECT_ENTRY)),
-				"objectDefinitionSettings", null);
-		}
-
 		if (objectDefinitionSettingsValuesMap.isEmpty()) {
 			return;
 		}
@@ -3645,19 +3656,6 @@ public class ObjectDefinitionLocalServiceImpl
 					ObjectDefinitionSettingConstants.
 						NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
 					objectDefinitionSettingsValue.getKey())) {
-
-				if (!BatchEngineThreadLocal.isBatchImportInProcess() &&
-					!objectDefinition.isRootDescendantNode()) {
-
-					_handleException(
-						new ObjectDefinitionSettingNameException.
-							NotAllowedNames(
-								objectDefinition.getShortName(),
-								Set.of(
-									ObjectDefinitionSettingConstants.
-										NAME_ALLOW_STANDALONE_OBJECT_ENTRY)),
-						"objectDefinitionSettings", null);
-				}
 
 				String allowStandaloneObjectEntry =
 					objectDefinitionSettingsValue.getValue();

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/definition/tree/manager/test/ObjectDefinitionTreeUtilTest.java
@@ -12,6 +12,7 @@ import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
@@ -19,12 +20,14 @@ import com.liferay.object.exception.ObjectRelationshipEdgeException;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionSetting;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -589,6 +592,48 @@ public class ObjectDefinitionTreeUtilTest {
 			).build(),
 			_objectDefinitionTreeFactory.create(rootNodeB.getPrimaryKey()),
 			_objectDefinitionLocalService);
+	}
+
+	@Test
+	public void testBindObjectDefinitionsWithAllowStandaloneObjectEntrySetting()
+		throws Exception {
+
+		// Bind a draft object definition to a published object definition
+
+		ObjectDefinition objectDefinitionA =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition("A");
+		ObjectDefinition objectDefinitionAA =
+			_addAndPublishCustomObjectDefinition("AA");
+
+		TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_assertAllowStandaloneObjectEntrySetting(
+			objectDefinitionAA, StringPool.TRUE);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// Bind a published object definition to a draft object definition
+
+		objectDefinitionA = _addAndPublishCustomObjectDefinition("A");
+		objectDefinitionAA = ObjectDefinitionTestUtil.addCustomObjectDefinition(
+			"AA");
+
+		TreeTestUtil.bind(
+			objectDefinitionA.getObjectDefinitionId(),
+			objectDefinitionAA.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_assertAllowStandaloneObjectEntrySetting(
+			objectDefinitionAA, StringPool.TRUE);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
+			_objectEntryLocalService, _objectRelationshipLocalService);
 	}
 
 	@Test
@@ -2531,6 +2576,21 @@ public class ObjectDefinitionTreeUtilTest {
 			null, values, ServiceContextTestUtil.getServiceContext());
 	}
 
+	private void _assertAllowStandaloneObjectEntrySetting(
+		ObjectDefinition objectDefinition,
+		String expectedAllowStandaloneObjectEntrySetting) {
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(
+			expectedAllowStandaloneObjectEntrySetting,
+			objectDefinitionSetting.getValue());
+	}
+
 	private void _assertRootObjectEntryIds(Map<ObjectEntry, Long> expectedMap)
 		throws Exception {
 
@@ -2743,6 +2803,10 @@ public class ObjectDefinitionTreeUtilTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	private ObjectDefinitionTreeFactory _objectDefinitionTreeFactory;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -3841,6 +3841,243 @@ public class ObjectDefinitionLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdateObjectDefinitionWithAllowStandaloneObjectEntry()
+		throws Exception {
+
+		// Invalid value
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		ObjectDefinition finalChildObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		String value = RandomTestUtil.randomString();
+
+		AssertUtils.assertFailure(
+			ObjectDefinitionSettingValueException.InvalidValue.class,
+			StringBundler.concat(
+				"The value ", value, " of setting \"",
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY,
+				"\" is invalid for object definition \"",
+				finalChildObjectDefinition.getShortName(), "\""),
+			() -> _updateCustomObjectDefinition(
+				finalChildObjectDefinition.getClassName(),
+				finalChildObjectDefinition,
+				Collections.singletonList(
+					new ObjectDefinitionSettingBuilder(
+					).name(
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+					).value(
+						value
+					).build())));
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				finalChildObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// The object definition can be updated after any publish ordering
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName());
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId());
+
+		_testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			childObjectDefinition);
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+
+		// The setting is not persisted when the object definition is not a
+		// root descendant
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		objectDefinition = _updateCustomObjectDefinition(
+			objectDefinition.getClassName(), objectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					StringPool.FALSE
+				).build()));
+
+		Assert.assertNull(
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+
+		// The setting is persisted when the object definition is a root
+		// descendant
+
+		parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		TreeTestUtil.bind(
+			parentObjectDefinition.getObjectDefinitionId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			_objectRelationshipLocalService);
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		_updateCustomObjectDefinition(
+			childObjectDefinition.getClassName(), childObjectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					StringPool.FALSE
+				).build()));
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				childObjectDefinition.getObjectDefinitionId());
+
+		_updateCustomObjectDefinition(
+			childObjectDefinition.getClassName(), childObjectDefinition,
+			Collections.emptyList());
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				childObjectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(
+			StringPool.FALSE, objectDefinitionSetting.getValue());
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
+	@Test
 	public void testUpdateObjectFolderId() throws Exception {
 		ObjectDefinition objectDefinition = _addCustomObjectDefinition(
 			ObjectDefinitionTestUtil.getRandomName());
@@ -5196,6 +5433,35 @@ public class ObjectDefinitionLocalServiceTest {
 			_objectDefinitionLocalService.deleteObjectDefinition(
 				objectDefinition2);
 		}
+	}
+
+	private void _testUpdateObjectDefinitionWithAllowStandaloneObjectEntry(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		String value = String.valueOf(RandomTestUtil.randomBoolean());
+
+		_updateCustomObjectDefinition(
+			objectDefinition.getClassName(), objectDefinition,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.
+						NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+				).value(
+					value
+				).build()));
+
+		ObjectDefinitionSetting objectDefinitionSetting =
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				objectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY);
+
+		Assert.assertEquals(value, objectDefinitionSetting.getValue());
 	}
 
 	private void

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/object/definitions/portlet/action/test/BoundObjectDefinitionsExportImportTest.java
@@ -9,8 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.BaseExportImportTestCase;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -29,6 +31,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -128,6 +131,80 @@ public class BoundObjectDefinitionsExportImportTest
 				)
 			).toString(),
 			getExportJSON("TestObjectDefinition1"), JSONCompareMode.LENIENT);
+
+		_deleteObjectDefinition("TESTOBJECTDEFINITION1", "objectRelationship1");
+		_deleteObjectDefinition("TESTOBJECTDEFINITION2", null);
+	}
+
+	@Test
+	public void testImportBoundObjectDefinitionsWithChildBeforeParent()
+		throws Exception {
+
+		JSONObject statusJSONObject = JSONUtil.put(
+			"code", 0
+		).put(
+			"label", "approved"
+		).put(
+			"label_i18n", "Approved"
+		);
+
+		JSONArray jsonArray = JSONUtil.putAll(
+			jsonFactory.createJSONObject(
+				defaultObjectDefinitionJSON
+			).put(
+				"externalReferenceCode", "TESTOBJECTDEFINITION2"
+			).put(
+				"name", "TestObjectDefinition2"
+			).put(
+				"objectDefinitionSettings",
+				JSONUtil.put(
+					JSONUtil.put(
+						"name",
+						ObjectDefinitionSettingConstants.
+							NAME_ALLOW_STANDALONE_OBJECT_ENTRY
+					).put(
+						"value", "true"
+					))
+			).put(
+				"scope", ObjectDefinitionConstants.SCOPE_COMPANY
+			).put(
+				"status", statusJSONObject
+			),
+			jsonFactory.createJSONObject(
+				defaultObjectDefinitionJSON
+			).put(
+				"externalReferenceCode", "TESTOBJECTDEFINITION1"
+			).put(
+				"name", "TestObjectDefinition1"
+			).put(
+				"objectRelationships",
+				JSONUtil.put(
+					createOneToManyObjectRelationship(
+						"TESTOBJECTDEFINITION1", "TESTOBJECTDEFINITION2",
+						"TestObjectDefinition2",
+						ObjectDefinitionConstants.SCOPE_COMPANY,
+						"objectRelationship1"))
+			).put(
+				"scope", ObjectDefinitionConstants.SCOPE_COMPANY
+			).put(
+				"status", statusJSONObject
+			));
+
+		importJSON(
+			"TESTOBJECTDEFINITION2", jsonArray.toString(),
+			"TestObjectDefinition2");
+
+		com.liferay.object.model.ObjectDefinition childObjectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"TESTOBJECTDEFINITION2", TestPropsValues.getCompanyId());
+
+		Assert.assertTrue(childObjectDefinition.isRootDescendantNode());
+		Assert.assertNotNull(
+			_objectDefinitionSettingLocalService.fetchObjectDefinitionSetting(
+				childObjectDefinition.getObjectDefinitionId(),
+				ObjectDefinitionSettingConstants.
+					NAME_ALLOW_STANDALONE_OBJECT_ENTRY));
 
 		_deleteObjectDefinition("TESTOBJECTDEFINITION1", "objectRelationship1");
 		_deleteObjectDefinition("TESTOBJECTDEFINITION2", null);
@@ -404,6 +481,10 @@ public class BoundObjectDefinitionsExportImportTest
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
 
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97186

## What Is Being Fixed

Importing or saving a root model descendant object definition failed on the allowStandaloneObjectEntry required validation. The transient root context could momentarily treat the setting as both required and not allowed, so the save or import was rejected across several publish orderings.

## How It Is Being Fixed

The setting is now managed by the system instead of required in the payload. The bind creates it for the child in every approval state, the update path ignores an incoming value when the object definition is not a root model edge child and preserves the persisted value when the payload omits it, and the conflicting required and not allowed validations were removed. The tests cover the setting across approval state combinations, updates that ignore, preserve, and reject an invalid value and succeed in every publish ordering, and a child imported before its parent. A separate baseline commit catches up the object-api version bumps for the constants and exception packages that earlier commits left unbumped.

## PR Check

**pr-check: PASS** — tested on `8569a6c8d6120754c5be4d31c1478360d16877dc`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8569a6c8d6120754c5be4d31c1478360d16877dc"} -->
