### PR TITLE
LPD-97230 Resolve string scope keys for the object entry folders page

### DIFF
--- a/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
+++ b/modules/apps/headless/headless-object/headless-object-impl/src/main/java/com/liferay/headless/object/internal/resource/v1_0/ObjectEntryFolderResourceImpl.java
@@ -308,7 +308,7 @@ public class ObjectEntryFolderResourceImpl
 						booleanQuery.getPreBooleanFilter();
 
 					booleanFilter.add(
-						new TermFilter(Field.GROUP_ID, scopeKey),
+						new TermFilter(Field.GROUP_ID, String.valueOf(groupId)),
 						BooleanClauseOccur.MUST);
 				}
 			},

--- a/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
+++ b/modules/apps/headless/headless-object/headless-object-test/src/testIntegration/java/com/liferay/headless/object/resource/v1_0/test/ObjectEntryFolderResourceTest.java
@@ -137,6 +137,14 @@ public class ObjectEntryFolderResourceTest
 
 	@Override
 	@Test
+	public void testGetScopeScopeKeyObjectEntryFoldersPage() throws Exception {
+		super.testGetScopeScopeKeyObjectEntryFoldersPage();
+
+		_testGetScopeScopeKeyObjectEntryFoldersPageWithGroupKey();
+	}
+
+	@Override
+	@Test
 	public void testGetScopeScopeKeyObjectEntryFoldersPageWithFilterDateTimeEquals()
 		throws Exception {
 
@@ -1183,6 +1191,26 @@ public class ObjectEntryFolderResourceTest
 		assertEquals(
 			Collections.singletonList(objectEntryFolder2),
 			(List<ObjectEntryFolder>)page.getItems());
+	}
+
+	private void _testGetScopeScopeKeyObjectEntryFoldersPageWithGroupKey()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			testGetScopeScopeKeyObjectEntryFoldersPage_addObjectEntryFolder(
+				String.valueOf(_testDepotEntry.getGroupId()),
+				randomObjectEntryFolder());
+
+		Page<ObjectEntryFolder> page =
+			objectEntryFolderResource.getScopeScopeKeyObjectEntryFoldersPage(
+				_testDepotEntryGroup.getGroupKey(), null, null, null, null,
+				Pagination.of(1, 10), null);
+
+		assertContains(
+			objectEntryFolder, (List<ObjectEntryFolder>)page.getItems());
+
+		objectEntryFolderResource.deleteObjectEntryFolder(
+			objectEntryFolder.getId());
 	}
 
 	private void _testPatchScopeScopeKeyObjectEntryFolderByExternalReferenceCodeWithGroupKey()


### PR DESCRIPTION
# What is this trying to solve?

Ticket: https://liferay.atlassian.net/browse/LPD-97230.

`GET /o/headless-object/v1.0/scopes/{scopeKey}/object-entry-folders` only worked when `{scopeKey}` was the numeric group ID. String scope keys (asset library key, group key, external reference code) returned an empty collection even though folders existed — unlike the other `/scopes/{scopeKey}/` endpoints.

# How am I fixing it?

In `ObjectEntryFolderResourceImpl.getScopeScopeKeyObjectEntryFoldersPage`, the scope key is already resolved to a `groupId`, but the search pre-filter built its `GROUP_ID` term from the raw `scopeKey` string:

```java
new TermFilter(Field.GROUP_ID, scopeKey)                  // before
new TermFilter(Field.GROUP_ID, String.valueOf(groupId))   // after
```

Numeric keys matched by luck; string keys matched nothing. One-line fix uses the resolved `groupId`. (The filter only applies when `flatten=false`, which is why `flatten=true` was an accidental workaround.)

# How can you verify that it works?

`ObjectEntryFolderResourceTest.testGetScopeScopeKeyObjectEntryFoldersPage` now creates a folder via the numeric key and fetches the page by the string group key, asserting the folder is returned.