### PR TITLE
LPD-97153 Prevent license registration failure on an empty server ID

### DIFF
--- a/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
@@ -163,7 +163,7 @@ public class DefaultLicenseManagerImpl implements LicenseManager {
 	public void registerLicense(JSONObject jsonObject) throws Exception {
 		String serverId = jsonObject.getString("serverId");
 
-		if (Validator.isNotNull(serverId) && (serverId.length() <= 2)) {
+		if (Validator.isNull(serverId) || (serverId.length() <= 2)) {
 			return;
 		}
 

--- a/portal-impl/test/unit/com/liferay/portal/license/util/DefaultLicenseManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/license/util/DefaultLicenseManagerImplTest.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.util;
+
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.LicenseUtil;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Victor Kammerer
+ */
+public class DefaultLicenseManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testRegisterLicense() throws Exception {
+		try (MockedStatic<LicenseUtil> licenseUtilMockedStatic =
+				Mockito.mockStatic(LicenseUtil.class)) {
+
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("licenseXML", "<license />"));
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("serverId", "[]"));
+
+			licenseUtilMockedStatic.verify(
+				() -> LicenseUtil.writeServerProperties(Mockito.any()),
+				Mockito.never());
+
+			_defaultLicenseManagerImpl.registerLicense(
+				JSONUtil.put("serverId", "[1, 2, 3]"));
+
+			licenseUtilMockedStatic.verify(
+				() -> LicenseUtil.writeServerProperties(Mockito.any()));
+		}
+	}
+
+	private final DefaultLicenseManagerImpl _defaultLicenseManagerImpl =
+		new DefaultLicenseManagerImpl();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97153

## What Is Being Fixed

Deploying a license `.xml` through the file-install path (for example, `docker cp` into the deploy directory) intermittently failed with an unhandled `StringIndexOutOfBoundsException: Range [1, -1) out of bounds for length 0`, surfacing inconsistently across internal `lpd-*` build images and blocking CMP validation.

The community fallback `DefaultLicenseManagerImpl.registerLicense` reads `serverId` from the request, but the `LicenseInstaller` file-install path supplies only `licenseXML`, so `getString("serverId")` returns an empty string. A guard added in 2016, `Validator.isNotNull(serverId) && (serverId.length() <= 2)`, never fires for an empty string because `isNotNull("")` is `false`, so the method falls through to `serverId.substring(1, serverId.length() - 1)` — `"".substring(1, -1)` — and throws. The apparent intermittency reflects which `LicenseManager` is active when file-install processes the license; the crash occurs only when the community fallback handles it.

## How It Is Being Fixed

The guard now returns early when the server ID is null, empty, or too short — `Validator.isNull(serverId) || (serverId.length() <= 2)` — restoring the intent of the original 2012 code and adding null-safety. A missing or empty server ID becomes a clean no-op, while a valid server-ID array continues through the existing parse-and-write path unchanged. A new unit test, `DefaultLicenseManagerImplTest`, covers registration without a server ID and with an empty array; it passes with the fix and reproduces the original `StringIndexOutOfBoundsException` when the fix is reverted.

## PR Check

**pr-check: PASS** — tested on `20c154174ff6642504b60b884a462a488d9d55b2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "20c154174ff6642504b60b884a462a488d9d55b2"} -->
