### PR TITLE
LPD-96612 Make the project info summary labels responsive

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/InfoSummary.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/InfoSummary.scss
@@ -55,6 +55,7 @@
 
 		&-value {
 			max-width: 12.5rem;
+			min-width: 0;
 		}
 	}
 
@@ -65,6 +66,13 @@
 
 		.label {
 			text-transform: none;
+			white-space: nowrap;
+
+			.label-item-expand {
+				display: block;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 		}
 	}
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/InfoSummary.scss
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/InfoSummary.scss
@@ -24,10 +24,13 @@
 
 	&-content {
 		&-container {
+			align-items: center;
 			border-top: 1px solid $secondary-l3;
-			display: flex;
-			flex-direction: column;
-			padding: 0.5rem 0;
+			column-gap: 1rem;
+			display: grid;
+			grid-template-columns: max-content 1fr;
+			padding: 1rem 1.5rem;
+			row-gap: 1rem;
 
 			&--hidden {
 				display: none;
@@ -35,17 +38,14 @@
 		}
 
 		&-item {
-			align-items: center;
-			display: grid;
+			display: contents;
 			font-size: 0.875rem;
-			grid-template-columns: 100px 1fr;
-			padding: 0.5rem 1.5rem;
 
 			.form-group {
 				height: 32px;
 				margin-bottom: 0;
 				max-width: 12.5rem;
-				width: 11vw;
+				width: 100%;
 			}
 		}
 
@@ -55,7 +55,6 @@
 
 		&-value {
 			max-width: 12.5rem;
-			width: 11vw;
 		}
 	}
 
@@ -75,7 +74,7 @@
 			max-width: 12.5rem;
 			min-height: unset !important;
 			transition: opacity 0.2s;
-			width: 11vw;
+			width: 100%;
 		}
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96612

## What Is Being Fixed

The Funnel Stages and Personas vocabularies on the project detail page's "Info" card were misaligned and inconsistently spaced. The label column was a fixed 100px, so a label sitting right at that width (such as "Funnel Stages", or a longer translation) wrapped or not depending on the font and operating system, and long labels crowded directly against their tags with no gap.

## How It Is Being Fixed

The info-summary content container is now a single shared CSS grid (rows use `display: contents`) whose label column sizes to its content via `max-content`, with a guaranteed `column-gap` between each label and its tags. Labels now adapt to their length in any locale, stay aligned across rows, and render consistently regardless of font or OS. The viewport-based `11vw` widths were replaced with container-relative sizing so the values scale with the panel rather than the viewport.

## Why Are There No Tests?

This change only adjusts SCSS layout (grid columns, gaps) with no testable logic; the responsive rendering was verified visually in the deployed bundle.

## PR Check

**pr-check: PASS** — tested on `08b7dd678663232420a5f356e1df9a3734829c3c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "08b7dd678663232420a5f356e1df9a3734829c3c"} -->
