### PR TITLE
LPD-97798 Allow depot roles to manage members via group permissions

### DIFF
--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/security/permission/wrapper/DepotPermissionCheckerWrapper.java
@@ -253,8 +253,20 @@ public class DepotPermissionCheckerWrapper extends PermissionCheckerWrapper {
 						return true;
 					}
 
-					return _depotEntryModelResourcePermission.contains(
-						this, group.getClassPK(), actionId);
+					if (_depotEntryModelResourcePermission.contains(
+							this, group.getClassPK(), actionId)) {
+
+						return true;
+					}
+
+					if (StringUtil.equals(
+							actionId, ActionKeys.ASSIGN_MEMBERS) ||
+						StringUtil.equals(actionId, ActionKeys.VIEW_MEMBERS)) {
+
+						return null;
+					}
+
+					return false;
 				}
 				catch (PortalException portalException) {
 					_log.error(portalException);

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/security/permission/wrapper/test/DepotPermissionCheckerWrapperTest.java
@@ -86,6 +86,48 @@ public class DepotPermissionCheckerWrapperTest {
 	}
 
 	@Test
+	public void testHasPermissionForADepotGroupDelegatesMemberPermissionsToGroup()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDepotEntry(TestPropsValues.getUserId());
+
+		DepotTestUtil.withRegularUser(
+			(user, role) -> {
+				PermissionChecker permissionChecker =
+					_permissionCheckerFactory.create(user);
+
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						depotEntry.getGroup(), Group.class.getName(),
+						depotEntry.getGroupId(), ActionKeys.ASSIGN_MEMBERS));
+				Assert.assertFalse(
+					permissionChecker.hasPermission(
+						depotEntry.getGroup(), Group.class.getName(),
+						depotEntry.getGroupId(), ActionKeys.VIEW_MEMBERS));
+
+				RoleTestUtil.addResourcePermission(
+					role, Group.class.getName(),
+					ResourceConstants.SCOPE_COMPANY,
+					String.valueOf(TestPropsValues.getCompanyId()),
+					ActionKeys.ASSIGN_MEMBERS);
+				RoleTestUtil.addResourcePermission(
+					role, Group.class.getName(),
+					ResourceConstants.SCOPE_COMPANY,
+					String.valueOf(TestPropsValues.getCompanyId()),
+					ActionKeys.VIEW_MEMBERS);
+
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						depotEntry.getGroup(), Group.class.getName(),
+						depotEntry.getGroupId(), ActionKeys.ASSIGN_MEMBERS));
+				Assert.assertTrue(
+					permissionChecker.hasPermission(
+						depotEntry.getGroup(), Group.class.getName(),
+						depotEntry.getGroupId(), ActionKeys.VIEW_MEMBERS));
+			});
+	}
+
+	@Test
 	public void testHasPermissionForADepotGroupDelegatesToDepot()
 		throws Exception {
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AddSpaceMembersFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/AddSpaceMembersFragmentRenderer.java
@@ -12,6 +12,8 @@ import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.learn.LearnMessageUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -64,6 +66,7 @@ public class AddSpaceMembersFragmentRenderer
 		String assetLibraryName = StringPool.BLANK;
 		long creatorUserId = 0;
 		String externalReferenceCode = StringPool.BLANK;
+		boolean hasAssignMembersPermission = false;
 		DepotEntry depotEntry = _depotEntryLocalService.fetchDepotEntry(
 			assetLibraryId);
 
@@ -75,6 +78,9 @@ public class AddSpaceMembersFragmentRenderer
 				themeDisplay.getLocale());
 			creatorUserId = group.getCreatorUserId();
 			externalReferenceCode = group.getExternalReferenceCode();
+			hasAssignMembersPermission = _groupModelResourcePermission.contains(
+				themeDisplay.getPermissionChecker(), group.getGroupId(),
+				ActionKeys.ASSIGN_MEMBERS);
 		}
 
 		return HashMapBuilder.<String, Object>put(
@@ -88,7 +94,7 @@ public class AddSpaceMembersFragmentRenderer
 		).put(
 			"externalReferenceCode", externalReferenceCode
 		).put(
-			"hasAssignMembersPermission", true
+			"hasAssignMembersPermission", hasAssignMembersPermission
 		).put(
 			"learnResources",
 			LearnMessageUtil.getReactDataJSONObject("site-cms-site-initializer")
@@ -100,5 +106,10 @@ public class AddSpaceMembersFragmentRenderer
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Group)"
+	)
+	private ModelResourcePermission<Group> _groupModelResourcePermission;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97798

## What Is Being Fixed

A user with a custom Space Role of subtype Project — a "Project Manager" — could not add members to a CMP project, even after being granted the member-management permission and added to the project. The "Add member" affordance appeared, but the action was rejected with a Forbidden error.

## How It Is Being Fixed

Membership on a project (or any depot) group is enforced by ASSIGN_MEMBERS on the group. DepotPermissionCheckerWrapper intercepts every Group-resource permission check on a depot group and delegated it solely to the DepotEntry model resource, silently ignoring any grant made on the Group resource. Because the Define Permissions UI lets an administrator grant ASSIGN_MEMBERS on either the Group resource (the "Members" section) or the DepotEntry resource (the "Configuration" section), a role granted the intuitive "Members" permission held a dead permission on projects.

The wrapper now falls back to the base Group-resource check for the ASSIGN_MEMBERS and VIEW_MEMBERS actions when the DepotEntry resource does not grant them, so both carriers work. Delegation for every other action is unchanged, preserving the existing asset-library, space, and design-library semantics.

Separately, AddSpaceMembersFragmentRenderer hardcoded the "add members" permission to true, so the UI always showed the affordance regardless of permission. It now performs the real ASSIGN_MEMBERS check, mirroring the sibling member-section renderers, so the affordance matches what the server allows.

## PR Check

**pr-check: PASS** — tested on `bf54b155057c359d81eac97f219f70bc11784ebb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bf54b155057c359d81eac97f219f70bc11784ebb"} -->
