### PR TITLE
LPD-96990 No feedback in the UI after bulk actions for workflow tasks finishes

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/BulkEditWorkflowAssigneeModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/BulkEditWorkflowAssigneeModalContent.tsx
@@ -13,7 +13,10 @@ import {
 	bulkAssignWorkflowTasks,
 	getAssignableUsersForWorkflowTasks,
 } from '../../utils/api';
-import {displayErrorToast} from '../../utils/toastUtil';
+import {
+	displayBulkAssignSuccessToast,
+	displayErrorToast,
+} from '../../utils/toastUtil';
 
 type Assignee = {
 	id: number;
@@ -89,6 +92,12 @@ export default function BulkEditWorkflowAssigneeModalContent({
 		);
 
 		if (!error) {
+			const assignee = assignableUsers.find(
+				(user) => user.id === selectedUserId
+			);
+
+			displayBulkAssignSuccessToast(assignee?.name ?? '', items.length);
+
 			closeModal();
 
 			loadData();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/BulkEditWorkflowDueDateModalContent.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/modal/BulkEditWorkflowDueDateModalContent.tsx
@@ -10,7 +10,10 @@ import moment from 'moment';
 import React, {useId, useState} from 'react';
 
 import {bulkUpdateWorkflowTaskDueDate} from '../../utils/api';
-import {displayErrorToast} from '../../utils/toastUtil';
+import {
+	displayBulkDueDateSuccessToast,
+	displayErrorToast,
+} from '../../utils/toastUtil';
 import DateField, {dateConfig} from '../DateField';
 
 type FDSItem = {embedded: {id: number}};
@@ -54,6 +57,8 @@ export default function BulkEditWorkflowDueDateModalContent({
 		);
 
 		if (!error) {
+			displayBulkDueDateSuccessToast(items.length);
+
 			closeModal();
 
 			loadData();

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/toastUtil.ts
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/utils/toastUtil.ts
@@ -40,6 +40,23 @@ const displayBulkAssignSuccessToast = (assignee: string, count: number) => {
 	});
 };
 
+const displayBulkDueDateSuccessToast = (count: number) => {
+	openToast({
+		message:
+			count === 1
+				? Liferay.Language.get(
+						'due-date-was-successfully-updated-for-one-task'
+					)
+				: sub(
+						Liferay.Language.get(
+							'due-date-was-successfully-updated-for-x-tasks'
+						),
+						String(count)
+					),
+		type: 'success',
+	});
+};
+
 const displayDeleteSuccessToast = (title: string) => {
 	openToast({
 		message: sub(
@@ -70,6 +87,7 @@ const displayStateSuccessToast = () => {
 export {
 	displayAssignSuccessToast,
 	displayBulkAssignSuccessToast,
+	displayBulkDueDateSuccessToast,
 	displayDeleteSuccessToast,
 	displayErrorToast,
 	displayStateSuccessToast,

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/BulkEditWorkflowAssigneeModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/BulkEditWorkflowAssigneeModalContent.spec.tsx
@@ -156,6 +156,31 @@ describe('BulkEditWorkflowAssigneeModalContent', () => {
 		});
 	});
 
+	it('shows a success toast on success', async () => {
+		mockGetAssignableUsersForWorkflowTasks.mockResolvedValueOnce(
+			mockAssignableUsersResponse
+		);
+		mockBulkAssignWorkflowTasks.mockResolvedValueOnce({error: null});
+
+		const {getByText} = render(
+			<BulkEditWorkflowAssigneeModalContent
+				closeModal={mockCloseModal}
+				loadData={mockLoadData}
+				selectedData={mockSelectedData as any}
+			/>
+		);
+
+		await waitFor(() => getByText('User A'));
+
+		fireEvent.submit(getByText('save').closest('form')!);
+
+		await waitFor(() =>
+			expect(mockOpenToast).toHaveBeenCalledWith(
+				expect.objectContaining({type: 'success'})
+			)
+		);
+	});
+
 	it('shows error toast and re-enables save when assign patch fails', async () => {
 		mockGetAssignableUsersForWorkflowTasks.mockResolvedValueOnce(
 			mockAssignableUsersResponse

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/BulkEditWorkflowDueDateModalContent.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/BulkEditWorkflowDueDateModalContent.spec.tsx
@@ -28,6 +28,12 @@ jest.mock('../../js/components/DateField', () => ({
 	),
 }));
 
+const mockOpenToast = jest.fn();
+
+jest.mock('frontend-js-components-web', () => ({
+	openToast: (...args: any[]) => mockOpenToast(...args),
+}));
+
 const mockBulkUpdateWorkflowTaskDueDate = jest.fn();
 
 jest.mock('../../js/utils/api', () => ({
@@ -135,5 +141,29 @@ describe('BulkEditWorkflowDueDateModalContent', () => {
 		);
 
 		expect(getByText('save')).toBeDisabled();
+	});
+
+	it('shows a success toast on success', async () => {
+		mockBulkUpdateWorkflowTaskDueDate.mockResolvedValueOnce({error: null});
+
+		const {getByTestId, getByText} = render(
+			<BulkEditWorkflowDueDateModalContent
+				closeModal={mockCloseModal}
+				loadData={mockLoadData}
+				selectedData={mockSelectedData as any}
+			/>
+		);
+
+		fireEvent.change(getByTestId('mock-date-field'), {
+			target: {value: '06/05/2026'},
+		});
+
+		fireEvent.submit(getByText('save').closest('form')!);
+
+		await waitFor(() =>
+			expect(mockOpenToast).toHaveBeenCalledWith(
+				expect.objectContaining({type: 'success'})
+			)
+		);
 	});
 });


### PR DESCRIPTION
## What

[Screen Recording 2026-07-08 16.19.webm](https://github.com/user-attachments/assets/8ee76308-9b64-4916-addd-b1c31ff16b3c)

Workflow-task bulk actions (**Update due date** and **Assign to…**) completed silently — no success toast, unlike project-task bulk actions. This wires the missing feedback.

- `Update due date` → shows `Due date was successfully updated for {n} tasks.` (singular/plural).
- `Assign to…` → shows `{n} tasks were successfully assigned to {assignee}.` (singular/plural) via the previously-unused `displayBulkAssignSuccessToast` helper.

Error toasts already existed and are unchanged. Both bulk actions are shared by the **My Workflow Tasks** and **All Tasks** views, so both are covered.

## How

- `toastUtil.ts` — add `displayBulkDueDateSuccessToast(count)`.
- `BulkEditWorkflowDueDateModalContent` / `BulkEditWorkflowAssigneeModalContent` — fire the success toast before closing on success.
- Added a success-toast assertion to each modal's spec.

## Tests

`yarn test` on both specs — 14 passing.

https://liferay.atlassian.net/browse/LPD-96990