### PR TITLE
LPD-97529 Fix SQL error filtering many-to-many related localized fields

### DIFF
--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/resource/v1_0/test/ObjectEntryResourceTest.java
@@ -6198,6 +6198,61 @@ public class ObjectEntryResourceTest {
 	}
 
 	@Test
+	public void testGetObjectEntriesPageWithFilterOnManyToManyRelatedLocalizedObjectField()
+		throws Exception {
+
+		ObjectDefinition objectDefinition1 = _publishLocalizedObjectDefinition(
+			_OBJECT_FIELD_NAME_TEXT);
+		String objectEntryValue1 = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry1 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition1,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, objectEntryValue1
+			).put(
+				_OBJECT_FIELD_NAME_TEXT + "_i18n",
+				HashMapBuilder.<String, Serializable>put(
+					"en_US", objectEntryValue1
+				).build()
+			).build());
+
+		ObjectDefinition objectDefinition2 = _publishLocalizedObjectDefinition(
+			_OBJECT_FIELD_NAME_TEXT);
+		String objectEntryValue2 = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry2 = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition2,
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME_TEXT, objectEntryValue2
+			).put(
+				_OBJECT_FIELD_NAME_TEXT + "_i18n",
+				HashMapBuilder.<String, Serializable>put(
+					"en_US", objectEntryValue2
+				).build()
+			).build());
+
+		ObjectRelationship objectRelationship =
+			_addObjectRelationshipAndRelateObjectEntries(
+				objectDefinition1, objectDefinition2,
+				objectEntry1.getObjectEntryId(),
+				objectEntry2.getObjectEntryId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		_assertObjectEntriesPageWithFilterOnRelatedLocalizedObjectField(
+			objectEntryValue1, objectDefinition1, objectRelationship,
+			objectEntryValue2);
+		_assertObjectEntriesPageWithFilterOnRelatedLocalizedObjectField(
+			objectEntryValue2, objectDefinition2, objectRelationship,
+			objectEntryValue1);
+
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			objectRelationship);
+
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition1);
+		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition2);
+	}
+
+	@Test
 	public void testGetObjectEntriesPageWithLocalizedObjectField()
 		throws Exception {
 
@@ -16281,6 +16336,43 @@ public class ObjectEntryResourceTest {
 	private void _assertNotFound(JSONObject jsonObject) {
 		Assert.assertEquals("NOT_FOUND", jsonObject.getString("status"));
 		Assert.assertNull(jsonObject.get("title"));
+	}
+
+	private void
+			_assertObjectEntriesPageWithFilterOnRelatedLocalizedObjectField(
+				String expectedObjectFieldValue,
+				ObjectDefinition objectDefinition,
+				ObjectRelationship objectRelationship,
+				String relatedObjectFieldValue)
+		throws Exception {
+
+		String filterString = StringBundler.concat(
+			objectRelationship.getName(), "/", _OBJECT_FIELD_NAME_TEXT, " eq '",
+			relatedObjectFieldValue, "'");
+
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			null,
+			StringBundler.concat(
+				objectDefinition.getRESTContextPath(), "?filter=",
+				URLCodec.encodeURL(filterString), "&nestedFields=",
+				objectRelationship.getName()),
+			Http.Method.GET);
+
+		JSONArray itemsJSONArray = jsonObject.getJSONArray("items");
+
+		Assert.assertEquals(
+			itemsJSONArray.toString(), 1, itemsJSONArray.length());
+
+		JSONObject itemJSONObject = itemsJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
+			expectedObjectFieldValue,
+			itemJSONObject.getString(_OBJECT_FIELD_NAME_TEXT));
+		Assert.assertEquals(
+			relatedObjectFieldValue,
+			JSONUtil.getValueAsString(
+				itemJSONObject, "JSONArray/" + objectRelationship.getName(),
+				"Object/0", "Object/" + _OBJECT_FIELD_NAME_TEXT));
 	}
 
 	private void _assertObjectEntryField(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl.java
@@ -10,6 +10,8 @@ import com.liferay.object.internal.entry.util.ObjectEntrySearchUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
 import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionLocalizationTable;
+import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionLocalizationTableFactory;
 import com.liferay.object.petra.sql.dsl.DynamicObjectDefinitionTable;
 import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTable;
 import com.liferay.object.petra.sql.dsl.DynamicObjectRelationshipMappingTableFactory;
@@ -58,6 +60,10 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 			dynamicObjectRelationshipMappingTableColumn =
 				dynamicObjectRelationshipMappingTable.getPrimaryKeyColumn2();
 
+		DynamicObjectDefinitionLocalizationTable
+			relatedDynamicObjectDefinitionLocalizationTable =
+				DynamicObjectDefinitionLocalizationTableFactory.create(
+					relatedObjectDefinition, objectFieldLocalService);
 		DynamicObjectDefinitionTable relatedDynamicObjectDefinitionTable =
 			getDynamicObjectDefinitionTable(relatedObjectDefinition);
 		DynamicObjectDefinitionTable relatedObjectDefinitionExtensionTable =
@@ -89,6 +95,12 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl
 							relatedObjectDefinitionExtensionTable.
 								getPrimaryKeyColumn()
 						)
+					).leftJoinOn(
+						relatedDynamicObjectDefinitionLocalizationTable,
+						ObjectEntrySearchUtil.
+							getLeftJoinLocalizationTablePredicate(
+								relatedDynamicObjectDefinitionLocalizationTable,
+								relatedDynamicObjectDefinitionTable, null)
 					).where(
 						ObjectEntrySearchUtil.getObjectEntryIndexPredicate(
 							groupIds, relatedObjectDefinition, predicate)

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/BaseObjectRelatedModelsPredicateProviderImplTestCase.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/BaseObjectRelatedModelsPredicateProviderImplTestCase.java
@@ -64,6 +64,12 @@ public abstract class BaseObjectRelatedModelsPredicateProviderImplTestCase {
 		);
 
 		Mockito.when(
+			objectDefinition.getLocalizationDBTableName()
+		).thenReturn(
+			dbTableName + "_l"
+		);
+
+		Mockito.when(
 			objectDefinition.getObjectDefinitionId()
 		).thenReturn(
 			objectDefinitionId

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
@@ -6,15 +6,21 @@
 package com.liferay.object.internal.related.models;
 
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryTable;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
+import java.util.Locale;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,6 +96,49 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest
 					ObjectDefinitionConstants.SCOPE_SITE)));
 	}
 
+	@Test
+	public void testGetPredicateWithRelatedLocalizedObjectField()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+		long objectDefinitionId1 = RandomTestUtil.randomLong();
+
+		ObjectDefinition objectDefinition = mockObjectDefinition(
+			companyId, objectDefinitionId1, RandomTestUtil.randomString(),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		long objectDefinitionId2 = RandomTestUtil.randomLong();
+
+		ObjectDefinition relatedObjectDefinition = mockObjectDefinition(
+			companyId, objectDefinitionId2, RandomTestUtil.randomString(),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.US);
+
+		String predicateString;
+
+		try {
+			predicateString = _getPredicateString(
+				new Long[] {RandomTestUtil.randomLong()}, objectDefinition,
+				_mockObjectFieldLocalServiceWithLocalizedObjectField(
+					objectDefinitionId2),
+				mockObjectRelationship(
+					objectDefinitionId1, objectDefinitionId2,
+					RandomTestUtil.randomString()),
+				relatedObjectDefinition);
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
+
+		Assert.assertTrue(
+			predicateString,
+			predicateString.contains(
+				relatedObjectDefinition.getLocalizationDBTableName()));
+	}
+
 	private String _getPredicateString(
 			Long[] groupIds, ObjectDefinition objectDefinition,
 			ObjectFieldLocalService objectFieldLocalService,
@@ -126,6 +175,42 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest
 				Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
 			Collections.emptyList()
+		);
+
+		return objectFieldLocalService;
+	}
+
+	private ObjectFieldLocalService
+		_mockObjectFieldLocalServiceWithLocalizedObjectField(
+			long objectDefinitionId) {
+
+		ObjectField objectField = Mockito.mock(ObjectField.class);
+
+		Mockito.when(
+			objectField.getDBColumnName()
+		).thenReturn(
+			"name_"
+		);
+
+		Mockito.when(
+			objectField.getDBType()
+		).thenReturn(
+			ObjectFieldConstants.DB_TYPE_STRING
+		);
+
+		Mockito.when(
+			objectField.isLocalized()
+		).thenReturn(
+			true
+		);
+
+		ObjectFieldLocalService objectFieldLocalService =
+			_mockObjectFieldLocalService();
+
+		Mockito.when(
+			objectFieldLocalService.getLocalizedObjectFields(objectDefinitionId)
+		).thenReturn(
+			Collections.singletonList(objectField)
 		);
 
 		return objectFieldLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97529

## What Is Being Fixed

Filtering the Headless REST API on a **localized** field of a **many-to-many** related object entry (e.g. `?filter=parentToChild/name eq 'Child 1'&nestedFields=parentToChild`) throws `SQLSyntaxErrorException: Unknown column '..._l.name_' in 'where clause'` (HTTP 500). The equivalent one-to-many filter already worked correctly; only many-to-many failed.

## How It Is Being Fixed

Localized object fields are stored in a separate `_l` localization table, not the entity's main table. When the OData filter targets a nested relationship path (`parentToChild/name`), the leaf field's column is resolved against whichever table actually holds it — for a localized field, that is the `_l` table. `ObjectEntryMtoMObjectRelatedModelsPredicateProviderImpl` built its correlated subquery joining the related object's main table, `ObjectEntry`, and its extension table, but never joined the `_l` localization table, unlike the equivalent `ObjectEntry1toMObjectRelatedModelsPredicateProviderImpl`. As soon as the filtered field was localized, the generated `WHERE` clause referenced a column on a table absent from that subquery's `FROM`/`JOIN`, producing the unknown column error.

The fix mirrors the already-correct one-to-many implementation: it adds a `leftJoinOn` against a `DynamicObjectDefinitionLocalizationTable`, built via `DynamicObjectDefinitionLocalizationTableFactory` and the same `ObjectEntrySearchUtil.getLeftJoinLocalizationTablePredicate` helper already used elsewhere in the codebase. A `LEFT JOIN` is used (not `INNER JOIN`) so entries without a translation for the current language are not dropped from the result set. The join factory returns `null` when the related object definition has no localized fields at all, which makes the added join a no-op for the far more common non-localized-field case, so existing many-to-many filtering behavior is unaffected.

Coverage is added at both layers: a unit test on the predicate provider asserting the localization join is emitted when the related field is localized, and an integration test reproducing the ticket's exact scenario end-to-end — two objects with a required localized field related many-to-many, filtered from both relationship directions via the real REST API.
