### PR TITLE
LPD-83615 Follow up - expect null message on closed report stream

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/EntryLocalServiceTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-test/src/testIntegration/java/com/liferay/portal/reports/engine/console/service/test/EntryLocalServiceTest.java
@@ -103,7 +103,7 @@ public class EntryLocalServiceTest {
 					FileUtil.exists(fileAttachment.getFileName()));
 
 				AssertUtils.assertFailure(
-					IOException.class, "Stream Closed",
+					IOException.class, null,
 					() -> {
 						InputStream inputStream =
 							fileAttachment.getInputStream();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83615

## What is being fixed

EntryLocalServiceTest.testAddEntry failed consistently after LPD-83615 migrated FileSystemStore.getFileAsStream from FileInputStream to Files.newInputStream. The test asserted that reading the closed report attachment stream throws IOException with the message "Stream Closed", which was the FileInputStream behavior. A closed NIO channel stream throws an IOException with a null message instead, so the assertion failed with expected:<Stream Closed> but was:<null>.

---

## How it is being fixed

Update the assertion to expect a null message while keeping the IOException type check. The test intent (the attachment stream is closed after delivery, so reading it fails) is preserved; only the message expectation, which was coupled to the removed FileInputStream implementation, is dropped.

---

## How can it be tested

**Integration test:** EntryLocalServiceTest.testAddEntry

```bash
cd modules
../gradlew :dxp:apps:portal-reports-engine-console:portal-reports-engine-console-test:testIntegration --tests com.liferay.portal.reports.engine.console.service.test.EntryLocalServiceTest
```

Verifies the report is emailed and its attachment stream is closed afterward (reading it throws IOException).
