### PR TITLE
LPD-77514 Match related object entries to the parent approval status

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/layout/display/page/test/ObjectEntryLayoutDisplayPageObjectProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/layout/display/page/test/ObjectEntryLayoutDisplayPageObjectProviderTest.java
@@ -9,14 +9,20 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderRegistry;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.test.util.TreeTestUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -26,6 +32,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -34,6 +41,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import java.io.Serializable;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -54,6 +62,14 @@ public class ObjectEntryLayoutDisplayPageObjectProviderTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetRelatedLayoutDisplayPageObjectProviders()
+		throws Exception {
+
+		_testGetRelatedLayoutDisplayPageObjectProvidersWithApprovedParentAndDraftChild();
+		_testGetRelatedLayoutDisplayPageObjectProvidersWithDraftObjectDefinitionTree();
+	}
 
 	@Test
 	public void testGetTitle() throws Exception {
@@ -143,7 +159,165 @@ public class ObjectEntryLayoutDisplayPageObjectProviderTest {
 	protected LayoutDisplayPageProviderRegistry
 		layoutDisplayPageProviderRegistry;
 
+	private ObjectEntry _addChildObjectEntry(
+			ObjectDefinition childObjectDefinition,
+			ObjectDefinition parentObjectDefinition,
+			ObjectEntry parentObjectEntry, ServiceContext serviceContext)
+		throws Exception {
+
+		return ObjectEntryTestUtil.addObjectEntry(
+			0, childObjectDefinition.getObjectDefinitionId(), serviceContext,
+			HashMapBuilder.<String, Serializable>put(
+				"r_objectRelationship_" +
+					parentObjectDefinition.getPKObjectFieldName(),
+				parentObjectEntry.getObjectEntryId()
+			).build());
+	}
+
+	private ObjectDefinition _enableObjectEntryDraft(
+		ObjectDefinition objectDefinition) {
+
+		objectDefinition.setEnableObjectEntryDraft(true);
+
+		return _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+	}
+
+	private List<? extends LayoutDisplayPageObjectProvider<?>>
+		_getRelatedLayoutDisplayPageObjectProviders(
+			ObjectEntry objectEntry, ObjectRelationship objectRelationship) {
+
+		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
+			layoutDisplayPageProviderRegistry.
+				getLayoutDisplayPageProviderByURLSeparator(
+					objectEntry.getCompanyId(),
+					FriendlyURLResolverConstants.URL_SEPARATOR_OBJECT_ENTRY);
+
+		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
+			layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
+				0, String.valueOf(objectEntry.getObjectEntryId()));
+
+		return layoutDisplayPageObjectProvider.
+			getRelatedLayoutDisplayPageObjectProviders(
+				objectRelationship.getName());
+	}
+
+	private void _testGetRelatedLayoutDisplayPageObjectProvidersWithApprovedParentAndDraftChild()
+		throws Exception {
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition childObjectDefinition = _enableObjectEntryDraft(
+			ObjectDefinitionTestUtil.publishObjectDefinition());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition,
+				childObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				"objectRelationship");
+
+		ObjectEntry parentObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, parentObjectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		Assert.assertTrue(parentObjectEntry.isApproved());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		ObjectEntry childObjectEntry = _addChildObjectEntry(
+			childObjectDefinition, parentObjectDefinition, parentObjectEntry,
+			serviceContext);
+
+		Assert.assertFalse(childObjectEntry.isApproved());
+
+		List<? extends LayoutDisplayPageObjectProvider<?>>
+			relatedLayoutDisplayPageObjectProviders =
+				_getRelatedLayoutDisplayPageObjectProviders(
+					parentObjectEntry, objectRelationship);
+
+		Assert.assertTrue(
+			relatedLayoutDisplayPageObjectProviders.toString(),
+			relatedLayoutDisplayPageObjectProviders.isEmpty());
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			childObjectDefinition);
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			parentObjectDefinition);
+	}
+
+	private void _testGetRelatedLayoutDisplayPageObjectProvidersWithDraftObjectDefinitionTree()
+		throws Exception {
+
+		ObjectDefinition parentObjectDefinition = _enableObjectEntryDraft(
+			ObjectDefinitionTestUtil.publishObjectDefinition());
+		ObjectDefinition childObjectDefinition = _enableObjectEntryDraft(
+			ObjectDefinitionTestUtil.publishObjectDefinition());
+
+		ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, parentObjectDefinition,
+				childObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				"objectRelationship");
+
+		TreeTestUtil.bind(
+			_objectRelationshipLocalService,
+			Collections.singletonList(objectRelationship));
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		ObjectEntry parentObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, parentObjectDefinition.getObjectDefinitionId(), serviceContext,
+			Collections.emptyMap());
+
+		Assert.assertFalse(parentObjectEntry.isApproved());
+
+		ObjectEntry childObjectEntry = _addChildObjectEntry(
+			childObjectDefinition, parentObjectDefinition, parentObjectEntry,
+			serviceContext);
+
+		Assert.assertFalse(childObjectEntry.isApproved());
+
+		List<? extends LayoutDisplayPageObjectProvider<?>>
+			relatedLayoutDisplayPageObjectProviders =
+				_getRelatedLayoutDisplayPageObjectProviders(
+					parentObjectEntry, objectRelationship);
+
+		Assert.assertEquals(
+			relatedLayoutDisplayPageObjectProviders.toString(), 1,
+			relatedLayoutDisplayPageObjectProviders.size());
+
+		LayoutDisplayPageObjectProvider<?>
+			relatedLayoutDisplayPageObjectProvider =
+				relatedLayoutDisplayPageObjectProviders.get(0);
+
+		Assert.assertEquals(
+			childObjectEntry.getObjectEntryId(),
+			relatedLayoutDisplayPageObjectProvider.getClassPK());
+
+		TreeTestUtil.deleteObjectDefinitionHierarchy(
+			_objectDefinitionLocalService,
+			new String[] {
+				parentObjectDefinition.getName(),
+				childObjectDefinition.getName()
+			},
+			_objectEntryLocalService, _objectRelationshipLocalService);
+	}
+
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
@@ -141,7 +141,8 @@ public class ObjectEntryLayoutDisplayPageObjectProvider
 			List<ObjectEntry> objectEntries =
 				_objectEntryLocalService.getOneToManyObjectEntries(
 					getGroupId(), objectRelationship.getObjectRelationshipId(),
-					null, true, _objectEntry.getObjectEntryId(), true, null,
+					null, _objectEntry.isApproved(),
+					_objectEntry.getObjectEntryId(), true, null,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 			ObjectDefinition objectDefinition =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-77514

## What Is Being Fixed

When a CMS content that has nested reference-structure or repeatable-group entries is duplicated with Copy To, the copy and its nested entries are created as drafts. Opening the copy in the content editor showed only the main entry — the nested draft entries were missing — because the object entry display page provider fetched the related one-to-many entries with a hard-coded approved-only filter.

## How It Is Being Fixed

ObjectEntryLayoutDisplayPageObjectProvider now queries the related one-to-many entries using the parent entry's approval status instead of always requiring approved. A non-approved parent (the Copy To draft being edited) surfaces its draft children, while an approved parent — the live, published render — still returns only approved children, preserving delivery behavior. Adds integration coverage for both cases.

## PR Check

**pr-check: PASS** — tested on `b8728a2109c3f4694d81dfa78e48d6705163feba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b8728a2109c3f4694d81dfa78e48d6705163feba"} -->
