### PR TITLE
LPD-96722 Stop duplicating documents selected in CMS upload fields

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2628,6 +2628,9 @@ public class ObjectEntryLocalServiceImpl
 			objectField.getObjectFieldSettings());
 
 		if (Objects.equals(
+				fileSource,
+				ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT) ||
+			Objects.equals(
 				fileSource, ObjectFieldSettingConstants.VALUE_DOCS_AND_MEDIA)) {
 
 			return;
@@ -2655,11 +2658,7 @@ public class ObjectEntryLocalServiceImpl
 
 		DLFolder dlFileEntryFolder = dlFileEntry.getFolder();
 
-		if ((groupId == 0) ||
-			Objects.equals(
-				fileSource,
-				ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT)) {
-
+		if (groupId == 0) {
 			groupId = dlFileEntry.getGroupId();
 		}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -1639,13 +1639,23 @@ public class ObjectEntryLocalServiceTest {
 			MapUtil.getLong(objectEntry.getValues(), objectField1.getName()),
 			StringPool.BLANK, 0);
 
+		long cmsBasicDocumentFileEntryId = MapUtil.getLong(
+			cmsBasicDocumentObjectEntry.getValues(), "file");
+
+		DLFileEntry cmsBasicDocumentDLFileEntry =
+			_dlFileEntryLocalService.getFileEntry(cmsBasicDocumentFileEntryId);
+
 		objectEntry = _addObjectEntry(
-			MapUtil.getLong(cmsBasicDocumentObjectEntry.getValues(), "file"),
-			objectField2.getName());
+			cmsBasicDocumentFileEntryId, objectField2.getName());
+
+		Assert.assertEquals(
+			cmsBasicDocumentFileEntryId,
+			MapUtil.getLong(objectEntry.getValues(), objectField2.getName()));
 
 		_assertDLFileEntry(
-			MapUtil.getLong(objectEntry.getValues(), objectField2.getName()),
-			_objectDefinition.getClassName(), objectEntry.getObjectEntryId());
+			cmsBasicDocumentFileEntryId,
+			cmsBasicDocumentDLFileEntry.getClassName(),
+			cmsBasicDocumentDLFileEntry.getClassPK());
 	}
 
 	@Test
@@ -7592,6 +7602,63 @@ public class ObjectEntryLocalServiceTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
+	public void testUpdateObjectEntryWithAttachmentObjectField()
+		throws Exception {
+
+		ObjectEntry cmsBasicDocumentObjectEntry =
+			_addCMSBasicDocumentObjectEntry();
+
+		long cmsBasicDocumentFileEntryId = MapUtil.getLong(
+			cmsBasicDocumentObjectEntry.getValues(), "file");
+
+		DLFileEntry cmsBasicDocumentDLFileEntry =
+			_dlFileEntryLocalService.getFileEntry(cmsBasicDocumentFileEntryId);
+
+		ObjectField objectField = _addAttachmentObjectField(
+			ObjectFieldSettingConstants.VALUE_CMS_BASIC_DOCUMENT);
+
+		ObjectEntry objectEntry = _addObjectEntry(
+			cmsBasicDocumentFileEntryId, objectField.getName());
+
+		Assert.assertEquals(
+			cmsBasicDocumentFileEntryId,
+			MapUtil.getLong(objectEntry.getValues(), objectField.getName()));
+
+		for (int i = 0; i < 2; i++) {
+			objectEntry = _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				objectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.putAll(
+					_objectEntryLocalService.getValues(objectEntry)
+				).put(
+					objectField.getName(), 0L
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+			objectEntry = _objectEntryLocalService.updateObjectEntry(
+				TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+				objectEntry.getObjectEntryFolderId(),
+				HashMapBuilder.putAll(
+					_objectEntryLocalService.getValues(objectEntry)
+				).put(
+					objectField.getName(), cmsBasicDocumentFileEntryId
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+			Assert.assertEquals(
+				cmsBasicDocumentFileEntryId,
+				MapUtil.getLong(
+					objectEntry.getValues(), objectField.getName()));
+		}
+
+		_assertDLFileEntry(
+			cmsBasicDocumentFileEntryId,
+			cmsBasicDocumentDLFileEntry.getClassName(),
+			cmsBasicDocumentDLFileEntry.getClassPK());
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
 	public void testUpdateObjectEntryWithAttachmentObjectFieldAndEnableObjectEntryVersioning()
 		throws Exception {
 
@@ -8404,8 +8471,7 @@ public class ObjectEntryLocalServiceTest {
 
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
-			RandomTestUtil.randomLocaleStringMap(),
-			DepotConstants.TYPE_ASSET_LIBRARY,
+			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_SPACE,
 			ServiceContextTestUtil.getServiceContext());
 
 		ObjectDefinition objectDefinition =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96722

## What Is Being Fixed

In a CMS content structure with an "upload" field set to "Upload or Select from Item Selector", selecting an existing Basic Document and re-saving duplicated the document on every save (test.pdf -> test (1).pdf -> test (2).pdf ...). The copies were written to an internal folder and accumulated invisibly with each re-selection.

## How It Is Being Fixed

This is an Objects bug rather than a CMS one: a CMS content structure is an object definition and its upload field is an attachment object field. In ObjectEntryLocalServiceImpl._addDLFileEntry, the documentsAndMedia file source already returned early to reference the selected library file, but the CMSBasicDocument source fell through and copied the file into the object definition's hidden folder under a uniquified name, with no deduplication, so every re-selection produced a fresh copy. The fix makes CMSBasicDocument take the same early-return path as documentsAndMedia -- referencing the selected document instead of copying it -- and drops the now-unreachable group-reset branch beneath it. As a result the content references the shared CMS document instead of owning a private copy, matching the behavior documentsAndMedia already had.

## PR Check

**pr-check: PASS** -- tested on `510e388f6033ab499c35c39c843a7feb11997c5d`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "510e388f6033ab499c35c39c843a7feb11997c5d"} -->
