### PR TITLE
LPD-89588 Follow up - Point ObjectEntryIndexedColumnSize test at v13_0_0

### DIFF
--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_0_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/upgrade/v13_0_0/test/ObjectEntryIndexedColumnSizeUpgradeProcessTest.java
@@ -62,7 +62,7 @@ public class ObjectEntryIndexedColumnSizeUpgradeProcessTest
 
 	@Override
 	protected String getUpgradeProcessClassName() {
-		return "com.liferay.object.internal.upgrade.v12_2_0." +
+		return "com.liferay.object.internal.upgrade.v13_0_0." +
 			"ObjectEntryIndexedColumnSizeUpgradeProcess";
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89588

## What is being fixed

Follow-up to LPD-89588. ObjectEntryIndexedColumnSizeUpgradeProcessTest fails with ArrayIndexOutOfBoundsException because getUpgradeProcessClassName() returns the stale class name com.liferay.object.internal.upgrade.v12_2_0.ObjectEntryIndexedColumnSizeUpgradeProcess. LPD-89588 relocated that upgrade process and the test to v13_0_0 but left the class-name string on the old v12_2_0 path, so the upgrade step registrator finds no match and UpgradeTestUtil.getUpgradeStep()[0] throws on an empty array.

---

## How it is being fixed

Updates getUpgradeProcessClassName() to return com.liferay.object.internal.upgrade.v13_0_0.ObjectEntryIndexedColumnSizeUpgradeProcess. One-line change; the product upgrade process already exists at v13_0_0.

---

## How can it be tested

**Integration test:** com.liferay.object.internal.upgrade.v13_0_0.test.ObjectEntryIndexedColumnSizeUpgradeProcessTest

```bash
cd modules
../gradlew :apps:object:object-test:testIntegration --tests com.liferay.object.internal.upgrade.v13_0_0.test.ObjectEntryIndexedColumnSizeUpgradeProcessTest
```

Both test methods pass. Before this change they fail at getUpgradeStep with ArrayIndexOutOfBoundsException.
