### PR TITLE
LPD-97663 Fix page crash when showing asset details on the Assets tab

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllRelatedAssetsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewAllRelatedAssetsSectionDisplayContextTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.info.constants.InfoDisplayWebKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Larissa Ribeiro
+ */
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
+)
+@RunWith(Arquillian.class)
+@Sync
+public class ViewAllRelatedAssetsSectionDisplayContextTest
+	extends BaseDisplayContextTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		_parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectRelationship = ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, _parentObjectDefinition,
+			_childObjectDefinition);
+
+		_objectEntry = _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_parentObjectDefinition.getObjectDefinitionId(), 0, null,
+			Collections.emptyMap(), ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testGetAdditionalProps() throws Exception {
+		Map<String, Object> additionalProps = ReflectionTestUtil.invoke(
+			_getViewAllRelatedAssetsSectionDisplayContext(
+				mockHttpServletRequest),
+			"getAdditionalProps", new Class<?>[0]);
+
+		Map<String, Object> breadcrumbProps =
+			(Map<String, Object>)additionalProps.get("breadcrumbProps");
+
+		Assert.assertNotNull(breadcrumbProps.get("breadcrumbItems"));
+	}
+
+	private Object _getViewAllRelatedAssetsSectionDisplayContext(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		httpServletRequest.setAttribute(
+			InfoDisplayWebKeys.INFO_ITEM, _objectEntry);
+		httpServletRequest.setAttribute(
+			"OBJECT_RELATIONSHIP", _objectRelationship);
+
+		_fragmentRenderer.render(
+			null, httpServletRequest, new MockHttpServletResponse());
+
+		return httpServletRequest.getAttribute(
+			"com.liferay.site.cms.site.initializer.internal.display.context." +
+				"ViewAllRelatedAssetsSectionDisplayContext");
+	}
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _childObjectDefinition;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewAllRelatedAssetsJSPSectionFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectRelationship _objectRelationship;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _parentObjectDefinition;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -61,6 +62,22 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
 		_objectRelationship = objectRelationship;
+	}
+
+	@Override
+	public Map<String, Object> getAdditionalProps() {
+		Map<String, Object> additionalProps = super.getAdditionalProps();
+
+		try {
+			additionalProps.put("breadcrumbProps", getBreadcrumbProps());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return additionalProps;
 	}
 
 	@Override

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/assets.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/assets.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from '../../site-cms-site-initializer/main/fixtures/cmsPagesTest';
+import {cmpPagesTest} from './fixtures/cmpPagesTest';
+
+const test = mergeTests(
+	cmpPagesTest,
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-58677': {enabled: true},
+	}),
+	loginTest()
+);
+
+const CMP_PROJECT = 'cmp/projects';
+const CMP_TASK = 'cmp/tasks';
+
+test(
+	'Info panel opens without crashing when showing details for a related asset',
+	{tag: ['@LPD-97663']},
+	async ({apiHelpers, page, projectPage, projectsPage}) => {
+		const assetTitle = `Asset ${getRandomString()}`;
+		const projectTitle = `Project ${getRandomString()}`;
+		const taskTag = 'L_CMP_TASK_' + Math.floor(Math.random() * 100000000);
+
+		let project;
+
+		await test.step('Create a project and a task', async () => {
+			project = await apiHelpers.objectEntry.postObjectEntry(
+				{
+					title: projectTitle,
+				},
+				CMP_PROJECT
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					keywords: [taskTag],
+					r_cmpProjectToCMPTasks_c_cmpProjectId: project.id,
+					title: getRandomString(),
+				},
+				CMP_TASK,
+				project.scopeKey
+			);
+		});
+
+		await test.step('Associate an asset to the task', async () => {
+			const space =
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: getRandomString(),
+					settings: {trashEnabled: true},
+					type: 'Space',
+				});
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{
+					keywords: [taskTag],
+					objectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+					title: assetTitle,
+				},
+				'cms/basic-web-contents',
+				space.name
+			);
+		});
+
+		await test.step('Open the project Assets tab', async () => {
+			await projectsPage.goto();
+
+			await projectsPage.getProject(projectTitle).click();
+
+			await projectPage.assetsTab.click();
+		});
+
+		await test.step('Click the Asset details option and assert it renders', async () => {
+			await page.getByRole('button', {name: assetTitle}).click();
+
+			await page.getByRole('menuitem', {name: 'Show Details'}).click();
+
+			await expect(
+				page.getByRole('heading', {name: assetTitle})
+			).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/ProjectPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/ProjectPage.ts
@@ -10,6 +10,7 @@ import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVis
 type BreadcrumbActions = 'Edit' | 'Watch Project' | 'Delete';
 
 export class ProjectPage {
+	readonly assetsTab: Locator;
 	readonly deleteButton: Locator;
 	readonly detailsTab: Locator;
 	readonly moreActionsButton: Locator;
@@ -19,6 +20,9 @@ export class ProjectPage {
 	readonly tasksTab: Locator;
 
 	constructor(page: Page) {
+		this.assetsTab = page.getByRole('tab', {
+			name: 'Assets',
+		});
 		this.deleteButton = page.getByRole('button', {
 			name: 'Delete',
 		});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97663 and https://liferay.atlassian.net/browse/LPD-97612

## What Is Being Fixed

On the CMS project view, opening the Assets tab and clicking "Show Details" on an asset crashed the page. The asset info panel's AssetMetadata component renders a location breadcrumb from breadcrumbProps, but the all-related-assets display context never provided breadcrumbProps, so ClayBreadcrumb received undefined items and threw, unmounting the whole Frontend Data Set. This is a regression from LPD-85726, which changed AssetMetadata to derive the breadcrumb items from breadcrumbProps instead of a hard-coded array.

## How It Is Being Fixed

ViewAllRelatedAssetsSectionDisplayContext now overrides getAdditionalProps to add breadcrumbProps, mirroring the Files and Contents section views. This gives AssetMetadata a defined breadcrumbItems array so the location breadcrumb renders and the panel no longer crashes. An integration test asserts breadcrumbProps is present in the view's additional props.

## PR Check

**pr-check: PASS** — tested on `0e3ec193301cfaa9940381921077517911e917b0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0e3ec193301cfaa9940381921077517911e917b0"} -->
