### PR TITLE
LPD-97796 Filter related-assets table by persona and funnel stage cell

### DIFF
--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -31,6 +31,14 @@ public class SearchResultEntityModel implements EntityModel {
 			new BooleanEntityField(
 				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
+				new IntegerEntityField(
+					"cmpFunnelStageCategoryIds",
+					locale -> Field.ASSET_INTERNAL_CATEGORY_IDS)),
+			new CollectionEntityField(
+				new IntegerEntityField(
+					"cmpPersonaCategoryIds",
+					locale -> Field.ASSET_INTERNAL_CATEGORY_IDS)),
+			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(
 				new IntegerEntityField(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/AssetCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/AssetCategorySelectionFDSFilter.java
@@ -7,27 +7,15 @@ package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
 
 import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetCategoryLocalService;
-import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
-import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
-import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marco Leo
@@ -47,12 +35,8 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = FDSFilter.class
 )
-public class AssetCategorySelectionFDSFilter extends BaseSelectionFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.INTEGER;
-	}
+public class AssetCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
 
 	@Override
 	public String getId() {
@@ -65,57 +49,20 @@ public class AssetCategorySelectionFDSFilter extends BaseSelectionFDSFilter {
 	}
 
 	@Override
-	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale) {
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId)
+		throws PortalException {
 
-		Group group = _groupLocalService.fetchGroup(
-			CompanyThreadLocal.getCompanyId(), GroupConstants.CMS);
-
-		if (group == null) {
-			return Collections.emptyList();
-		}
-
-		try {
-			List<SelectionFDSFilterItem> selectionFDSFilterItems =
-				new ArrayList<>();
-
-			for (AssetVocabulary assetVocabulary :
-					_assetVocabularyLocalService.getGroupVocabularies(
-						group.getGroupId())) {
-
-				for (AssetCategory assetCategory :
-						_assetCategoryLocalService.getVocabularyCategories(
-							assetVocabulary.getVocabularyId(),
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
-
-					selectionFDSFilterItems.add(
-						new SelectionFDSFilterItem(
-							StringBundler.concat(
-								assetCategory.getTitle(locale), " (",
-								assetVocabulary.getTitle(locale), ")"),
-							assetCategory.getCategoryId()));
-				}
-			}
-
-			return selectionFDSFilterItems;
-		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
+		return assetVocabularyLocalService.getGroupVocabularies(groupId);
 	}
 
 	@Override
-	public boolean isAutocompleteEnabled() {
-		return true;
+	protected String getSelectionFDSFilterItemLabel(
+		AssetCategory assetCategory, AssetVocabulary assetVocabulary,
+		Locale locale) {
+
+		return StringBundler.concat(
+			assetCategory.getTitle(locale), " (",
+			assetVocabulary.getTitle(locale), ")");
 	}
-
-	@Reference
-	private AssetCategoryLocalService _assetCategoryLocalService;
-
-	@Reference
-	private AssetVocabularyLocalService _assetVocabularyLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilter.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marco Leo
+ * @author Roberto Díaz
+ * @author Fábio Alves
+ */
+public abstract class BaseCategorySelectionFDSFilter
+	extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.INTEGER;
+	}
+
+	@Override
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+
+		Group group = groupLocalService.fetchGroup(
+			CompanyThreadLocal.getCompanyId(), GroupConstants.CMS);
+
+		if (group == null) {
+			return Collections.emptyList();
+		}
+
+		try {
+			List<SelectionFDSFilterItem> selectionFDSFilterItems =
+				new ArrayList<>();
+
+			for (AssetVocabulary assetVocabulary :
+					getAssetVocabularies(group.getGroupId())) {
+
+				for (AssetCategory assetCategory :
+						assetCategoryLocalService.getVocabularyCategories(
+							assetVocabulary.getVocabularyId(),
+							QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+					selectionFDSFilterItems.add(
+						new SelectionFDSFilterItem(
+							getSelectionFDSFilterItemLabel(
+								assetCategory, assetVocabulary, locale),
+							assetCategory.getCategoryId()));
+				}
+			}
+
+			return selectionFDSFilterItems;
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
+	@Override
+	public boolean isAutocompleteEnabled() {
+		return true;
+	}
+
+	protected abstract List<AssetVocabulary> getAssetVocabularies(long groupId)
+		throws PortalException;
+
+	protected List<AssetVocabulary> getAssetVocabularies(
+		String assetVocabularyExternalReferenceCode, long groupId) {
+
+		AssetVocabulary assetVocabulary =
+			assetVocabularyLocalService.
+				fetchAssetVocabularyByExternalReferenceCode(
+					assetVocabularyExternalReferenceCode, groupId);
+
+		if (assetVocabulary == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(assetVocabulary);
+	}
+
+	protected String getSelectionFDSFilterItemLabel(
+		AssetCategory assetCategory, AssetVocabulary assetVocabulary,
+		Locale locale) {
+
+		return assetCategory.getTitle(locale);
+	}
+
+	@Reference
+	protected AssetCategoryLocalService assetCategoryLocalService;
+
+	@Reference
+	protected AssetVocabularyLocalService assetVocabularyLocalService;
+
+	@Reference
+	protected GroupLocalService groupLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilter.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_RELATED_ASSETS_SECTION,
+		"service.ranking:Integer=99"
+	},
+	service = FDSFilter.class
+)
+public class FunnelStageCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "cmpFunnelStageCategoryIds";
+	}
+
+	@Override
+	public String getLabel() {
+		return "funnel-stage";
+	}
+
+	@Override
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId) {
+		return getAssetVocabularies("L_CMP_FUNNEL_STAGE", groupId);
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilter.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.frontend.data.set.filter.FDSFilter;
+import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Fábio Alves
+ */
+@Component(
+	property = {
+		"frontend.data.set.name=" + CMSSiteInitializerFDSNames.ALL_RELATED_ASSETS_SECTION,
+		"service.ranking:Integer=99"
+	},
+	service = FDSFilter.class
+)
+public class PersonaCategorySelectionFDSFilter
+	extends BaseCategorySelectionFDSFilter {
+
+	@Override
+	public String getId() {
+		return "cmpPersonaCategoryIds";
+	}
+
+	@Override
+	public String getLabel() {
+		return "persona";
+	}
+
+	@Override
+	protected List<AssetVocabulary> getAssetVocabularies(long groupId) {
+		return getAssetVocabularies("L_CMP_PERSONAS", groupId);
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilterTestCase.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseCategorySelectionFDSFilterTestCase.java
@@ -1,0 +1,163 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Fábio Alves
+ */
+public abstract class BaseCategorySelectionFDSFilterTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		_baseCategorySelectionFDSFilter = getCategorySelectionFDSFilter();
+
+		_setUpAssetCategoryLocalService();
+		_setUpAssetVocabularyLocalService();
+		_setUpGroupLocalService();
+	}
+
+	@Test
+	public void testGetSelectionFDSFilterItems() {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_COMPANY_ID)) {
+
+			List<SelectionFDSFilterItem> selectionFDSFilterItems =
+				_baseCategorySelectionFDSFilter.getSelectionFDSFilterItems(
+					_locale);
+
+			Assert.assertEquals(
+				selectionFDSFilterItems.toString(), 1,
+				selectionFDSFilterItems.size());
+
+			SelectionFDSFilterItem selectionFDSFilterItem =
+				selectionFDSFilterItems.get(0);
+
+			Assert.assertEquals(
+				_ASSET_CATEGORY_TITLE, selectionFDSFilterItem.getLabel());
+			Assert.assertEquals(
+				_ASSET_CATEGORY_ID, selectionFDSFilterItem.getValue());
+		}
+	}
+
+	protected abstract String getAssetVocabularyExternalReferenceCode();
+
+	protected abstract BaseCategorySelectionFDSFilter
+		getCategorySelectionFDSFilter();
+
+	private void _setUpAssetCategoryLocalService() {
+		Mockito.when(
+			_assetCategory.getCategoryId()
+		).thenReturn(
+			_ASSET_CATEGORY_ID
+		);
+
+		Mockito.when(
+			_assetCategory.getTitle(_locale)
+		).thenReturn(
+			_ASSET_CATEGORY_TITLE
+		);
+
+		Mockito.when(
+			_assetCategoryLocalService.getVocabularyCategories(
+				Mockito.eq(_ASSET_VOCABULARY_ID), Mockito.anyInt(),
+				Mockito.anyInt(), Mockito.any())
+		).thenReturn(
+			List.of(_assetCategory)
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_baseCategorySelectionFDSFilter, "assetCategoryLocalService",
+			_assetCategoryLocalService);
+	}
+
+	private void _setUpAssetVocabularyLocalService() {
+		Mockito.when(
+			_assetVocabulary.getVocabularyId()
+		).thenReturn(
+			_ASSET_VOCABULARY_ID
+		);
+
+		Mockito.when(
+			_assetVocabularyLocalService.
+				fetchAssetVocabularyByExternalReferenceCode(
+					getAssetVocabularyExternalReferenceCode(), _GROUP_ID)
+		).thenReturn(
+			_assetVocabulary
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_baseCategorySelectionFDSFilter, "assetVocabularyLocalService",
+			_assetVocabularyLocalService);
+	}
+
+	private void _setUpGroupLocalService() {
+		Mockito.when(
+			_group.getGroupId()
+		).thenReturn(
+			_GROUP_ID
+		);
+
+		Mockito.when(
+			_groupLocalService.fetchGroup(_COMPANY_ID, GroupConstants.CMS)
+		).thenReturn(
+			_group
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_baseCategorySelectionFDSFilter, "groupLocalService",
+			_groupLocalService);
+	}
+
+	private static final long _ASSET_CATEGORY_ID = RandomTestUtil.randomLong();
+
+	private static final String _ASSET_CATEGORY_TITLE =
+		RandomTestUtil.randomString();
+
+	private static final long _ASSET_VOCABULARY_ID =
+		RandomTestUtil.randomLong();
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	private final AssetCategory _assetCategory = Mockito.mock(
+		AssetCategory.class);
+	private final AssetCategoryLocalService _assetCategoryLocalService =
+		Mockito.mock(AssetCategoryLocalService.class);
+	private final AssetVocabulary _assetVocabulary = Mockito.mock(
+		AssetVocabulary.class);
+	private final AssetVocabularyLocalService _assetVocabularyLocalService =
+		Mockito.mock(AssetVocabularyLocalService.class);
+	private BaseCategorySelectionFDSFilter _baseCategorySelectionFDSFilter;
+	private final Group _group = Mockito.mock(Group.class);
+	private final GroupLocalService _groupLocalService = Mockito.mock(
+		GroupLocalService.class);
+	private final Locale _locale = LocaleUtil.US;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/FunnelStageCategorySelectionFDSFilterTest.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Fábio Alves
+ */
+public class FunnelStageCategorySelectionFDSFilterTest
+	extends BaseCategorySelectionFDSFilterTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetProperties() {
+		Assert.assertEquals(
+			FDSEntityFieldTypes.INTEGER,
+			_funnelStageCategorySelectionFDSFilter.getEntityFieldType());
+		Assert.assertEquals(
+			"cmpFunnelStageCategoryIds",
+			_funnelStageCategorySelectionFDSFilter.getId());
+		Assert.assertEquals(
+			"funnel-stage", _funnelStageCategorySelectionFDSFilter.getLabel());
+	}
+
+	@Override
+	protected String getAssetVocabularyExternalReferenceCode() {
+		return "L_CMP_FUNNEL_STAGE";
+	}
+
+	@Override
+	protected BaseCategorySelectionFDSFilter getCategorySelectionFDSFilter() {
+		return _funnelStageCategorySelectionFDSFilter;
+	}
+
+	private final FunnelStageCategorySelectionFDSFilter
+		_funnelStageCategorySelectionFDSFilter =
+			new FunnelStageCategorySelectionFDSFilter();
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilterTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/PersonaCategorySelectionFDSFilterTest.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.frontend.data.set.filter;
+
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Fábio Alves
+ */
+public class PersonaCategorySelectionFDSFilterTest
+	extends BaseCategorySelectionFDSFilterTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetProperties() {
+		Assert.assertEquals(
+			FDSEntityFieldTypes.INTEGER,
+			_personaCategorySelectionFDSFilter.getEntityFieldType());
+		Assert.assertEquals(
+			"cmpPersonaCategoryIds",
+			_personaCategorySelectionFDSFilter.getId());
+		Assert.assertEquals(
+			"persona", _personaCategorySelectionFDSFilter.getLabel());
+	}
+
+	@Override
+	protected String getAssetVocabularyExternalReferenceCode() {
+		return "L_CMP_PERSONAS";
+	}
+
+	@Override
+	protected BaseCategorySelectionFDSFilter getCategorySelectionFDSFilter() {
+		return _personaCategorySelectionFDSFilter;
+	}
+
+	private final PersonaCategorySelectionFDSFilter
+		_personaCategorySelectionFDSFilter =
+			new PersonaCategorySelectionFDSFilter();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97796

## What Is Being Fixed

The related-assets table in the CMS site initializer could not be filtered by Persona or Funnel Stage matrix cell. The existing category-selection filters also duplicated the group/vocabulary/category lookup logic with no shared base.

## How It Is Being Fixed

Adds BaseCategorySelectionFDSFilter to centralize the group, vocabulary, and category lookup and the filter-item building. AssetCategorySelectionFDSFilter is refactored onto this base, and two new filters — PersonaCategorySelectionFDSFilter and FunnelStageCategorySelectionFDSFilter — extend it, resolving their vocabularies by external reference code (L_CMP_PERSONAS, L_CMP_FUNNEL_STAGE). SearchResultEntityModel exposes cmpPersonaCategoryIds and cmpFunnelStageCategoryIds as filterable integer collection fields backed by the asset internal category ids, enabling OData filtering of the table by those cells. Unit tests cover both new filters.

## PR Check

**pr-check: PASS** — tested on `3a3b04af84c87c4924cafafacb75ea2c9e2e0943`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3a3b04af84c87c4924cafafacb75ea2c9e2e0943"} -->
