### PR TITLE
LPD-97796 Filter related-assets table by persona and funnel stage cell

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -31,6 +31,14 @@ public class SearchResultEntityModel implements EntityModel {
 			new BooleanEntityField(
 				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
+				new IntegerEntityField(
+					"cmpFunnelStageCategoryIds",
+					locale -> Field.ASSET_INTERNAL_CATEGORY_IDS)),
+			new CollectionEntityField(
+				new IntegerEntityField(
+					"cmpPersonaCategoryIds",
+					locale -> Field.ASSET_INTERNAL_CATEGORY_IDS)),
+			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(
 				new IntegerEntityField(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/AssetCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/AssetCategorySelectionFDSFilter.java
@@ -7,27 +7,15 @@ package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetCategoryLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
-import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
-import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marco Leo
@@ -47,12 +35,8 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = FDSFilter.class
 )
-public class AssetCategorySelectionFDSFilter extends BaseSelectionFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.INTEGER;
-	}
+public class AssetCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
 
 	@Override
 	public String getId() {
@@ -65,57 +49,20 @@ public class AssetCategorySelectionFDSFilter extends BaseSelectionFDSFilter {
 	}
 
 	@Override
-	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale) {
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId)
+		throws PortalException {
 
-		Group group = _groupLocalService.fetchGroup(
-			CompanyThreadLocal.getCompanyId(), GroupConstants.CMS);
-
-		if (group == null) {
-			return Collections.emptyList();
-		}
-
-		try {
-			List<SelectionFDSFilterItem> selectionFDSFilterItems =
-				new ArrayList<>();
-
-			for (AssetVocabulary assetVocabulary :
-					_assetVocabularyLocalService.getGroupVocabularies(
-						group.getGroupId())) {
-
-				for (AssetCategory assetCategory :
-						_assetCategoryLocalService.getVocabularyCategories(
-							assetVocabulary.getVocabularyId(),
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
-
-					selectionFDSFilterItems.add(
-						new SelectionFDSFilterItem(
-							StringBundler.concat(
-								assetCategory.getTitle(locale), " (",
-								assetVocabulary.getTitle(locale), ")"),
-							assetCategory.getCategoryId()));
-				}
-			}
-
-			return selectionFDSFilterItems;
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
+		return assetVocabularyLocalService.getGroupVocabularies(groupId);
 	}
 
 	@Override
-	public boolean isAutocompleteEnabled() {
-		return true;
+	protected String getSelectionFDSFilterItemLabel(
+		AssetCategory assetCategory, AssetVocabulary assetVocabulary,
+		Locale locale) {
+
+		return StringBundler.concat(
+			assetCategory.getTitle(locale), " (",
+			assetVocabulary.getTitle(locale), ")");
 	}
-
-	@Reference
-	private AssetCategoryLocalService _assetCategoryLocalService;
-
-	@Reference
-	private AssetVocabularyLocalService _assetVocabularyLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilter.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Leo
+ * @author Roberto Díaz
+ * @author Fábio Alves
+ */
+public abstract class BaseCategorySelectionFDSFilter
+	extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		Group group = groupLocalService.fetchGroup(
+			CompanyThreadLocal.getCompanyId(), GroupConstants.CMS);
+
+		if (group == null) {
+			return Collections.emptyList();
+		}
+
+		try {
+			List<SelectionFDSFilterItem> selectionFDSFilterItems =
+				new ArrayList<>();
+
+			for (AssetVocabulary assetVocabulary :
+					getAssetVocabularies(group.getGroupId())) {
+
+				for (AssetCategory assetCategory :
+						assetCategoryLocalService.getVocabularyCategories(
+							assetVocabulary.getVocabularyId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+					selectionFDSFilterItems.add(
+						new SelectionFDSFilterItem(
+							getSelectionFDSFilterItemLabel(
+								assetCategory, assetVocabulary, locale),
+							assetCategory.getCategoryId()));
+				}
+			}
+
+			return selectionFDSFilterItems;
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
+
+	protected abstract List<AssetVocabulary> getAssetVocabularies(long groupId)
+		throws PortalException;
+
+	protected List<AssetVocabulary> getAssetVocabularies(
+		long groupId, String vocabularyExternalReferenceCode) {
+
+		AssetVocabulary assetVocabulary =
+			assetVocabularyLocalService.
+				fetchAssetVocabularyByExternalReferenceCode(
+					vocabularyExternalReferenceCode, groupId);
+
+		if (assetVocabulary == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(assetVocabulary);
+	}
+
+	protected String getSelectionFDSFilterItemLabel(
+		AssetCategory assetCategory, AssetVocabulary assetVocabulary,
+		Locale locale) {
+
+		return assetCategory.getTitle(locale);
+	}
+
+	@Reference
+	protected AssetCategoryLocalService assetCategoryLocalService;
+
+	@Reference
+	protected AssetVocabularyLocalService assetVocabularyLocalService;
+
+	@Reference
+	protected GroupLocalService groupLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilter.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_RELATED_ASSETS_SECTION,
+		"service.ranking:Integer=99"
+	},
+	service = FDSFilter.class
+)
+public class FunnelStageCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "cmpFunnelStageCategoryIds";
+	}
+
+	@Override
+	public String getLabel() {
+		return "funnel-stage";
+	}
+
+	@Override
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId) {
+		return getAssetVocabularies(groupId, "L_CMP_FUNNEL_STAGE");
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilter.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_RELATED_ASSETS_SECTION,
+		"service.ranking:Integer=99"
+	},
+	service = FDSFilter.class
+)
+public class PersonaCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "cmpPersonaCategoryIds";
+	}
+
+	@Override
+	public String getLabel() {
+		return "persona";
+	}
+
+	@Override
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId) {
+		return getAssetVocabularies(groupId, "L_CMP_PERSONAS");
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilterTest.java
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Fábio Alves
+ */
+public class FunnelStageCategorySelectionFDSFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_funnelStageCategorySelectionFDSFilter =
+			new FunnelStageCategorySelectionFDSFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_funnelStageCategorySelectionFDSFilter, "assetCategoryLocalService",
+			_assetCategoryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_funnelStageCategorySelectionFDSFilter,
+			"assetVocabularyLocalService", _assetVocabularyLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_funnelStageCategorySelectionFDSFilter, "groupLocalService",
+			_groupLocalService);
+	}
+
+	@Test
+	public void testGetProperties() {
+		Assert.assertEquals(
+			FDSEntityFieldTypes.INTEGER,
+			_funnelStageCategorySelectionFDSFilter.getEntityFieldType());
+		Assert.assertEquals(
+			"cmpFunnelStageCategoryIds",
+			_funnelStageCategorySelectionFDSFilter.getId());
+		Assert.assertEquals(
+			"funnel-stage", _funnelStageCategorySelectionFDSFilter.getLabel());
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItems() throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_COMPANY_ID)) {
+
+			Mockito.when(
+				_group.getGroupId()
+			).thenReturn(
+				_GROUP_ID
+			);
+
+			Mockito.when(
+				_groupLocalService.fetchGroup(_COMPANY_ID, GroupConstants.CMS)
+			).thenReturn(
+				_group
+			);
+
+			AssetVocabulary assetVocabulary = Mockito.mock(
+				AssetVocabulary.class);
+
+			Mockito.when(
+				_assetVocabularyLocalService.
+					fetchAssetVocabularyByExternalReferenceCode(
+						"L_CMP_FUNNEL_STAGE", _GROUP_ID)
+			).thenReturn(
+				assetVocabulary
+			);
+
+			AssetCategory assetCategory = Mockito.mock(AssetCategory.class);
+
+			long assetCategoryId = RandomTestUtil.randomLong();
+
+			Mockito.when(
+				assetCategory.getCategoryId()
+			).thenReturn(
+				assetCategoryId
+			);
+
+			String assetCategoryTitle = RandomTestUtil.randomString();
+
+			Mockito.when(
+				assetCategory.getTitle(_locale)
+			).thenReturn(
+				assetCategoryTitle
+			);
+
+			long vocabularyId = RandomTestUtil.randomLong();
+
+			Mockito.when(
+				assetVocabulary.getVocabularyId()
+			).thenReturn(
+				vocabularyId
+			);
+
+			Mockito.when(
+				_assetCategoryLocalService.getVocabularyCategories(
+					Mockito.eq(vocabularyId), Mockito.anyInt(),
+					Mockito.anyInt(), Mockito.any())
+			).thenReturn(
+				List.of(assetCategory)
+			);
+
+			List<SelectionFDSFilterItem> selectionFDSFilterItems =
+				_funnelStageCategorySelectionFDSFilter.
+					getSelectionFDSFilterItems(_locale);
+
+			Assert.assertEquals(
+				selectionFDSFilterItems.toString(), 1,
+				selectionFDSFilterItems.size());
+
+			SelectionFDSFilterItem selectionFDSFilterItem =
+				selectionFDSFilterItems.get(0);
+
+			Assert.assertEquals(
+				assetCategoryId, selectionFDSFilterItem.getValue());
+			Assert.assertEquals(
+				assetCategoryTitle, selectionFDSFilterItem.getLabel());
+		}
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	@Mock
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Mock
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private FunnelStageCategorySelectionFDSFilter
+		_funnelStageCategorySelectionFDSFilter;
+
+	@Mock
+	private Group _group;
+
+	@Mock
+	private GroupLocalService _groupLocalService;
+
+	private final Locale _locale = LocaleUtil.US;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilterTest.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Fábio Alves
+ */
+public class PersonaCategorySelectionFDSFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_personaCategorySelectionFDSFilter =
+			new PersonaCategorySelectionFDSFilter();
+
+		ReflectionTestUtil.setFieldValue(
+			_personaCategorySelectionFDSFilter, "assetCategoryLocalService",
+			_assetCategoryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_personaCategorySelectionFDSFilter, "assetVocabularyLocalService",
+			_assetVocabularyLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_personaCategorySelectionFDSFilter, "groupLocalService",
+			_groupLocalService);
+	}
+
+	@Test
+	public void testGetProperties() {
+		Assert.assertEquals(
+			FDSEntityFieldTypes.INTEGER,
+			_personaCategorySelectionFDSFilter.getEntityFieldType());
+		Assert.assertEquals(
+			"cmpPersonaCategoryIds",
+			_personaCategorySelectionFDSFilter.getId());
+		Assert.assertEquals(
+			"persona", _personaCategorySelectionFDSFilter.getLabel());
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItems() throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_COMPANY_ID)) {
+
+			Mockito.when(
+				_group.getGroupId()
+			).thenReturn(
+				_GROUP_ID
+			);
+
+			Mockito.when(
+				_groupLocalService.fetchGroup(_COMPANY_ID, GroupConstants.CMS)
+			).thenReturn(
+				_group
+			);
+
+			AssetVocabulary assetVocabulary = Mockito.mock(
+				AssetVocabulary.class);
+
+			Mockito.when(
+				_assetVocabularyLocalService.
+					fetchAssetVocabularyByExternalReferenceCode(
+						"L_CMP_PERSONAS", _GROUP_ID)
+			).thenReturn(
+				assetVocabulary
+			);
+
+			AssetCategory assetCategory = Mockito.mock(AssetCategory.class);
+
+			long assetCategoryId = RandomTestUtil.randomLong();
+
+			Mockito.when(
+				assetCategory.getCategoryId()
+			).thenReturn(
+				assetCategoryId
+			);
+
+			String assetCategoryTitle = RandomTestUtil.randomString();
+
+			Mockito.when(
+				assetCategory.getTitle(_locale)
+			).thenReturn(
+				assetCategoryTitle
+			);
+
+			long vocabularyId = RandomTestUtil.randomLong();
+
+			Mockito.when(
+				assetVocabulary.getVocabularyId()
+			).thenReturn(
+				vocabularyId
+			);
+
+			Mockito.when(
+				_assetCategoryLocalService.getVocabularyCategories(
+					Mockito.eq(vocabularyId), Mockito.anyInt(),
+					Mockito.anyInt(), Mockito.any())
+			).thenReturn(
+				List.of(assetCategory)
+			);
+
+			List<SelectionFDSFilterItem> selectionFDSFilterItems =
+				_personaCategorySelectionFDSFilter.getSelectionFDSFilterItems(
+					_locale);
+
+			Assert.assertEquals(
+				selectionFDSFilterItems.toString(), 1,
+				selectionFDSFilterItems.size());
+
+			SelectionFDSFilterItem selectionFDSFilterItem =
+				selectionFDSFilterItems.get(0);
+
+			Assert.assertEquals(
+				assetCategoryId, selectionFDSFilterItem.getValue());
+			Assert.assertEquals(
+				assetCategoryTitle, selectionFDSFilterItem.getLabel());
+		}
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	@Mock
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Mock
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@Mock
+	private Group _group;
+
+	@Mock
+	private GroupLocalService _groupLocalService;
+
+	private final Locale _locale = LocaleUtil.US;
+	private PersonaCategorySelectionFDSFilter
+		_personaCategorySelectionFDSFilter;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97796

## What Is Being Fixed

The Content Coverage Matrix renders one cell per persona and funnel stage, showing how many project assets carry both that persona and that funnel stage. Clicking a cell should filter the project's related-assets data set down to exactly those assets, but it could not. The data set exposed a single combined category filter (taxonomyCategoryIds), and selecting multiple categories inside one FDS filter ORs them, so a cell click could only express "persona OR funnel stage" rather than the conjunction a cell represents. That combined filter also mapped to assetCategoryIds (public categories), while CMP personas and funnel stages are internal vocabularies indexed under assetInternalCategoryIds, the same field the matrix counts against, so filtering the public field returned nothing and the table never matched the cell counts.

## How It Is Being Fixed

The single combined filter is split into two distinct, vocabulary-scoped INTEGER selection filters, cmpPersonaCategoryIds and cmpFunnelStageCategoryIds. Because FDS ANDs the clauses contributed by separate filters, the two together produce the required "persona AND funnel stage." Keeping them as INTEGER selection filters also makes the uncategorized cells work, since the project-relative "No Persona" and "No Funnel Stage" columns filter via exclude (not (field in (all project categories))), which a single combined filter could not express. A BaseCategorySelectionFDSFilter is extracted so the persona, funnel-stage, and existing asset-category filters share the vocabulary lookup and item-building logic. On the search side, two new entity-model tokens, cmpPersonaCategoryIds and cmpFunnelStageCategoryIds, are added to SearchResultEntityModel, both mapping to assetInternalCategoryIds, giving each vocabulary its own filterable field so the two filters can be scoped and AND-ed independently and the table results align with the matrix totals.

## PR Check

**pr-check: PASS** — tested on `6774f4ce1261492ee0e36db9e390af08573ca3a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6774f4ce1261492ee0e36db9e390af08573ca3a4"} -->
