### PR TITLE
LPD-80025 Include user group members in the members selection filter

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectsSectionDisplayContext.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/display/context/ViewProjectsSectionDisplayContext.java
@@ -25,6 +25,7 @@ import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.S
 import com.liferay.site.cmp.site.initializer.internal.frontend.data.set.filter.TagSelectionFDSFilter;
 import com.liferay.site.cmp.site.initializer.internal.util.ActionUtil;
 import com.liferay.site.cmp.site.initializer.internal.util.ObjectEntryUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDepotEntryGroupUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -48,6 +49,12 @@ public class ViewProjectsSectionDisplayContext
 
 		_assetTagLocalService = assetTagLocalService;
 		_depotEntryLocalService = depotEntryLocalService;
+	}
+
+	public Map<String, Object> getAdditionalProps() {
+		return HashMapBuilder.<String, Object>put(
+			"filter", CMSDepotEntryGroupUtil.getFilterString()
+		).build();
 	}
 
 	public String getAPIURL() {

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/js/components/props_transformer/ProjectsFDSPropsTransformer.tsx
@@ -165,6 +165,7 @@ export default function ProjectsFDSPropsTransformer({
 				manageMembersAction({
 					assetLibraryCreatorUserId: creatorUserId,
 					externalReferenceCode: scopeExternalReferenceCode,
+					filter: additionalProps?.filter,
 					hasAssignMembersPermission: 'assign-members' in actions,
 					title: Liferay.Language.get('all-members'),
 				});

--- a/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/view_projects.jsp
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/resources/META-INF/resources/view_projects.jsp
@@ -13,6 +13,7 @@ ViewProjectsSectionDisplayContext viewProjectsSectionDisplayContext = (ViewProje
 
 <div class="cms-section custom-empty-state">
 	<frontend-data-set:headless-display
+		additionalProps="<%= viewProjectsSectionDisplayContext.getAdditionalProps() %>"
 		apiURL="<%= viewProjectsSectionDisplayContext.getAPIURL() %>"
 		creationMenu="<%= viewProjectsSectionDisplayContext.getCreationMenu() %>"
 		emptyState="<%= viewProjectsSectionDisplayContext.getEmptyState() %>"

--- a/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
+++ b/modules/apps/site/site-cms-site-initializer-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site CMS Site Initializer API
 Bundle-SymbolicName: com.liferay.site.cms.site.initializer.api
-Bundle-Version: 4.3.1
+Bundle-Version: 4.4.0
 Export-Package:\
 	com.liferay.site.cms.site.initializer.bulk.selection,\
 	com.liferay.site.cms.site.initializer.configuration,\

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDepotEntryGroupUtil.java
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/java/com/liferay/site/cms/site/initializer/util/CMSDepotEntryGroupUtil.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.util;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Pedro Leite
+ */
+public class CMSDepotEntryGroupUtil {
+
+	public static String getFilterString() {
+		List<Long> depotEntryGroupIds =
+			DepotEntryLocalServiceUtil.getDepotEntryGroupIds(
+				CompanyThreadLocal.getCompanyId(), DepotConstants.TYPE_SPACE);
+
+		String filterString =
+			"groupIds in (" + StringUtil.merge(depotEntryGroupIds) + ")";
+
+		Set<Long> depotEntryUserGroupIds = new HashSet<>();
+
+		for (long depotEntryGroupId : depotEntryGroupIds) {
+			depotEntryUserGroupIds.addAll(
+				TransformUtil.transform(
+					UserGroupLocalServiceUtil.getGroupUserGroups(
+						depotEntryGroupId),
+					UserGroup::getUserGroupId));
+		}
+
+		if (SetUtil.isEmpty(depotEntryUserGroupIds)) {
+			return filterString;
+		}
+
+		return StringBundler.concat(
+			"(", filterString, " or userGroupIds in ('",
+			StringUtil.merge(depotEntryUserGroupIds, "', '"), "'))");
+	}
+
+}

--- a/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
+++ b/modules/apps/site/site-cms-site-initializer-api/src/main/resources/com/liferay/site/cms/site/initializer/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDepotEntryGroupUtilTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/util/test/CMSDepotEntryGroupUtilTest.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.cms.site.initializer.util.CMSDepotEntryGroupUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Pedro Leite
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class CMSDepotEntryGroupUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetFilterString() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		long groupId = depotEntry.getGroupId();
+
+		Assert.assertEquals(
+			"groupIds in (" + groupId + ")",
+			CMSDepotEntryGroupUtil.getFilterString());
+
+		UserGroup userGroup = UserGroupTestUtil.addUserGroup();
+
+		_groupLocalService.addUserGroupGroups(
+			userGroup.getUserGroupId(), new long[] {groupId});
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"(groupIds in (", groupId, ") or userGroupIds in ('",
+				userGroup.getUserGroupId(), "'))"),
+			CMSDepotEntryGroupUtil.getFilterString());
+
+		_userGroupLocalService.deleteUserGroup(userGroup);
+
+		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceMembersSummarySectionDisplayContext.java
@@ -24,10 +24,10 @@ import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
 import com.liferay.site.cms.site.initializer.internal.util.SpaceSummaryHeaderUtil;
+import com.liferay.site.cms.site.initializer.util.CMSDepotEntryGroupUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -49,7 +49,6 @@ public class ViewSpaceMembersSummarySectionDisplayContext {
 			UserLocalService userLocalService)
 		throws PortalException {
 
-		_depotEntryLocalService = depotEntryLocalService;
 		_groupId = groupId;
 		_groupModelResourcePermission = groupModelResourcePermission;
 		_httpServletRequest = httpServletRequest;
@@ -148,12 +147,7 @@ public class ViewSpaceMembersSummarySectionDisplayContext {
 						return null;
 					}
 
-					List<Long> depotEntryGroupIds =
-						_depotEntryLocalService.getDepotEntryGroupIds(
-							_group.getCompanyId(), DepotConstants.TYPE_SPACE);
-
-					return "groupIds in (" +
-						StringUtil.merge(depotEntryGroupIds) + ")";
+					return CMSDepotEntryGroupUtil.getFilterString();
 				}
 			).build(),
 			_getSpaceMembersHeaderTitle(), StringPool.BLANK);
@@ -194,7 +188,6 @@ public class ViewSpaceMembersSummarySectionDisplayContext {
 	}
 
 	private final DepotEntry _depotEntry;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private final String _externalReferenceCode;
 	private final Group _group;
 	private final long _groupId;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/props_transformer/AssetsFDSPropsTransformer.tsx
@@ -151,6 +151,7 @@ export type AdditionalProps = {
 	defaultPermissionAdditionalProps?: any;
 	fileMimeTypeCssClasses: Record<string, string>;
 	fileMimeTypeIcons: Record<string, string>;
+	filter?: string;
 	galleryViewEnabled?: boolean;
 	objectDefinitionCssClasses: Record<string, string>;
 	objectDefinitionIcons: Record<string, string>;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-80025

**What is being fixed:** When adding a project member, a user who does not belong to a Space directly but is a member of a User Group associated with that Space did not appear in the selection list. The candidate filter only matched users with direct site membership (the `groupIds` search field), so membership inherited through a User Group was excluded.

**How it is being fixed:** The members selection filter now also matches users by the `userGroupIds` search field, so users reachable through a User Group associated with a Space are included. The filter-building logic was extracted into a new shared `CMSDepotEntryGroupUtil.getFilterString()` in `site-cms-site-initializer-api` and reused by both entry points: the "view all members" action on the space summary header, and the "view members" action on the projects data set, which previously opened the modal with no filter at all. An integration test covers the new utility.