### PR TITLE
LPD-97690 Hide the Select All checkbox in views without item selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -1979,7 +1979,7 @@ const FrontendDataSetContent = ({
 		setAdditionalAPIURLParameters(parameters);
 	}
 
-	const selectable = !!selectionType;
+	const selectable = !!selectionType && (activeView.selectable ?? true);
 
 	const {className} = useFDSDrop({
 		targetDropRef: dataSetWrapperRef,
@@ -2129,7 +2129,7 @@ const FrontendDataSetContent = ({
 				selectedItems,
 				selectedItemsKey,
 				selectedItemsValue,
-				selectionType,
+				selectionType: selectable ? selectionType : undefined,
 				showBulkActionsManagementBar,
 				showBulkActionsManagementBarActions,
 				showInfoPanel: infoPanelComponent ? true : false,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -295,6 +295,7 @@ export interface IView {
 	label?: string;
 	name?: string;
 	schema?: ISchema;
+	selectable?: boolean;
 	setItemComponentProps?: ({item, props}: {item: any; props: any}) => any;
 	showPagination?: boolean;
 	thumbnail?: string;

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectTasksFDSPropsTransformer.tsx
@@ -84,6 +84,7 @@ export default function ProjectTasksFDSPropsTransformer({
 			symbol: '',
 			title: 'embedded.title',
 		},
+		selectable: false,
 		showPagination: false,
 		thumbnail: 'calendar',
 	};
@@ -108,6 +109,7 @@ export default function ProjectTasksFDSPropsTransformer({
 			symbol: '',
 			title: 'embedded.title',
 		},
+		selectable: false,
 		showPagination: false,
 		thumbnail: 'columns',
 	};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97690

## What Is Being Fixed

In a CMP project's Tasks tab, the frontend-data-set toolbar rendered a bulk-selection "Select All" checkbox in the Kanban and Calendar views, even though neither view renders per-task checkboxes. Users could "select all" with no way to see or manage individual selections.

## How It Is Being Fixed

Selection was declared once for the whole data set (selectionType="multiple"), with no per-view opt-out. This adds a per-view selectable flag to the frontend-data-set IView interface, mirroring the existing per-view showPagination pattern. FrontendDataSet now derives the effective selection state from the active view (selectable = !!selectionType && (activeView.selectable ?? true)) and feeds it to the management bar context, so both the Select All checkbox and the bulk-actions bar disappear on non-selectable views while the table view is unaffected. The CMP project tasks props transformer sets selectable: false on the Kanban and Calendar views.

## Why Are There No Tests?

The change only removes a UI control from views that never supported per-item selection; it adds no new behavior to exercise. Visibility is now driven by an existing per-view flag, and the touched modules' existing Jest suites continue to pass.

## PR Check

**pr-check: PASS** — tested on `07056c063c74c66276843b37c803491d5685c0ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "07056c063c74c66276843b37c803491d5685c0ac"} -->
