### PR TITLE
LPD-97608 Allow organization members to view their own organizations

### DIFF
--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/permission/contributor/OrganizationSearchPermissionFilterContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/permission/contributor/OrganizationSearchPermissionFilterContributor.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.organizations.internal.search.spi.model.permission.contributor;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.UserBag;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.search.spi.model.permission.contributor.SearchPermissionFilterContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Yuri Monteiro
+ */
+@Component(
+	property = "indexer.class.name=com.liferay.portal.kernel.model.Organization",
+	service = SearchPermissionFilterContributor.class
+)
+public class OrganizationSearchPermissionFilterContributor
+	implements SearchPermissionFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, long companyId, long[] groupIds,
+		long userId, PermissionChecker permissionChecker, String className) {
+
+		if (!className.equals(Organization.class.getName()) || (userId == 0)) {
+			return;
+		}
+
+		try {
+			UserBag userBag = permissionChecker.getUserBag();
+
+			long[] userOrgIds = userBag.getUserOrgIds();
+
+			if (ArrayUtil.isEmpty(userOrgIds)) {
+				return;
+			}
+
+			TermsFilter termsFilter = new TermsFilter(Field.ENTRY_CLASS_PK);
+
+			termsFilter.addValues(ArrayUtil.toStringArray(userOrgIds));
+
+			booleanFilter.add(termsFilter, BooleanClauseOccur.SHOULD);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OrganizationSearchPermissionFilterContributor.class);
+
+}

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/internal/search/spi/model/permission/contributor/test/OrganizationSearchPermissionFilterContributorTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/internal/search/spi/model/permission/contributor/test/OrganizationSearchPermissionFilterContributorTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.organizations.internal.search.spi.model.permission.contributor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.model.uid.UIDFactory;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Yuri Monteiro
+ */
+@RunWith(Arquillian.class)
+public class OrganizationSearchPermissionFilterContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-97608")
+	public void testWhenHasOrganizationMembershipSearch() throws Exception {
+		_organization = OrganizationTestUtil.addOrganization();
+
+		_user = UserTestUtil.addUser();
+
+		_assertSearch(_user);
+
+		_userLocalService.addOrganizationUser(
+			_organization.getOrganizationId(), _user);
+
+		_assertSearch(_user, _uidFactory.getUID(_organization));
+	}
+
+	private void _assertSearch(User user, String... expectedUIDs)
+		throws Exception {
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).entryClassNames(
+				Organization.class.getName()
+			).modelIndexerClasses(
+				Organization.class
+			).withSearchContext(
+				searchContext -> searchContext.setUserId(user.getUserId())
+			);
+
+		SearchResponse searchResponse = _searcher.search(
+			searchRequestBuilder.build());
+
+		Assert.assertEquals(expectedUIDs.length, searchResponse.getTotalHits());
+
+		if (expectedUIDs.length == 0) {
+			return;
+		}
+
+		DocumentsAssert.assertValues(
+			searchResponse.getResponseString(), searchResponse.getDocuments(),
+			Field.UID,
+			StringBundler.concat(
+				"[", StringUtil.merge(expectedUIDs, ", "), "]"));
+	}
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@Inject
+	private UIDFactory _uidFactory;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/object/system/test/OrganizationSystemObjectDefinitionManagerTest.java
+++ b/modules/apps/organizations/organizations-test/src/testIntegration/java/com/liferay/organizations/object/system/test/OrganizationSystemObjectDefinitionManagerTest.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -227,6 +229,31 @@ public class OrganizationSystemObjectDefinitionManagerTest
 	}
 
 	@Test
+	@TestInfo("LPD-97608")
+	public void testGetOrAddEmptyBaseModelWithOrganizationMember()
+		throws Exception {
+
+		setUser(TestPropsValues.getUser());
+
+		_organization = OrganizationTestUtil.addOrganization();
+
+		_user = UserTestUtil.addUser();
+
+		_organizationLocalService.addUserOrganization(
+			_user.getUserId(), _organization);
+
+		setUser(_user);
+
+		Organization organization =
+			(Organization)systemObjectDefinitionManager.getOrAddEmptyBaseModel(
+				_organization.getExternalReferenceCode(), _user);
+
+		Assert.assertEquals(
+			_organization.getOrganizationId(),
+			organization.getOrganizationId());
+	}
+
+	@Test
 	public void testGetters() throws Exception {
 		Assert.assertEquals(
 			"L_ORGANIZATION",
@@ -355,7 +382,13 @@ public class OrganizationSystemObjectDefinitionManagerTest
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
+	@DeleteAfterTestRun
+	private Organization _organization;
+
 	@Inject
 	private OrganizationLocalService _organizationLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/permission/OrganizationPermissionUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/permission/OrganizationPermissionUtil.java
@@ -6,11 +6,14 @@
 package com.liferay.portal.kernel.service.permission;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
@@ -81,6 +84,12 @@ public class OrganizationPermissionUtil {
 			String actionId)
 		throws PortalException {
 
+		if (actionId.equals(ActionKeys.VIEW) &&
+			_hasUserOrg(organization, permissionChecker)) {
+
+			return true;
+		}
+
 		return _contains(
 			permissionChecker, organization.getGroupId(), organization,
 			actionId);
@@ -121,5 +130,25 @@ public class OrganizationPermissionUtil {
 
 		return false;
 	}
+
+	private static boolean _hasUserOrg(
+		Organization organization, PermissionChecker permissionChecker) {
+
+		try {
+			UserBag userBag = permissionChecker.getUserBag();
+
+			return userBag.hasUserOrg(organization);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OrganizationPermissionUtil.class);
 
 }


### PR DESCRIPTION
Related issue: [LPD-97608](https://liferay.atlassian.net/browse/LPD-97608)

## What Is Being Fixed

On a content page, a Form Container mapped to a custom object renders an `Organization` relationship field as the `INPUTS-select-from-list` fragment. For a non-admin user who is a member of an organization (but holds no explicit VIEW grant on it), the picker returned "No results were found." while an admin saw the organization. Even when the picker was populated, saving the entry returned `403`.

## How It Is Being Fixed

The picker fetches `/o/headless-admin-user/v1.0/organizations`, which is Elasticsearch-backed and permission-filtered. The organization document only carries permission data for roles holding an explicit VIEW `ResourcePermission`; plain membership lives in `Users_Orgs` and is invisible to that filter, so members are excluded. The imperative side has the same gap: `OrganizationPermissionUtil.contains(...)` had no membership clause, so `OrganizationService.getOrAddEmptyOrganization(...)` on the save path threw `PrincipalException` for a member.

The fix aligns both permission layers with direct organization membership, shipped together. In `portal-kernel`, `OrganizationPermissionUtil.contains(...)` now returns `true` for `VIEW` when the current user is a direct member of the organization (`UserBag.hasUserOrg`), which heals the save path, the single `GET /organizations/{id}`, and admin-form value re-hydration; this mirrors the existing `UserPermissionUtil` in the same package. In `organizations-service`, a new `OrganizationSearchPermissionFilterContributor` adds a `SHOULD` `TermsFilter(ENTRY_CLASS_PK)` from `UserBag.getUserOrgIds()`, so the permission-filtered index search matches the imperative semantics without a reindex, following the `UserSearchPermissionFilterContributor` precedent in `users-admin`.

## Tests

New integration tests (both verified red-without-fix, then green):

- `OrganizationSystemObjectDefinitionManagerTest#testGetOrAddEmptyBaseModelWithOrganizationMember` — member resolves their own org on the save path (fails without the kernel clause).
- `OrganizationSearchPermissionFilterContributorTest#testWhenIsOrganizationMemberSearch` — member finds their own org in permission-filtered search (fails without the contributor).

Local test plan run before this PR, selected by blast radius (the kernel VIEW clause is exercised imperatively across organization services; the contributor is exercised by the ES-backed organizations endpoint the picker calls). All green against a running bundle:

| Test class | Result | Time |
| --- | --- | --- |
| `OrganizationSystemObjectDefinitionManagerTest` | PASS | 34s |
| `OrganizationSearchPermissionFilterContributorTest` | PASS | 18s |
| `OrganizationServiceTest` (kernel VIEW-clause regression) | PASS (6) | 25s |
| `UserSearchPermissionFilterContributorTest` (search-permission machinery + `contains` MANAGE_*) | PASS (4) | 32s |
| `OrganizationResourceTest` (headless organizations endpoint contract) | PASS (117, 9 skipped) | 12m14s |

## PR Check

**pr-check: PASS** — tested on `66f0573818f8fcdc3aa8093df3c866404720a2a3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS (`ant all`, 8m39s) |
| Per-Module Compile | PASS (via Full Portal Build — organizations-service deployed) |
| Integration Test Compile | PASS (obviated by Full Portal Build; testIntegration compiled and ran green in the test plan) |
| Cross-Module Compile | PASS (n/a — no testIntegration or deprecated consumers of `OrganizationPermissionUtil`) |
| Baseline | PASS (exported API unchanged — no version bump) |
| Java Unit Tests | PASS (n/a — no unit counterpart; logic covered by integration tests) |

<!-- pr-check {"result": "success", "sha": "66f0573818f8fcdc3aa8093df3c866404720a2a3"} -->


[LPD-97608]: https://liferay.atlassian.net/browse/LPD-97608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ