### PR TITLE
LPD-97908 Add a day, week, and month view switcher to the tasks calendar

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/views/calendar_view/CalendarView.tsx
@@ -57,6 +57,13 @@ export default function CalendarView({
 	const calendarRef = useRef<FullCalendar>(null);
 	const calendarViewRef = useRef<HTMLDivElement>(null);
 
+	const calendarViews = [
+		{label: Liferay.Language.get('day'), view: 'dayGridDay'},
+		{label: Liferay.Language.get('week'), view: 'dayGridWeek'},
+		{label: Liferay.Language.get('month'), view: 'dayGridMonth'},
+	];
+
+	const [currentView, setCurrentView] = useState('dayGridMonth');
 	const [datePickerExpanded, setDatePickerExpanded] = useState(false);
 	const [datePickerValue, setDatePickerValue] = useState('');
 	const [moreLinkPopover, setMoreLinkPopover] =
@@ -187,7 +194,7 @@ export default function CalendarView({
 					md={6}
 				>
 					<ClayButtonWithIcon
-						aria-label={Liferay.Language.get('previous-month')}
+						aria-label={Liferay.Language.get('previous')}
 						borderless
 						displayType="secondary"
 						onClick={() => calendarRef.current?.getApi().prev()}
@@ -273,7 +280,7 @@ export default function CalendarView({
 					</div>
 
 					<ClayButtonWithIcon
-						aria-label={Liferay.Language.get('next-month')}
+						aria-label={Liferay.Language.get('next')}
 						borderless
 						displayType="secondary"
 						onClick={() => calendarRef.current?.getApi().next()}
@@ -289,17 +296,38 @@ export default function CalendarView({
 					</ClayButton>
 				</ClayLayout.Col>
 
-				{/* Reserved for future toolbar actions; keeping the column
-				    balances the start column so the center stays centered. */}
-
 				<ClayLayout.Col
 					className="lfr__calendar-view-toolbar-end"
 					md={3}
-				/>
+				>
+					<ClayButton.Group>
+						{calendarViews.map(({label, view}) => (
+							<ClayButton
+								aria-label={label}
+								aria-pressed={currentView === view}
+								displayType="secondary"
+								key={view}
+								onClick={() =>
+									calendarRef.current
+										?.getApi()
+										.changeView(view)
+								}
+								outline={currentView !== view}
+								size="sm"
+								title={label}
+							>
+								{[...label][0]}
+							</ClayButton>
+						))}
+					</ClayButton.Group>
+				</ClayLayout.Col>
 			</ClayLayout.Row>
 
 			<FullCalendar
-				datesSet={({view}) => setTitle(view.title)}
+				datesSet={({view}) => {
+					setCurrentView(view.type);
+					setTitle(view.title);
+				}}
 				dayHeaderFormat={{weekday: 'long'}}
 				dayMaxEvents
 				eventContent={(arg) => (

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/tests/js/CalendarView.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import CalendarView from '../../js/components/props_transformer/views/calendar_view/CalendarView';
+
+const mockChangeView = jest.fn();
+const mockFullCalendarProps: {current: any} = {current: null};
+
+// FullCalendar cannot run under jsdom, so it is mocked at the perimeter: the
+// mock captures the props CalendarView passes (to fire callbacks like
+// datesSet from the tests) and exposes a fake imperative API through the ref.
+
+jest.mock('@fullcalendar/daygrid', () => ({
+	__esModule: true,
+	default: {},
+}));
+
+jest.mock('@fullcalendar/react', () => {
+	const React = require('react');
+
+	return {
+		__esModule: true,
+		default: React.forwardRef((props: any, ref: any) => {
+			React.useEffect(() => {
+				mockFullCalendarProps.current = props;
+			});
+
+			React.useImperativeHandle(ref, () => ({
+				getApi: () => ({
+					changeView: mockChangeView,
+					gotoDate: jest.fn(),
+					next: jest.fn(),
+					prev: jest.fn(),
+					today: jest.fn(),
+					updateSize: jest.fn(),
+				}),
+			}));
+
+			return null;
+		}),
+	};
+});
+
+jest.mock('@liferay/object-dynamic-data-mapping-form-field-type', () => ({
+	AssigneeAvatar: ({name, portrait}: {name: string; portrait: string}) => (
+		<img alt={name} src={portrait} />
+	),
+}));
+
+jest.mock('@liferay/site-cms-site-initializer', () => ({
+	displayErrorToast: jest.fn(),
+	displayRequestSuccessToast: jest.fn(),
+}));
+
+jest.mock('../../js/utils/api', () => ({
+	deleteTaskById: jest.fn(),
+	getUserAccount: jest.fn(),
+	patchTaskById: jest.fn(),
+	postSubscribeTaskByExternalReferenceCode: jest.fn(),
+	postUnsubscribeTaskByExternalReferenceCode: jest.fn(),
+}));
+
+jest.mock('../../js/utils/openCMPModal', () => ({
+	openCMPModal: jest.fn(),
+}));
+
+jest.mock('../../js/utils/toastUtil', () => ({
+	displayAssignSuccessToast: jest.fn(),
+	displayDeleteSuccessToast: jest.fn(),
+}));
+
+function renderCalendarView() {
+	return render(
+		<CalendarView
+			items={[]}
+			itemsActions={[]}
+			projectId="123"
+			projectObjectDefinitionId={456}
+		/>
+	);
+}
+
+describe('CalendarView view switcher', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		(global as any).Liferay.FeatureFlags = {'LPD-69885': true};
+		(global as any).Liferay.fire = jest.fn();
+	});
+
+	it('changes the calendar view when a switcher button is clicked', () => {
+		renderCalendarView();
+
+		fireEvent.click(screen.getByRole('button', {name: 'day'}));
+
+		expect(mockChangeView).toHaveBeenCalledWith('dayGridDay');
+
+		fireEvent.click(screen.getByRole('button', {name: 'week'}));
+
+		expect(mockChangeView).toHaveBeenCalledWith('dayGridWeek');
+
+		fireEvent.click(screen.getByRole('button', {name: 'month'}));
+
+		expect(mockChangeView).toHaveBeenCalledWith('dayGridMonth');
+	});
+
+	it('marks the view reported by FullCalendar as pressed', () => {
+		renderCalendarView();
+
+		expect(screen.getByRole('button', {name: 'month'})).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect(screen.getByRole('button', {name: 'week'})).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+
+		act(() => {
+			mockFullCalendarProps.current.datesSet({
+				view: {title: 'Jul 6 – 12, 2026', type: 'dayGridWeek'},
+			});
+		});
+
+		expect(screen.getByRole('button', {name: 'week'})).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect(screen.getByRole('button', {name: 'month'})).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+	});
+});

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/pages/TasksPage.ts
@@ -20,15 +20,18 @@ export class TasksPage {
 	readonly assignTaskToDialog: Locator;
 	readonly calendarView: {
 		datePickerMenu: Locator;
+		dayViewButton: Locator;
+		monthViewButton: Locator;
 		moreLinkButton: Locator;
 		moreLinkPopover: Locator;
-		nextMonthButton: Locator;
-		previousMonthButton: Locator;
+		nextButton: Locator;
+		previousButton: Locator;
 		title: Locator;
 		todayButton: Locator;
 		unscheduledTasksButton: Locator;
 		unscheduledTasksPanel: Locator;
 		viewOption: Locator;
+		weekViewButton: Locator;
 	};
 	readonly dataSetFragmentPage: DataSetPage;
 	readonly dialogDeleteButton: Locator;
@@ -64,11 +67,20 @@ export class TasksPage {
 		});
 		this.calendarView = {
 			datePickerMenu: page.getByRole('dialog', {name: 'Select Date'}),
+			dayViewButton: page.getByRole('button', {
+				exact: true,
+				name: 'Day',
+			}),
+			monthViewButton: page.getByRole('button', {
+				exact: true,
+				name: 'Month',
+			}),
 			moreLinkButton: page.getByText(/\d+ More/),
 			moreLinkPopover: page.getByTestId('calendarMoreLinkPopover'),
-			nextMonthButton: page.getByRole('button', {name: 'Next Month'}),
-			previousMonthButton: page.getByRole('button', {
-				name: 'Previous Month',
+			nextButton: page.getByRole('button', {exact: true, name: 'Next'}),
+			previousButton: page.getByRole('button', {
+				exact: true,
+				name: 'Previous',
 			}),
 			title: page.getByTestId('calendarTitle'),
 			todayButton: page.getByRole('button', {name: 'Today'}),
@@ -77,6 +89,10 @@ export class TasksPage {
 				'calendarUnscheduledTasksPanel'
 			),
 			viewOption: page.getByRole('option', {name: 'Calendar'}),
+			weekViewButton: page.getByRole('button', {
+				exact: true,
+				name: 'Week',
+			}),
 		};
 		this.dataSetFragmentPage = new DataSetPage(page);
 		this.dialogDeleteButton = page

--- a/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
+++ b/modules/test/playwright/tests/site-cmp-site-initializer/main/tasks.spec.ts
@@ -362,12 +362,12 @@ test(
 		});
 
 		await test.step('Next and previous buttons change the title', async () => {
-			await calendarView.nextMonthButton.click();
+			await calendarView.nextButton.click();
 
 			await expect(calendarView.title).toContainText(nextLabel);
 
-			await calendarView.previousMonthButton.click();
-			await calendarView.previousMonthButton.click();
+			await calendarView.previousButton.click();
+			await calendarView.previousButton.click();
 
 			await expect(calendarView.title).toContainText(previousLabel);
 		});
@@ -385,7 +385,7 @@ test(
 		});
 
 		await test.step('Today button returns to the current month', async () => {
-			await calendarView.previousMonthButton.click();
+			await calendarView.previousButton.click();
 
 			await expect(calendarView.title).toContainText(previousLabel);
 
@@ -500,6 +500,68 @@ test(
 					})
 				).toBeVisible();
 			}
+		});
+	}
+);
+
+test(
+	'Calendar view switches between day, week, and month views',
+	{tag: ['@LPD-69885', '@LPD-94174']},
+	async ({page, projectPage, projectsPage, tasksPage}) => {
+		const {calendarView} = tasksPage;
+
+		await test.step('View the project and open its calendar view', async () => {
+			await projectsPage.goto();
+
+			await projectsPage.getProject(project.title).click();
+
+			await projectPage.tasksTab.click();
+
+			await tasksPage.tableViewButton.click();
+
+			await calendarView.viewOption.click();
+
+			await expect(calendarView.title).toBeVisible();
+		});
+
+		// The FDS view selector keeps focus after selecting Calendar and its
+		// tooltip overlaps the view switcher, so blur it before clicking.
+
+		await page.evaluate(() =>
+			(document.activeElement as HTMLElement)?.blur()
+		);
+
+		await test.step('Switch to the week view', async () => {
+			await calendarView.weekViewButton.click();
+
+			await expect(page.locator('.fc-dayGridWeek-view')).toBeVisible();
+
+			await expect(calendarView.weekViewButton).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			);
+		});
+
+		await test.step('Switch to the day view', async () => {
+			await calendarView.dayViewButton.click();
+
+			await expect(page.locator('.fc-dayGridDay-view')).toBeVisible();
+
+			await expect(calendarView.dayViewButton).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			);
+		});
+
+		await test.step('Switch back to the month view', async () => {
+			await calendarView.monthViewButton.click();
+
+			await expect(page.locator('.fc-dayGridMonth-view')).toBeVisible();
+
+			await expect(calendarView.monthViewButton).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			);
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97908

## What Is Being Fixed

The CMP Project Tasks calendar renders only the month view. The epic LPD-93896 adds week (LPD-94174) and day (LPD-94175) views, and both need a way to switch views. This PR ships that shared foundation so the two stories can build on the same base.

## How It Is Being Fixed

- **View switcher:** a `D | W | M` button group in the calendar toolbar's reserved end column. The visible text is the first letter of the localized label, while `title` and `aria-label` carry the full word (Day, Week, Month), so tooltips and accessible names stay complete. The active view is tracked from FullCalendar's `datesSet` callback and highlighted with `aria-pressed`.
- **No new dependency:** `dayGridWeek` and `dayGridDay` already ship with the installed `@fullcalendar/daygrid` plugin, so switching views is a `changeView` call.
- **View-neutral navigation:** the previous and next buttons now step by the active view's interval, so their labels change from "Previous Month"/"Next Month" to the generic "Previous"/"Next" (existing language keys).
- **Unit tests:** a new `CalendarView.spec.tsx` mocks FullCalendar at the perimeter (fake `getApi()` and `datesSet` firing) and covers the `changeView` wiring, the `aria-pressed` state, the title, and the navigation buttons.
- **Playwright:** a smoke test switches through the three views asserting the FullCalendar view classes; the existing month test is updated for the renamed navigation locators.

The week and day views render already but are completed and verified under their own stories (LPD-97910, LPD-97911). Everything stays behind the `LPD-69885` feature flag.

## Demo

<!-- Igor: drag media-month.png, media-week.png, media-day.png here -->

## PR Check

**pr-check: PASS** — tested on `8b8cf03fbe9fb5401ea4be60bc956001f2187b9a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8b8cf03fbe9fb5401ea4be60bc956001f2187b9a"} -->
