### PR TITLE
LPD-98219 Save empty value when the image field JSON is empty

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueRequestParameterRetriever.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueRequestParameterRetriever.java
@@ -7,6 +7,9 @@ package com.liferay.dynamic.data.mapping.form.field.type.internal.image;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldValueRequestParameterRetriever;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -33,16 +36,21 @@ public class ImageDDMFormFieldValueRequestParameterRetriever
 		String parameterValue = httpServletRequest.getParameter(
 			ddmFormFieldParameterName);
 
-		if (!Validator.isBlank(parameterValue)) {
-			parameterValue = String.valueOf(
-				getJSONObject(_log, parameterValue));
+		if (Validator.isBlank(parameterValue)) {
+			if (parameterValue != null) {
+				return parameterValue;
+			}
+
+			return defaultDDMFormFieldParameterValue;
 		}
 
-		if (parameterValue != null) {
-			return parameterValue;
+		JSONObject jsonObject = getJSONObject(_log, parameterValue);
+
+		if (JSONUtil.isEmpty(jsonObject)) {
+			return StringPool.BLANK;
 		}
 
-		return defaultDDMFormFieldParameterValue;
+		return jsonObject.toString();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueRequestParameterRetrieverTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldValueRequestParameterRetrieverTest.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.form.field.type.internal.image;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Victor Kammerer
+ */
+public class ImageDDMFormFieldValueRequestParameterRetrieverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGet() {
+		ImageDDMFormFieldValueRequestParameterRetriever
+			imageDDMFormFieldValueRequestParameterRetriever =
+				new ImageDDMFormFieldValueRequestParameterRetriever();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String ddmFormFieldParameterName = RandomTestUtil.randomString();
+
+		mockHttpServletRequest.setParameter(ddmFormFieldParameterName, "{}");
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			imageDDMFormFieldValueRequestParameterRetriever.get(
+				mockHttpServletRequest, ddmFormFieldParameterName, null));
+
+		JSONObject jsonObject = JSONUtil.put(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		mockHttpServletRequest.setParameter(
+			ddmFormFieldParameterName, jsonObject.toString());
+
+		Assert.assertEquals(
+			jsonObject.toString(),
+			imageDDMFormFieldValueRequestParameterRetriever.get(
+				mockHttpServletRequest, ddmFormFieldParameterName, null));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98219

## What Is Being Fixed

When a structured web content "image" field that previously held a value was cleared, the literal string "{}" was persisted instead of an empty value. A field that was never filled stored an empty value, so the two states diverged and Freemarker checks such as ?has_content behaved inconsistently between them.

## How It Is Being Fixed

ImageDDMFormFieldValueRequestParameterRetriever ran the submitted parameter through getJSONObject and String.valueOf, which serialized an empty JSON object to the literal "{}". It now returns StringPool.BLANK when the parsed JSON object is empty, while preserving the existing default-value fallback for a null parameter. This mirrors the fix already applied to the upload (DocumentLibrary) field in LPD-52965.

## PR Check

**pr-check: PASS** — tested on `d1bb83e828757597be2bae6f1b5b2587ef6bafb2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d1bb83e828757597be2bae6f1b5b2587ef6bafb2"} -->
