### PR TITLE
LPD-95457 Fix phone number country picker selection in Playwright test

### DIFF
--- a/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntryLocalized.spec.ts
@@ -1272,7 +1272,10 @@ test.describe('Localized object entries are saved correctly', () => {
 
 				await userPrefixDropdown.click();
 
-				await page.getByRole('option', {name: /United States/}).click();
+				await page
+					.getByRole('option', {name: /United States/})
+					.locator('..')
+					.click();
 
 				await expect(userPrefixDropdown).toHaveText(enUserPrefix);
 
@@ -1290,7 +1293,10 @@ test.describe('Localized object entries are saved correctly', () => {
 
 				await userPrefixDropdown.click();
 
-				await page.getByRole('option', {name: /Brazil/}).click();
+				await page
+					.getByRole('option', {name: /Brazil/})
+					.locator('..')
+					.click();
 
 				await expect(userPrefixDropdown).toHaveText(ptUserPrefix);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95457

## What Is Being Fixed

The "Phone Number fields" Playwright test in `objectEntryLocalized.spec.ts` failed consistently when selecting a country from the phone number field's Country Code picker. The click on the country option never landed, and the test timed out after 90 seconds.

## How It Is Being Fixed

Each option in the Clay Picker renders as a `<button role="option">` nested inside an `<li role="presentation">` wrapper that captures pointer events, so a click targeting the option button is always intercepted by its wrapping list item and retries until the test times out. The test now finds the option by its accessible name and clicks the wrapping list item — the element that actually receives the pointer event — which selects the country reliably. Both the en_US (United States) and pt_BR (Brazil) selections were updated. The affected test passed 8 consecutive local runs after the change.

## Why Are There No Tests?

This change is itself a fix to a Playwright test; there is no product code change to cover. Correctness was verified by running the affected test 8 times in a row locally, all passing.

## PR Check

**pr-check: PASS** — tested on `e6cf042d2741ac10387ebc09be2230482e53a8f9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "e6cf042d2741ac10387ebc09be2230482e53a8f9"} -->
