### PR TITLE
LPD-96935 Add content coverage REST endpoint

### DIFF
--- a/modules/apps/headless/headless-cmp/headless-cmp-api/bnd.bnd
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless CMP API
 Bundle-SymbolicName: com.liferay.headless.cmp.api
-Bundle-Version: 2.0.5
+Bundle-Version: 2.1.0
 Export-Package:\
 	com.liferay.headless.cmp.dto.v1_0,\
 	com.liferay.headless.cmp.resource.v1_0

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/ContentCoverage.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/ContentCoverage.java
@@ -1,0 +1,428 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+@GraphQLName("ContentCoverage")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ContentCoverage")
+public class ContentCoverage implements Serializable {
+
+	public static ContentCoverage toDTO(String json) {
+		return ObjectMapperUtil.readValue(ContentCoverage.class, json);
+	}
+
+	public static ContentCoverage unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(ContentCoverage.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public ContentCoverageEntry[] getContentCoverageEntries() {
+		if (_contentCoverageEntriesSupplier != null) {
+			contentCoverageEntries = _contentCoverageEntriesSupplier.get();
+
+			_contentCoverageEntriesSupplier = null;
+		}
+
+		return contentCoverageEntries;
+	}
+
+	public void setContentCoverageEntries(
+		ContentCoverageEntry[] contentCoverageEntries) {
+
+		this.contentCoverageEntries = contentCoverageEntries;
+
+		_contentCoverageEntriesSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setContentCoverageEntries(
+		UnsafeSupplier<ContentCoverageEntry[], Exception>
+			contentCoverageEntriesUnsafeSupplier) {
+
+		_contentCoverageEntriesSupplier = () -> {
+			try {
+				return contentCoverageEntriesUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected ContentCoverageEntry[] contentCoverageEntries;
+
+	@JsonIgnore
+	private Supplier<ContentCoverageEntry[]> _contentCoverageEntriesSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public FunnelStage[] getFunnelStages() {
+		if (_funnelStagesSupplier != null) {
+			funnelStages = _funnelStagesSupplier.get();
+
+			_funnelStagesSupplier = null;
+		}
+
+		return funnelStages;
+	}
+
+	public void setFunnelStages(FunnelStage[] funnelStages) {
+		this.funnelStages = funnelStages;
+
+		_funnelStagesSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFunnelStages(
+		UnsafeSupplier<FunnelStage[], Exception> funnelStagesUnsafeSupplier) {
+
+		_funnelStagesSupplier = () -> {
+			try {
+				return funnelStagesUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected FunnelStage[] funnelStages;
+
+	@JsonIgnore
+	private Supplier<FunnelStage[]> _funnelStagesSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Persona[] getPersonas() {
+		if (_personasSupplier != null) {
+			personas = _personasSupplier.get();
+
+			_personasSupplier = null;
+		}
+
+		return personas;
+	}
+
+	public void setPersonas(Persona[] personas) {
+		this.personas = personas;
+
+		_personasSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPersonas(
+		UnsafeSupplier<Persona[], Exception> personasUnsafeSupplier) {
+
+		_personasSupplier = () -> {
+			try {
+				return personasUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Persona[] personas;
+
+	@JsonIgnore
+	private Supplier<Persona[]> _personasSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getTotalAssetCount() {
+		if (_totalAssetCountSupplier != null) {
+			totalAssetCount = _totalAssetCountSupplier.get();
+
+			_totalAssetCountSupplier = null;
+		}
+
+		return totalAssetCount;
+	}
+
+	public void setTotalAssetCount(Long totalAssetCount) {
+		this.totalAssetCount = totalAssetCount;
+
+		_totalAssetCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalAssetCount(
+		UnsafeSupplier<Long, Exception> totalAssetCountUnsafeSupplier) {
+
+		_totalAssetCountSupplier = () -> {
+			try {
+				return totalAssetCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long totalAssetCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalAssetCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ContentCoverage)) {
+			return false;
+		}
+
+		ContentCoverage contentCoverage = (ContentCoverage)object;
+
+		return Objects.equals(toString(), contentCoverage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		ContentCoverageEntry[] contentCoverageEntries =
+			getContentCoverageEntries();
+
+		if (contentCoverageEntries != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentCoverageEntries\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < contentCoverageEntries.length; i++) {
+				sb.append(String.valueOf(contentCoverageEntries[i]));
+
+				if ((i + 1) < contentCoverageEntries.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		FunnelStage[] funnelStages = getFunnelStages();
+
+		if (funnelStages != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"funnelStages\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < funnelStages.length; i++) {
+				sb.append(String.valueOf(funnelStages[i]));
+
+				if ((i + 1) < funnelStages.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Persona[] personas = getPersonas();
+
+		if (personas != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"personas\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < personas.length; i++) {
+				sb.append(String.valueOf(personas[i]));
+
+				if ((i + 1) < personas.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Long totalAssetCount = getTotalAssetCount();
+
+		if (totalAssetCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalAssetCount\": ");
+
+			sb.append(totalAssetCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cmp.dto.v1_0.ContentCoverage",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-259510662

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/ContentCoverageEntry.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/ContentCoverageEntry.java
@@ -1,0 +1,346 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+@GraphQLName("ContentCoverageEntry")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ContentCoverageEntry")
+public class ContentCoverageEntry implements Serializable {
+
+	public static ContentCoverageEntry toDTO(String json) {
+		return ObjectMapperUtil.readValue(ContentCoverageEntry.class, json);
+	}
+
+	public static ContentCoverageEntry unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			ContentCoverageEntry.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getFunnelStageId() {
+		if (_funnelStageIdSupplier != null) {
+			funnelStageId = _funnelStageIdSupplier.get();
+
+			_funnelStageIdSupplier = null;
+		}
+
+		return funnelStageId;
+	}
+
+	public void setFunnelStageId(String funnelStageId) {
+		this.funnelStageId = funnelStageId;
+
+		_funnelStageIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFunnelStageId(
+		UnsafeSupplier<String, Exception> funnelStageIdUnsafeSupplier) {
+
+		_funnelStageIdSupplier = () -> {
+			try {
+				return funnelStageIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String funnelStageId;
+
+	@JsonIgnore
+	private Supplier<String> _funnelStageIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getPersonaId() {
+		if (_personaIdSupplier != null) {
+			personaId = _personaIdSupplier.get();
+
+			_personaIdSupplier = null;
+		}
+
+		return personaId;
+	}
+
+	public void setPersonaId(String personaId) {
+		this.personaId = personaId;
+
+		_personaIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPersonaId(
+		UnsafeSupplier<String, Exception> personaIdUnsafeSupplier) {
+
+		_personaIdSupplier = () -> {
+			try {
+				return personaIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String personaId;
+
+	@JsonIgnore
+	private Supplier<String> _personaIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getTotalCount() {
+		if (_totalCountSupplier != null) {
+			totalCount = _totalCountSupplier.get();
+
+			_totalCountSupplier = null;
+		}
+
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+
+		_totalCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		_totalCountSupplier = () -> {
+			try {
+				return totalCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long totalCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ContentCoverageEntry)) {
+			return false;
+		}
+
+		ContentCoverageEntry contentCoverageEntry =
+			(ContentCoverageEntry)object;
+
+		return Objects.equals(toString(), contentCoverageEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String funnelStageId = getFunnelStageId();
+
+		if (funnelStageId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"funnelStageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(funnelStageId));
+
+			sb.append("\"");
+		}
+
+		String personaId = getPersonaId();
+
+		if (personaId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"personaId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(personaId));
+
+			sb.append("\"");
+		}
+
+		Long totalCount = getTotalCount();
+
+		if (totalCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(totalCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cmp.dto.v1_0.ContentCoverageEntry",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1787738554

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/FunnelStage.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/FunnelStage.java
@@ -1,0 +1,401 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+@GraphQLName("FunnelStage")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "FunnelStage")
+public class FunnelStage implements Serializable {
+
+	public static FunnelStage toDTO(String json) {
+		return ObjectMapperUtil.readValue(FunnelStage.class, json);
+	}
+
+	public static FunnelStage unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(FunnelStage.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getDescription() {
+		if (_descriptionSupplier != null) {
+			description = _descriptionSupplier.get();
+
+			_descriptionSupplier = null;
+		}
+
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+
+		_descriptionSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		_descriptionSupplier = () -> {
+			try {
+				return descriptionUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String description;
+
+	@JsonIgnore
+	private Supplier<String> _descriptionSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String id;
+
+	@JsonIgnore
+	private Supplier<String> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof FunnelStage)) {
+			return false;
+		}
+
+		FunnelStage funnelStage = (FunnelStage)object;
+
+		return Objects.equals(toString(), funnelStage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String description = getDescription();
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(id));
+
+			sb.append("\"");
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cmp.dto.v1_0.FunnelStage",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:447944762

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/Persona.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/dto/v1_0/Persona.java
@@ -1,0 +1,401 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Persona")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Persona")
+public class Persona implements Serializable {
+
+	public static Persona toDTO(String json) {
+		return ObjectMapperUtil.readValue(Persona.class, json);
+	}
+
+	public static Persona unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Persona.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getDescription() {
+		if (_descriptionSupplier != null) {
+			description = _descriptionSupplier.get();
+
+			_descriptionSupplier = null;
+		}
+
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+
+		_descriptionSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		_descriptionSupplier = () -> {
+			try {
+				return descriptionUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String description;
+
+	@JsonIgnore
+	private Supplier<String> _descriptionSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String id;
+
+	@JsonIgnore
+	private Supplier<String> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Persona)) {
+			return false;
+		}
+
+		Persona persona = (Persona)object;
+
+		return Objects.equals(toString(), persona.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String description = getDescription();
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		String id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(id));
+
+			sb.append("\"");
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.cmp.dto.v1_0.Persona",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1624574490

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/resource/v1_0/ContentCoverageResource.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/java/com/liferay/headless/cmp/resource/v1_0/ContentCoverageResource.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.resource.v1_0;
+
+import com.liferay.headless.cmp.dto.v1_0.ContentCoverage;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-cmp/v1.0
+ *
+ * @author Carolina Barbosa
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface ContentCoverageResource {
+
+	public ContentCoverage getProjectContentCoverage(Long projectId)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public ContentCoverageResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-210441053

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/resources/com/liferay/headless/cmp/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/resources/com/liferay/headless/cmp/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/resources/com/liferay/headless/cmp/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cmp/headless-cmp-api/src/main/resources/com/liferay/headless/cmp/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/ContentCoverage.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/ContentCoverage.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.dto.v1_0;
+
+import com.liferay.headless.cmp.client.function.UnsafeSupplier;
+import com.liferay.headless.cmp.client.serdes.v1_0.ContentCoverageSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class ContentCoverage implements Cloneable, Serializable {
+
+	public static ContentCoverage toDTO(String json) {
+		return ContentCoverageSerDes.toDTO(json);
+	}
+
+	public ContentCoverageEntry[] getContentCoverageEntries() {
+		return contentCoverageEntries;
+	}
+
+	public void setContentCoverageEntries(
+		ContentCoverageEntry[] contentCoverageEntries) {
+
+		this.contentCoverageEntries = contentCoverageEntries;
+	}
+
+	public void setContentCoverageEntries(
+		UnsafeSupplier<ContentCoverageEntry[], Exception>
+			contentCoverageEntriesUnsafeSupplier) {
+
+		try {
+			contentCoverageEntries = contentCoverageEntriesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected ContentCoverageEntry[] contentCoverageEntries;
+
+	public FunnelStage[] getFunnelStages() {
+		return funnelStages;
+	}
+
+	public void setFunnelStages(FunnelStage[] funnelStages) {
+		this.funnelStages = funnelStages;
+	}
+
+	public void setFunnelStages(
+		UnsafeSupplier<FunnelStage[], Exception> funnelStagesUnsafeSupplier) {
+
+		try {
+			funnelStages = funnelStagesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected FunnelStage[] funnelStages;
+
+	public Persona[] getPersonas() {
+		return personas;
+	}
+
+	public void setPersonas(Persona[] personas) {
+		this.personas = personas;
+	}
+
+	public void setPersonas(
+		UnsafeSupplier<Persona[], Exception> personasUnsafeSupplier) {
+
+		try {
+			personas = personasUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Persona[] personas;
+
+	public Long getTotalAssetCount() {
+		return totalAssetCount;
+	}
+
+	public void setTotalAssetCount(Long totalAssetCount) {
+		this.totalAssetCount = totalAssetCount;
+	}
+
+	public void setTotalAssetCount(
+		UnsafeSupplier<Long, Exception> totalAssetCountUnsafeSupplier) {
+
+		try {
+			totalAssetCount = totalAssetCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalAssetCount;
+
+	@Override
+	public ContentCoverage clone() throws CloneNotSupportedException {
+		return (ContentCoverage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ContentCoverage)) {
+			return false;
+		}
+
+		ContentCoverage contentCoverage = (ContentCoverage)object;
+
+		return Objects.equals(toString(), contentCoverage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ContentCoverageSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-188819515

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/ContentCoverageEntry.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/ContentCoverageEntry.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.dto.v1_0;
+
+import com.liferay.headless.cmp.client.function.UnsafeSupplier;
+import com.liferay.headless.cmp.client.serdes.v1_0.ContentCoverageEntrySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class ContentCoverageEntry implements Cloneable, Serializable {
+
+	public static ContentCoverageEntry toDTO(String json) {
+		return ContentCoverageEntrySerDes.toDTO(json);
+	}
+
+	public String getFunnelStageId() {
+		return funnelStageId;
+	}
+
+	public void setFunnelStageId(String funnelStageId) {
+		this.funnelStageId = funnelStageId;
+	}
+
+	public void setFunnelStageId(
+		UnsafeSupplier<String, Exception> funnelStageIdUnsafeSupplier) {
+
+		try {
+			funnelStageId = funnelStageIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String funnelStageId;
+
+	public String getPersonaId() {
+		return personaId;
+	}
+
+	public void setPersonaId(String personaId) {
+		this.personaId = personaId;
+	}
+
+	public void setPersonaId(
+		UnsafeSupplier<String, Exception> personaIdUnsafeSupplier) {
+
+		try {
+			personaId = personaIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String personaId;
+
+	public Long getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		try {
+			totalCount = totalCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalCount;
+
+	@Override
+	public ContentCoverageEntry clone() throws CloneNotSupportedException {
+		return (ContentCoverageEntry)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ContentCoverageEntry)) {
+			return false;
+		}
+
+		ContentCoverageEntry contentCoverageEntry =
+			(ContentCoverageEntry)object;
+
+		return Objects.equals(toString(), contentCoverageEntry.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ContentCoverageEntrySerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1301110973

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/FunnelStage.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/FunnelStage.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.dto.v1_0;
+
+import com.liferay.headless.cmp.client.function.UnsafeSupplier;
+import com.liferay.headless.cmp.client.serdes.v1_0.FunnelStageSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class FunnelStage implements Cloneable, Serializable {
+
+	public static FunnelStage toDTO(String json) {
+		return FunnelStageSerDes.toDTO(json);
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String id;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public FunnelStage clone() throws CloneNotSupportedException {
+		return (FunnelStage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof FunnelStage)) {
+			return false;
+		}
+
+		FunnelStage funnelStage = (FunnelStage)object;
+
+		return Objects.equals(toString(), funnelStage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return FunnelStageSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1656259707

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/Persona.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/dto/v1_0/Persona.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.dto.v1_0;
+
+import com.liferay.headless.cmp.client.function.UnsafeSupplier;
+import com.liferay.headless.cmp.client.serdes.v1_0.PersonaSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class Persona implements Cloneable, Serializable {
+
+	public static Persona toDTO(String json) {
+		return PersonaSerDes.toDTO(json);
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<String, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String id;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public Persona clone() throws CloneNotSupportedException {
+		return (Persona)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Persona)) {
+			return false;
+		}
+
+		Persona persona = (Persona)object;
+
+		return Objects.equals(toString(), persona.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PersonaSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1625909049

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/resource/v1_0/ContentCoverageResource.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/resource/v1_0/ContentCoverageResource.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.resource.v1_0;
+
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.client.http.HttpInvoker;
+import com.liferay.headless.cmp.client.problem.Problem;
+import com.liferay.headless.cmp.client.serdes.v1_0.ContentCoverageSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public interface ContentCoverageResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public ContentCoverage getProjectContentCoverage(Long projectId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getProjectContentCoverageHttpResponse(
+			Long projectId)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public ContentCoverageResource build() {
+			return new ContentCoverageResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class ContentCoverageResourceImpl
+		implements ContentCoverageResource {
+
+		public ContentCoverage getProjectContentCoverage(Long projectId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getProjectContentCoverageHttpResponse(projectId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return ContentCoverageSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getProjectContentCoverageHttpResponse(
+				Long projectId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-cmp/v1.0/projects/{projectId}/content-coverage");
+
+			httpInvoker.path("projectId", projectId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private ContentCoverageResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			ContentCoverageResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1287165357

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/ContentCoverageEntrySerDes.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/ContentCoverageEntrySerDes.java
@@ -1,0 +1,270 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.serdes.v1_0;
+
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverageEntry;
+import com.liferay.headless.cmp.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class ContentCoverageEntrySerDes {
+
+	public static ContentCoverageEntry toDTO(String json) {
+		ContentCoverageEntryJSONParser contentCoverageEntryJSONParser =
+			new ContentCoverageEntryJSONParser();
+
+		return contentCoverageEntryJSONParser.parseToDTO(json);
+	}
+
+	public static ContentCoverageEntry[] toDTOs(String json) {
+		ContentCoverageEntryJSONParser contentCoverageEntryJSONParser =
+			new ContentCoverageEntryJSONParser();
+
+		return contentCoverageEntryJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ContentCoverageEntry contentCoverageEntry) {
+		if (contentCoverageEntry == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (contentCoverageEntry.getFunnelStageId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"funnelStageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentCoverageEntry.getFunnelStageId()));
+
+			sb.append("\"");
+		}
+
+		if (contentCoverageEntry.getPersonaId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"personaId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentCoverageEntry.getPersonaId()));
+
+			sb.append("\"");
+		}
+
+		if (contentCoverageEntry.getTotalCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(contentCoverageEntry.getTotalCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ContentCoverageEntryJSONParser contentCoverageEntryJSONParser =
+			new ContentCoverageEntryJSONParser();
+
+		return contentCoverageEntryJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		ContentCoverageEntry contentCoverageEntry) {
+
+		if (contentCoverageEntry == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (contentCoverageEntry.getFunnelStageId() == null) {
+			map.put("funnelStageId", null);
+		}
+		else {
+			map.put(
+				"funnelStageId",
+				String.valueOf(contentCoverageEntry.getFunnelStageId()));
+		}
+
+		if (contentCoverageEntry.getPersonaId() == null) {
+			map.put("personaId", null);
+		}
+		else {
+			map.put(
+				"personaId",
+				String.valueOf(contentCoverageEntry.getPersonaId()));
+		}
+
+		if (contentCoverageEntry.getTotalCount() == null) {
+			map.put("totalCount", null);
+		}
+		else {
+			map.put(
+				"totalCount",
+				String.valueOf(contentCoverageEntry.getTotalCount()));
+		}
+
+		return map;
+	}
+
+	public static class ContentCoverageEntryJSONParser
+		extends BaseJSONParser<ContentCoverageEntry> {
+
+		@Override
+		protected ContentCoverageEntry createDTO() {
+			return new ContentCoverageEntry();
+		}
+
+		@Override
+		protected ContentCoverageEntry[] createDTOArray(int size) {
+			return new ContentCoverageEntry[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "funnelStageId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "personaId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			ContentCoverageEntry contentCoverageEntry,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "funnelStageId")) {
+				if (jsonParserFieldValue != null) {
+					contentCoverageEntry.setFunnelStageId(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "personaId")) {
+				if (jsonParserFieldValue != null) {
+					contentCoverageEntry.setPersonaId(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					contentCoverageEntry.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1218678967

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/ContentCoverageSerDes.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/ContentCoverageSerDes.java
@@ -1,0 +1,359 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.serdes.v1_0;
+
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverageEntry;
+import com.liferay.headless.cmp.client.dto.v1_0.FunnelStage;
+import com.liferay.headless.cmp.client.dto.v1_0.Persona;
+import com.liferay.headless.cmp.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class ContentCoverageSerDes {
+
+	public static ContentCoverage toDTO(String json) {
+		ContentCoverageJSONParser contentCoverageJSONParser =
+			new ContentCoverageJSONParser();
+
+		return contentCoverageJSONParser.parseToDTO(json);
+	}
+
+	public static ContentCoverage[] toDTOs(String json) {
+		ContentCoverageJSONParser contentCoverageJSONParser =
+			new ContentCoverageJSONParser();
+
+		return contentCoverageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ContentCoverage contentCoverage) {
+		if (contentCoverage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (contentCoverage.getContentCoverageEntries() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentCoverageEntries\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < contentCoverage.getContentCoverageEntries().length; i++) {
+
+				sb.append(
+					String.valueOf(
+						contentCoverage.getContentCoverageEntries()[i]));
+
+				if ((i + 1) <
+						contentCoverage.getContentCoverageEntries().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (contentCoverage.getFunnelStages() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"funnelStages\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < contentCoverage.getFunnelStages().length; i++) {
+				sb.append(String.valueOf(contentCoverage.getFunnelStages()[i]));
+
+				if ((i + 1) < contentCoverage.getFunnelStages().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (contentCoverage.getPersonas() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"personas\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < contentCoverage.getPersonas().length; i++) {
+				sb.append(String.valueOf(contentCoverage.getPersonas()[i]));
+
+				if ((i + 1) < contentCoverage.getPersonas().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (contentCoverage.getTotalAssetCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalAssetCount\": ");
+
+			sb.append(contentCoverage.getTotalAssetCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ContentCoverageJSONParser contentCoverageJSONParser =
+			new ContentCoverageJSONParser();
+
+		return contentCoverageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(ContentCoverage contentCoverage) {
+		if (contentCoverage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (contentCoverage.getContentCoverageEntries() == null) {
+			map.put("contentCoverageEntries", null);
+		}
+		else {
+			map.put(
+				"contentCoverageEntries",
+				String.valueOf(contentCoverage.getContentCoverageEntries()));
+		}
+
+		if (contentCoverage.getFunnelStages() == null) {
+			map.put("funnelStages", null);
+		}
+		else {
+			map.put(
+				"funnelStages",
+				String.valueOf(contentCoverage.getFunnelStages()));
+		}
+
+		if (contentCoverage.getPersonas() == null) {
+			map.put("personas", null);
+		}
+		else {
+			map.put("personas", String.valueOf(contentCoverage.getPersonas()));
+		}
+
+		if (contentCoverage.getTotalAssetCount() == null) {
+			map.put("totalAssetCount", null);
+		}
+		else {
+			map.put(
+				"totalAssetCount",
+				String.valueOf(contentCoverage.getTotalAssetCount()));
+		}
+
+		return map;
+	}
+
+	public static class ContentCoverageJSONParser
+		extends BaseJSONParser<ContentCoverage> {
+
+		@Override
+		protected ContentCoverage createDTO() {
+			return new ContentCoverage();
+		}
+
+		@Override
+		protected ContentCoverage[] createDTOArray(int size) {
+			return new ContentCoverage[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "contentCoverageEntries")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "funnelStages")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "personas")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalAssetCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			ContentCoverage contentCoverage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "contentCoverageEntries")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					ContentCoverageEntry[] contentCoverageEntriesArray =
+						new ContentCoverageEntry[jsonParserFieldValues.length];
+
+					for (int i = 0; i < contentCoverageEntriesArray.length;
+						 i++) {
+
+						contentCoverageEntriesArray[i] =
+							ContentCoverageEntrySerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					contentCoverage.setContentCoverageEntries(
+						contentCoverageEntriesArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "funnelStages")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					FunnelStage[] funnelStagesArray =
+						new FunnelStage[jsonParserFieldValues.length];
+
+					for (int i = 0; i < funnelStagesArray.length; i++) {
+						funnelStagesArray[i] = FunnelStageSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					contentCoverage.setFunnelStages(funnelStagesArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "personas")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					Persona[] personasArray =
+						new Persona[jsonParserFieldValues.length];
+
+					for (int i = 0; i < personasArray.length; i++) {
+						personasArray[i] = PersonaSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					contentCoverage.setPersonas(personasArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalAssetCount")) {
+				if (jsonParserFieldValue != null) {
+					contentCoverage.setTotalAssetCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:130357898

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/FunnelStageSerDes.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/FunnelStageSerDes.java
@@ -1,0 +1,300 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.serdes.v1_0;
+
+import com.liferay.headless.cmp.client.dto.v1_0.FunnelStage;
+import com.liferay.headless.cmp.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class FunnelStageSerDes {
+
+	public static FunnelStage toDTO(String json) {
+		FunnelStageJSONParser funnelStageJSONParser =
+			new FunnelStageJSONParser();
+
+		return funnelStageJSONParser.parseToDTO(json);
+	}
+
+	public static FunnelStage[] toDTOs(String json) {
+		FunnelStageJSONParser funnelStageJSONParser =
+			new FunnelStageJSONParser();
+
+		return funnelStageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(FunnelStage funnelStage) {
+		if (funnelStage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (funnelStage.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(funnelStage.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (funnelStage.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(funnelStage.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (funnelStage.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(funnelStage.getId()));
+
+			sb.append("\"");
+		}
+
+		if (funnelStage.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(funnelStage.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		FunnelStageJSONParser funnelStageJSONParser =
+			new FunnelStageJSONParser();
+
+		return funnelStageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(FunnelStage funnelStage) {
+		if (funnelStage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (funnelStage.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put(
+				"description", String.valueOf(funnelStage.getDescription()));
+		}
+
+		if (funnelStage.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(funnelStage.getExternalReferenceCode()));
+		}
+
+		if (funnelStage.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(funnelStage.getId()));
+		}
+
+		if (funnelStage.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(funnelStage.getName()));
+		}
+
+		return map;
+	}
+
+	public static class FunnelStageJSONParser
+		extends BaseJSONParser<FunnelStage> {
+
+		@Override
+		protected FunnelStage createDTO() {
+			return new FunnelStage();
+		}
+
+		@Override
+		protected FunnelStage[] createDTOArray(int size) {
+			return new FunnelStage[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			FunnelStage funnelStage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					funnelStage.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					funnelStage.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					funnelStage.setId((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					funnelStage.setName((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:2032640535

--- a/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/PersonaSerDes.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-client/src/main/java/com/liferay/headless/cmp/client/serdes/v1_0/PersonaSerDes.java
@@ -1,0 +1,295 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.client.serdes.v1_0;
+
+import com.liferay.headless.cmp.client.dto.v1_0.Persona;
+import com.liferay.headless.cmp.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public class PersonaSerDes {
+
+	public static Persona toDTO(String json) {
+		PersonaJSONParser personaJSONParser = new PersonaJSONParser();
+
+		return personaJSONParser.parseToDTO(json);
+	}
+
+	public static Persona[] toDTOs(String json) {
+		PersonaJSONParser personaJSONParser = new PersonaJSONParser();
+
+		return personaJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Persona persona) {
+		if (persona == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (persona.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(persona.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (persona.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(persona.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (persona.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(persona.getId()));
+
+			sb.append("\"");
+		}
+
+		if (persona.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(persona.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PersonaJSONParser personaJSONParser = new PersonaJSONParser();
+
+		return personaJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Persona persona) {
+		if (persona == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (persona.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put("description", String.valueOf(persona.getDescription()));
+		}
+
+		if (persona.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(persona.getExternalReferenceCode()));
+		}
+
+		if (persona.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(persona.getId()));
+		}
+
+		if (persona.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(persona.getName()));
+		}
+
+		return map;
+	}
+
+	public static class PersonaJSONParser extends BaseJSONParser<Persona> {
+
+		@Override
+		protected Persona createDTO() {
+			return new Persona();
+		}
+
+		@Override
+		protected Persona[] createDTOArray(int size) {
+			return new Persona[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Persona persona, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					persona.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					persona.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					persona.setId((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					persona.setName((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1516077167

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/rest-openapi.yaml
@@ -1,5 +1,66 @@
 components:
     schemas:
+        ContentCoverage:
+            properties:
+                contentCoverageEntries:
+                    items:
+                        $ref: "#/components/schemas/ContentCoverageEntry"
+                    readOnly: true
+                    type: array
+                funnelStages:
+                    items:
+                        $ref: "#/components/schemas/FunnelStage"
+                    readOnly: true
+                    type: array
+                personas:
+                    items:
+                        $ref: "#/components/schemas/Persona"
+                    readOnly: true
+                    type: array
+                totalAssetCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
+        ContentCoverageEntry:
+            properties:
+                funnelStageId:
+                    readOnly: true
+                    type: string
+                personaId:
+                    readOnly: true
+                    type: string
+                totalCount:
+                    format: int64
+                    readOnly: true
+                    type: integer
+        FunnelStage:
+            properties:
+                description:
+                    readOnly: true
+                    type: string
+                externalReferenceCode:
+                    readOnly: true
+                    type: string
+                id:
+                    readOnly: true
+                    type: string
+                name:
+                    readOnly: true
+                    type: string
+        Persona:
+            properties:
+                description:
+                    readOnly: true
+                    type: string
+                externalReferenceCode:
+                    readOnly: true
+                    type: string
+                id:
+                    readOnly: true
+                    type: string
+                name:
+                    readOnly: true
+                    type: string
         TaskAssignee:
             properties:
                 externalReferenceCode:
@@ -43,6 +104,26 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/projects/{projectId}/content-coverage":
+        get:
+            operationId: getProjectContentCoverage
+            parameters:
+                -   in: path
+                    name: projectId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ContentCoverage"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/ContentCoverage"
+            tags: ["ContentCoverage"]
     "/projects/{projectId}/task-statistics":
         get:
             operationId: getProjectTaskStatistics

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/graphql/query/v1_0/Query.java
@@ -5,8 +5,10 @@
 
 package com.liferay.headless.cmp.internal.graphql.query.v1_0;
 
+import com.liferay.headless.cmp.dto.v1_0.ContentCoverage;
 import com.liferay.headless.cmp.dto.v1_0.TaskAssignee;
 import com.liferay.headless.cmp.dto.v1_0.TaskStatistics;
+import com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource;
 import com.liferay.headless.cmp.resource.v1_0.TaskAssigneeResource;
 import com.liferay.headless.cmp.resource.v1_0.TaskStatisticsResource;
 import com.liferay.petra.function.UnsafeConsumer;
@@ -39,6 +41,14 @@ import org.osgi.service.component.ComponentServiceObjects;
 @Generated("")
 public class Query {
 
+	public static void setContentCoverageResourceComponentServiceObjects(
+		ComponentServiceObjects<ContentCoverageResource>
+			contentCoverageResourceComponentServiceObjects) {
+
+		_contentCoverageResourceComponentServiceObjects =
+			contentCoverageResourceComponentServiceObjects;
+	}
+
 	public static void setTaskAssigneeResourceComponentServiceObjects(
 		ComponentServiceObjects<TaskAssigneeResource>
 			taskAssigneeResourceComponentServiceObjects) {
@@ -53,6 +63,23 @@ public class Query {
 
 		_taskStatisticsResourceComponentServiceObjects =
 			taskStatisticsResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {projectContentCoverage(projectId: ___){contentCoverageEntries, funnelStages, personas, totalAssetCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public ContentCoverage projectContentCoverage(
+			@GraphQLName("projectId") Long projectId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_contentCoverageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			contentCoverageResource ->
+				contentCoverageResource.getProjectContentCoverage(projectId));
 	}
 
 	/**
@@ -109,6 +136,39 @@ public class Query {
 			this::_populateResourceContext,
 			taskStatisticsResource -> taskStatisticsResource.getTaskStatistics(
 				_filterBiFunction.apply(taskStatisticsResource, filterString)));
+	}
+
+	@GraphQLName("ContentCoveragePage")
+	public class ContentCoveragePage {
+
+		public ContentCoveragePage(Page contentCoveragePage) {
+			actions = contentCoveragePage.getActions();
+
+			items = contentCoveragePage.getItems();
+			lastPage = contentCoveragePage.getLastPage();
+			page = contentCoveragePage.getPage();
+			pageSize = contentCoveragePage.getPageSize();
+			totalCount = contentCoveragePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<ContentCoverage> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
 	}
 
 	@GraphQLName("TaskAssigneePage")
@@ -197,6 +257,26 @@ public class Query {
 	}
 
 	private void _populateResourceContext(
+			ContentCoverageResource contentCoverageResource)
+		throws Exception {
+
+		contentCoverageResource.setContextAcceptLanguage(_acceptLanguage);
+		contentCoverageResource.setContextCompany(_company);
+		contentCoverageResource.setContextHttpServletRequest(
+			_httpServletRequest);
+		contentCoverageResource.setContextHttpServletResponse(
+			_httpServletResponse);
+		contentCoverageResource.setContextUriInfo(_uriInfo);
+		contentCoverageResource.setContextUser(_user);
+		contentCoverageResource.setGroupLocalService(_groupLocalService);
+		contentCoverageResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		contentCoverageResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		contentCoverageResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private void _populateResourceContext(
 			TaskAssigneeResource taskAssigneeResource)
 		throws Exception {
 
@@ -235,6 +315,8 @@ public class Query {
 		taskStatisticsResource.setRoleLocalService(_roleLocalService);
 	}
 
+	private static ComponentServiceObjects<ContentCoverageResource>
+		_contentCoverageResourceComponentServiceObjects;
 	private static ComponentServiceObjects<TaskAssigneeResource>
 		_taskAssigneeResourceComponentServiceObjects;
 	private static ComponentServiceObjects<TaskStatisticsResource>
@@ -257,4 +339,4 @@ public class Query {
 	private com.liferay.portal.kernel.model.User _user;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-364237438
+// LIFERAY-REST-BUILDER-HASH:-901392475

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -7,8 +7,10 @@ package com.liferay.headless.cmp.internal.graphql.servlet.v1_0;
 
 import com.liferay.headless.cmp.internal.graphql.mutation.v1_0.Mutation;
 import com.liferay.headless.cmp.internal.graphql.query.v1_0.Query;
+import com.liferay.headless.cmp.internal.resource.v1_0.ContentCoverageResourceImpl;
 import com.liferay.headless.cmp.internal.resource.v1_0.TaskAssigneeResourceImpl;
 import com.liferay.headless.cmp.internal.resource.v1_0.TaskStatisticsResourceImpl;
+import com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource;
 import com.liferay.headless.cmp.resource.v1_0.TaskAssigneeResource;
 import com.liferay.headless.cmp.resource.v1_0.TaskStatisticsResource;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -36,6 +38,8 @@ public class ServletDataImpl implements ServletData {
 
 	@Activate
 	public void activate(BundleContext bundleContext) {
+		Query.setContentCoverageResourceComponentServiceObjects(
+			_contentCoverageResourceComponentServiceObjects);
 		Query.setTaskAssigneeResourceComponentServiceObjects(
 			_taskAssigneeResourceComponentServiceObjects);
 		Query.setTaskStatisticsResourceComponentServiceObjects(
@@ -77,6 +81,11 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"query#projectContentCoverage",
+						new ObjectValuePair<>(
+							ContentCoverageResourceImpl.class,
+							"getProjectContentCoverage"));
+					put(
 						"query#taskAssignees",
 						new ObjectValuePair<>(
 							TaskAssigneeResourceImpl.class,
@@ -95,6 +104,10 @@ public class ServletDataImpl implements ServletData {
 			};
 
 	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<ContentCoverageResource>
+		_contentCoverageResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
 	private ComponentServiceObjects<TaskAssigneeResource>
 		_taskAssigneeResourceComponentServiceObjects;
 
@@ -103,4 +116,4 @@ public class ServletDataImpl implements ServletData {
 		_taskStatisticsResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1438817288
+// LIFERAY-REST-BUILDER-HASH:-544864076

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/BaseContentCoverageResourceImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/BaseContentCoverageResourceImpl.java
@@ -1,0 +1,522 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.internal.resource.v1_0;
+
+import com.liferay.headless.cmp.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseContentCoverageResourceImpl
+	implements ContentCoverageResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-cmp/v1.0/projects/{projectId}/content-coverage'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "projectId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "ContentCoverage")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/projects/{projectId}/content-coverage")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public ContentCoverage getProjectContentCoverage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("projectId")
+			Long projectId)
+		throws Exception {
+
+		return new ContentCoverage();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-cmp";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseContentCoverageResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:1679994135

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/ContentCoverageResourceImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/ContentCoverageResourceImpl.java
@@ -1,0 +1,297 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.internal.resource.v1_0;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.headless.cmp.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.dto.v1_0.ContentCoverageEntry;
+import com.liferay.headless.cmp.dto.v1_0.FunnelStage;
+import com.liferay.headless.cmp.dto.v1_0.Persona;
+import com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.aggregation.Aggregations;
+import com.liferay.portal.search.aggregation.bucket.Bucket;
+import com.liferay.portal.search.aggregation.bucket.FiltersAggregation;
+import com.liferay.portal.search.aggregation.bucket.FiltersAggregationResult;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.QueriesUtil;
+import com.liferay.portal.search.query.TermsQuery;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.site.cms.site.initializer.constants.CMSWorkflowConstants;
+import com.liferay.site.cms.site.initializer.util.AssetTagUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/content-coverage.properties",
+	scope = ServiceScope.PROTOTYPE, service = ContentCoverageResource.class
+)
+public class ContentCoverageResourceImpl
+	extends BaseContentCoverageResourceImpl {
+
+	@Override
+	public ContentCoverage getProjectContentCoverage(Long projectId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-58677")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			projectId);
+
+		Set<String> assetTagNames = AssetTagUtil.getRelatedAssetTagNames(
+			_assetTagLocalService, _objectDefinitionLocalService, objectEntry,
+			_objectEntryLocalService,
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByExternalReferenceCode(
+					"L_CMP_PROJECT_TO_L_CMP_TASKS",
+					objectEntry.getObjectDefinitionId()));
+
+		List<AssetCategory> assetCategories =
+			_assetCategoryLocalService.getCategories(
+				objectEntry.getModelClassName(), projectId);
+
+		List<AssetCategory> funnelStageAssetCategories = _getAssetCategories(
+			assetCategories, "L_CMP_FUNNEL_STAGE");
+
+		List<AssetCategory> personaAssetCategories = _getAssetCategories(
+			assetCategories, "L_CMP_PERSONAS");
+
+		SearchResponse searchResponse = _search(
+			assetTagNames, funnelStageAssetCategories, personaAssetCategories);
+
+		return new ContentCoverage() {
+			{
+				setContentCoverageEntries(
+					() -> _toContentCoverageEntries(searchResponse));
+				setFunnelStages(
+					() -> transformToArray(
+						funnelStageAssetCategories,
+						assetCategory -> new FunnelStage() {
+							{
+								setDescription(
+									() -> assetCategory.getDescription(
+										contextAcceptLanguage.
+											getPreferredLocale()));
+								setExternalReferenceCode(
+									assetCategory::getExternalReferenceCode);
+								setId(
+									() -> String.valueOf(
+										assetCategory.getCategoryId()));
+								setName(
+									() -> assetCategory.getTitle(
+										contextAcceptLanguage.
+											getPreferredLocale()));
+							}
+						},
+						FunnelStage.class));
+				setPersonas(
+					() -> transformToArray(
+						personaAssetCategories,
+						assetCategory -> new Persona() {
+							{
+								setDescription(
+									() -> assetCategory.getDescription(
+										contextAcceptLanguage.
+											getPreferredLocale()));
+								setExternalReferenceCode(
+									assetCategory::getExternalReferenceCode);
+								setId(
+									() -> String.valueOf(
+										assetCategory.getCategoryId()));
+								setName(
+									() -> assetCategory.getTitle(
+										contextAcceptLanguage.
+											getPreferredLocale()));
+							}
+						},
+						Persona.class));
+				setTotalAssetCount(searchResponse::getCount);
+			}
+		};
+	}
+
+	private FiltersAggregation _createFiltersAggregation(
+		List<AssetCategory> assetCategories, String name) {
+
+		FiltersAggregation filtersAggregation = _aggregations.filters(
+			name, Field.ASSET_INTERNAL_CATEGORY_IDS);
+
+		for (AssetCategory assetCategory : assetCategories) {
+			filtersAggregation.addKeyedQuery(
+				String.valueOf(assetCategory.getCategoryId()),
+				QueriesUtil.term(
+					Field.ASSET_INTERNAL_CATEGORY_IDS,
+					assetCategory.getCategoryId()));
+		}
+
+		filtersAggregation.setOtherBucket(true);
+		filtersAggregation.setOtherBucketKey("-1");
+
+		return filtersAggregation;
+	}
+
+	private List<AssetCategory> _getAssetCategories(
+		List<AssetCategory> assetCategories,
+		String vocabularyExternalReferenceCode) {
+
+		return ListUtil.filter(
+			assetCategories,
+			assetCategory -> StringUtil.startsWith(
+				assetCategory.getExternalReferenceCode(),
+				vocabularyExternalReferenceCode));
+	}
+
+	private SearchResponse _search(
+		Set<String> assetTagNames,
+		List<AssetCategory> funnelStageAssetCategories,
+		List<AssetCategory> personaAssetCategories) {
+
+		TermsQuery assetTagNamesQuery = QueriesUtil.terms(
+			"assetTagNames.lowercase");
+
+		for (String assetTagName : assetTagNames) {
+			assetTagNamesQuery.addValue(assetTagName);
+		}
+
+		TermsQuery cmsSectionQuery = QueriesUtil.terms("cms_section");
+
+		cmsSectionQuery.addValues("contents", "files");
+
+		TermsQuery statusQuery = QueriesUtil.terms(Field.STATUS);
+
+		statusQuery.addValues(
+			(Object[])ArrayUtil.toStringArray(CMSWorkflowConstants.STATUSES));
+
+		BooleanQuery booleanQuery = QueriesUtil.booleanQuery();
+
+		booleanQuery.addFilterQueryClauses(
+			assetTagNamesQuery, cmsSectionQuery, statusQuery,
+			QueriesUtil.term("rootDescendantNode", false));
+
+		FiltersAggregation filtersAggregation = _createFiltersAggregation(
+			personaAssetCategories, _PERSONAS_AGGREGATION_NAME);
+
+		filtersAggregation.addChildAggregation(
+			_createFiltersAggregation(
+				funnelStageAssetCategories, _FUNNEL_STAGES_AGGREGATION_NAME));
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				contextCompany.getCompanyId()
+			).emptySearchEnabled(
+				true
+			).query(
+				booleanQuery
+			).size(
+				0
+			);
+
+		searchRequestBuilder.addAggregation(filtersAggregation);
+
+		return _searcher.search(searchRequestBuilder.build());
+	}
+
+	private ContentCoverageEntry[] _toContentCoverageEntries(
+		SearchResponse searchResponse) {
+
+		FiltersAggregationResult personasAggregationResult =
+			(FiltersAggregationResult)searchResponse.getAggregationResult(
+				_PERSONAS_AGGREGATION_NAME);
+
+		if (personasAggregationResult == null) {
+			return new ContentCoverageEntry[0];
+		}
+
+		List<ContentCoverageEntry> contentCoverageEntries = new ArrayList<>();
+
+		for (Bucket personaBucket : personasAggregationResult.getBuckets()) {
+			FiltersAggregationResult funnelStagesAggregationResult =
+				(FiltersAggregationResult)
+					personaBucket.getChildAggregationResult(
+						_FUNNEL_STAGES_AGGREGATION_NAME);
+
+			if (funnelStagesAggregationResult == null) {
+				continue;
+			}
+
+			for (Bucket funnelStageBucket :
+					funnelStagesAggregationResult.getBuckets()) {
+
+				if (funnelStageBucket.getDocCount() == 0) {
+					continue;
+				}
+
+				contentCoverageEntries.add(
+					new ContentCoverageEntry() {
+						{
+							setFunnelStageId(funnelStageBucket::getKey);
+							setPersonaId(personaBucket::getKey);
+							setTotalCount(funnelStageBucket::getDocCount);
+						}
+					});
+			}
+		}
+
+		return contentCoverageEntries.toArray(new ContentCoverageEntry[0]);
+	}
+
+	private static final String _FUNNEL_STAGES_AGGREGATION_NAME =
+		"funnelStages";
+
+	private static final String _PERSONAS_AGGREGATION_NAME = "personas";
+
+	@Reference
+	private Aggregations _aggregations;
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -85,6 +85,8 @@ public class OpenAPIResourceImpl {
 
 	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
 		{
+			add(ContentCoverageResourceImpl.class);
+
 			add(TaskAssigneeResourceImpl.class);
 
 			add(TaskStatisticsResourceImpl.class);
@@ -94,4 +96,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-708869429
+// LIFERAY-REST-BUILDER-HASH:-415201948

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/factory/ContentCoverageResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/java/com/liferay/headless/cmp/internal/resource/v1_0/factory/ContentCoverageResourceFactoryImpl.java
@@ -1,0 +1,335 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.internal.resource.v1_0.factory;
+
+import com.liferay.headless.cmp.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-cmp/v1.0/ContentCoverage",
+	service = ContentCoverageResource.Factory.class
+)
+@Generated("")
+public class ContentCoverageResourceFactoryImpl
+	implements ContentCoverageResource.Factory {
+
+	@Override
+	public ContentCoverageResource.Builder create() {
+		return new ContentCoverageResource.Builder() {
+
+			@Override
+			public ContentCoverageResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, ContentCoverageResource>
+					contentCoverageResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_contentCoverageResourceProxyProviderFunction;
+
+				return contentCoverageResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public ContentCoverageResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public ContentCoverageResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public ContentCoverageResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public ContentCoverageResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public ContentCoverageResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public ContentCoverageResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, ContentCoverageResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			ContentCoverageResource.class.getClassLoader(),
+			ContentCoverageResource.class);
+
+		try {
+			Constructor<ContentCoverageResource> constructor =
+				(Constructor<ContentCoverageResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		ContentCoverageResource contentCoverageResource =
+			_componentServiceObjects.getService();
+
+		contentCoverageResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		contentCoverageResource.setContextCompany(company);
+
+		contentCoverageResource.setContextHttpServletRequest(
+			httpServletRequest);
+		contentCoverageResource.setContextHttpServletResponse(
+			httpServletResponse);
+		contentCoverageResource.setContextUriInfo(uriInfo);
+		contentCoverageResource.setContextUser(user);
+		contentCoverageResource.setExpressionConvert(_expressionConvert);
+		contentCoverageResource.setFilterParserProvider(_filterParserProvider);
+		contentCoverageResource.setGroupLocalService(_groupLocalService);
+		contentCoverageResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		contentCoverageResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		contentCoverageResource.setRoleLocalService(_roleLocalService);
+		contentCoverageResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(contentCoverageResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(contentCoverageResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<ContentCoverageResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, ContentCoverageResource>
+				_contentCoverageResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1307990412

--- a/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-coverage.properties
+++ b/modules/apps/headless/headless-cmp/headless-cmp-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/content-coverage.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.cmp.dto.v1_0.ContentCoverage
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.CMP)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseContentCoverageResourceTestCase.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/BaseContentCoverageResourceTestCase.java
@@ -1,0 +1,876 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.client.http.HttpInvoker;
+import com.liferay.headless.cmp.client.pagination.Page;
+import com.liferay.headless.cmp.client.resource.v1_0.ContentCoverageResource;
+import com.liferay.headless.cmp.client.serdes.v1_0.ContentCoverageSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carolina Barbosa
+ * @generated
+ */
+@Generated("")
+public abstract class BaseContentCoverageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_contentCoverageResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		contentCoverageResource = ContentCoverageResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		ContentCoverage contentCoverage1 = randomContentCoverage();
+
+		String json = objectMapper.writeValueAsString(contentCoverage1);
+
+		ContentCoverage contentCoverage2 = ContentCoverageSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(contentCoverage1, contentCoverage2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		ContentCoverage contentCoverage = randomContentCoverage();
+
+		String json1 = objectMapper.writeValueAsString(contentCoverage);
+		String json2 = ContentCoverageSerDes.toJSON(contentCoverage);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		ContentCoverage contentCoverage = randomContentCoverage();
+
+		String json = ContentCoverageSerDes.toJSON(contentCoverage);
+
+		Assert.assertFalse(json.contains(regex));
+
+		contentCoverage = ContentCoverageSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetProjectContentCoverage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetProjectContentCoverage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
+	public void testGraphQLGetProjectContentCoverageNotFound()
+		throws Exception {
+
+		Assert.assertTrue(true);
+	}
+
+	protected void assertContains(
+		ContentCoverage contentCoverage,
+		List<ContentCoverage> contentCoverages) {
+
+		boolean contains = false;
+
+		for (ContentCoverage item : contentCoverages) {
+			if (equals(contentCoverage, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			contentCoverages + " does not contain " + contentCoverage,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		ContentCoverage contentCoverage1, ContentCoverage contentCoverage2) {
+
+		Assert.assertTrue(
+			contentCoverage1 + " does not equal " + contentCoverage2,
+			equals(contentCoverage1, contentCoverage2));
+	}
+
+	protected void assertEquals(
+		List<ContentCoverage> contentCoverages1,
+		List<ContentCoverage> contentCoverages2) {
+
+		Assert.assertEquals(contentCoverages1.size(), contentCoverages2.size());
+
+		for (int i = 0; i < contentCoverages1.size(); i++) {
+			ContentCoverage contentCoverage1 = contentCoverages1.get(i);
+			ContentCoverage contentCoverage2 = contentCoverages2.get(i);
+
+			assertEquals(contentCoverage1, contentCoverage2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<ContentCoverage> contentCoverages1,
+		List<ContentCoverage> contentCoverages2) {
+
+		Assert.assertEquals(contentCoverages1.size(), contentCoverages2.size());
+
+		for (ContentCoverage contentCoverage1 : contentCoverages1) {
+			boolean contains = false;
+
+			for (ContentCoverage contentCoverage2 : contentCoverages2) {
+				if (equals(contentCoverage1, contentCoverage2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				contentCoverages2 + " does not contain " + contentCoverage1,
+				contains);
+		}
+	}
+
+	protected void assertValid(ContentCoverage contentCoverage)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"contentCoverageEntries", additionalAssertFieldName)) {
+
+				if (contentCoverage.getContentCoverageEntries() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("funnelStages", additionalAssertFieldName)) {
+				if (contentCoverage.getFunnelStages() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("personas", additionalAssertFieldName)) {
+				if (contentCoverage.getPersonas() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalAssetCount", additionalAssertFieldName)) {
+				if (contentCoverage.getTotalAssetCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<ContentCoverage> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<ContentCoverage> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<ContentCoverage> contentCoverages =
+			page.getItems();
+
+		int size = contentCoverages.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.cmp.dto.v1_0.ContentCoverage.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		ContentCoverage contentCoverage1, ContentCoverage contentCoverage2) {
+
+		if (contentCoverage1 == contentCoverage2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"contentCoverageEntries", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						contentCoverage1.getContentCoverageEntries(),
+						contentCoverage2.getContentCoverageEntries())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("funnelStages", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						contentCoverage1.getFunnelStages(),
+						contentCoverage2.getFunnelStages())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("personas", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						contentCoverage1.getPersonas(),
+						contentCoverage2.getPersonas())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalAssetCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						contentCoverage1.getTotalAssetCount(),
+						contentCoverage2.getTotalAssetCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_contentCoverageResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_contentCoverageResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		ContentCoverage contentCoverage) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("contentCoverageEntries")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("funnelStages")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("personas")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("totalAssetCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected ContentCoverage randomContentCoverage() throws Exception {
+		return new ContentCoverage() {
+			{
+				totalAssetCount = RandomTestUtil.randomLong();
+			}
+		};
+	}
+
+	protected ContentCoverage randomIrrelevantContentCoverage()
+		throws Exception {
+
+		ContentCoverage randomIrrelevantContentCoverage =
+			randomContentCoverage();
+
+		return randomIrrelevantContentCoverage;
+	}
+
+	protected ContentCoverage randomPatchContentCoverage() throws Exception {
+		return randomContentCoverage();
+	}
+
+	protected ContentCoverageResource contentCoverageResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseContentCoverageResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.cmp.resource.v1_0.ContentCoverageResource
+		_contentCoverageResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1484390313

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
@@ -6,15 +6,262 @@
 package com.liferay.headless.cmp.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverage;
+import com.liferay.headless.cmp.client.dto.v1_0.ContentCoverageEntry;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cmp.site.initializer.test.util.CMPTestUtil;
 
-import org.junit.Ignore;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Carolina Barbosa
+ * @author Fábio Alves
  */
-@Ignore
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-58677")}
+)
 @RunWith(Arquillian.class)
 public class ContentCoverageResourceTest
 	extends BaseContentCoverageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		_group = CMPTestUtil.getOrAddGroup(ContentCoverageResourceTest.class);
+
+		_projectObjectEntry = CMPTestUtil.addProjectObjectEntry();
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		_objectEntryLocalService.deleteObjectEntry(_projectObjectEntry);
+		_depotEntryLocalService.deleteDepotEntry(_depotEntry);
+	}
+
+	@Override
+	@Test
+	public void testGetProjectContentCoverage() throws Exception {
+		AssetCategory funnelStageAssetCategory =
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					"L_CMP_FUNNEL_STAGE_AWARENESS", _group.getGroupId());
+		AssetCategory personaAssetCategory =
+			_assetCategoryLocalService.
+				fetchAssetCategoryByExternalReferenceCode(
+					"L_CMP_PERSONAS_CHAMPION", _group.getGroupId());
+
+		long[] assetCategoryIds = {
+			funnelStageAssetCategory.getCategoryId(),
+			personaAssetCategory.getCategoryId()
+		};
+
+		_partialUpdateObjectEntry(
+			assetCategoryIds, new String[0], _projectObjectEntry);
+
+		String assetTagName = "L_CMP_TASK_" + RandomTestUtil.randomString(10);
+
+		_partialUpdateObjectEntry(
+			new long[0], new String[] {assetTagName},
+			CMPTestUtil.addTaskObjectEntry(_projectObjectEntry));
+
+		_testGetProjectContentCoverage(_toContentCoverage(0L));
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", TestPropsValues.getCompanyId());
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.
+				getObjectEntryFolderByExternalReferenceCode(
+					ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+					_depotEntry.getGroupId(), _depotEntry.getCompanyId());
+
+		_partialUpdateObjectEntry(
+			assetCategoryIds, new String[] {assetTagName},
+			_addObjectEntry(objectDefinition, objectEntryFolder));
+		_partialUpdateObjectEntry(
+			new long[0], new String[] {assetTagName},
+			_addObjectEntry(objectDefinition, objectEntryFolder));
+
+		_testGetProjectContentCoverage(
+			_toContentCoverage(
+				2L,
+				_toContentCoverageEntry(
+					String.valueOf(funnelStageAssetCategory.getCategoryId()),
+					String.valueOf(personaAssetCategory.getCategoryId()), 1L),
+				_toContentCoverageEntry("-1", "-1", 1L)));
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetProjectContentCoverage() {
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetProjectContentCoverageNotFound() {
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"totalAssetCount"};
+	}
+
+	private ObjectEntry _addObjectEntry(
+			ObjectDefinition objectDefinition,
+			ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			_depotEntry.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			objectEntryFolder.getObjectEntryFolderId(), null,
+			HashMapBuilder.<String, Serializable>put(
+				"title_i18n",
+				(Serializable)HashMapBuilder.put(
+					"en_US", RandomTestUtil.randomString()
+				).build()
+			).build(),
+			ServiceContextTestUtil.getServiceContext(_depotEntry.getGroupId()));
+	}
+
+	private void _partialUpdateObjectEntry(
+			long[] assetCategoryIds, String[] assetTagNames,
+			ObjectEntry objectEntry)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(objectEntry.getGroupId());
+
+		serviceContext.setAssetCategoryIds(assetCategoryIds);
+		serviceContext.setAssetTagNames(assetTagNames);
+
+		_objectEntryLocalService.partialUpdateObjectEntry(
+			objectEntry.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(), new HashMap<>(),
+			serviceContext);
+	}
+
+	private void _testGetProjectContentCoverage(
+			ContentCoverage expectedContentCoverage)
+		throws Exception {
+
+		ContentCoverage contentCoverage =
+			contentCoverageResource.getProjectContentCoverage(
+				_projectObjectEntry.getObjectEntryId());
+
+		assertEquals(expectedContentCoverage, contentCoverage);
+
+		Assert.assertEquals(
+			new HashSet<>(
+				Arrays.asList(
+					expectedContentCoverage.getContentCoverageEntries())),
+			new HashSet<>(
+				Arrays.asList(contentCoverage.getContentCoverageEntries())));
+	}
+
+	private ContentCoverage _toContentCoverage(
+		long totalAssetCount, ContentCoverageEntry... contentCoverageEntries) {
+
+		ContentCoverage contentCoverage = new ContentCoverage();
+
+		contentCoverage.setContentCoverageEntries(contentCoverageEntries);
+		contentCoverage.setTotalAssetCount(totalAssetCount);
+
+		return contentCoverage;
+	}
+
+	private ContentCoverageEntry _toContentCoverageEntry(
+		String funnelStageId, String personaId, long totalCount) {
+
+		ContentCoverageEntry contentCoverageEntry = new ContentCoverageEntry();
+
+		contentCoverageEntry.setFunnelStageId(funnelStageId);
+		contentCoverageEntry.setPersonaId(personaId);
+		contentCoverageEntry.setTotalCount(totalCount);
+
+		return contentCoverageEntry;
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	private DepotEntry _depotEntry;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectEntry _projectObjectEntry;
+
 }

--- a/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
+++ b/modules/apps/headless/headless-cmp/headless-cmp-test/src/testIntegration/java/com/liferay/headless/cmp/resource/v1_0/test/ContentCoverageResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.cmp.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Carolina Barbosa
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class ContentCoverageResourceTest
+	extends BaseContentCoverageResourceTestCase {
+}

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/AssetTagUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/AssetTagUtil.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.util;
+
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Fábio Alves
+ */
+public class AssetTagUtil {
+
+	public static Set<String> getAssetTagNames(
+		AssetTagLocalService assetTagLocalService,
+		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
+
+		return SetUtil.fromList(
+			TransformUtil.transform(
+				assetTagLocalService.getTags(
+					objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId()),
+				assetTag -> {
+					if (!StringUtil.startsWith(
+							assetTag.getName(),
+							objectDefinition.getExternalReferenceCode())) {
+
+						return null;
+					}
+
+					return assetTag.getName();
+				}));
+	}
+
+	public static Set<String> getRelatedAssetTagNames(
+			AssetTagLocalService assetTagLocalService,
+			ObjectDefinitionLocalService objectDefinitionLocalService,
+			ObjectEntry objectEntry,
+			ObjectEntryLocalService objectEntryLocalService,
+			ObjectRelationship objectRelationship)
+		throws PortalException {
+
+		Set<String> assetTagNames = new HashSet<>();
+
+		if (objectRelationship == null) {
+			return assetTagNames;
+		}
+
+		for (ObjectEntry relatedObjectEntry :
+				objectEntryLocalService.getOneToManyObjectEntries(
+					objectEntry.getGroupId(),
+					objectRelationship.getObjectRelationshipId(), null, false,
+					objectEntry.getObjectEntryId(), true, null,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			assetTagNames.addAll(
+				getAssetTagNames(
+					assetTagLocalService,
+					objectDefinitionLocalService.fetchObjectDefinition(
+						relatedObjectEntry.getObjectDefinitionId()),
+					relatedObjectEntry));
+		}
+
+		return assetTagNames;
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/BaseRelatedAssetsSectionDisplayContext.java
@@ -23,9 +23,9 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.site.cms.site.initializer.util.AssetTagUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -129,21 +129,8 @@ public abstract class BaseRelatedAssetsSectionDisplayContext
 	protected Set<String> getTagNames(
 		ObjectDefinition objectDefinition, ObjectEntry objectEntry) {
 
-		return SetUtil.fromList(
-			TransformUtil.transform(
-				assetTagLocalService.getTags(
-					objectDefinition.getClassName(),
-					objectEntry.getObjectEntryId()),
-				assetTag -> {
-					if (!StringUtil.startsWith(
-							assetTag.getName(),
-							objectDefinition.getExternalReferenceCode())) {
-
-						return null;
-					}
-
-					return assetTag.getName();
-				}));
+		return AssetTagUtil.getAssetTagNames(
+			assetTagLocalService, objectDefinition, objectEntry);
 	}
 
 	protected final AssetTagLocalService assetTagLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewAllRelatedAssetsSectionDisplayContext.java
@@ -16,7 +16,6 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -24,11 +23,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.site.cms.site.initializer.util.AssetTagUtil;
 import com.liferay.translation.exporter.TranslationInfoItemFieldValuesExporterRegistry;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -97,30 +96,20 @@ public class ViewAllRelatedAssetsSectionDisplayContext
 
 	@Override
 	protected String[] getKeywords() {
-		Set<String> tagNames = new HashSet<>();
-
 		try {
-			for (ObjectEntry relatedObjectEntry :
-					_objectEntryLocalService.getOneToManyObjectEntries(
-						objectEntry.getGroupId(),
-						_objectRelationship.getObjectRelationshipId(), null,
-						false, objectEntry.getObjectEntryId(), true, null,
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+			Set<String> assetTagNames = AssetTagUtil.getRelatedAssetTagNames(
+				assetTagLocalService, _objectDefinitionLocalService,
+				objectEntry, _objectEntryLocalService, _objectRelationship);
 
-				tagNames.addAll(
-					getTagNames(
-						_objectDefinitionLocalService.fetchObjectDefinition(
-							relatedObjectEntry.getObjectDefinitionId()),
-						relatedObjectEntry));
-			}
+			return assetTagNames.toArray(new String[0]);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(portalException);
 			}
-		}
 
-		return tagNames.toArray(new String[0]);
+			return new String[0];
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96935

## What Is Being Fixed

The CMP application had no headless API to report how a project's content is distributed across funnel stages and personas. Clients need a single endpoint returning the funnel stages, personas, and per-combination asset coverage for a given project.

## How It Is Being Fixed

Adds a Content Coverage REST endpoint to the headless-cmp module. The rest-openapi operation exposes ContentCoverage, ContentCoverageEntry, FunnelStage, and Persona DTOs; ContentCoverageResourceImpl resolves the project's asset categories, groups them into funnel stages and personas by vocabulary, and derives coverage entries from the related asset tags. The related-asset-tag logic is extracted into a reusable AssetTagUtil in the site-cms-site-initializer API so the initializer display contexts and the new endpoint share one implementation. An integration test covers the endpoint.

## PR Check

**pr-check: PASS** — tested on `fcee37ffb710b33fbea99c654b9486867c205506`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "fcee37ffb710b33fbea99c654b9486867c205506"} -->
